### PR TITLE
feature: Closes Node coverage gaps

### DIFF
--- a/docs/coverage-rationale.md
+++ b/docs/coverage-rationale.md
@@ -1,0 +1,116 @@
+# Coverage rationale
+
+`pnpm coverage` reports a measured Node-side number (see
+[`packages/tui/README.md`](../packages/tui/README.md#coverage) for the Node/Bun
+split). This document is the honest companion to that number: it accounts,
+concretely and line-by-line, for **every** thing the number does not cover, so
+the percentage is never read as "100% of everything" and no gap is silent.
+
+Each entry states the file, the specific lines/branches, what the code does, and
+the concrete reason it is not unit-tested. Where the reason is "real behavior, not
+yet tested," it says so and links the issue that will close it — it is not dressed
+up as "unreachable."
+
+Line numbers drift as files change; they are anchors, not contracts. Re-run
+`pnpm coverage` for the live picture.
+
+## 1. Excluded from instrumentation (not in the number at all)
+
+These files are excluded in `vitest.config.ts`. They are not Node-unit-testable
+surfaces, so instrumenting them would only report dead 0% and make the percentage
+dishonest.
+
+| File | Why excluded | What guards it instead |
+| --- | --- | --- |
+| `packages/tui/src/app.ts` | Self-executing Bun entry: top-level `await`, openTUI renderer construction, `process.exit` startup glue. Never runs under Node's `vitest run`. | `pnpm dev` (manual) + the keypress smoke for the wiring it delegates to. |
+| `packages/tui/src/mount-app.ts` | Bun-only openTUI wiring (`@opentui/core` import, keypress subscription, `requestRender`). Never runs under Node. | `pnpm smoke:tui` drives real `j`/`k`/`enter` through it on the real openTUI test renderer. |
+| `packages/tui/src/smoke-openTui.ts` | The Bun smoke harness itself. | It *is* the test; running it (`pnpm smoke:tui`) is the assertion. |
+| `packages/tui/src/report.ts` | A 22-line `tsx` CLI script: a top-level `try/catch` orchestrating already-tested functions (`resolveFundReviewFilePath`, `loadFundReview`, `buildCompositionReport`, `formatCompositionReport`). Same category as the script entries above — no unit to assert beyond a `process.stdout.write`. | Its constituent functions are unit-tested directly (`review-file.test.ts`, `fund-composition.test.ts`). |
+
+## 2. Defensive / unreachable guards (kept on purpose, cannot be tested honestly)
+
+These branches exist to make each function safe in isolation, but a prior check
+in the real call path makes them unreachable. Testing them would require faking a
+state the pipeline already excludes, so they are documented rather than tested.
+
+**`packages/engine/src/parse.ts`**
+
+- `validateNamedRecords` `!Array.isArray(value)` (~L148-150) — every caller
+  (`portfolios` directly, plus `validateAccounts` / `validateInstruments`) only
+  runs after the top-level `requiredArrays` loop has already confirmed the value
+  is an array.
+- `validateReserves` `!Array.isArray(value)` (~L233-235) and `validatePositions`
+  `!Array.isArray(value)` (~L261-263) — `reserves` and `positions` are both in
+  the same top-level `requiredArrays` check, so these are unreachable from
+  `parseFundReview`.
+- `validateCapitalRecordIds` `if (!isRecord(record) || typeof record.id !==
+  "string") continue` (~L415-417) — by the time this runs, every reserve and
+  position has passed `validateCapitalRecordShape`, which already required a
+  record carrying a non-empty string `id`.
+- `parseReviewInput` invalid-json catch, `error instanceof Error ? error.message
+  : String(error)` false branch (~L448) — `JSON.parse` only throws `SyntaxError`
+  (an `Error`), so the `String(error)` fallback never runs.
+
+**`packages/tui/src/review-file.ts`**
+
+- `normalizeLoadFundReviewError` `error instanceof Error ? error : new
+  Error(String(error))` false branch (~L108) — the only throwers reaching it
+  (`readFile`, `parseFundReviewError`) throw `Error` instances; the
+  non-`Error` fallback is a defensive coercion. (The `ENOENT`/`EISDIR`/`EACCES`
+  branches above it *are* tested, the last one skipped only when running as
+  root — see `review-file.test.ts`.)
+
+## 3. Low-value presentation branches (deferred with #72)
+
+**`packages/engine/src/format.ts`** (99.3% lines) — display-string branches in
+the CLI report that carry no logic, reachable only by hand-building zero-state
+`CompositionReport`s:
+
+- `formatRowFocus` `if (!row) return "No live records"` (~L128) — an undefined
+  summary focus (empty section).
+- `formatDataSafety` `shortDeferred > 0` ternary and the `warnings.length > 0 ?
+  … : "no warnings"` strings (~L141-142, L150, L173).
+
+These are pure presentation. They share the display layer with the renderer work
+in **#72** and are folded into that issue rather than tested here.
+
+**`packages/engine/src/price-journey.ts`** (100% lines) — the journeys sort
+comparator's `|| a.label.localeCompare(b.label)` tie-break (~L104 branch) runs
+only when two journeys have equal point counts. A tie-break ordering detail; not
+worth a crafted multi-journey fixture this increment.
+
+## 4. Real, reachable behavior — not yet tested (tracked in #72)
+
+This is the honest part: the following are **not** defensive and **not**
+low-value. They are shippable behavior that the suite does not yet exercise, so a
+regression could pass green. They are deferred to a dedicated increment, not
+excused. See **[#72](https://github.com/AmetAlvirde/numisma/issues/72)**.
+
+**`packages/engine/src/compose.ts`** (94.0% lines / 90.1% branches)
+
+- Reserve missing-reference exclusion (~L286-289).
+- Position `unsupported-execution-mode` warning + exclusion (~L342-351).
+- Position `currency-mismatch` warnings against Account and Instrument currency
+  (~L399-417).
+- Lot-level invalid-numeric warnings: empty lots, non-numeric quantity/cost,
+  invalid `entryFx` (~L429-437).
+- `detailLinesForRow` portfolio / tempo / account drill-down filtering
+  (~L530-556).
+
+**`packages/tui/src/dashboard.ts`** (94.5% lines / 86.4% branches)
+
+- Empty-section "No live records." line (~L141-143).
+- Empty-detail body message and `emptyDetailMessage` variants (~L297, L341-351).
+- Tier-expansion row rendering and `detailTitle` tempo/account branches
+  (~L336-351).
+- Summary "No live records" fallback (~L383-384).
+- Typed-row detail-table rendering branches (tempo/account/reserve) still
+  partially uncovered (~L243-258 branches).
+
+## What this number means
+
+After this pass, every Node module's *meaningful, reachable* behavior is either
+unit-tested or listed in §4 with an owning issue. §1–§3 account for what is
+deliberately not in the number. "Reliable" here means *measured and accounted
+for* — not "100% of everything," and explicitly not yet covering the §4 behavior
+or the Bun-only wiring.

--- a/packages/engine/README.md
+++ b/packages/engine/README.md
@@ -65,3 +65,8 @@ From the repo root:
 - `pnpm typecheck` — guards the public surface and the no-deep-import boundary.
 - `pnpm test` — the behavioral suite plus the characterization snapshots and the
   engine↔TUI formatter contract test.
+- `pnpm coverage` — the measured Node-side coverage number. Everything it does
+  not cover (defensive/unreachable guards, low-value presentation branches, and
+  the reachable `compose.ts` behavior still deferred) is accounted for
+  line-by-line in
+  [`docs/coverage-rationale.md`](../../docs/coverage-rationale.md).

--- a/packages/engine/src/engine-internals.test.ts
+++ b/packages/engine/src/engine-internals.test.ts
@@ -1,0 +1,81 @@
+// Direct unit tests for the small internal helpers whose guard/edge branches the
+// fixture-driven `fund-composition.test.ts` does not reach. These are imported
+// from their sibling modules (not the public `index.ts`) on purpose — they are
+// internal kernel helpers, and this is the same direct-import seam `parse.ts`
+// already relies on. Covers the otherwise-uncovered branches called out in
+// docs/coverage-rationale.md.
+import { indexById, percentOfFund } from "./internal.js";
+import { pad, padLeft } from "./format.js";
+import { buildPriceJourneys } from "./price-journey.js";
+import type { FundReviewData, Warning } from "./contracts.js";
+import { describe, expect, it } from "vitest";
+
+describe("internal.percentOfFund", () => {
+  it("returns 0 when the fund value is 0 (no division by zero)", () => {
+    expect(percentOfFund(50, 0)).toBe(0);
+  });
+
+  it("computes a percentage against a non-zero fund value", () => {
+    expect(percentOfFund(25, 100)).toBe(25);
+  });
+});
+
+describe("internal.indexById", () => {
+  it("throws when a record has no id", () => {
+    expect(() => indexById([{ id: "", name: "Nameless" }], "account")).toThrowError(
+      "Found account without id.",
+    );
+  });
+
+  it("throws on a duplicate id", () => {
+    expect(() =>
+      indexById(
+        [
+          { id: "dup", name: "First" },
+          { id: "dup", name: "Second" },
+        ],
+        "instrument",
+      ),
+    ).toThrowError("Duplicate instrument id: dup");
+  });
+
+  it("indexes well-formed records by id", () => {
+    const index = indexById([{ id: "a", name: "A" }], "portfolio");
+    expect(index.get("a")).toMatchObject({ name: "A" });
+  });
+});
+
+describe("format.pad / format.padLeft truncation", () => {
+  it("truncates an over-wide value with a trailing tilde", () => {
+    expect(pad("abcdef", 4)).toBe("abc~");
+  });
+
+  it("pads a short value to the requested width", () => {
+    expect(pad("ab", 4)).toBe("ab  ");
+  });
+
+  it("hard-truncates an over-wide left-padded value", () => {
+    expect(padLeft("abcdef", 4)).toBe("abcd");
+  });
+
+  it("left-pads a short value to the requested width", () => {
+    expect(padLeft("ab", 4)).toBe("  ab");
+  });
+});
+
+describe("price-journey.buildPriceJourneys — zero first price", () => {
+  it("reports a 0% change when the first anchor price is 0", () => {
+    const warnings: Warning[] = [];
+    const data = {
+      instruments: [{ id: "inst-1", name: "Apple", symbol: "AAPL", currency: "USD" }],
+      closes: [
+        { instrumentId: "inst-1", asOf: "2026-05-20", price: 0 },
+        { instrumentId: "inst-1", asOf: "2026-05-28", price: 10 },
+      ],
+    } as unknown as FundReviewData;
+
+    const [journey] = buildPriceJourneys(data, warnings);
+
+    expect(journey).toMatchObject({ firstPrice: 0, latestPrice: 10, changePct: 0 });
+  });
+});

--- a/packages/engine/src/parse-validation.test.ts
+++ b/packages/engine/src/parse-validation.test.ts
@@ -1,0 +1,340 @@
+// Exhaustive coverage of `parseFundReview`'s blocking validation branches.
+// `fund-composition.test.ts` covers the happy path and a representative handful
+// of failures; this file walks every remaining `validate*`/`require*` error
+// return so the parser's rejection behavior is guarded branch-by-branch rather
+// than inferred. Each case mutates a known-valid base into exactly one defect.
+import { parseFundReview } from "./index.js";
+import { describe, expect, it } from "vitest";
+
+/** A minimal, known-valid review. Every test clones and breaks one field. */
+function validReview() {
+  return {
+    fund: { id: "fund-1", name: "Main Fund", baseCurrency: "USD" },
+    review: { asOf: "2026-05-28", usdMxn: 20 },
+    portfolios: [{ id: "core", name: "Core" }],
+    accounts: [{ id: "acc-1", name: "Broker", platform: "XTB", currency: "USD" }],
+    instruments: [{ id: "inst-1", name: "Apple", symbol: "AAPL", currency: "USD" }],
+    reserves: [
+      {
+        id: "reserve-1",
+        portfolioId: "core",
+        tempo: "Reserve",
+        executionMode: "live",
+        accountId: "acc-1",
+        currency: "USD",
+        amount: 100,
+      },
+    ],
+    positions: [
+      {
+        id: "position-1",
+        portfolioId: "core",
+        tempo: "Capital",
+        executionMode: "live",
+        accountId: "acc-1",
+        instrumentId: "inst-1",
+        direction: "long",
+        markPrice: 10,
+        currency: "USD",
+        lots: [{ quantity: 1, cost: 5, tier: "c1" }],
+      },
+    ],
+  };
+}
+
+/** Clone the valid base, apply one mutation, parse. */
+function brokenBy(mutate: (review: Record<string, any>) => void): ReturnType<typeof parseFundReview> {
+  const review = structuredClone(validReview()) as Record<string, any>;
+  mutate(review);
+  return parseFundReview(review);
+}
+
+describe("parseFundReview — the valid base parses", () => {
+  it("accepts the known-valid fixture every other case mutates", () => {
+    expect(parseFundReview(validReview())).toMatchObject({ kind: "ok" });
+  });
+});
+
+describe("parseFundReview — top-level shape", () => {
+  it("rejects a non-object top-level value", () => {
+    expect(parseFundReview(42)).toMatchObject({ kind: "schema-error", path: "$" });
+  });
+
+  it("rejects a missing required array", () => {
+    expect(brokenBy((r) => delete r.positions)).toMatchObject({
+      kind: "schema-error",
+      path: "positions",
+    });
+  });
+
+  it("rejects a missing fund object", () => {
+    expect(brokenBy((r) => (r.fund = 5))).toMatchObject({
+      kind: "schema-error",
+      path: "fund",
+    });
+  });
+
+  it("rejects an empty fund id", () => {
+    expect(brokenBy((r) => (r.fund.id = ""))).toMatchObject({
+      kind: "schema-error",
+      path: "fund.id",
+    });
+  });
+
+  it("rejects an empty fund name", () => {
+    expect(brokenBy((r) => (r.fund.name = ""))).toMatchObject({
+      kind: "schema-error",
+      path: "fund.name",
+    });
+  });
+
+  it("rejects a missing review object", () => {
+    expect(brokenBy((r) => (r.review = 5))).toMatchObject({
+      kind: "schema-error",
+      path: "review",
+    });
+  });
+
+  it("rejects a missing review.asOf", () => {
+    expect(brokenBy((r) => delete r.review.asOf)).toMatchObject({
+      kind: "schema-error",
+      path: "review.asOf",
+    });
+  });
+});
+
+describe("parseFundReview — named records (portfolios)", () => {
+  it("rejects a non-object record", () => {
+    expect(brokenBy((r) => (r.portfolios[0] = 5))).toMatchObject({
+      kind: "schema-error",
+      path: "portfolios[0]",
+    });
+  });
+
+  it("rejects an empty record id", () => {
+    expect(brokenBy((r) => (r.portfolios[0].id = ""))).toMatchObject({
+      kind: "schema-error",
+      path: "portfolios[0].id",
+    });
+  });
+
+  it("rejects an empty record name", () => {
+    expect(brokenBy((r) => (r.portfolios[0].name = ""))).toMatchObject({
+      kind: "schema-error",
+      path: "portfolios[0].name",
+    });
+  });
+
+  it("rejects a duplicate record id", () => {
+    expect(
+      brokenBy((r) => r.portfolios.push({ id: "core", name: "Dup" })),
+    ).toMatchObject({
+      kind: "duplicate-reference-id",
+      recordType: "portfolio",
+      id: "core",
+    });
+  });
+});
+
+describe("parseFundReview — accounts and instruments", () => {
+  it("rejects a missing account platform", () => {
+    expect(brokenBy((r) => delete r.accounts[0].platform)).toMatchObject({
+      kind: "schema-error",
+      path: "accounts[0].platform",
+    });
+  });
+
+  it("rejects a missing account currency", () => {
+    expect(brokenBy((r) => delete r.accounts[0].currency)).toMatchObject({
+      kind: "schema-error",
+      path: "accounts[0].currency",
+    });
+  });
+
+  it("rejects a missing instrument symbol", () => {
+    expect(brokenBy((r) => delete r.instruments[0].symbol)).toMatchObject({
+      kind: "schema-error",
+      path: "instruments[0].symbol",
+    });
+  });
+
+  it("rejects a missing instrument currency", () => {
+    expect(brokenBy((r) => delete r.instruments[0].currency)).toMatchObject({
+      kind: "schema-error",
+      path: "instruments[0].currency",
+    });
+  });
+
+  it("propagates a named-record failure from accounts", () => {
+    expect(brokenBy((r) => (r.accounts[0] = 5))).toMatchObject({
+      kind: "schema-error",
+      path: "accounts[0]",
+    });
+  });
+
+  it("propagates a named-record failure from instruments", () => {
+    expect(brokenBy((r) => (r.instruments[0] = 5))).toMatchObject({
+      kind: "schema-error",
+      path: "instruments[0]",
+    });
+  });
+});
+
+describe("parseFundReview — capital record shape (reserves)", () => {
+  it("rejects a non-object reserve", () => {
+    expect(brokenBy((r) => (r.reserves[0] = 5))).toMatchObject({
+      kind: "schema-error",
+      path: "reserves[0]",
+    });
+  });
+
+  it("rejects a missing capital-record field", () => {
+    expect(brokenBy((r) => delete r.reserves[0].portfolioId)).toMatchObject({
+      kind: "schema-error",
+      path: "reserves[0].portfolioId",
+    });
+  });
+
+  it("rejects a non-numeric reserve amount", () => {
+    expect(brokenBy((r) => (r.reserves[0].amount = "lots"))).toMatchObject({
+      kind: "schema-error",
+      path: "reserves[0].amount",
+    });
+  });
+
+  it("rejects malformed reserve lots when present", () => {
+    expect(
+      brokenBy((r) => (r.reserves[0].lots = [{ quantity: "x", tier: "c1" }])),
+    ).toMatchObject({
+      kind: "schema-error",
+      path: "reserves[0].lots[0].quantity",
+    });
+  });
+});
+
+describe("parseFundReview — positions", () => {
+  it("rejects a missing instrumentId", () => {
+    expect(brokenBy((r) => delete r.positions[0].instrumentId)).toMatchObject({
+      kind: "schema-error",
+      path: "positions[0].instrumentId",
+    });
+  });
+
+  it("rejects a missing direction", () => {
+    expect(brokenBy((r) => delete r.positions[0].direction)).toMatchObject({
+      kind: "schema-error",
+      path: "positions[0].direction",
+    });
+  });
+
+  it("rejects a non-numeric markPrice", () => {
+    expect(brokenBy((r) => (r.positions[0].markPrice = "high"))).toMatchObject({
+      kind: "schema-error",
+      path: "positions[0].markPrice",
+    });
+  });
+
+  it("rejects a malformed position capital-record shape", () => {
+    expect(brokenBy((r) => delete r.positions[0].portfolioId)).toMatchObject({
+      kind: "schema-error",
+      path: "positions[0].portfolioId",
+    });
+  });
+});
+
+describe("parseFundReview — lots", () => {
+  it("rejects an empty lots array", () => {
+    expect(brokenBy((r) => (r.positions[0].lots = []))).toMatchObject({
+      kind: "schema-error",
+      path: "positions[0].lots",
+    });
+  });
+
+  it("rejects a non-object lot", () => {
+    expect(brokenBy((r) => (r.positions[0].lots = [5]))).toMatchObject({
+      kind: "schema-error",
+      path: "positions[0].lots[0]",
+    });
+  });
+
+  it("rejects a non-numeric lot cost", () => {
+    expect(
+      brokenBy((r) => (r.positions[0].lots = [{ quantity: 1, cost: "x", tier: "c1" }])),
+    ).toMatchObject({
+      kind: "schema-error",
+      path: "positions[0].lots[0].cost",
+    });
+  });
+
+  it("rejects an invalid lot tier", () => {
+    expect(
+      brokenBy((r) => (r.positions[0].lots = [{ quantity: 1, cost: 5, tier: "c9" }])),
+    ).toMatchObject({
+      kind: "schema-error",
+      path: "positions[0].lots[0].tier",
+    });
+  });
+
+  it("rejects a non-numeric entryFx when present", () => {
+    expect(
+      brokenBy(
+        (r) =>
+          (r.positions[0].lots = [{ quantity: 1, cost: 5, tier: "c1", entryFx: "x" }]),
+      ),
+    ).toMatchObject({
+      kind: "schema-error",
+      path: "positions[0].lots[0].entryFx",
+    });
+  });
+});
+
+describe("parseFundReview — optional closes", () => {
+  it("rejects a non-array closes", () => {
+    expect(brokenBy((r) => (r.closes = 5))).toMatchObject({
+      kind: "schema-error",
+      path: "closes",
+    });
+  });
+
+  it("rejects a non-object close", () => {
+    expect(brokenBy((r) => (r.closes = [5]))).toMatchObject({
+      kind: "schema-error",
+      path: "closes[0]",
+    });
+  });
+
+  it("rejects a missing close instrumentId", () => {
+    expect(brokenBy((r) => (r.closes = [{ asOf: "2026-05-28", price: 1 }]))).toMatchObject({
+      kind: "schema-error",
+      path: "closes[0].instrumentId",
+    });
+  });
+
+  it("rejects a missing close asOf", () => {
+    expect(
+      brokenBy((r) => (r.closes = [{ instrumentId: "inst-1", price: 1 }])),
+    ).toMatchObject({
+      kind: "schema-error",
+      path: "closes[0].asOf",
+    });
+  });
+
+  it("rejects a non-numeric close price", () => {
+    expect(
+      brokenBy(
+        (r) => (r.closes = [{ instrumentId: "inst-1", asOf: "2026-05-28", price: "x" }]),
+      ),
+    ).toMatchObject({
+      kind: "schema-error",
+      path: "closes[0].price",
+    });
+  });
+
+  it("accepts a well-formed closes entry", () => {
+    expect(
+      brokenBy(
+        (r) => (r.closes = [{ instrumentId: "inst-1", asOf: "2026-05-28", price: 9 }]),
+      ),
+    ).toMatchObject({ kind: "ok" });
+  });
+});

--- a/packages/tui/README.md
+++ b/packages/tui/README.md
@@ -17,10 +17,12 @@ under Node while the terminal glue stays isolated in a Bun-only layer.
 - `dashboard.ts` — the `DashboardLine`/`DashboardAction` line model the reducer
   consumes (`dashboard.test.ts`).
 - `review-file.ts` — fund-review path resolution and loading (`review-file.test.ts`).
-- `report.ts` — the `tsx` CLI report entry (`pnpm report`).
 
-**Bun-only (excluded from the coverage number):**
+**Excluded from the coverage number (scripts + Bun-only wiring):**
 
+- `report.ts` — the `tsx` CLI report entry (`pnpm report`). A thin script: a
+  top-level `try/catch` orchestrating already-tested engine/review functions, no
+  unit to assert. Its constituent functions are unit-tested directly.
 - `app.ts` — the self-executing `pnpm dev` entry: path resolution, openTUI
   renderer construction, fail-fast/exit codes, then `mountApp`.
 - `mount-app.ts` — the openTUI-coupled wiring: renderable construction, keypress
@@ -29,10 +31,12 @@ under Node while the terminal glue stays isolated in a Bun-only layer.
   `buildDashboardLines`) whose results are passed into the pure core.
 - `smoke-openTui.ts` — the Bun smoke (`pnpm smoke:tui`).
 
-These three files run under Bun against the real openTUI renderer. They never
-execute under Node's `vitest run`, so instrumenting them would only report them
-as dead 0% and make the percentage dishonest. They are excluded from the
-coverage `include` in `vitest.config.ts`.
+The openTUI files run under Bun against the real renderer and never execute under
+Node's `vitest run`, so instrumenting them would only report dead 0% and make the
+percentage dishonest; `report.ts` is a script entry with no unit to assert. All
+four are excluded from the coverage `include` in `vitest.config.ts`, and the
+exclusion (plus every remaining uncovered line) is accounted for concretely in
+[`docs/coverage-rationale.md`](../../docs/coverage-rationale.md).
 
 ## Coverage
 
@@ -45,6 +49,12 @@ drives real `j`/`k`/`enter` keypresses through `mountApp` and the real openTUI
 test renderer and asserts the cursor moved and a detail row rendered. The
 measured number replaces the prior "all the codebase is reliable" inference from
 reading. No coverage threshold or CI gate is enforced.
+
+Everything the number does **not** cover — the excluded scripts/wiring above,
+the defensive/unreachable guards, and the real behavior still deferred (tracked
+in [#72](https://github.com/AmetAlvirde/numisma/issues/72)) — is accounted for
+line-by-line in [`docs/coverage-rationale.md`](../../docs/coverage-rationale.md),
+so no gap is silent.
 
 ## Decision record: interaction-core / mountApp split (no ADR)
 

--- a/packages/tui/src/review-file.test.ts
+++ b/packages/tui/src/review-file.test.ts
@@ -1,4 +1,4 @@
-import { mkdir, mkdtemp } from "node:fs/promises";
+import { chmod, mkdir, mkdtemp, writeFile } from "node:fs/promises";
 import { resolve } from "node:path";
 import { tmpdir } from "node:os";
 import {
@@ -50,6 +50,22 @@ describe("@numisma/tui review file resolution", () => {
       `);
   });
 
+  it("accepts the inline --file=<path> form", () => {
+    expect(
+      resolveFundReviewFilePath(["node", "script", "--file=cli-review.json"]),
+    ).toBe(resolve("cli-review.json"));
+  });
+
+  it("rejects an empty inline --file= value explicitly", () => {
+    expect(() => resolveFundReviewFilePath(["node", "script", "--file="]))
+      .toThrowError("Missing value for --file.");
+  });
+
+  it("skips empty argv entries without treating them as paths", () => {
+    expect(resolveFundReviewFilePath(["node", "script", "", "review.json"]))
+      .toBe(resolve("review.json"));
+  });
+
   it("rejects ambiguous bare positional json paths", () => {
     expect(() =>
       resolveFundReviewFilePath([
@@ -96,4 +112,86 @@ describe("@numisma/tui review file loading", () => {
       `Fund review path is a directory, not a file: ${directoryPath}`,
     );
   });
+
+  it("loads and parses a well-formed review file", async () => {
+    const filePath = await writeReviewFile(JSON.stringify(validReviewJson()));
+
+    await expect(loadFundReview(filePath)).resolves.toMatchObject({
+      fund: { id: "fund-1", baseCurrency: "USD" },
+    });
+  });
+
+  it("surfaces invalid JSON content with the invalid-json blocking message", async () => {
+    const filePath = await writeReviewFile("{ not json");
+
+    await expect(loadFundReview(filePath)).rejects.toThrowError(
+      /Blocking validation error \(invalid-json\)/,
+    );
+  });
+
+  it("surfaces a schema failure with the generic blocking message", async () => {
+    const filePath = await writeReviewFile(JSON.stringify({ fund: {} }));
+
+    await expect(loadFundReview(filePath)).rejects.toThrowError(
+      /Blocking validation error \(schema-error\)/,
+    );
+  });
+
+  it("surfaces an unreadable file as a not-readable error", async () => {
+    if (process.getuid?.() === 0) {
+      // root bypasses the mode bits, so EACCES can't be provoked; the branch is
+      // exercised on non-root dev/CI. Documented in docs/coverage-rationale.md.
+      return;
+    }
+    const filePath = await writeReviewFile(JSON.stringify(validReviewJson()));
+    await chmod(filePath, 0o000);
+
+    await expect(loadFundReview(filePath)).rejects.toThrowError(
+      `Fund review file is not readable: ${filePath}`,
+    );
+
+    await chmod(filePath, 0o600);
+  });
 });
+
+async function writeReviewFile(contents: string): Promise<string> {
+  const dir = await mkdtemp(resolve(tmpdir(), "numisma-review-load-"));
+  const filePath = resolve(dir, "review.json");
+  await writeFile(filePath, contents, "utf8");
+  return filePath;
+}
+
+function validReviewJson() {
+  return {
+    fund: { id: "fund-1", name: "Main Fund", baseCurrency: "USD" },
+    review: { asOf: "2026-05-28", usdMxn: 20 },
+    portfolios: [{ id: "core", name: "Core" }],
+    accounts: [{ id: "acc-1", name: "Broker", platform: "XTB", currency: "USD" }],
+    instruments: [{ id: "inst-1", name: "Apple", symbol: "AAPL", currency: "USD" }],
+    reserves: [
+      {
+        id: "reserve-1",
+        portfolioId: "core",
+        tempo: "Reserve",
+        executionMode: "live",
+        accountId: "acc-1",
+        currency: "USD",
+        amount: 100,
+      },
+    ],
+    positions: [
+      {
+        id: "position-1",
+        portfolioId: "core",
+        tempo: "Capital",
+        executionMode: "live",
+        accountId: "acc-1",
+        instrumentId: "inst-1",
+        direction: "long",
+        markPrice: 10,
+        currency: "USD",
+        lots: [{ quantity: 1, cost: 5, tier: "c1" }],
+      },
+    ],
+  };
+}

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -14,6 +14,11 @@ export default defineConfig({
       exclude: [
         "**/*.test.ts",
         "**/*.d.ts",
+        // Thin script entries: top-level orchestration over already-tested
+        // functions, no unit to assert. See docs/coverage-rationale.md.
+        "packages/tui/src/report.ts",
+        // Bun-only openTUI wiring: never executes under Node's vitest run, so
+        // instrumenting it would only report dead 0%. Guarded by `pnpm smoke:tui`.
         "packages/tui/src/app.ts",
         "packages/tui/src/mount-app.ts",
         "packages/tui/src/smoke-openTui.ts",


### PR DESCRIPTION
Body:
- Raises measured Node coverage 89.15% → 96.68% by unit-testing the parse.ts validation branches, review-file.ts error/arg paths, and small engine kernel helpers.
- Excludes the thin report.ts CLI script from instrumentation (same category as the Bun-only wiring).
- Adds docs/coverage-rationale.md accounting for every uncovered line concretely (excluded scripts, defensive guards, deferred behavior), linked from both package READMEs.
- Splits the genuinely-reachable compose.ts/dashboard.ts behavior coverage into #72 rather than papering over it.
- Closes #71 