### PR TITLE
fix(price-feed): pace Twelve Data equities under the 8-credit/min free-tier cap

### DIFF
--- a/docs/price-feed-ops.md
+++ b/docs/price-feed-ops.md
@@ -41,6 +41,52 @@ Both files are templates: replace `__REPO_DIR__` / `__HOME__` before installing.
   `data/`-is-private posture: secrets are a machine-local artifact beside the repo,
   not in it.
 
+### Twelve Data free tier: why the run pauses ~1 minute
+
+The Twelve Data **Basic (free)** plan allows **8 API credits/minute** (800/day), and
+a batched `time_series` request costs **1 credit per symbol**. The registry has **9**
+Twelve Data symbols (3 US equities + 6 `*-mxn` USD legs), so fetching all 9 at once
+is 9 credits > 8 ⇒ **HTTP 429**. The fetch therefore paces equities in chunks of
+`twelveDataMaxSymbolsPerMinute` (default **8**), sleeping `twelveDataPauseMs`
+(default **60 s**) between chunks — you'll see `pausing 60s for the Twelve Data
+per-minute credit quota to reset…` in the output. **A daily run consequently takes
+~1 minute, not seconds; that pause is expected, not a hang.** (Both knobs live in
+`packages/price-feed/src/config.ts`; a paid tier with a higher per-minute cap can
+raise `twelveDataMaxSymbolsPerMinute` ≥ 9 to fetch every symbol in one window and
+skip the pause.)
+
+### Why plaintext-at-rest is the right posture here (and when to upgrade)
+
+These are **free, read-only, revocable market-data keys** — not exchange/trading
+keys. They carry no write access, move no money, and expose no PII. The blast
+radius of a leak is "someone reads public prices on your quota until you
+regenerate the key." Against that thin threat, a `chmod 600` file outside the repo
+is proportionate, and it keeps the hands-off 18:00 launchd run dead-simple: no
+interactive keychain/vault unlock that could block a scheduled, non-login job.
+
+**Your real defense is fast revocation, not encryption-at-rest.** If a key ever
+leaks (committed by mistake, copied into a shared backup, pasted somewhere):
+
+- **Twelve Data:** sign in → API dashboard → regenerate/roll the API key, then
+  update `TWELVEDATA_API_KEY` in the env file.
+- **Banxico SIE:** the token is tied to your SIE account — request a new token
+  (email signup flow) and replace `BANXICO_TOKEN`. The old token stops working
+  once reissued.
+- **Binance:** nothing to revoke — the daily fetch uses keyless public REST.
+
+After rotating, re-run the manual dry run to confirm the new credential works.
+
+**Upgrade the posture (to macOS Keychain or 1Password/Bitwarden CLI) only when a
+real trigger appears** — do not pre-build it:
+
+- a **write-capable or trading** key enters the picture (real money at risk), or
+- a **second machine or operator** needs the same secret, or
+- a **hosted surface** ships (then use the platform's secret store / Vercel env,
+  not a machine-local file at all).
+
+Until then, the friction of a non-interactive vault unlock buys encryption the
+threat model does not need.
+
 ## Install the daily schedule (macOS launchd)
 
 1. Set the Mac's timezone to America/Mexico_City (or adjust the plist `Hour`/`Minute`

--- a/packages/price-feed/src/config.ts
+++ b/packages/price-feed/src/config.ts
@@ -39,6 +39,23 @@ export interface PriceFeedConfig extends MarkClock {
    * not a CWD-relative `"data"`. Callers may still override with any path.
    */
   dataDir: string;
+  /**
+   * Max Twelve Data symbols fetched per minute. The free Basic tier caps at 8 API
+   * CREDITS/minute and a batched `time_series` request costs 1 CREDIT PER SYMBOL
+   * (per Twelve Data docs) — so the registry's 9 equity symbols cannot clear the
+   * cap in one request (9 credits > 8 ⇒ HTTP 429), batched or not. The fetch
+   * therefore paces equities in chunks of this size, sleeping {@link twelveDataPauseMs}
+   * between chunks. Default 8 = the free cap; a paid tier can raise this to fetch
+   * every symbol in one window (set it ≥ the equity count to disable pacing).
+   */
+  twelveDataMaxSymbolsPerMinute: number;
+  /**
+   * Milliseconds to pause between Twelve Data chunks so the per-minute credit quota
+   * resets before the next chunk. Default 60_000 (the quota resets each minute). A
+   * daily fetch with 9 equity symbols therefore takes ~one extra minute; that is
+   * fine for a daily/scheduled run and the only cost of staying on the free tier.
+   */
+  twelveDataPauseMs: number;
 }
 
 /**
@@ -76,6 +93,8 @@ export const DEFAULT_CONFIG: PriceFeedConfig = {
   requestTimeoutMs: 10_000,
   fixMaxStaleDays: 4,
   dataDir: resolveWorkspaceDataDir(),
+  twelveDataMaxSymbolsPerMinute: 8,
+  twelveDataPauseMs: 60_000,
 };
 
 /**

--- a/packages/price-feed/src/fetch-prices.test.ts
+++ b/packages/price-feed/src/fetch-prices.test.ts
@@ -8,8 +8,14 @@ import { mkdtemp, readFile, rm } from "node:fs/promises";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { afterEach, beforeEach, describe, expect, it } from "vitest";
-import { runPriceFetch } from "./fetch-prices.js";
+import { runPriceFetch as runPriceFetchRaw, type RunOptions } from "./fetch-prices.js";
 import { resolvePriceFeedPaths } from "./paths.js";
+
+// Default a no-op sleep so Twelve Data pacing never waits a real minute in the
+// suite (the default 8/min cap chunks the 9 equities into [8, 1] with a 60s pause).
+// A test that asserts pacing passes its own sleepImpl — spread last, so it wins.
+const runPriceFetch = (options: RunOptions = {}) =>
+  runPriceFetchRaw({ sleepImpl: async () => {}, ...options });
 
 // 2026-07-03T12:00Z = 06:00 in CDMX on the 3rd → asOf "2026-07-03".
 const RUN_INSTANT = new Date("2026-07-03T12:00:00.000Z");
@@ -66,9 +72,9 @@ interface Overrides {
    * Keyed by provider symbol (e.g. ETHUSDT, EWW) or "FIX". A crypto/FIX override
    * returns the whole `Response` for that (single) request. A Twelve Data equity
    * override injects that symbol's SLICE into the batched keyed response — its
-   * `Response` body is parsed and placed under the symbol key (Twelve Data now
-   * fetches every equity in ONE comma-separated request, so a per-symbol failure
-   * is a `status:"error"` slice, not a per-request HTTP status).
+   * `Response` body is parsed and placed under the symbol key (Twelve Data fetches
+   * equities in PACED comma-separated batches, so a per-symbol failure is a
+   * `status:"error"` slice, not a per-request HTTP status).
    */
   [key: string]: () => Response | Promise<Response>;
 }
@@ -338,8 +344,8 @@ describe("runPriceFetch — request timeout attribution (R4)", () => {
       config: { dataDir, markTime: "00:00", requestTimeoutMs: 20 },
       fetchImpl: ((url: string | URL | Request, init?: RequestInit) => {
         const href = typeof url === "string" ? url : url.toString();
-        // The equities now ride ONE batched Twelve Data request; a stall aborts the
-        // whole batch, so every equity symbol times out attributably (R4) while crypto
+        // The equities ride PACED batched Twelve Data requests; a stall aborts each
+        // chunk, so every equity symbol times out attributably (R4) while crypto
         // still completes — a stalled provider can never hang or silently drop the run.
         if (href.includes("api.twelvedata.com")) {
           return new Promise<Response>((_resolve, reject) => {
@@ -362,5 +368,65 @@ describe("runPriceFetch — request timeout attribution (R4)", () => {
     // All 9 Twelve Data symbols timed out; the 4 crypto quotes still stored.
     expect(result.failures).toHaveLength(9);
     expect(result.storedCount).toBe(4);
+  });
+});
+
+describe("runPriceFetch — Twelve Data pacing under the free-tier credit cap", () => {
+  // Record the symbol list of every Twelve Data request so we can assert the batches.
+  function recordingFetch(batches: string[][]): typeof fetch {
+    return ((url: string | URL | Request) => {
+      const href = typeof url === "string" ? url : url.toString();
+      if (href.includes("api.twelvedata.com")) {
+        const match = /[?&]symbol=([^&]+)/.exec(href);
+        batches.push(decodeURIComponent(match![1]!).split(","));
+        return twelveDataBatchResponse(href, {});
+      }
+      return mockFetch()(url as string);
+    }) as typeof fetch;
+  }
+
+  it("chunks the 9 equity symbols into ≤8-credit windows with one 60s pause between", async () => {
+    const batches: string[][] = [];
+    const sleeps: number[] = [];
+
+    const result = await runPriceFetch({
+      config: { dataDir, markTime: "00:00", twelveDataMaxSymbolsPerMinute: 8, twelveDataPauseMs: 60_000 },
+      fetchImpl: recordingFetch(batches),
+      now: () => RUN_INSTANT,
+      credentials: CREDENTIALS,
+      sleepImpl: async (ms) => {
+        sleeps.push(ms);
+      },
+    });
+
+    // 9 symbols, 8/min cap → two windows of 8 + 1; NEVER a single 9-credit request.
+    expect(batches.map((b) => b.length)).toEqual([8, 1]);
+    expect(batches.every((b) => b.length <= 8)).toBe(true);
+    // Exactly one pause, BETWEEN the two chunks (never after the last).
+    expect(sleeps).toEqual([60_000]);
+    // Pacing changes timing, not coverage: all 13 still stored and marked.
+    expect(result.storedCount).toBe(13);
+    expect(result.emittedCount).toBe(13);
+    expect(result.failures).toEqual([]);
+  });
+
+  it("makes one request and never pauses when the cap fits every symbol (paid tier)", async () => {
+    const batches: string[][] = [];
+    const sleeps: number[] = [];
+
+    await runPriceFetch({
+      config: { dataDir, markTime: "00:00", twelveDataMaxSymbolsPerMinute: 60 },
+      fetchImpl: recordingFetch(batches),
+      now: () => RUN_INSTANT,
+      credentials: CREDENTIALS,
+      sleepImpl: async (ms) => {
+        sleeps.push(ms);
+      },
+    });
+
+    // A cap ≥ the equity count collapses to one batch and disables pacing entirely.
+    expect(batches).toHaveLength(1);
+    expect(batches[0]).toHaveLength(9);
+    expect(sleeps).toEqual([]);
   });
 });

--- a/packages/price-feed/src/fetch-prices.ts
+++ b/packages/price-feed/src/fetch-prices.ts
@@ -12,12 +12,16 @@
  * Three providers ride ONE reliability envelope (R4): Binance (crypto, keyless),
  * Twelve Data (US equities, `TWELVEDATA_API_KEY`), and Banxico SF43718 (USD/MXN
  * FIX, `BANXICO_TOKEN`). Binance is fetched one symbol at a time (keyless, no rate
- * budget worth batching); Twelve Data is fetched in ONE batched multi-symbol
- * request, because the free tier's 8 req/min cap cannot fit the registry's 9
- * Twelve Data symbols as 9 sequential calls (the 9th 429s and the run dies). Either
- * way a bad symbol stays individually attributable instead of masking the others.
- * Partial progress is always kept — a failure records and continues; the run exits
- * non-zero so a scheduler notices.
+ * budget worth batching). Twelve Data is fetched in batched multi-symbol requests
+ * that are PACED across minute windows: the free tier caps at 8 API CREDITS/minute
+ * and a batched `time_series` costs 1 CREDIT PER SYMBOL, so the registry's 9 equity
+ * symbols exceed the cap in a single request (9 credits > 8 ⇒ HTTP 429) — batching
+ * alone does NOT fix it. The fetch therefore chunks equities into
+ * `twelveDataMaxSymbolsPerMinute`-sized batches and sleeps `twelveDataPauseMs`
+ * between chunks so each window stays under the cap (config.ts). Either way a bad
+ * symbol stays individually attributable instead of masking the others. Partial
+ * progress is always kept — a failure records and continues; the run exits non-zero
+ * so a scheduler notices.
  *
  * Non-trading-day honesty (finding 3): the schedule fires 7 days/week so crypto —
  * which trades 24/7 — marks every day. Equities do NOT trade weekends/holidays, so
@@ -120,6 +124,12 @@ export interface RunOptions {
   now?: () => Date;
   /** Provider credentials; default to the environment. Injectable for tests. */
   credentials?: Partial<ProviderCredentials>;
+  /**
+   * Injectable sleep used to PACE Twelve Data chunks under the free-tier per-minute
+   * credit cap. Defaults to a real `setTimeout` wait; tests pass a no-op so pacing
+   * logic is exercised without waiting a real minute.
+   */
+  sleepImpl?: (ms: number) => Promise<void>;
 }
 
 /** One fetched instrument paired with its registry row (needed to build the mark). */
@@ -144,6 +154,8 @@ export async function runPriceFetch(options: RunOptions = {}): Promise<FetchRunR
   };
   const fetchImpl = options.fetchImpl ?? fetch;
   const now = options.now ?? (() => new Date());
+  const sleepImpl =
+    options.sleepImpl ?? ((ms: number) => new Promise<void>((resolve) => setTimeout(resolve, ms)));
   const instant = now();
   const asOf = tradingDayAsOf(instant, config.timeZone);
   const paths = resolvePriceFeedPaths(config.dataDir);
@@ -163,16 +175,31 @@ export async function runPriceFetch(options: RunOptions = {}): Promise<FetchRunR
   await fetchInto(binanceEntries, successes, failures, paths.pricesDir, asOf, (entry) =>
     fetchBinanceDailyClose(entry, { timeoutMs: config.requestTimeoutMs, fetchImpl, now }),
   );
-  // Equities (Twelve Data): ONE batched multi-symbol request (rate-limit fix) — 9
-  // sequential calls would blow the 8 req/min free-tier cap; a bad symbol is still
-  // per-instrument attributable within the batch.
-  const equityResults = await fetchTwelveDataDailyCloses(equityEntries, {
-    timeoutMs: config.requestTimeoutMs,
-    apiKey: credentials.twelveDataApiKey,
-    fetchImpl,
-    now,
-  });
-  await recordResults(equityResults, successes, failures, paths.pricesDir, asOf);
+  // Equities (Twelve Data): batched, but PACED across minute windows. The free tier
+  // caps at 8 CREDITS/min and a batch costs 1 credit PER SYMBOL, so all 9 symbols in
+  // one request is 9 credits > 8 ⇒ 429. Chunk to `twelveDataMaxSymbolsPerMinute` and
+  // sleep `twelveDataPauseMs` between chunks so each window stays under the cap. A
+  // bad symbol is still per-instrument attributable within its chunk.
+  const equityChunks = chunk(equityEntries, Math.max(1, config.twelveDataMaxSymbolsPerMinute));
+  for (let i = 0; i < equityChunks.length; i++) {
+    if (i > 0) {
+      // Pace the next chunk so the free-tier per-minute credit quota resets first.
+      // Announce it — a silent ~1-minute gap otherwise looks like a hung run.
+      console.info(
+        `  pausing ${Math.round(config.twelveDataPauseMs / 1000)}s for the Twelve Data ` +
+          `per-minute credit quota to reset (chunk ${i + 1}/${equityChunks.length}, ` +
+          `${equityChunks[i]!.length} symbol(s))…`,
+      );
+      await sleepImpl(config.twelveDataPauseMs);
+    }
+    const equityResults = await fetchTwelveDataDailyCloses(equityChunks[i]!, {
+      timeoutMs: config.requestTimeoutMs,
+      apiKey: credentials.twelveDataApiKey,
+      fetchImpl,
+      now,
+    });
+    await recordResults(equityResults, successes, failures, paths.pricesDir, asOf);
+  }
 
   // Two-plane rule: the store always upserts above; marks only at/after mark time.
   const markEmitted = isAtOrAfterMarkTime(instant, config);
@@ -192,6 +219,15 @@ export async function runPriceFetch(options: RunOptions = {}): Promise<FetchRunR
     failures,
     staleEquitySkips,
   };
+}
+
+/** Split `items` into consecutive chunks of at most `size` (size ≥ 1). */
+function chunk<T>(items: readonly T[], size: number): T[][] {
+  const out: T[][] = [];
+  for (let i = 0; i < items.length; i += size) {
+    out.push(items.slice(i, i + size));
+  }
+  return out;
 }
 
 /**
@@ -224,8 +260,8 @@ async function fetchInto(
 /**
  * Fold a BATCHED provider's per-entry results into the same success/failure tally
  * a sequential `fetchInto` produces: each `observation` is stored, each `error` is
- * recorded as a per-symbol failure. Used for the one-shot Twelve Data batch so a
- * single bad symbol in the batch stays individually attributable.
+ * recorded as a per-symbol failure. Called once per paced Twelve Data chunk so a
+ * single bad symbol in a chunk stays individually attributable.
  */
 async function recordResults(
   results: readonly ProviderFetchResult[],

--- a/packages/price-feed/src/twelvedata-provider.ts
+++ b/packages/price-feed/src/twelvedata-provider.ts
@@ -9,13 +9,15 @@
  * an `AbortController` timeout so a stalled provider cannot hang a scheduled run,
  * and every failure carries the symbol so it stays per-symbol attributable.
  *
- * BATCHING (rate-limit fix): the free tier caps at 8 requests/minute, but the
- * registry has 9 Twelve Data symbols (3 US equities + 6 `*-mxn` USD legs). Nine
- * back-to-back single-symbol calls blow the cap — the 9th 429s, fails the run, and
- * the spine never ingests. So the orchestrator uses {@link fetchTwelveDataDailyCloses},
- * which packs every symbol into ONE comma-separated request that returns an object
- * keyed by symbol. A bad/failed symbol still becomes only THAT instrument's failure
- * (the others in the batch succeed), preserving per-symbol attribution.
+ * BATCHING + PACING (rate-limit fix): the free tier caps at 8 API CREDITS/minute
+ * and a batched `time_series` costs 1 CREDIT PER SYMBOL, so the registry's 9 Twelve
+ * Data symbols (3 US equities + 6 `*-mxn` USD legs) are 9 credits > 8 — a single
+ * request 429s no matter how it is batched. This function packs a GIVEN chunk of
+ * symbols into ONE comma-separated request (returning an object keyed by symbol);
+ * the orchestrator (`fetch-prices.ts`) is what splits the 9 symbols into ≤8-credit
+ * chunks and paces them a minute apart. A bad/failed symbol still becomes only THAT
+ * instrument's failure (the others in the chunk succeed), preserving per-symbol
+ * attribution.
  *
  * Provider decision (PRD-#105 open question 1): Twelve Data over Alpha Vantage —
  * see the equities rows in `@numisma/engine`'s registry for the rationale. The API

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -4,6 +4,9 @@ settings:
   autoInstallPeers: true
   excludeLinksFromLockfile: false
 
+overrides:
+  esbuild: '>=0.28.1'
+
 importers:
 
   .:
@@ -68,314 +71,158 @@ packages:
     resolution: {integrity: sha512-6zABk/ECA/QYSCQ1NGiVwwbQerUCZ+TQbp64Q3AgmfNvurHH0j8TtXa1qbShXA6qqkpAj4V5W8pP6mLe1mcMqA==}
     engines: {node: '>=18'}
 
-  '@esbuild/aix-ppc64@0.27.7':
-    resolution: {integrity: sha512-EKX3Qwmhz1eMdEJokhALr0YiD0lhQNwDqkPYyPhiSwKrh7/4KRjQc04sZ8db+5DVVnZ1LmbNDI1uAMPEUBnQPg==}
+  '@esbuild/aix-ppc64@0.28.1':
+    resolution: {integrity: sha512-Svl7tq8k/08+p6CXPpRjQ1fKX+1odH/BQbb48fV6fj3CWHhsoIOoY87w1oHXm0qEpkIK3ZfVgp0hed3XBXzXMQ==}
     engines: {node: '>=18'}
     cpu: [ppc64]
     os: [aix]
 
-  '@esbuild/aix-ppc64@0.28.0':
-    resolution: {integrity: sha512-lhRUCeuOyJQURhTxl4WkpFTjIsbDayJHih5kZC1giwE+MhIzAb7mEsQMqMf18rHLsrb5qI1tafG20mLxEWcWlA==}
-    engines: {node: '>=18'}
-    cpu: [ppc64]
-    os: [aix]
-
-  '@esbuild/android-arm64@0.27.7':
-    resolution: {integrity: sha512-62dPZHpIXzvChfvfLJow3q5dDtiNMkwiRzPylSCfriLvZeq0a1bWChrGx/BbUbPwOrsWKMn8idSllklzBy+dgQ==}
+  '@esbuild/android-arm64@0.28.1':
+    resolution: {integrity: sha512-34EGEbCIAgosYz6goLcopX6Mo7NyGv9tfwEM2/7Ce2VcVRk568iSvniGWcUXIy7wEDR1wzolcxcriFVrWYcwBg==}
     engines: {node: '>=18'}
     cpu: [arm64]
     os: [android]
 
-  '@esbuild/android-arm64@0.28.0':
-    resolution: {integrity: sha512-+WzIXQOSaGs33tLEgYPYe/yQHf0WTU0X42Jca3y8NWMbUVhp7rUnw+vAsRC/QiDrdD31IszMrZy+qwPOPjd+rw==}
-    engines: {node: '>=18'}
-    cpu: [arm64]
-    os: [android]
-
-  '@esbuild/android-arm@0.27.7':
-    resolution: {integrity: sha512-jbPXvB4Yj2yBV7HUfE2KHe4GJX51QplCN1pGbYjvsyCZbQmies29EoJbkEc+vYuU5o45AfQn37vZlyXy4YJ8RQ==}
+  '@esbuild/android-arm@0.28.1':
+    resolution: {integrity: sha512-0k2F129Xdio1TdJfzJ8sy1Q47vUD2NnwdhiAf7drUN1EBTfPf4hsFCtmMgu/6m8JSzsBrlmVjudMBQqOfG8usQ==}
     engines: {node: '>=18'}
     cpu: [arm]
     os: [android]
 
-  '@esbuild/android-arm@0.28.0':
-    resolution: {integrity: sha512-wqh0ByljabXLKHeWXYLqoJ5jKC4XBaw6Hk08OfMrCRd2nP2ZQ5eleDZC41XHyCNgktBGYMbqnrJKq/K/lzPMSQ==}
-    engines: {node: '>=18'}
-    cpu: [arm]
-    os: [android]
-
-  '@esbuild/android-x64@0.27.7':
-    resolution: {integrity: sha512-x5VpMODneVDb70PYV2VQOmIUUiBtY3D3mPBG8NxVk5CogneYhkR7MmM3yR/uMdITLrC1ml/NV1rj4bMJuy9MCg==}
+  '@esbuild/android-x64@0.28.1':
+    resolution: {integrity: sha512-dbwY7ltSMDWsRatcRpCnES4F+im88OCUgGZjy52shC7GqHRE/cYlxNbB4Z4UpJswpcc4Qxd2oE/ufM0p61IKng==}
     engines: {node: '>=18'}
     cpu: [x64]
     os: [android]
 
-  '@esbuild/android-x64@0.28.0':
-    resolution: {integrity: sha512-+VJggoaKhk2VNNqVL7f6S189UzShHC/mR9EE8rDdSkdpN0KflSwWY/gWjDrNxxisg8Fp1ZCD9jLMo4m0OUfeUA==}
-    engines: {node: '>=18'}
-    cpu: [x64]
-    os: [android]
-
-  '@esbuild/darwin-arm64@0.27.7':
-    resolution: {integrity: sha512-5lckdqeuBPlKUwvoCXIgI2D9/ABmPq3Rdp7IfL70393YgaASt7tbju3Ac+ePVi3KDH6N2RqePfHnXkaDtY9fkw==}
+  '@esbuild/darwin-arm64@0.28.1':
+    resolution: {integrity: sha512-TZbWkQY7kvTAXbXUT7uVACR5cMHsDiSz9z7ZKAX/RTq/WJEk3QyRr0wZpNhBDX+/0CtdqUIJlOiodQcta6tY3Q==}
     engines: {node: '>=18'}
     cpu: [arm64]
     os: [darwin]
 
-  '@esbuild/darwin-arm64@0.28.0':
-    resolution: {integrity: sha512-0T+A9WZm+bZ84nZBtk1ckYsOvyA3x7e2Acj1KdVfV4/2tdG4fzUp91YHx+GArWLtwqp77pBXVCPn2We7Letr0Q==}
-    engines: {node: '>=18'}
-    cpu: [arm64]
-    os: [darwin]
-
-  '@esbuild/darwin-x64@0.27.7':
-    resolution: {integrity: sha512-rYnXrKcXuT7Z+WL5K980jVFdvVKhCHhUwid+dDYQpH+qu+TefcomiMAJpIiC2EM3Rjtq0sO3StMV/+3w3MyyqQ==}
+  '@esbuild/darwin-x64@0.28.1':
+    resolution: {integrity: sha512-zfdzgK9ACBNZLI/CyHTOx81SyNbM6YXn7rxSgX97VjyiPl9W1i4Ka4fgKECEoFCKGpvBj5qArWIGgQjOwkgskQ==}
     engines: {node: '>=18'}
     cpu: [x64]
     os: [darwin]
 
-  '@esbuild/darwin-x64@0.28.0':
-    resolution: {integrity: sha512-fyzLm/DLDl/84OCfp2f/XQ4flmORsjU7VKt8HLjvIXChJoFFOIL6pLJPH4Yhd1n1gGFF9mPwtlN5Wf82DZs+LQ==}
-    engines: {node: '>=18'}
-    cpu: [x64]
-    os: [darwin]
-
-  '@esbuild/freebsd-arm64@0.27.7':
-    resolution: {integrity: sha512-B48PqeCsEgOtzME2GbNM2roU29AMTuOIN91dsMO30t+Ydis3z/3Ngoj5hhnsOSSwNzS+6JppqWsuhTp6E82l2w==}
+  '@esbuild/freebsd-arm64@0.28.1':
+    resolution: {integrity: sha512-wG2EA8ENdEI0qhkSZMjfqrdY+ziCYCPMmtZjjIwOmXFjmyzEHn+UUxk5of+SYsjtfs3VpnlC7QLzSI5hY/rOAw==}
     engines: {node: '>=18'}
     cpu: [arm64]
     os: [freebsd]
 
-  '@esbuild/freebsd-arm64@0.28.0':
-    resolution: {integrity: sha512-l9GeW5UZBT9k9brBYI+0WDffcRxgHQD8ShN2Ur4xWq/NFzUKm3k5lsH4PdaRgb2w7mI9u61nr2gI2mLI27Nh3Q==}
-    engines: {node: '>=18'}
-    cpu: [arm64]
-    os: [freebsd]
-
-  '@esbuild/freebsd-x64@0.27.7':
-    resolution: {integrity: sha512-jOBDK5XEjA4m5IJK3bpAQF9/Lelu/Z9ZcdhTRLf4cajlB+8VEhFFRjWgfy3M1O4rO2GQ/b2dLwCUGpiF/eATNQ==}
+  '@esbuild/freebsd-x64@0.28.1':
+    resolution: {integrity: sha512-i7dZ9vQgnvSCzi/rYCXNgtF/U+eKZNJBzu3eTQbRgHnM7tNSizLOkRFAl3qzVc/Op/u5YkHHa4pf/3DOYHthLQ==}
     engines: {node: '>=18'}
     cpu: [x64]
     os: [freebsd]
 
-  '@esbuild/freebsd-x64@0.28.0':
-    resolution: {integrity: sha512-BXoQai/A0wPO6Es3yFJ7APCiKGc1tdAEOgeTNy3SsB491S3aHn4S4r3e976eUnPdU+NbdtmBuLncYir2tMU9Nw==}
-    engines: {node: '>=18'}
-    cpu: [x64]
-    os: [freebsd]
-
-  '@esbuild/linux-arm64@0.27.7':
-    resolution: {integrity: sha512-RZPHBoxXuNnPQO9rvjh5jdkRmVizktkT7TCDkDmQ0W2SwHInKCAV95GRuvdSvA7w4VMwfCjUiPwDi0ZO6Nfe9A==}
+  '@esbuild/linux-arm64@0.28.1':
+    resolution: {integrity: sha512-yHs+0uc8+nvEAfAfxrWQKK5peSNzBc4PegcMO0EJ2hT71uA7vB8Ihg2e77R2P7SG5uYjPbHlLLmve4LLLRCf0g==}
     engines: {node: '>=18'}
     cpu: [arm64]
     os: [linux]
 
-  '@esbuild/linux-arm64@0.28.0':
-    resolution: {integrity: sha512-RVyzfb3FWsGA55n6WY0MEIEPURL1FcbhFE6BffZEMEekfCzCIMtB5yyDcFnVbTnwk+CLAgTujmV/Lgvih56W+A==}
-    engines: {node: '>=18'}
-    cpu: [arm64]
-    os: [linux]
-
-  '@esbuild/linux-arm@0.27.7':
-    resolution: {integrity: sha512-RkT/YXYBTSULo3+af8Ib0ykH8u2MBh57o7q/DAs3lTJlyVQkgQvlrPTnjIzzRPQyavxtPtfg0EopvDyIt0j1rA==}
+  '@esbuild/linux-arm@0.28.1':
+    resolution: {integrity: sha512-qVXBOHQS+d5Y722GwJzJUtOLlX7km3CraOaGormF1pDtPd2C/l1SHRPgjLunLGe51Sh5YYWKMFDyV4SxgMQYTQ==}
     engines: {node: '>=18'}
     cpu: [arm]
     os: [linux]
 
-  '@esbuild/linux-arm@0.28.0':
-    resolution: {integrity: sha512-CjaaREJagqJp7iTaNQjjidaNbCKYcd4IDkzbwwxtSvjI7NZm79qiHc8HqciMddQ6CKvJT6aBd8lO9kN/ZudLlw==}
-    engines: {node: '>=18'}
-    cpu: [arm]
-    os: [linux]
-
-  '@esbuild/linux-ia32@0.27.7':
-    resolution: {integrity: sha512-GA48aKNkyQDbd3KtkplYWT102C5sn/EZTY4XROkxONgruHPU72l+gW+FfF8tf2cFjeHaRbWpOYa/uRBz/Xq1Pg==}
+  '@esbuild/linux-ia32@0.28.1':
+    resolution: {integrity: sha512-d1z4ZuP0ajrfz/FhGT4vv278rX8KnPPJx8i5+AtK7TYbx9Le9F1hyzurZpkEyjkGa9dUGhQow4C1NmeGvqxN2w==}
     engines: {node: '>=18'}
     cpu: [ia32]
     os: [linux]
 
-  '@esbuild/linux-ia32@0.28.0':
-    resolution: {integrity: sha512-KBnSTt1kxl9x70q+ydterVdl+Cn0H18ngRMRCEQfrbqdUuntQQ0LoMZv47uB97NljZFzY6HcfqEZ2SAyIUTQBQ==}
-    engines: {node: '>=18'}
-    cpu: [ia32]
-    os: [linux]
-
-  '@esbuild/linux-loong64@0.27.7':
-    resolution: {integrity: sha512-a4POruNM2oWsD4WKvBSEKGIiWQF8fZOAsycHOt6JBpZ+JN2n2JH9WAv56SOyu9X5IqAjqSIPTaJkqN8F7XOQ5Q==}
+  '@esbuild/linux-loong64@0.28.1':
+    resolution: {integrity: sha512-M5sRjUVZrkm1OAPR3dlOYzNmN+loZKGVi1VUQGrwuqLcbR6qeAz+famMhjASeH3YVKvZz+zT1jlh/keC3Rj/lg==}
     engines: {node: '>=18'}
     cpu: [loong64]
     os: [linux]
 
-  '@esbuild/linux-loong64@0.28.0':
-    resolution: {integrity: sha512-zpSlUce1mnxzgBADvxKXX5sl8aYQHo2ezvMNI8I0lbblJtp8V4odlm3Yzlj7gPyt3T8ReksE6bK+pT3WD+aJRg==}
-    engines: {node: '>=18'}
-    cpu: [loong64]
-    os: [linux]
-
-  '@esbuild/linux-mips64el@0.27.7':
-    resolution: {integrity: sha512-KabT5I6StirGfIz0FMgl1I+R1H73Gp0ofL9A3nG3i/cYFJzKHhouBV5VWK1CSgKvVaG4q1RNpCTR2LuTVB3fIw==}
+  '@esbuild/linux-mips64el@0.28.1':
+    resolution: {integrity: sha512-mRObBZeHh2OxcBFPWE/FjylkRgZdYuiTR3vaTozquCGOH14iP9oN4x4Ge81CoIDYQrXmIxpFumJBu5MtZpnQJQ==}
     engines: {node: '>=18'}
     cpu: [mips64el]
     os: [linux]
 
-  '@esbuild/linux-mips64el@0.28.0':
-    resolution: {integrity: sha512-2jIfP6mmjkdmeTlsX/9vmdmhBmKADrWqN7zcdtHIeNSCH1SqIoNI63cYsjQR8J+wGa4Y5izRcSHSm8K3QWmk3w==}
-    engines: {node: '>=18'}
-    cpu: [mips64el]
-    os: [linux]
-
-  '@esbuild/linux-ppc64@0.27.7':
-    resolution: {integrity: sha512-gRsL4x6wsGHGRqhtI+ifpN/vpOFTQtnbsupUF5R5YTAg+y/lKelYR1hXbnBdzDjGbMYjVJLJTd2OFmMewAgwlQ==}
+  '@esbuild/linux-ppc64@0.28.1':
+    resolution: {integrity: sha512-slScBsMAb3GFDcdrCgLwZtPYRoH2H/youv10QiZyRjmsP48fznoveWytSgCI/R0ZcUgpc0ZhIUEx6LHts8yrfQ==}
     engines: {node: '>=18'}
     cpu: [ppc64]
     os: [linux]
 
-  '@esbuild/linux-ppc64@0.28.0':
-    resolution: {integrity: sha512-bc0FE9wWeC0WBm49IQMPSPILRocGTQt3j5KPCA8os6VprfuJ7KD+5PzESSrJ6GmPIPJK965ZJHTUlSA6GNYEhg==}
-    engines: {node: '>=18'}
-    cpu: [ppc64]
-    os: [linux]
-
-  '@esbuild/linux-riscv64@0.27.7':
-    resolution: {integrity: sha512-hL25LbxO1QOngGzu2U5xeXtxXcW+/GvMN3ejANqXkxZ/opySAZMrc+9LY/WyjAan41unrR3YrmtTsUpwT66InQ==}
+  '@esbuild/linux-riscv64@0.28.1':
+    resolution: {integrity: sha512-kw0owk1o0GFETUJyW0jc0G4Yzs0BHZn0JDZ8JRT088vjJYX777BAs1fDGxAC+q831qOs2DTC96mNsG2opdfyyQ==}
     engines: {node: '>=18'}
     cpu: [riscv64]
     os: [linux]
 
-  '@esbuild/linux-riscv64@0.28.0':
-    resolution: {integrity: sha512-SQPZOwoTTT/HXFXQJG/vBX8sOFagGqvZyXcgLA3NhIqcBv1BJU1d46c0rGcrij2B56Z2rNiSLaZOYW5cUk7yLQ==}
-    engines: {node: '>=18'}
-    cpu: [riscv64]
-    os: [linux]
-
-  '@esbuild/linux-s390x@0.27.7':
-    resolution: {integrity: sha512-2k8go8Ycu1Kb46vEelhu1vqEP+UeRVj2zY1pSuPdgvbd5ykAw82Lrro28vXUrRmzEsUV0NzCf54yARIK8r0fdw==}
+  '@esbuild/linux-s390x@0.28.1':
+    resolution: {integrity: sha512-/lAIjX8aYFRByhh6L5rYtPEDRqa9de/4V/juOXcta5frjvzXO4/sqEtyytse0g3zZFuWu5cDN0MkLz2qRDD2Ag==}
     engines: {node: '>=18'}
     cpu: [s390x]
     os: [linux]
 
-  '@esbuild/linux-s390x@0.28.0':
-    resolution: {integrity: sha512-SCfR0HN8CEEjnYnySJTd2cw0k9OHB/YFzt5zgJEwa+wL/T/raGWYMBqwDNAC6dqFKmJYZoQBRfHjgwLHGSrn3Q==}
-    engines: {node: '>=18'}
-    cpu: [s390x]
-    os: [linux]
-
-  '@esbuild/linux-x64@0.27.7':
-    resolution: {integrity: sha512-hzznmADPt+OmsYzw1EE33ccA+HPdIqiCRq7cQeL1Jlq2gb1+OyWBkMCrYGBJ+sxVzve2ZJEVeePbLM2iEIZSxA==}
+  '@esbuild/linux-x64@0.28.1':
+    resolution: {integrity: sha512-u/anNYF2mmVOEDwLtnQ1wOr3EZ9sTNGLWrsYGYwHWzGA3Si84IOkHXlbWTD1NB+9/1lcnweYKO54uhxZydNzfA==}
     engines: {node: '>=18'}
     cpu: [x64]
     os: [linux]
 
-  '@esbuild/linux-x64@0.28.0':
-    resolution: {integrity: sha512-us0dSb9iFxIi8srnpl931Nvs65it/Jd2a2K3qs7fz2WfGPHqzfzZTfec7oxZJRNPXPnNYZtanmRc4AL/JwVzHQ==}
-    engines: {node: '>=18'}
-    cpu: [x64]
-    os: [linux]
-
-  '@esbuild/netbsd-arm64@0.27.7':
-    resolution: {integrity: sha512-b6pqtrQdigZBwZxAn1UpazEisvwaIDvdbMbmrly7cDTMFnw/+3lVxxCTGOrkPVnsYIosJJXAsILG9XcQS+Yu6w==}
+  '@esbuild/netbsd-arm64@0.28.1':
+    resolution: {integrity: sha512-oks0DYbLwWMmaakTsCb+zL4E+aHRVLom9IJZOAthMQEPiQmydXHkziYEsGYRx0uNV/IjEKGAV941JzH02pflqw==}
     engines: {node: '>=18'}
     cpu: [arm64]
     os: [netbsd]
 
-  '@esbuild/netbsd-arm64@0.28.0':
-    resolution: {integrity: sha512-CR/RYotgtCKwtftMwJlUU7xCVNg3lMYZ0RzTmAHSfLCXw3NtZtNpswLEj/Kkf6kEL3Gw+BpOekRX0BYCtklhUw==}
-    engines: {node: '>=18'}
-    cpu: [arm64]
-    os: [netbsd]
-
-  '@esbuild/netbsd-x64@0.27.7':
-    resolution: {integrity: sha512-OfatkLojr6U+WN5EDYuoQhtM+1xco+/6FSzJJnuWiUw5eVcicbyK3dq5EeV/QHT1uy6GoDhGbFpprUiHUYggrw==}
+  '@esbuild/netbsd-x64@0.28.1':
+    resolution: {integrity: sha512-aeL6lAnN89Hz43Mlh1G8ARasbuoYvSITDEx0tHh5b7jJnHcssqgjy9Yx430GDpmCa6OyrKoS0aNRjKundRizGg==}
     engines: {node: '>=18'}
     cpu: [x64]
     os: [netbsd]
 
-  '@esbuild/netbsd-x64@0.28.0':
-    resolution: {integrity: sha512-nU1yhmYutL+fQ71Kxnhg8uEOdC0pwEW9entHykTgEbna2pw2dkbFSMeqjjyHZoCmt8SBkOSvV+yNmm94aUrrqw==}
-    engines: {node: '>=18'}
-    cpu: [x64]
-    os: [netbsd]
-
-  '@esbuild/openbsd-arm64@0.27.7':
-    resolution: {integrity: sha512-AFuojMQTxAz75Fo8idVcqoQWEHIXFRbOc1TrVcFSgCZtQfSdc1RXgB3tjOn/krRHENUB4j00bfGjyl2mJrU37A==}
+  '@esbuild/openbsd-arm64@0.28.1':
+    resolution: {integrity: sha512-MEFJe5C3R8pwXdZ5Y21oo6m7ePiS0d9pWucn99O/wvyJZChoIQKrQDxKrGeW8F5+T0okTHesAmDeiHDTIq0V/Q==}
     engines: {node: '>=18'}
     cpu: [arm64]
     os: [openbsd]
 
-  '@esbuild/openbsd-arm64@0.28.0':
-    resolution: {integrity: sha512-cXb5vApOsRsxsEl4mcZ1XY3D4DzcoMxR/nnc4IyqYs0rTI8ZKmW6kyyg+11Z8yvgMfAEldKzP7AdP64HnSC/6g==}
-    engines: {node: '>=18'}
-    cpu: [arm64]
-    os: [openbsd]
-
-  '@esbuild/openbsd-x64@0.27.7':
-    resolution: {integrity: sha512-+A1NJmfM8WNDv5CLVQYJ5PshuRm/4cI6WMZRg1by1GwPIQPCTs1GLEUHwiiQGT5zDdyLiRM/l1G0Pv54gvtKIg==}
+  '@esbuild/openbsd-x64@0.28.1':
+    resolution: {integrity: sha512-i/ZLIOafE0Z8cI/XANJAixoJL/uRAoS2xOA3rb0xN+KK0K177cMAsQYkzHtBrtMXAKuAc7HGgcWiZ/sRC1Nxgw==}
     engines: {node: '>=18'}
     cpu: [x64]
     os: [openbsd]
 
-  '@esbuild/openbsd-x64@0.28.0':
-    resolution: {integrity: sha512-8wZM2qqtv9UP3mzy7HiGYNH/zjTA355mpeuA+859TyR+e+Tc08IHYpLJuMsfpDJwoLo1ikIJI8jC3GFjnRClzA==}
-    engines: {node: '>=18'}
-    cpu: [x64]
-    os: [openbsd]
-
-  '@esbuild/openharmony-arm64@0.27.7':
-    resolution: {integrity: sha512-+KrvYb/C8zA9CU/g0sR6w2RBw7IGc5J2BPnc3dYc5VJxHCSF1yNMxTV5LQ7GuKteQXZtspjFbiuW5/dOj7H4Yw==}
+  '@esbuild/openharmony-arm64@0.28.1':
+    resolution: {integrity: sha512-ge+Z7EXFNt2BO1oAMsVpiQ8EwndV9i1xXerAeTIK7AtPs3bKFXQM7nlRxDSIUIMeueR1CNXxqztLzdNeReKBJg==}
     engines: {node: '>=18'}
     cpu: [arm64]
     os: [openharmony]
 
-  '@esbuild/openharmony-arm64@0.28.0':
-    resolution: {integrity: sha512-FLGfyizszcef5C3YtoyQDACyg95+dndv79i2EekILBofh5wpCa1KuBqOWKrEHZg3zrL3t5ouE5jgr94vA+Wb2w==}
-    engines: {node: '>=18'}
-    cpu: [arm64]
-    os: [openharmony]
-
-  '@esbuild/sunos-x64@0.27.7':
-    resolution: {integrity: sha512-ikktIhFBzQNt/QDyOL580ti9+5mL/YZeUPKU2ivGtGjdTYoqz6jObj6nOMfhASpS4GU4Q/Clh1QtxWAvcYKamA==}
+  '@esbuild/sunos-x64@0.28.1':
+    resolution: {integrity: sha512-BEjgtECkL3vY+SaSQ6nzVfiALUeFxpawyp8Jmf5PtYhf1Ug40N1h/hxlhts+f1FvSvarEigdxS3BlSMI2PJLcQ==}
     engines: {node: '>=18'}
     cpu: [x64]
     os: [sunos]
 
-  '@esbuild/sunos-x64@0.28.0':
-    resolution: {integrity: sha512-1ZgjUoEdHZZl/YlV76TSCz9Hqj9h9YmMGAgAPYd+q4SicWNX3G5GCyx9uhQWSLcbvPW8Ni7lj4gDa1T40akdlw==}
-    engines: {node: '>=18'}
-    cpu: [x64]
-    os: [sunos]
-
-  '@esbuild/win32-arm64@0.27.7':
-    resolution: {integrity: sha512-7yRhbHvPqSpRUV7Q20VuDwbjW5kIMwTHpptuUzV+AA46kiPze5Z7qgt6CLCK3pWFrHeNfDd1VKgyP4O+ng17CA==}
+  '@esbuild/win32-arm64@0.28.1':
+    resolution: {integrity: sha512-lCv9eK/H6ZJWbE7bh2nw54CZ9M2nupBxJcTsdk/QQnWkdSjKGuxmmH8/GWrlT1eMmZfn4dGcCjRte397WqfQXA==}
     engines: {node: '>=18'}
     cpu: [arm64]
     os: [win32]
 
-  '@esbuild/win32-arm64@0.28.0':
-    resolution: {integrity: sha512-Q9StnDmQ/enxnpxCCLSg0oo4+34B9TdXpuyPeTedN/6+iXBJ4J+zwfQI28u/Jl40nOYAxGoNi7mFP40RUtkmUA==}
-    engines: {node: '>=18'}
-    cpu: [arm64]
-    os: [win32]
-
-  '@esbuild/win32-ia32@0.27.7':
-    resolution: {integrity: sha512-SmwKXe6VHIyZYbBLJrhOoCJRB/Z1tckzmgTLfFYOfpMAx63BJEaL9ExI8x7v0oAO3Zh6D/Oi1gVxEYr5oUCFhw==}
+  '@esbuild/win32-ia32@0.28.1':
+    resolution: {integrity: sha512-zvb/mB2bSCoJOpoCBgYKKpX6YM6mJBlBUVUtVj41DlZJVEB6/0CKlRYxP5wWl1C1ILiCoAU5wZZ4q1P3qeS6Eg==}
     engines: {node: '>=18'}
     cpu: [ia32]
     os: [win32]
 
-  '@esbuild/win32-ia32@0.28.0':
-    resolution: {integrity: sha512-zF3ag/gfiCe6U2iczcRzSYJKH1DCI+ByzSENHlM2FcDbEeo5Zd2C86Aq0tKUYAJJ1obRP84ymxIAksZUcdztHA==}
-    engines: {node: '>=18'}
-    cpu: [ia32]
-    os: [win32]
-
-  '@esbuild/win32-x64@0.27.7':
-    resolution: {integrity: sha512-56hiAJPhwQ1R4i+21FVF7V8kSD5zZTdHcVuRFMW0hn753vVfQN8xlx4uOPT4xoGH0Z/oVATuR82AiqSTDIpaHg==}
-    engines: {node: '>=18'}
-    cpu: [x64]
-    os: [win32]
-
-  '@esbuild/win32-x64@0.28.0':
-    resolution: {integrity: sha512-pEl1bO9mfAmIC+tW5btTmrKaujg3zGtUmWNdCw/xs70FBjwAL3o9OEKNHvNmnyylD6ubxUERiEhdsL0xBQ9efw==}
+  '@esbuild/win32-x64@0.28.1':
+    resolution: {integrity: sha512-bm4Mowrv+GXMlpWX++EcXw/iLyd1o3+bJkC2DkWXYVvgZCqD/bSj9ctZeAMC3cIxgjRVR2Dufaiu4YPxr5gW1A==}
     engines: {node: '>=18'}
     cpu: [x64]
     os: [win32]
@@ -725,13 +572,8 @@ packages:
   es-module-lexer@1.7.0:
     resolution: {integrity: sha512-jEQoCwk8hyb2AZziIOLhDqpm5+2ww5uIE6lkO/6jcOCusfk6LhMHpXXfBLXTZ7Ydyt0j4VoUQv6uGNYbdW+kBA==}
 
-  esbuild@0.27.7:
-    resolution: {integrity: sha512-IxpibTjyVnmrIQo5aqNpCgoACA/dTKLTlhMHihVHhdkxKyPO1uBBthumT0rdHmcsk9uMonIWS0m4FljWzILh3w==}
-    engines: {node: '>=18'}
-    hasBin: true
-
-  esbuild@0.28.0:
-    resolution: {integrity: sha512-sNR9MHpXSUV/XB4zmsFKN+QgVG82Cc7+/aaxJ8Adi8hyOac+EXptIp45QBPaVyX3N70664wRbTcLTOemCAnyqw==}
+  esbuild@0.28.1:
+    resolution: {integrity: sha512-HrJrvZv5ayxBzPfwphOoNzkzOIIlifzk0KJrGK2c8R4+LKpMtpYLQeUdjnwjWv/LZlkH2laZk+4w78pi99D4Vw==}
     engines: {node: '>=18'}
     hasBin: true
 
@@ -1103,160 +945,82 @@ snapshots:
 
   '@bcoe/v8-coverage@1.0.2': {}
 
-  '@esbuild/aix-ppc64@0.27.7':
+  '@esbuild/aix-ppc64@0.28.1':
     optional: true
 
-  '@esbuild/aix-ppc64@0.28.0':
+  '@esbuild/android-arm64@0.28.1':
     optional: true
 
-  '@esbuild/android-arm64@0.27.7':
+  '@esbuild/android-arm@0.28.1':
     optional: true
 
-  '@esbuild/android-arm64@0.28.0':
+  '@esbuild/android-x64@0.28.1':
     optional: true
 
-  '@esbuild/android-arm@0.27.7':
+  '@esbuild/darwin-arm64@0.28.1':
     optional: true
 
-  '@esbuild/android-arm@0.28.0':
+  '@esbuild/darwin-x64@0.28.1':
     optional: true
 
-  '@esbuild/android-x64@0.27.7':
+  '@esbuild/freebsd-arm64@0.28.1':
     optional: true
 
-  '@esbuild/android-x64@0.28.0':
+  '@esbuild/freebsd-x64@0.28.1':
     optional: true
 
-  '@esbuild/darwin-arm64@0.27.7':
+  '@esbuild/linux-arm64@0.28.1':
     optional: true
 
-  '@esbuild/darwin-arm64@0.28.0':
+  '@esbuild/linux-arm@0.28.1':
     optional: true
 
-  '@esbuild/darwin-x64@0.27.7':
+  '@esbuild/linux-ia32@0.28.1':
     optional: true
 
-  '@esbuild/darwin-x64@0.28.0':
+  '@esbuild/linux-loong64@0.28.1':
     optional: true
 
-  '@esbuild/freebsd-arm64@0.27.7':
+  '@esbuild/linux-mips64el@0.28.1':
     optional: true
 
-  '@esbuild/freebsd-arm64@0.28.0':
+  '@esbuild/linux-ppc64@0.28.1':
     optional: true
 
-  '@esbuild/freebsd-x64@0.27.7':
+  '@esbuild/linux-riscv64@0.28.1':
     optional: true
 
-  '@esbuild/freebsd-x64@0.28.0':
+  '@esbuild/linux-s390x@0.28.1':
     optional: true
 
-  '@esbuild/linux-arm64@0.27.7':
+  '@esbuild/linux-x64@0.28.1':
     optional: true
 
-  '@esbuild/linux-arm64@0.28.0':
+  '@esbuild/netbsd-arm64@0.28.1':
     optional: true
 
-  '@esbuild/linux-arm@0.27.7':
+  '@esbuild/netbsd-x64@0.28.1':
     optional: true
 
-  '@esbuild/linux-arm@0.28.0':
+  '@esbuild/openbsd-arm64@0.28.1':
     optional: true
 
-  '@esbuild/linux-ia32@0.27.7':
+  '@esbuild/openbsd-x64@0.28.1':
     optional: true
 
-  '@esbuild/linux-ia32@0.28.0':
+  '@esbuild/openharmony-arm64@0.28.1':
     optional: true
 
-  '@esbuild/linux-loong64@0.27.7':
+  '@esbuild/sunos-x64@0.28.1':
     optional: true
 
-  '@esbuild/linux-loong64@0.28.0':
+  '@esbuild/win32-arm64@0.28.1':
     optional: true
 
-  '@esbuild/linux-mips64el@0.27.7':
+  '@esbuild/win32-ia32@0.28.1':
     optional: true
 
-  '@esbuild/linux-mips64el@0.28.0':
-    optional: true
-
-  '@esbuild/linux-ppc64@0.27.7':
-    optional: true
-
-  '@esbuild/linux-ppc64@0.28.0':
-    optional: true
-
-  '@esbuild/linux-riscv64@0.27.7':
-    optional: true
-
-  '@esbuild/linux-riscv64@0.28.0':
-    optional: true
-
-  '@esbuild/linux-s390x@0.27.7':
-    optional: true
-
-  '@esbuild/linux-s390x@0.28.0':
-    optional: true
-
-  '@esbuild/linux-x64@0.27.7':
-    optional: true
-
-  '@esbuild/linux-x64@0.28.0':
-    optional: true
-
-  '@esbuild/netbsd-arm64@0.27.7':
-    optional: true
-
-  '@esbuild/netbsd-arm64@0.28.0':
-    optional: true
-
-  '@esbuild/netbsd-x64@0.27.7':
-    optional: true
-
-  '@esbuild/netbsd-x64@0.28.0':
-    optional: true
-
-  '@esbuild/openbsd-arm64@0.27.7':
-    optional: true
-
-  '@esbuild/openbsd-arm64@0.28.0':
-    optional: true
-
-  '@esbuild/openbsd-x64@0.27.7':
-    optional: true
-
-  '@esbuild/openbsd-x64@0.28.0':
-    optional: true
-
-  '@esbuild/openharmony-arm64@0.27.7':
-    optional: true
-
-  '@esbuild/openharmony-arm64@0.28.0':
-    optional: true
-
-  '@esbuild/sunos-x64@0.27.7':
-    optional: true
-
-  '@esbuild/sunos-x64@0.28.0':
-    optional: true
-
-  '@esbuild/win32-arm64@0.27.7':
-    optional: true
-
-  '@esbuild/win32-arm64@0.28.0':
-    optional: true
-
-  '@esbuild/win32-ia32@0.27.7':
-    optional: true
-
-  '@esbuild/win32-ia32@0.28.0':
-    optional: true
-
-  '@esbuild/win32-x64@0.27.7':
-    optional: true
-
-  '@esbuild/win32-x64@0.28.0':
+  '@esbuild/win32-x64@0.28.1':
     optional: true
 
   '@isaacs/cliui@8.0.2':
@@ -1549,63 +1313,34 @@ snapshots:
 
   es-module-lexer@1.7.0: {}
 
-  esbuild@0.27.7:
+  esbuild@0.28.1:
     optionalDependencies:
-      '@esbuild/aix-ppc64': 0.27.7
-      '@esbuild/android-arm': 0.27.7
-      '@esbuild/android-arm64': 0.27.7
-      '@esbuild/android-x64': 0.27.7
-      '@esbuild/darwin-arm64': 0.27.7
-      '@esbuild/darwin-x64': 0.27.7
-      '@esbuild/freebsd-arm64': 0.27.7
-      '@esbuild/freebsd-x64': 0.27.7
-      '@esbuild/linux-arm': 0.27.7
-      '@esbuild/linux-arm64': 0.27.7
-      '@esbuild/linux-ia32': 0.27.7
-      '@esbuild/linux-loong64': 0.27.7
-      '@esbuild/linux-mips64el': 0.27.7
-      '@esbuild/linux-ppc64': 0.27.7
-      '@esbuild/linux-riscv64': 0.27.7
-      '@esbuild/linux-s390x': 0.27.7
-      '@esbuild/linux-x64': 0.27.7
-      '@esbuild/netbsd-arm64': 0.27.7
-      '@esbuild/netbsd-x64': 0.27.7
-      '@esbuild/openbsd-arm64': 0.27.7
-      '@esbuild/openbsd-x64': 0.27.7
-      '@esbuild/openharmony-arm64': 0.27.7
-      '@esbuild/sunos-x64': 0.27.7
-      '@esbuild/win32-arm64': 0.27.7
-      '@esbuild/win32-ia32': 0.27.7
-      '@esbuild/win32-x64': 0.27.7
-
-  esbuild@0.28.0:
-    optionalDependencies:
-      '@esbuild/aix-ppc64': 0.28.0
-      '@esbuild/android-arm': 0.28.0
-      '@esbuild/android-arm64': 0.28.0
-      '@esbuild/android-x64': 0.28.0
-      '@esbuild/darwin-arm64': 0.28.0
-      '@esbuild/darwin-x64': 0.28.0
-      '@esbuild/freebsd-arm64': 0.28.0
-      '@esbuild/freebsd-x64': 0.28.0
-      '@esbuild/linux-arm': 0.28.0
-      '@esbuild/linux-arm64': 0.28.0
-      '@esbuild/linux-ia32': 0.28.0
-      '@esbuild/linux-loong64': 0.28.0
-      '@esbuild/linux-mips64el': 0.28.0
-      '@esbuild/linux-ppc64': 0.28.0
-      '@esbuild/linux-riscv64': 0.28.0
-      '@esbuild/linux-s390x': 0.28.0
-      '@esbuild/linux-x64': 0.28.0
-      '@esbuild/netbsd-arm64': 0.28.0
-      '@esbuild/netbsd-x64': 0.28.0
-      '@esbuild/openbsd-arm64': 0.28.0
-      '@esbuild/openbsd-x64': 0.28.0
-      '@esbuild/openharmony-arm64': 0.28.0
-      '@esbuild/sunos-x64': 0.28.0
-      '@esbuild/win32-arm64': 0.28.0
-      '@esbuild/win32-ia32': 0.28.0
-      '@esbuild/win32-x64': 0.28.0
+      '@esbuild/aix-ppc64': 0.28.1
+      '@esbuild/android-arm': 0.28.1
+      '@esbuild/android-arm64': 0.28.1
+      '@esbuild/android-x64': 0.28.1
+      '@esbuild/darwin-arm64': 0.28.1
+      '@esbuild/darwin-x64': 0.28.1
+      '@esbuild/freebsd-arm64': 0.28.1
+      '@esbuild/freebsd-x64': 0.28.1
+      '@esbuild/linux-arm': 0.28.1
+      '@esbuild/linux-arm64': 0.28.1
+      '@esbuild/linux-ia32': 0.28.1
+      '@esbuild/linux-loong64': 0.28.1
+      '@esbuild/linux-mips64el': 0.28.1
+      '@esbuild/linux-ppc64': 0.28.1
+      '@esbuild/linux-riscv64': 0.28.1
+      '@esbuild/linux-s390x': 0.28.1
+      '@esbuild/linux-x64': 0.28.1
+      '@esbuild/netbsd-arm64': 0.28.1
+      '@esbuild/netbsd-x64': 0.28.1
+      '@esbuild/openbsd-arm64': 0.28.1
+      '@esbuild/openbsd-x64': 0.28.1
+      '@esbuild/openharmony-arm64': 0.28.1
+      '@esbuild/sunos-x64': 0.28.1
+      '@esbuild/win32-arm64': 0.28.1
+      '@esbuild/win32-ia32': 0.28.1
+      '@esbuild/win32-x64': 0.28.1
 
   estree-walker@3.0.3:
     dependencies:
@@ -1838,7 +1573,7 @@ snapshots:
 
   tsx@4.22.3:
     dependencies:
-      esbuild: 0.28.0
+      esbuild: 0.28.1
     optionalDependencies:
       fsevents: 2.3.3
 
@@ -1869,7 +1604,7 @@ snapshots:
 
   vite@7.3.5(@types/node@24.12.4)(tsx@4.22.3):
     dependencies:
-      esbuild: 0.27.7
+      esbuild: 0.28.1
       fdir: 6.5.0(picomatch@4.0.4)
       picomatch: 4.0.4
       postcss: 8.5.15

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -3,3 +3,9 @@ packages:
 
 allowBuilds:
   esbuild: true
+
+# Force the patched esbuild across the tree (transitive via vite/vitest + tsx).
+# Closes GHSA-g7r4-m6w7-qqqr (dev-only, Windows dev-server file read); < 0.28.1
+# is vulnerable. Patch bump satisfies vite@7's and tsx@4's esbuild ranges.
+overrides:
+  esbuild: ">=0.28.1"


### PR DESCRIPTION
Post-merge bugfix on the price-feed increment merged in #109. Closes #111.

## Problem

The daily fetch 429s on every equity. #109 batched Twelve Data on the premise that the free tier caps at **8 requests/minute** — so one batched `time_series` request would clear it. Wrong premise: the free Basic tier caps at **8 API *credits*/minute** (800/day) and a batched request costs **1 credit per symbol**. The 9 Twelve Data symbols (3 US equities + 6 `*-mxn` USD legs) = **9 credits > 8 ⇒ deterministic HTTP 429**, batched or not.

## Fix

Chunk equities into `twelveDataMaxSymbolsPerMinute`-sized batches (default 8 = the free cap) and sleep `twelveDataPauseMs` (default 60s) between chunks so each minute window stays under the credit cap. Stays on the free tier ($0); a paid tier can set the chunk size ≥ the equity count to disable pacing.

Blast radius is the fetch-and-store phase only — the mark-time gate, `buildMarks`, the weekend/holiday stale-equity skip, and the `USD × FIX` derivation are untouched.

## Reliability audit

| Property | Verdict |
|---|---|
| Chunk math (`chunk(9, max(1,8))` → `[8,1]`) | ✅ `Math.max(1, …)` guards a 0/negative config from looping forever |
| Pacing placement (`if (i > 0)`) | ✅ sleeps between chunks only — exactly `chunks−1` pauses |
| Per-symbol attribution | ✅ a bad symbol in a chunk fails alone; siblings still store |
| Partial progress (R4) | ✅ each chunk is stored before the next chunk's sleep+fetch |
| Timeout envelope (R4) | ✅ each chunk request still bounded by `requestTimeoutMs`; sleep is separate |
| Test hygiene | ✅ injectable `sleepImpl` (real `setTimeout` default, no-op in tests) — no 60s wait leaks into the suite |
| Live proof | ✅ 13/13 fetched against the real API, spine ingested, exit 0 |

## Cost

A daily run now takes ~1 extra minute (one 60s pause). Documented in `docs/price-feed-ops.md`.

## Verification

- `pnpm --filter @numisma/price-feed typecheck` — clean
- `vitest run` — 58 passed (2 new pacing tests: `[8,1]` split with exactly one 60s pause; paid-tier single-batch with no pause)
- Live wrapper run — 13/13 stored, spine ingested 4 marks, exit 0