### PR TITLE
feat(price-feed): mark crypto on the settled UTC daily close, gated uniformly (#130)

### DIFF
--- a/apps/price-feed/src/binance-provider.ts
+++ b/apps/price-feed/src/binance-provider.ts
@@ -1,10 +1,12 @@
 /**
  * The Binance public-REST provider (crypto, keyless). It performs network IO only
- * — no domain decisions: it fetches a symbol's latest daily-close observation and
- * hands the raw close back for the pure engine to turn into a quote/mark. Every
- * call is bounded by an `AbortController` timeout (R4) so a stalled provider can
- * never hang a scheduled run, and every failure carries the symbol so it stays
- * per-symbol attributable.
+ * — no domain decisions: it fetches a symbol's last COMPLETED (settled) daily-close
+ * observation and hands the raw close back for the pure engine to turn into a
+ * quote/mark. It requests the newest TWO daily klines and takes the older, settled
+ * one — never the still-running current-day candle (a live spot reading dressed as
+ * a close). Every call is bounded by an `AbortController` timeout (R4) so a stalled
+ * provider can never hang a scheduled run, and every failure carries the symbol so
+ * it stays per-symbol attributable.
  */
 import type { InstrumentRegistryEntry } from "@numisma/engine";
 
@@ -36,10 +38,13 @@ export interface FetchOptions {
 }
 
 /**
- * Fetch the latest daily close for one registry entry from Binance. Throws a
- * symbol-attributable error on HTTP failure, an unexpected payload shape, a
- * non-positive close, or a timeout — the orchestrator records it as a per-symbol
- * failure and keeps going.
+ * Fetch the last COMPLETED daily close for one registry entry from Binance. It asks
+ * for the newest two 1d klines (`limit=2`) — Binance returns them ascending as
+ * `[completed D, running D+1]` — and takes the settled candle `rows[0]`, never the
+ * still-running `rows[1]`. Throws a symbol-attributable error on HTTP failure, an
+ * unexpected payload shape, a payload with fewer than 2 rows (no settled candle to
+ * mark), a non-positive close, or a timeout — the orchestrator records it as a
+ * per-symbol failure and keeps going, never silently falling back to a running mark.
  */
 export async function fetchBinanceDailyClose(
   entry: InstrumentRegistryEntry,
@@ -51,7 +56,7 @@ export async function fetchBinanceDailyClose(
   const timer = setTimeout(() => controller.abort(), options.timeoutMs);
   let res: Response;
   try {
-    const url = `${BINANCE_KLINES}?symbol=${entry.symbol}&interval=1d&limit=1`;
+    const url = `${BINANCE_KLINES}?symbol=${entry.symbol}&interval=1d&limit=2`;
     res = await fetchImpl(url, { signal: controller.signal });
   } catch (error) {
     if (error instanceof Error && error.name === "AbortError") {
@@ -70,7 +75,17 @@ export async function fetchBinanceDailyClose(
     throw new Error(`Binance ${entry.symbol} -> HTTP ${res.status} ${res.statusText}`);
   }
   const rows = (await res.json()) as unknown;
-  const row = Array.isArray(rows) ? rows[0] : undefined;
+  if (!Array.isArray(rows)) {
+    throw new Error(`Binance ${entry.symbol} -> unexpected payload shape`);
+  }
+  // Binance returns the newest two 1d klines ascending as [completed D, running
+  // D+1]. Fewer than two rows means there is no SETTLED candle to mark — a
+  // symbol-attributable failure (R4), never a silent fall-back to a running mark.
+  if (rows.length < 2) {
+    throw new Error(`Binance ${entry.symbol} -> expected >=2 klines, got ${rows.length}`);
+  }
+  // Take the completed candle (the older row), never the still-running rows[1].
+  const row = rows[0];
   if (!Array.isArray(row)) {
     throw new Error(`Binance ${entry.symbol} -> unexpected payload shape`);
   }
@@ -79,11 +94,10 @@ export async function fetchBinanceDailyClose(
   if (!Number.isFinite(close) || close <= 0) {
     throw new Error(`Binance ${entry.symbol} -> non-positive close ${String(row[4])}`);
   }
-  // The bar's own date, from its `openTime` (epoch ms), in UTC. Crypto trades 24/7
-  // so this date is informational only — the orchestrator does NOT gate crypto
-  // marks on it (a Saturday bar is a real close), and it is deliberately NOT forced
-  // to equal the CDMX trading-day `asOf`. Fall back to the fetch date if a payload
-  // ever omits a usable openTime (crypto is ungated, so this never hides staleness).
+  // The completed bar's own date, from its `openTime` (epoch ms), in UTC. The
+  // orchestrator gates the crypto mark on this equalling the run's `asOf`; at/after
+  // 18:00 CDMX the settled UTC candle's date equals `asOf` by construction. Fall
+  // back to the fetch date only if a payload ever omits a usable openTime.
   const openTime = Number(row[0]);
   const observationDate = (Number.isFinite(openTime) ? new Date(openTime) : now())
     .toISOString()

--- a/apps/price-feed/src/fetch-prices.test.ts
+++ b/apps/price-feed/src/fetch-prices.test.ts
@@ -512,6 +512,41 @@ describe("runPriceFetch — crypto marks the settled UTC candle, gated uniformly
     expect(inbox.map((e) => e.id)).toContain(`pm-btc-${AS_OF}`);
   });
 
+  it("at the real 18:00-CDMX fire (00:00 UTC), the completed UTC candle aligns with asOf and crypto marks", async () => {
+    // Pin the invariant the crypto gate rests on IN PRODUCTION: the real fire is
+    // 18:00 CDMX = 00:00 UTC the next day. At that instant Binance's completed 1d
+    // candle (the UTC day that just closed, Jul 22) lines up with the CDMX-anchored
+    // asOf "by construction" — and the candle dates here are computed from the fire
+    // instant, NOT pinned to asOf, so a broken offset (changed markTime, reinstated
+    // DST, Binance row-order flip) would surface as a skip instead of staying green.
+    const FIRE = new Date("2026-07-23T00:00:00.000Z"); // = 18:00 CDMX on 2026-07-22
+    const result = await runPriceFetch({
+      config: { dataDir, markTime: "18:00", timeZone: "America/Mexico_City" },
+      now: () => FIRE,
+      fetchImpl: mockFetch({
+        // What Binance returns at 00:00 UTC: [completed Jul 22, running Jul 23].
+        // The completed candle's UTC day (2026-07-22) must equal the CDMX-anchored asOf.
+        BTCUSDT: () =>
+          new Response(
+            JSON.stringify([
+              klineRow(Date.UTC(2026, 6, 22), 65000),
+              klineRow(Date.UTC(2026, 6, 23), 66000),
+            ]),
+            { status: 200 },
+          ),
+      }),
+      credentials: CREDENTIALS,
+    });
+
+    // asOf is the CDMX calendar day of the fire = 2026-07-22, and it equals the
+    // completed candle's UTC day → BTC marks, never lands in staleMarkSkips. (The
+    // other default mocks are pinned to Jul 3 and simply skip at this instant; the
+    // assertions concern BTC's alignment at the real boundary alone.)
+    const inbox = await readInbox();
+    expect(inbox.map((e) => e.id)).toContain("pm-btc-2026-07-22");
+    expect(result.staleMarkSkips.map((s) => s.instrumentId)).not.toContain("btc");
+  });
+
   it("routes crypto and equity through ONE gate — a misaligned bar of each lands in staleMarkSkips", async () => {
     const result = await runPriceFetch({
       config: { dataDir, markTime: "00:00" },

--- a/apps/price-feed/src/fetch-prices.test.ts
+++ b/apps/price-feed/src/fetch-prices.test.ts
@@ -53,11 +53,20 @@ const EQUITY_CLOSES: Record<string, number> = {
 
 const FIX_RATE = 18.5;
 
-function klineResponse(close: number): Response {
-  const openTime = Date.UTC(2026, 6, 3);
+// Build one Binance 1d kline row for the UTC day `openTime` starts, with `close`.
+function klineRow(openTime: number, close: number): unknown[] {
   const closeTime = openTime + 86_399_999;
-  const row = [openTime, "0", "0", "0", String(close), "10", closeTime, "0", 0, "0", "0", "0"];
-  return new Response(JSON.stringify([row]), { status: 200 });
+  return [openTime, "0", "0", "0", String(close), "10", closeTime, "0", 0, "0", "0", "0"];
+}
+
+// The real Binance shape: the newest TWO 1d klines ascending as [completed D,
+// running D+1]. The completed candle (day AS_OF) carries `close`; the running
+// candle (D+1) carries a clearly different close so a test can prove the settled
+// one is chosen, never the running spot reading. The provider takes rows[0].
+function klineResponse(close: number): Response {
+  const completed = klineRow(Date.UTC(2026, 6, 3), close);
+  const running = klineRow(Date.UTC(2026, 6, 4), close + 1000);
+  return new Response(JSON.stringify([completed, running]), { status: 200 });
 }
 
 function fixResponse(rate: string, fecha = "03/07/2026"): Response {
@@ -428,5 +437,107 @@ describe("runPriceFetch — Twelve Data pacing under the free-tier credit cap", 
     expect(batches).toHaveLength(1);
     expect(batches[0]).toHaveLength(9);
     expect(sleeps).toEqual([]);
+  });
+});
+
+describe("runPriceFetch — crypto marks the settled UTC candle, gated uniformly", () => {
+  it("marks the completed candle's close, never the running D+1 candle", async () => {
+    await runPriceFetch({
+      config: { dataDir, markTime: "00:00" },
+      fetchImpl: mockFetch(),
+      now: () => RUN_INSTANT,
+      credentials: CREDENTIALS,
+    });
+
+    const inbox = await readInbox();
+    const btc = inbox.find((event) => event.id === `pm-btc-${AS_OF}`);
+    // klineResponse pairs the completed close (65000) with a running D+1 close of
+    // 66000. The mark must carry the settled candle, never the live running one.
+    expect(btc?.id).toBe(`pm-btc-${AS_OF}`);
+    expect(btc?.price).toBe(CRYPTO_CLOSES.BTCUSDT);
+    expect(btc?.price).not.toBe(CRYPTO_CLOSES.BTCUSDT! + 1000);
+  });
+
+  it("cleanly skips a crypto bar whose completed candle predates asOf — INFO, no mark, no failure", async () => {
+    const result = await runPriceFetch({
+      config: { dataDir, markTime: "00:00" },
+      fetchImpl: mockFetch({
+        // RENDER's completed candle is a prior UTC day (a late/missed fire): its
+        // observationDate ("2026-07-02") ≠ asOf, so the uniform gate skips it.
+        RENDERUSDT: () =>
+          new Response(
+            JSON.stringify([klineRow(Date.UTC(2026, 6, 2), 8.2), klineRow(Date.UTC(2026, 6, 3), 8.3)]),
+            { status: 200 },
+          ),
+      }),
+      now: () => RUN_INSTANT,
+      credentials: CREDENTIALS,
+    });
+
+    // RENDER is a clean INFO skip: recorded once in staleMarkSkips, never a failure.
+    expect(result.failures.map((f) => f.instrumentId)).not.toContain("render");
+    expect(result.staleMarkSkips.map((s) => s.instrumentId)).toEqual(["render"]);
+    expect(result.staleMarkSkips[0]).toMatchObject({
+      instrumentId: "render",
+      symbol: "RENDERUSDT",
+      observationDate: "2026-07-02",
+      asOf: AS_OF,
+    });
+    // No render mark; the other 12 instruments still marked.
+    const inbox = await readInbox();
+    expect(inbox.map((e) => e.id)).not.toContain(`pm-render-${AS_OF}`);
+    expect(inbox).toHaveLength(12);
+  });
+
+  it("treats a thin (<2-row) Binance payload as a per-symbol failure (R4), others unaffected", async () => {
+    const result = await runPriceFetch({
+      config: { dataDir, markTime: "00:00" },
+      fetchImpl: mockFetch({
+        // A single-row payload has no settled candle to mark — attributable failure.
+        GRAMUSDT: () =>
+          new Response(JSON.stringify([klineRow(Date.UTC(2026, 6, 3), 5.5)]), { status: 200 }),
+      }),
+      now: () => RUN_INSTANT,
+      credentials: CREDENTIALS,
+    });
+
+    expect(result.failures.map((f) => f.instrumentId)).toContain("gram");
+    expect(result.failures.find((f) => f.instrumentId === "gram")?.message).toMatch(
+      /expected >=2 klines, got 1/,
+    );
+    // Isolation: the thin symbol fails alone; the other 12 store and mark.
+    expect(result.storedCount).toBe(12);
+    const inbox = await readInbox();
+    expect(inbox.map((e) => e.id)).not.toContain(`pm-gram-${AS_OF}`);
+    expect(inbox.map((e) => e.id)).toContain(`pm-btc-${AS_OF}`);
+  });
+
+  it("routes crypto and equity through ONE gate — a misaligned bar of each lands in staleMarkSkips", async () => {
+    const result = await runPriceFetch({
+      config: { dataDir, markTime: "00:00" },
+      fetchImpl: mockFetch({
+        // A misaligned crypto bar (completed candle on a prior UTC day)…
+        ETHUSDT: () =>
+          new Response(
+            JSON.stringify([klineRow(Date.UTC(2026, 6, 2), 3400), klineRow(Date.UTC(2026, 6, 3), 3500)]),
+            { status: 200 },
+          ),
+        // …and a misaligned equity bar (Twelve Data slice dated a prior trading day).
+        AAPL: () =>
+          new Response(
+            JSON.stringify({ status: "ok", values: [{ datetime: "2026-07-02", close: "212.5" }] }),
+            { status: 200 },
+          ),
+      }),
+      now: () => RUN_INSTANT,
+      credentials: CREDENTIALS,
+    });
+
+    // The twelvedata-only special case is gone: both flow through the same gate.
+    expect(result.staleMarkSkips.map((s) => s.instrumentId).sort()).toEqual(["aapl", "eth"]);
+    expect(result.failures).toEqual([]);
+    const inbox = await readInbox();
+    expect(inbox.map((e) => e.id)).not.toContain(`pm-eth-${AS_OF}`);
+    expect(inbox.map((e) => e.id)).not.toContain(`pm-aapl-${AS_OF}`);
   });
 });

--- a/apps/price-feed/src/fetch-prices.ts
+++ b/apps/price-feed/src/fetch-prices.ts
@@ -23,14 +23,16 @@
  * progress is always kept — a failure records and continues; the run exits non-zero
  * so a scheduler notices.
  *
- * Non-trading-day honesty (finding 3): the schedule fires 7 days/week so crypto —
- * which trades 24/7 — marks every day. Equities do NOT trade weekends/holidays, so
- * on those days Twelve Data returns the LAST trading day's bar; emitting it under
- * today's `asOf` would append a misdated, never-moved stale mark. Each equity mark
- * is therefore gated on the provider bar's `observationDate` equaling the run's
- * `asOf`; a mismatch is an INFO skip (market closed, no fresh close), never a
- * failure, so the run stays clean and the crypto marks still ingest. Crypto is
- * intentionally UNGATED (a Saturday crypto bar is a real close).
+ * Freshness honesty (finding 3 / ADR-005): EVERY instrument's mark is gated on the
+ * provider bar's `observationDate` equalling the run's trading-day `asOf` — one
+ * uniform rule for crypto, US equities, and derived `*-mxn` alike. Equities do NOT
+ * trade weekends/holidays, so on those days Twelve Data returns the LAST trading
+ * day's bar; crypto reads the last SETTLED UTC daily candle. Either way, emitting a
+ * bar that predates `asOf` would append a misdated, never-moved stale mark, so it is
+ * an INFO skip (market closed for equities; a late/missed fire or provider hiccup
+ * for crypto), never a failure — the run stays clean. In normal operation at/after
+ * 18:00 CDMX the settled UTC candle's date equals `asOf` by construction, so the
+ * gate does not fire for crypto.
  *
  * MXN honesty (ADR-005): `*-mxn` instruments store the raw USD leg as their
  * disposable quote and get a DERIVED `USD × FIX` mark with the `usdMxn` snapshot
@@ -72,13 +74,15 @@ export interface FetchFailure {
 }
 
 /**
- * One equity whose fresh mark was intentionally SKIPPED this run because the market
- * was closed (weekend/holiday): the provider's latest bar (`observationDate`)
- * predates the run's trading-day `asOf`, so emitting it would append a misdated
- * stale mark. This is expected INFO, NOT a {@link FetchFailure} — it must not force
- * a non-zero exit and must not block the spine.
+ * One instrument whose fresh mark was intentionally SKIPPED this run because its bar
+ * (`observationDate`) predates the run's trading-day `asOf`, so emitting it would
+ * append a misdated stale mark. For an equity this means the market was closed
+ * (weekend/holiday); for crypto it means a late/missed fire or a provider hiccup —
+ * NOT a market-closed day, since crypto trades 24/7. Either way this is expected
+ * INFO, NOT a {@link FetchFailure} — it must not force a non-zero exit and must not
+ * block the spine.
  */
-export interface EquityMarkSkip {
+export interface MarkSkip {
   instrumentId: string;
   symbol: string;
   /** The provider's latest bar date (`YYYY-MM-DD`) — a prior trading day. */
@@ -108,12 +112,13 @@ export interface FetchRunResult {
   marks: PriceMarkedEvent[];
   failures: FetchFailure[];
   /**
-   * Equity marks skipped because the market was closed (weekend/holiday): the
-   * provider's latest bar predates `asOf`, so no fresh close exists to mark. These
-   * are INFO, not failures — the run stays clean and crypto still marks. Empty
-   * before the mark time (no marks are built then) and on ordinary trading days.
+   * Marks skipped because the instrument's bar predates `asOf`, so no fresh close
+   * exists to mark: an equity on a closed market (weekend/holiday), or a crypto bar
+   * from a late/missed fire or provider hiccup. These are INFO, not failures — the
+   * run stays clean and the other instruments still mark. Empty before the mark time
+   * (no marks are built then) and on ordinary at/after-18:00 CDMX runs.
    */
-  staleEquitySkips: EquityMarkSkip[];
+  staleMarkSkips: MarkSkip[];
 }
 
 export interface RunOptions {
@@ -136,7 +141,7 @@ export interface RunOptions {
 interface FetchedQuote {
   entry: InstrumentRegistryEntry;
   quote: Quote;
-  /** The provider bar's own date (`YYYY-MM-DD`); gates equity mark freshness. */
+  /** The provider bar's own date (`YYYY-MM-DD`); gates every mark's freshness. */
   observationDate: string;
 }
 
@@ -168,7 +173,7 @@ export async function runPriceFetch(options: RunOptions = {}): Promise<FetchRunR
 
   const successes: FetchedQuote[] = [];
   const failures: FetchFailure[] = [];
-  const staleEquitySkips: EquityMarkSkip[] = [];
+  const staleMarkSkips: MarkSkip[] = [];
 
   // Crypto (Binance): keyless, so fetch one symbol at a time — no rate budget worth
   // batching, and each stays individually attributable.
@@ -204,7 +209,7 @@ export async function runPriceFetch(options: RunOptions = {}): Promise<FetchRunR
   // Two-plane rule: the store always upserts above; marks only at/after mark time.
   const markEmitted = isAtOrAfterMarkTime(instant, config);
   const marks = markEmitted
-    ? await buildMarks(successes, failures, staleEquitySkips, asOf, config, credentials, fetchImpl)
+    ? await buildMarks(successes, failures, staleMarkSkips, asOf, config, credentials, fetchImpl)
     : [];
   const emittedCount = await emitMarksToInbox(paths.inbox, marks);
 
@@ -217,7 +222,7 @@ export async function runPriceFetch(options: RunOptions = {}): Promise<FetchRunR
     markEmitted,
     marks,
     failures,
-    staleEquitySkips,
+    staleMarkSkips,
   };
 }
 
@@ -310,18 +315,20 @@ async function storeSuccess(
  * missing or stale FIX fails every `*-mxn` derivation loudly and attributably — the
  * direct marks still emit (partial progress kept).
  *
- * Per-provider bar-date validation (finding 3): an EQUITY (Twelve Data) mark is
- * built only when the provider bar's `observationDate` equals the run's trading-day
- * `asOf`. On a weekend/holiday the latest bar is a prior trading day, so the equity
- * (incl. each `*-mxn` USD leg) is SKIPPED as INFO — recorded in `staleEquitySkips`,
- * never a failure. CRYPTO (Binance) trades 24/7, so it is UNGATED: a daily crypto
- * bar is a legitimately fresh close every day, and its UTC bar date is deliberately
- * NOT forced to equal the CDMX `asOf`.
+ * Uniform bar-date validation (finding 3 / ADR-005): EVERY mark — crypto (Binance),
+ * US equity (Twelve Data), and derived `*-mxn` — is built only when the provider
+ * bar's `observationDate` equals the run's trading-day `asOf`. One rule, no
+ * per-source special case. On a weekend/holiday an equity's latest bar is a prior
+ * trading day; a crypto bar can predate `asOf` on a late/missed fire or a provider
+ * hiccup. Either way the instrument (incl. each `*-mxn` USD leg) is SKIPPED as INFO
+ * — recorded in `staleMarkSkips`, never a failure. In normal operation at/after
+ * 18:00 CDMX the settled UTC crypto candle's date equals `asOf` by construction, so
+ * the gate does not fire for crypto.
  */
 async function buildMarks(
   successes: readonly FetchedQuote[],
   failures: FetchFailure[],
-  staleEquitySkips: EquityMarkSkip[],
+  staleMarkSkips: MarkSkip[],
   asOf: string,
   config: PriceFeedConfig,
   credentials: ProviderCredentials,
@@ -332,7 +339,7 @@ async function buildMarks(
   // bar is today's trading day). On a market-closed day every equity self-skips
   // below, so fetching the FIX then is not only wasted — a FIX outage would push a
   // spurious failure and block the spine for marks that were never going to emit.
-  if (successes.some((s) => s.entry.derived && isFreshEquityBar(s, asOf))) {
+  if (successes.some((s) => s.entry.derived && isFreshBar(s, asOf))) {
     try {
       fix = await fetchBanxicoFix({
         timeoutMs: config.requestTimeoutMs,
@@ -353,11 +360,12 @@ async function buildMarks(
   const marks: PriceMarkedEvent[] = [];
   for (const success of successes) {
     const { entry, quote, observationDate } = success;
-    // Equity market-closed skip: no fresh close for today's asOf. INFO, not failure.
-    if (entry.source === "twelvedata" && !isFreshEquityBar(success, asOf)) {
-      staleEquitySkips.push({ instrumentId: entry.instrumentId, symbol: entry.symbol, observationDate, asOf });
+    // Uniform freshness skip: the bar predates today's asOf, so no fresh close to
+    // mark. INFO, not failure — fires for crypto, equity, and derived alike.
+    if (!isFreshBar(success, asOf)) {
+      staleMarkSkips.push({ instrumentId: entry.instrumentId, symbol: entry.symbol, observationDate, asOf });
       console.info(
-        `  equity mark skipped — no fresh close for ${asOf}: ${entry.instrumentId} ` +
+        `  mark skipped — no fresh close for ${asOf}: ${entry.instrumentId} ` +
           `${entry.symbol} (latest bar ${observationDate})`,
       );
       continue;
@@ -380,7 +388,7 @@ async function buildMarks(
   return marks;
 }
 
-/** Whether an equity's fetched bar is today's trading day (a fresh close to mark). */
-function isFreshEquityBar(success: FetchedQuote, asOf: string): boolean {
+/** Whether an instrument's fetched bar is today's trading day (a fresh close to mark). */
+function isFreshBar(success: FetchedQuote, asOf: string): boolean {
   return success.observationDate === asOf;
 }

--- a/apps/price-feed/src/rejection-check.test.ts
+++ b/apps/price-feed/src/rejection-check.test.ts
@@ -178,7 +178,7 @@ describe("derived MXN marks are pre-checked at USD×FIX, not the raw USD quote (
       markEmitted: true,
       marks: [derived],
       failures: [],
-      staleEquitySkips: [],
+      staleMarkSkips: [],
     };
     expect(marksFromRun(result)).toEqual([derived]);
     // Before the mark time, nothing is pre-checked even if marks are present.
@@ -216,7 +216,7 @@ describe("loadSpineReference + scanFetchedMarks — reads the real genesis/log o
       // pre-check reads these constructed marks, not a re-derivation from quotes.
       marks: [markFromQuote(quote("btc", price))],
       failures: [],
-      staleEquitySkips: [],
+      staleMarkSkips: [],
     };
   }
 
@@ -330,7 +330,7 @@ describe("scanFetchedMarks folds the pending inbox exactly as ingestInbox does",
       markEmitted: true,
       marks: marks as FetchRunResult["marks"],
       failures: [],
-      staleEquitySkips: [],
+      staleMarkSkips: [],
     };
   }
 


### PR DESCRIPTION
## Summary

- **Completed-candle read** (`binance-provider`): request `limit=2` and
  mark `rows[0]` — the confirmed prior-day UTC close — instead of the
  running candle; `<2` rows is a symbol-attributable failure, not a
  silent skip.
- **Uniform freshness gate** (`fetch-prices`): dropped the
  `source === "twelvedata"` special case; all instruments now share a
  single `observationDate === asOf` check, so crypto marks are rejected
  for the same reason equities are.
- **Rename**: `EquityMarkSkip` → `MarkSkip`, `staleEquitySkips` →
  `staleMarkSkips`, `isFreshEquityBar` → `isFreshBar` — scope is now
  instrument-agnostic.
- No `packages/engine` or schema change.

## Verification

| Suite | Result |
|---|---|
| Targeted (`binance-provider` + `fetch-prices`) | 15 / 15 passed |
| `apps/price-feed` | 62 / 62 passed |
| Full `pnpm test` | 551 / 551 passed |
| TypeScript (`tsc --noEmit`) | clean |

New test coverage: 2-candle Binance mock, settled-close assertion, crypto
skip, thin-symbol guard, uniform-gate across instrument types.

Closes #130
Closes #129