### PR TITLE
Harden durable-log ingest capture against a stale allowlist (#132)

### DIFF
--- a/apps/tui/src/ingest-commit-hardening.test.ts
+++ b/apps/tui/src/ingest-commit-hardening.test.ts
@@ -208,3 +208,90 @@ describe("captureIngestCommit — exec safety + scoped staging in a real repo", 
     expect(git(dir, ["log", "-1", "--format=%B"]).stdout).not.toMatch(/Co-Authored-By/i);
   });
 });
+
+describe("captureIngestCommit — allowlist (.gitignore) repos mirroring accumulus (#132)", () => {
+  // A fresh appended mark, so the durable LOG is genuinely dirty when capture runs —
+  // the real daily shape (the append lands first, then capture commits it). Without
+  // this the log is unchanged since seed and the scenario can't prove it was captured.
+  const DAY2 = { ...MARK, id: "mark-aapl-day2", asOf: "2026-06-07" };
+
+  // The allowlist strategy inlined here (root-relative, since the test's dataDir IS the
+  // repo root) mirrors accumulus's PATTERN — ignore all, then negate the durable files —
+  // WITHOUT reading the sibling repo's real .gitignore, so the suite stays decoupled.
+  const FIXED_ALLOWLIST = [
+    "*",
+    "!/.gitignore",
+    "!/genesis.json",
+    "!/events.jsonl",
+    "!/preferences.jsonl",
+    "!/head-digest.json",
+  ];
+  // The pre-fix drift (issue #132): the 4th durable file is still negated under its DEAD
+  // name, so the real head-digest.json falls under the `*` catch-all and is IGNORED.
+  const DRIFTED_ALLOWLIST = [
+    "*",
+    "!/.gitignore",
+    "!/genesis.json",
+    "!/events.jsonl",
+    "!/preferences.jsonl",
+    "!/checkpoint.json",
+  ];
+
+  /**
+   * A throwaway repo seeded like accumulus: an allowlist `.gitignore`, a committed
+   * genesis + one-line events log, then a SECOND mark appended to the log left dirty in
+   * the working tree (the state capture is called in). No remote, so the best-effort
+   * push warns — callers spy stderr to keep it quiet / assert on it.
+   */
+  async function makeAllowlistRepo(ignoreLines: string[]): Promise<string> {
+    const dir = await tempDir("numisma-allowlist-");
+    await writeFile(resolve(dir, ".gitignore"), `${ignoreLines.join("\n")}\n`, "utf8");
+    await writeFile(resolve(dir, "genesis.json"), JSON.stringify(GENESIS), "utf8");
+    await writeFile(resolve(dir, "events.jsonl"), logLine(MARK), "utf8");
+    git(dir, ["init", "-q"]);
+    git(dir, ["config", "user.email", "test@example.com"]);
+    git(dir, ["config", "user.name", "Test Operator"]);
+    git(dir, ["config", "commit.gpgsign", "false"]);
+    git(dir, ["add", ".gitignore", "genesis.json", "events.jsonl"]);
+    git(dir, ["commit", "-q", "-m", "seed"]);
+    // The day's append: now events.jsonl is dirty, exactly as after a real ingest.
+    await writeFile(resolve(dir, "events.jsonl"), logLine(MARK) + logLine(DAY2), "utf8");
+    return dir;
+  }
+
+  it("captures both the appended log AND head-digest under the correct allowlist (locks Q1's fixed state)", async () => {
+    const dir = await makeAllowlistRepo(FIXED_ALLOWLIST);
+    const { folded, appended } = foldedFixture();
+    const stderr = spyStderr();
+
+    await captureIngestCommit({ dataDir: dir, folded, appendedEvents: appended, appVersion: "v" });
+
+    // head-digest.json is now tracked (allowlisted) and the new commit captured it...
+    expect(git(dir, ["ls-files"]).stdout).toContain("head-digest.json");
+    const committed = git(dir, ["diff-tree", "--no-commit-id", "--name-only", "-r", "HEAD"]).stdout;
+    expect(committed).toContain("head-digest.json");
+    // ...alongside the day's appended mark (the log landed, not just the seed).
+    expect(git(dir, ["show", "HEAD:events.jsonl"]).stdout).toContain("mark-aapl-day2");
+    // No durable file was refused.
+    expect(stderr.warnings()).not.toMatch(/add failed/i);
+  });
+
+  it("still captures the LOG when head-digest is only-ignored — per-file add never aborts the batch (Q2 vs. the 17-day outage)", async () => {
+    // The drifted allowlist ignores head-digest.json. The OLD atomic `git add
+    // events.jsonl head-digest.json …` aborted WHOLESALE on that only-ignored pathspec,
+    // dropping the durable log too — the exact silent miss. Per-file staging must let
+    // the log through and only warn on the file that truly can't stage.
+    const dir = await makeAllowlistRepo(DRIFTED_ALLOWLIST);
+    const { folded, appended } = foldedFixture();
+    const stderr = spyStderr();
+
+    await captureIngestCommit({ dataDir: dir, folded, appendedEvents: appended, appVersion: "v" });
+
+    // The appended log DID land in a new commit (old atomic code left it uncommitted).
+    expect(git(dir, ["show", "HEAD:events.jsonl"]).stdout).toContain("mark-aapl-day2");
+    // head-digest.json is genuinely ignored here — it never sneaks into history.
+    expect(git(dir, ["ls-files"]).stdout).not.toContain("head-digest.json");
+    // The refused file warned loudly and by name (reaches an operator, unlike a drop).
+    expect(stderr.warnings()).toMatch(/add failed for head-digest\.json/i);
+  });
+});

--- a/apps/tui/src/ingest-commit.test.ts
+++ b/apps/tui/src/ingest-commit.test.ts
@@ -20,6 +20,10 @@ import {
 import { afterEach, describe, expect, it, vi } from "vitest";
 import { captureIngestCommit, readAppVersion } from "./ingest-commit.js";
 
+// The real-repo case spawns several git children (init, per-file add, commit, push);
+// give it headroom so it never flakes on the 5s default under full-suite parallel load.
+vi.setConfig({ testTimeout: 30_000 });
+
 const createdDirs: string[] = [];
 
 afterEach(async () => {

--- a/apps/tui/src/ingest-commit.ts
+++ b/apps/tui/src/ingest-commit.ts
@@ -183,12 +183,26 @@ export async function captureIngestCommit(input: {
       return;
     }
 
-    // 2) stage ONLY the durable files that exist (never `git add -A`, so a stray
-    //    `prices/foo.json` or `*.tmp` in the dataDir can never be captured).
+    // 2) stage ONLY the durable files that exist, EACH in its own `git add` (never
+    //    `git add -A`, so a stray `prices/foo.json` or `*.tmp` in the dataDir can never
+    //    be captured). Per-file, not one atomic add of the whole list: a single
+    //    only-ignored pathspec (e.g. a stale accumulus allowlist that excludes
+    //    head-digest) makes `git add` abort the ENTIRE batch, which is exactly how the
+    //    durable log went uncaptured for 17 days. Each file that refuses to stage warns
+    //    loudly and is skipped; the rest — the log above all — still commit. Q3's
+    //    post-check is the hard backstop that reddens the job if the LOG is left dirty.
     const present = TRACKED_FILES.filter((file) => existsSync(join(dataDir, file)));
-    const add = runGit(dataDir, ["add", ...present]);
-    if (!add.ok) {
-      warn(`⚠️ accumulus git add failed — ingest not captured in git (append is durable). ${add.stderr.trim()}`);
+    let stagedAny = false;
+    for (const file of present) {
+      const add = runGit(dataDir, ["add", file]);
+      if (add.ok) {
+        stagedAny = true;
+      } else {
+        warn(`⚠️ accumulus git add failed for ${file} — that file not captured this ingest (append is durable). ${add.stderr.trim()}`);
+      }
+    }
+    if (!stagedAny) {
+      warn(`⚠️ accumulus git add staged nothing — ingest not captured in git (append is durable).`);
       return;
     }
 

--- a/context/product.md
+++ b/context/product.md
@@ -39,12 +39,11 @@ execution behavior, and decision history across Tempos.
 - MVP work excludes broker or exchange integrations, automated execution, team
   workflows, second-party approvals, SaaS deployment, and full back-test or
   forward-test engines.
-- **Automated market data is post-MVP and in progress.** Its MVP exclusion was a
-  sequencing choice, not a permanent boundary. Prices now arrive automatically
-  from free sources through the two-plane price model (ADR-005): a disposable,
-  re-fetchable price store beside the event log, and the sparse `PriceMarked`
-  valuation mark on the existing validated inbox. Manual `PriceMarked` authoring
-  remains the permanent fallback.
+- **Automated market data works through the two-plane price model (ADR-005):** a
+  disposable, re-fetchable price store beside the event log, and the sparse
+  `PriceMarked` valuation mark on the existing validated inbox. Prices arrive
+  automatically from free sources. Manual `PriceMarked` authoring remains the
+  permanent fallback.
 - Taxes may be annotated or exported later, but tax logic is not core decision
   logic for the MVP.
 

--- a/docs/price-feed-ops.md
+++ b/docs/price-feed-ops.md
@@ -100,10 +100,13 @@ threat model does not need.
    points the ledger at the sibling private `accumulus` repo. launchd **cannot expand
    `~`**, so the plist's `NUMISMA_DATA_DIR` must be an **absolute** path (e.g.
    `/Users/you/Dev/accumulus/data`) — unlike the code default, which derives
-   `~/Dev/accumulus/data` from `os.homedir()`. If left unset the code default applies
-   to `pnpm` invocations, but the wrapper's step-3 auto-commit requires the var to be
-   explicitly set — when it is absent the commit step is skipped with a logged warning
-   and the durable log is left uncommitted after that run.
+   `~/Dev/accumulus/data` from `os.homedir()`. If left unset the wrapper's step-3
+   auto-commit and step-4 post-check both fall back to that **same** `~/Dev/accumulus/data`
+   default — the exact tree the in-process capture writes to — so an unset var is still
+   committed and still post-checked (no silent "log left uncommitted" gap). Setting it
+   explicitly is only required when your `accumulus` checkout lives somewhere else.
+   (On a fresh box with no `accumulus` checkout at all, the default path is not a git
+   repo, so step 3 degrades gracefully — a logged warning and skip, never a FATAL.)
 4. Install and load:
 
    ```sh
@@ -206,16 +209,23 @@ Confirm, in order:
    the equity marks emit normally; re-check this on the first weekend run.
 5. **Auto-commit (step 3):** after a run that appended new marks, the log reads
    `committed durable-log changes (not pushed)` and `git -C "$NUMISMA_DATA_DIR" log
-   -1` shows a commit from this run. A same-day re-run reads `no tracked data changes
-   to commit (idempotent no-op run)`. If instead it reads `NUMISMA_DATA_DIR unset —
-   skipping`, set the var explicitly in the plist (see install step 3 above) and
-   re-run — when unset the auto-commit is skipped with a warning.
+   -1` (or the `~/Dev/accumulus/data` default when the var is unset) shows a commit
+   from this run. A same-day re-run reads `no tracked data changes to commit
+   (idempotent no-op run)`. A first-time **untracked** source-of-truth file (e.g. an
+   initial `genesis.json`) is staged and committed too — the backstop is not limited
+   to tracked modifications. If instead it reads `WARNING: … is not inside a git repo
+   — skipping`, the resolved data dir has no `accumulus` checkout: create/clone it, or
+   point `NUMISMA_DATA_DIR` at the right path (see install step 3 above), and re-run.
 6. **Post-check (step 4):** a clean run ends with `post-check OK: durable log
    committed clean`. If the source-of-truth log is somehow left uncommitted after
    both the in-process capture and the step-3 backstop, the run logs `FATAL: durable
    LOG uncaptured …` and **exits non-zero so launchd surfaces a red job** — the miss
-   is never silent (issue #132). A lagging `head-digest.json` warns but does not fail
-   the run (it is a forensic breadcrumb, not the source of truth).
+   is never silent (issue #132). The post-check targets the same resolved data dir as
+   step 3 (`NUMISMA_DATA_DIR`, else the `~/Dev/accumulus/data` default the in-process
+   capture writes to), so an unset var no longer disables it. A lagging
+   `head-digest.json` warns but does not fail the run (it is a forensic breadcrumb,
+   not the source of truth); the warning uses `git status --ignored` so it fires even
+   when the breadcrumb is only-ignored-and-present, the actual #132 shape.
 
 ### Dry-run record
 

--- a/docs/price-feed-ops.md
+++ b/docs/price-feed-ops.md
@@ -14,7 +14,7 @@ Everything here is machine-local. Nothing secret or trade-derived enters the rep
 
 | File | Role |
 | --- | --- |
-| `ops/price-feed/run-daily-fetch.sh` | Wrapper the scheduler calls. Sets a PATH that can find `pnpm`, sources tokens, runs `pnpm prices:fetch`, and — only on a clean fetch — `pnpm spine`. Preserves the non-zero exit code so the scheduler notices a failure or rejection. |
+| `ops/price-feed/run-daily-fetch.sh` | Wrapper the scheduler calls. Sets a PATH that can find `pnpm`, sources tokens, runs `pnpm prices:fetch`; on a clean fetch: (2) `pnpm spine` then (3) an auto-commit of any new data-repo changes scoped to `$NUMISMA_DATA_DIR` — idempotent if no new marks, never pushes. Preserves the non-zero exit code so the scheduler notices a failure or rejection. |
 | `ops/price-feed/com.numisma.pricefeed.daily.plist` | launchd definition firing the wrapper at 18:00 local (the default mark time), **every day** (see "Why the schedule fires 7 days/week" below). |
 
 Both files are templates: replace `__REPO_DIR__` / `__HOME__` before installing.
@@ -100,8 +100,10 @@ threat model does not need.
    points the ledger at the sibling private `accumulus` repo. launchd **cannot expand
    `~`**, so the plist's `NUMISMA_DATA_DIR` must be an **absolute** path (e.g.
    `/Users/you/Dev/accumulus/data`) — unlike the code default, which derives
-   `~/Dev/accumulus/data` from `os.homedir()`. Leave it unset only if this machine
-   should use that default.
+   `~/Dev/accumulus/data` from `os.homedir()`. If left unset the code default applies
+   to `pnpm` invocations, but the wrapper's step-3 auto-commit requires the var to be
+   explicitly set — when it is absent the commit step is skipped with a logged warning
+   and the durable log is left uncommitted after that run.
 4. Install and load:
 
    ```sh
@@ -202,6 +204,12 @@ Confirm, in order:
    `*-mxn` legs), the crypto marks still emit, and the wrapper exit stays `0` — a
    market-closed skip is expected INFO, not a failure. If you install on a weekday,
    the equity marks emit normally; re-check this on the first weekend run.
+5. **Auto-commit (step 3):** after a run that appended new marks, the log reads
+   `committed durable-log changes (not pushed)` and `git -C "$NUMISMA_DATA_DIR" log
+   -1` shows a commit from this run. A same-day re-run reads `no tracked data changes
+   to commit (idempotent no-op run)`. If instead it reads `NUMISMA_DATA_DIR unset —
+   skipping`, set the var explicitly in the plist (see install step 3 above) and
+   re-run — when unset the auto-commit is skipped with a warning.
 
 ### Dry-run record
 

--- a/docs/price-feed-ops.md
+++ b/docs/price-feed-ops.md
@@ -14,7 +14,7 @@ Everything here is machine-local. Nothing secret or trade-derived enters the rep
 
 | File | Role |
 | --- | --- |
-| `ops/price-feed/run-daily-fetch.sh` | Wrapper the scheduler calls. Sets a PATH that can find `pnpm`, sources tokens, runs `pnpm prices:fetch`; on a clean fetch: (2) `pnpm spine` then (3) an auto-commit of any new data-repo changes scoped to `$NUMISMA_DATA_DIR` — idempotent if no new marks, never pushes. Preserves the non-zero exit code so the scheduler notices a failure or rejection. |
+| `ops/price-feed/run-daily-fetch.sh` | Wrapper the scheduler calls. Sets a PATH that can find `pnpm`, sources tokens, runs `pnpm prices:fetch`; on a clean fetch: (2) `pnpm spine` then (3) an auto-commit of any new data-repo changes scoped to `$NUMISMA_DATA_DIR` — idempotent if no new marks, never pushes — then (4) a post-check that **fails the job** if the durable event log is still uncommitted (lenient warn for the `head-digest.json` breadcrumb). Preserves the non-zero exit code so the scheduler notices a failure or rejection. |
 | `ops/price-feed/com.numisma.pricefeed.daily.plist` | launchd definition firing the wrapper at 18:00 local (the default mark time), **every day** (see "Why the schedule fires 7 days/week" below). |
 
 Both files are templates: replace `__REPO_DIR__` / `__HOME__` before installing.
@@ -210,6 +210,12 @@ Confirm, in order:
    to commit (idempotent no-op run)`. If instead it reads `NUMISMA_DATA_DIR unset —
    skipping`, set the var explicitly in the plist (see install step 3 above) and
    re-run — when unset the auto-commit is skipped with a warning.
+6. **Post-check (step 4):** a clean run ends with `post-check OK: durable log
+   committed clean`. If the source-of-truth log is somehow left uncommitted after
+   both the in-process capture and the step-3 backstop, the run logs `FATAL: durable
+   LOG uncaptured …` and **exits non-zero so launchd surfaces a red job** — the miss
+   is never silent (issue #132). A lagging `head-digest.json` warns but does not fail
+   the run (it is a forensic breadcrumb, not the source of truth).
 
 ### Dry-run record
 

--- a/ops/price-feed/run-daily-fetch.sh
+++ b/ops/price-feed/run-daily-fetch.sh
@@ -104,4 +104,30 @@ fi
 #    surfaced to the scheduler too.
 echo "[$STAMP] prices:fetch clean — ingesting marks via pnpm spine"
 pnpm spine
+
+# 3) Persist the appended marks to the private data repo. `pnpm spine` appends the
+#    day's marks to events.jsonl but leaves that change UNCOMMITTED — a stray
+#    reset/checkout would silently lose real fund data (exactly how a multi-day
+#    backlog once piled up in the working tree). Commit the tracked data changes so
+#    the durable log is actually durable. Scoped to the data dir (never sweeps
+#    unrelated repo edits), idempotent (a no-new-marks run commits nothing), and it
+#    NEVER pushes — pushing to the remote stays a manual, reviewed step.
+DATA_DIR="${NUMISMA_DATA_DIR:-}"
+if [[ -z "$DATA_DIR" ]]; then
+  echo "[$STAMP] NUMISMA_DATA_DIR unset — skipping data-repo commit (durable log left uncommitted)."
+elif ! git -C "$DATA_DIR" rev-parse --git-dir >/dev/null 2>&1; then
+  echo "[$STAMP] WARNING: $DATA_DIR is not inside a git repo — skipping commit (durable log left uncommitted)."
+else
+  git -C "$DATA_DIR" add -u -- .
+  if git -C "$DATA_DIR" diff --cached --quiet -- .; then
+    echo "[$STAMP] no tracked data changes to commit (idempotent no-op run)."
+  else
+    git -C "$DATA_DIR" commit -q \
+      -m "data: daily price marks $STAMP" \
+      -m "Auto-committed by run-daily-fetch.sh after spine ingest. Not pushed (push is a manual, reviewed step)." \
+      -- .
+    echo "[$STAMP] committed durable-log changes (not pushed)."
+  fi
+fi
+
 echo "[$STAMP] price-feed daily run complete."

--- a/ops/price-feed/run-daily-fetch.sh
+++ b/ops/price-feed/run-daily-fetch.sh
@@ -112,13 +112,30 @@ pnpm spine
 #    the durable log is actually durable. Scoped to the data dir (never sweeps
 #    unrelated repo edits), idempotent (a no-new-marks run commits nothing), and it
 #    NEVER pushes — pushing to the remote stays a manual, reviewed step.
-DATA_DIR="${NUMISMA_DATA_DIR:-}"
-if [[ -z "$DATA_DIR" ]]; then
-  echo "[$STAMP] NUMISMA_DATA_DIR unset — skipping data-repo commit (durable log left uncommitted)."
-elif ! git -C "$DATA_DIR" rev-parse --git-dir >/dev/null 2>&1; then
+#
+#    DATA_DIR defaults to the SAME tree the in-process capture writes to
+#    (apps/tui/src/ingest-commit.ts derives ~/Dev/accumulus/data from os.homedir()
+#    when NUMISMA_DATA_DIR is unset), so this backstop AND the step-4 post-check
+#    always target the dir actually written to — never a no-op that leaves a failed
+#    capture uncommitted while the job stays green.
+#
+#    `git add -u` restages tracked modifications only, so a FIRST-TIME untracked
+#    source-of-truth file (e.g. an initial genesis.json) would slip past this
+#    backstop and then FATAL the post-check. The three source-of-truth files are
+#    NEVER ignored, so also add them explicitly. head-digest.json is deliberately
+#    NOT added here — it may be intentionally ignored, and `git add` of an ignored
+#    path aborts under `set -e`. Each explicit add is guarded on file existence so a
+#    missing optional file doesn't trip `set -e`.
+DATA_DIR="${NUMISMA_DATA_DIR:-$HOME/Dev/accumulus/data}"
+if ! git -C "$DATA_DIR" rev-parse --git-dir >/dev/null 2>&1; then
   echo "[$STAMP] WARNING: $DATA_DIR is not inside a git repo — skipping commit (durable log left uncommitted)."
 else
   git -C "$DATA_DIR" add -u -- .
+  for f in events.jsonl genesis.json preferences.jsonl; do
+    if [[ -e "$DATA_DIR/$f" ]]; then
+      git -C "$DATA_DIR" add -- "$f"
+    fi
+  done
   if git -C "$DATA_DIR" diff --cached --quiet -- .; then
     echo "[$STAMP] no tracked data changes to commit (idempotent no-op run)."
   else
@@ -139,8 +156,13 @@ fi
 #    source-of-truth (STRICT — dirty ⇒ non-zero exit), head-digest.json is a forensic
 #    breadcrumb (LENIENT — warn only). Paths are relative to $DATA_DIR, which is the
 #    accumulus `data/` subdir holding the durable files directly.
-if [[ -n "$DATA_DIR" ]] && git -C "$DATA_DIR" rev-parse --git-dir >/dev/null 2>&1; then
-  DIGEST_DIRTY="$(git -C "$DATA_DIR" status --porcelain -- head-digest.json)"
+if git -C "$DATA_DIR" rev-parse --git-dir >/dev/null 2>&1; then
+  # --ignored is REQUIRED: head-digest.json in the #132 shape is only-ignored (an
+  # allowlist .gitignore keeps it out of history), and plain `git status --porcelain`
+  # shows nothing for an ignored path even when named explicitly — so the warning
+  # would be dead in exactly the drift case it documents. With --ignored it fires for
+  # both tracked-modified (` M`) and ignored-present (`!!`) states.
+  DIGEST_DIRTY="$(git -C "$DATA_DIR" status --porcelain --ignored -- head-digest.json)"
   if [[ -n "$DIGEST_DIRTY" ]]; then
     echo "[$STAMP] WARNING: head-digest.json uncaptured after ingest (forensic breadcrumb lagging, not fatal):"
     echo "$DIGEST_DIRTY"

--- a/ops/price-feed/run-daily-fetch.sh
+++ b/ops/price-feed/run-daily-fetch.sh
@@ -130,4 +130,31 @@ else
   fi
 fi
 
+# 4) Post-check: assert the durable log actually landed. The 17-day silent miss
+#    (the in-process capture skipping every run, issue #132) was invisible because a
+#    launchd job's stderr goes to an UNREAD log — a "loud warning" reaches no one;
+#    only a FAILED job reaches the operator. So after the in-process capture AND the
+#    step-3 backstop have both run, verify the data-dir working tree is clean and
+#    turn the job RED if it is not. Split by ADR stance: the event log is the
+#    source-of-truth (STRICT — dirty ⇒ non-zero exit), head-digest.json is a forensic
+#    breadcrumb (LENIENT — warn only). Paths are relative to $DATA_DIR, which is the
+#    accumulus `data/` subdir holding the durable files directly.
+if [[ -n "$DATA_DIR" ]] && git -C "$DATA_DIR" rev-parse --git-dir >/dev/null 2>&1; then
+  DIGEST_DIRTY="$(git -C "$DATA_DIR" status --porcelain -- head-digest.json)"
+  if [[ -n "$DIGEST_DIRTY" ]]; then
+    echo "[$STAMP] WARNING: head-digest.json uncaptured after ingest (forensic breadcrumb lagging, not fatal):"
+    echo "$DIGEST_DIRTY"
+  fi
+  LOG_DIRTY="$(git -C "$DATA_DIR" status --porcelain -- events.jsonl genesis.json preferences.jsonl)"
+  if [[ -n "$LOG_DIRTY" ]]; then
+    echo "[$STAMP] FATAL: durable LOG uncaptured after ingest + backstop — real fund data at risk:"
+    echo "$LOG_DIRTY"
+    echo "[$STAMP] The source-of-truth log is dirty/uncommitted in $DATA_DIR. Investigate the"
+    echo "[$STAMP] in-process capture (apps/tui/src/ingest-commit.ts) and the accumulus allowlist"
+    echo "[$STAMP] (.gitignore). See issue #132 and docs/durable-log-ops.md."
+    exit 1
+  fi
+  echo "[$STAMP] post-check OK: durable log committed clean in $DATA_DIR."
+fi
+
 echo "[$STAMP] price-feed daily run complete."


### PR DESCRIPTION
Fixes the silent-failure class behind issue #132: the in-process durable-log capture skipped **every ingest since deploy** because a half-finished `checkpoint.json → head-digest.json` rename left accumulus's allowlist ignoring the real `head-digest.json`, so the single atomic `git add` aborted wholesale on the only-ignored pathspec — dropping the durable event log with it. ~17 days of real marks sat uncommitted, one `git reset --hard` from loss.

## What's in this PR (numisma, code only — no fund data)

- **`ingest-commit.ts` — per-file resilient staging (Q2):** each durable file gets its own `git add`; a file that refuses to stage warns loudly *by name* and is skipped, but the rest — the log above all — still commit. Keeps the allowlist-only guard (never `git add -A`).
- **`run-daily-fetch.sh` — post-check (Q3):** after `pnpm spine` + the step-3 backstop, assert the data-dir tree is clean. **Strict on the log** (dirty ⇒ non-zero exit ⇒ launchd shows a red job — the miss can never again be an unread stderr warning); **lenient on `head-digest.json`** (forensic breadcrumb: warn, don't fail).
- **Regression tests (Q4):** two cases over inline allowlist repos mirroring accumulus's strategy (decoupled — no read of the sibling repo). One locks the fixed state (head-digest lands); one reproduces the outage (head-digest only-ignored) and asserts the log still commits — **verified to go red on the old atomic-add code**.
- **Docs:** step-4 post-check documented in `docs/price-feed-ops.md`.

## Companion fix (accumulus data repo — the correctness gate, Q1)

Committed separately in `~/Dev/accumulus` (`70e8a26`), **not yet pushed** — carries no fund data into numisma:
- `.gitignore`: add `!/data/head-digest.json`, drop the stale `!/data/checkpoint.json`.
- `git rm --cached data/checkpoint.json` + remove the fossil from disk. `git ls-files data/` now reads exactly the four durable files.

## Verification

- Full suite green: **554 passed / 11 skipped**.
- New regression test confirmed **red on the old atomic-add code**, green with per-file staging.
- Q5 (shell backstop) kept as defense-in-depth; unchanged.

## Reliability review

Requested on this PR — focus on the silent-failure class (unattended job, unread stderr) and the "never lose the log" contract.

Closes #132