### PR TITLE
Pushes the real folded fund composition, not a fixture

### DIFF
--- a/apps/tui/README.md
+++ b/apps/tui/README.md
@@ -25,10 +25,15 @@ under Node while the terminal glue stays isolated in a Bun-only layer.
 - `review-file.ts` — fund-review path resolution and loading
   (`review-file.test.ts`). Kept for the fold↔snapshot parity check; no longer on
   the `pnpm dev` / `pnpm report` path, which read the event store.
-- `event-store.ts` — the durable event-store IO: path resolution, genesis load,
-  log load with quarantine, the validated ingest boundary (dedup / atomic append
-  / archive), and `loadFoldedReview`. The reliability core
-  (`event-store.test.ts`).
+- `event-store.ts` — the write/ingest half of the durable event-store IO: the
+  validated ingest boundary (dedup / atomic append / archive), legacy-log
+  migration, inbox archival, magnitude-threshold env plumbing, and
+  `parseAsOfArg`. The read path — path resolution, genesis load, log load with
+  quarantine, and `loadFoldedReview` — was lifted out into
+  [`@numisma/event-store`](../../packages/event-store) so `apps/web`'s push can
+  fold the durable log without depending on the TUI. The reliability core
+  (`event-store.test.ts`; the read path's own unit tests live in the package's
+  `event-store.test.ts`).
 - `startup.ts` — `prepareStartup`, the data path that runs before the renderer
   (`--as-of` → ingest → surface report → fold), shared by `app.ts` and the
   openTUI verification harness (`startup.test.ts`).

--- a/apps/tui/package.json
+++ b/apps/tui/package.json
@@ -5,6 +5,7 @@
   "type": "module",
   "dependencies": {
     "@numisma/engine": "workspace:*",
+    "@numisma/event-store": "workspace:*",
     "@opentui/core": "0.2.15"
   },
   "scripts": {

--- a/apps/tui/src/app.ts
+++ b/apps/tui/src/app.ts
@@ -1,5 +1,5 @@
 import { mountApp } from "./mount-app.js";
-import { resolveEventStorePaths } from "./event-store.js";
+import { resolveEventStorePaths } from "@numisma/event-store";
 import { prepareStartup, type StartupPlan } from "./startup.js";
 
 // PROTOTYPE (mvi 2026-06-29-portfolio-persistence): the real TUI surface now

--- a/apps/tui/src/event-store.test.ts
+++ b/apps/tui/src/event-store.test.ts
@@ -9,15 +9,17 @@ import { mkdir, mkdtemp, readdir, readFile, rm, stat, writeFile } from "node:fs/
 import { dirname, resolve } from "node:path";
 import { tmpdir } from "node:os";
 import {
-  ingestInbox,
   loadEventLog,
   loadFoldedReview,
-  migrateLegacyLog,
-  parseMagnitudeThresholdArg,
   quarantineLogPath,
   resolveEventStorePaths,
-  SPINE_MAGNITUDE_THRESHOLD_ENV,
   type EventStorePaths,
+} from "@numisma/event-store";
+import {
+  ingestInbox,
+  migrateLegacyLog,
+  parseMagnitudeThresholdArg,
+  SPINE_MAGNITUDE_THRESHOLD_ENV,
 } from "./event-store.js";
 import type { SuppliedCashLeg } from "@numisma/engine";
 import { afterEach, describe, expect, it } from "vitest";
@@ -402,48 +404,6 @@ describe("appendEvents — atomic append (temp + rename)", () => {
     }
     // The temp image is renamed away, never left behind.
     expect(await exists(`${paths.log}.tmp`)).toBe(false);
-  });
-});
-
-describe("loadEventLog — log-line quarantine", () => {
-  it("quarantines one corrupt line, loads the rest, and surfaces the bad line", async () => {
-    const good = JSON.stringify(openBtc());
-    const later = JSON.stringify(markAapl(160));
-    const log = `${good}\nthis is not json\n${later}\n`;
-    const paths = await makeStore({ log });
-
-    const { events, quarantined } = await loadEventLog(paths.log);
-
-    expect(events.map((event) => event.id)).toEqual(["open-btc", "mark-aapl"]);
-    expect(quarantined).toHaveLength(1);
-    expect(quarantined[0]).toMatchObject({ lineNumber: 2, line: "this is not json" });
-    // The bad line is durably surfaced to the side lane for the user to fix.
-    const lane = await readFile(quarantineLogPath(paths.log), "utf8");
-    expect(lane).toContain("this is not json");
-  });
-
-  it("fails loud on the fold path when any line is unloadable (never a partial fold)", async () => {
-    // ADR-003 amendment (M1): the fold/ingest read no longer degrades gracefully —
-    // a dropped line would silently skew NAV, so loadFoldedReview refuses to fold a
-    // partial log. The quarantine side lane is still surfaced for diagnostics.
-    const log = `${JSON.stringify(openBtc())}\n{ broken\n`;
-    const paths = await makeStore({ log });
-
-    await expect(loadFoldedReview(paths)).rejects.toThrow(/unloadable line/i);
-
-    // The bad line is still surfaced to the side lane for the operator to fix.
-    const lane = await readFile(quarantineLogPath(paths.log), "utf8");
-    expect(lane).toContain("{ broken");
-  });
-
-  it("self-heals: a clean log removes a stale quarantine lane", async () => {
-    const paths = await makeStore({ log: `${JSON.stringify(openBtc())}\n` });
-    await writeFile(quarantineLogPath(paths.log), "stale\n", "utf8");
-
-    const { quarantined } = await loadEventLog(paths.log);
-
-    expect(quarantined).toHaveLength(0);
-    expect(await exists(quarantineLogPath(paths.log))).toBe(false);
   });
 });
 

--- a/apps/tui/src/event-store.ts
+++ b/apps/tui/src/event-store.ts
@@ -1,8 +1,11 @@
 /**
- * PROTOTYPE (mvi 2026-06-29-portfolio-persistence). Access-surface half of the
- * event-sourcing spine — the file IO, inbox detection, dedup persistence, and
- * startup orchestration that ADR-001 keeps OUT of `@numisma/engine`. The pure
- * fold + event validation live in the engine (`foldEvents` / `parseEvent`).
+ * PROTOTYPE (mvi 2026-06-29-portfolio-persistence). WRITE half of the
+ * event-sourcing spine — the inbox ingest, dedup persistence, atomic append,
+ * archival, the one-shot legacy migration, and the argv/env operator knobs that
+ * ADR-001 keeps OUT of `@numisma/engine`. The pure fold + event validation live in
+ * the engine (`foldEvents` / `parseEvent`); the durable log's READ path (path
+ * resolution, genesis load, log load, quarantine, the folded review) lives in
+ * `@numisma/event-store`, shared with the web push, and is imported back here.
  *
  * Durable truth on disk:
  *   - data/genesis.json          immutable t0 seed (a FundReviewData shape)
@@ -14,13 +17,13 @@
  * DURABILITY (reliable conversion, ADR-003 slice 3):
  *   - Archives are stamped with the wall-clock ingest moment and refuse to clobber
  *     a prior archive; a zero-new re-drop archives nothing.
- *   - A corrupt log line is quarantined to a side lane and surfaced; the rest of
- *     the log still loads and startup proceeds.
+ *   - A corrupt log line is quarantined to a side lane and surfaced; the read path
+ *     then refuses to fold a partial log.
  *   - Append is atomic (write a full next image to a sibling temp file, then
  *     rename over the log) so an interrupted write cannot truncate a line.
  */
-import { mkdir, readFile, rename, rm, stat, writeFile } from "node:fs/promises";
-import { dirname, join, resolve } from "node:path";
+import { mkdir, rename, stat, writeFile } from "node:fs/promises";
+import { dirname, join } from "node:path";
 import { captureIngestCommit, readAppVersion, resolveWorkspaceRoot } from "./ingest-commit.js";
 import {
   applyEventToReference,
@@ -30,64 +33,21 @@ import {
   foldEvents,
   migrateLegacyEvent,
   parseEvent,
-  parseFundReview,
-  resolveDataDir,
-  type FundReviewData,
   type PortfolioEvent,
   type SuppliedCashLeg,
 } from "@numisma/engine";
-
-export interface EventStorePaths {
-  genesis: string;
-  log: string;
-  inbox: string;
-  ingestedDir: string;
-}
+import {
+  assertLogFullyLoaded,
+  loadEventLog,
+  loadGenesis,
+  readOptional,
+  type EventStorePaths,
+} from "@numisma/event-store";
 
 export interface IngestReport {
   newCount: number;
   duplicateCount: number;
   archivedTo?: string;
-}
-
-/** A log line that failed to parse, diverted to the quarantine lane on read. */
-export interface QuarantinedLine {
-  lineNumber: number;
-  line: string;
-  reason: string;
-}
-
-/** The result of reading the append-only log: the good events plus any corrupt
- * lines that were quarantined rather than aborting the load. */
-export interface EventLogLoad {
-  events: PortfolioEvent[];
-  quarantined: QuarantinedLine[];
-}
-
-/**
- * Resolve the default dataDir root honoring the `NUMISMA_DATA_DIR` env var — the
- * SINGLE knob that moves EVERY plane. The resolution rule (env override with an
- * absolute, homedir-derived accumulus default; relative values rejected) is the
- * pure engine `resolveDataDir`; this thin wrapper keeps the public name the tui
- * callers already use.
- */
-export function resolveDataDirDefault(): string {
-  return resolveDataDir();
-}
-
-/** The quarantine lane sits beside the log it shadows. */
-export function quarantineLogPath(logPath: string): string {
-  return `${logPath}.quarantine`;
-}
-
-export function resolveEventStorePaths(dataDir = resolveDataDirDefault()): EventStorePaths {
-  const base = resolve(dataDir);
-  return {
-    genesis: join(base, "genesis.json"),
-    log: join(base, "events.jsonl"),
-    inbox: join(base, "inbox", "transactions.json"),
-    ingestedDir: join(base, "ingested"),
-  };
 }
 
 /**
@@ -172,107 +132,6 @@ function magnitudeThresholdSource(
     return { value: fromEnv, origin: SPINE_MAGNITUDE_THRESHOLD_ENV };
   }
   return undefined;
-}
-
-/** Read and structurally validate the immutable genesis seed. */
-export async function loadGenesis(genesisPath: string): Promise<FundReviewData> {
-  const raw = await readFile(genesisPath, "utf8");
-  const parsed = parseFundReview(raw);
-  if (parsed.kind !== "ok") {
-    throw new Error(`Genesis seed failed validation (${parsed.kind}) at ${genesisPath}.`);
-  }
-  return parsed.value;
-}
-
-/**
- * Read the append-only log, validating each line into a typed event. A line that
- * fails to parse is diverted to the quarantine lane (returned, and surfaced to a
- * durable `events.jsonl.quarantine` sidecar) instead of aborting the load, so a
- * single corrupt line degrades gracefully rather than bricking startup. The rest
- * of the log still loads. The log file itself is never mutated on read.
- */
-export async function loadEventLog(logPath: string): Promise<EventLogLoad> {
-  const raw = await readOptional(logPath);
-  const events: PortfolioEvent[] = [];
-  const quarantined: QuarantinedLine[] = [];
-  if (raw !== undefined) {
-    for (const [index, line] of raw.split("\n").entries()) {
-      const trimmed = line.trim();
-      if (!trimmed) {
-        continue;
-      }
-      const parsed = parseLogLine(trimmed);
-      if (parsed.ok) {
-        events.push(parsed.event);
-      } else {
-        quarantined.push({ lineNumber: index + 1, line: trimmed, reason: parsed.reason });
-      }
-    }
-  }
-  await surfaceQuarantine(logPath, quarantined);
-  return { events, quarantined };
-}
-
-/**
- * Fail loud when the durable log holds any line that would not load. A dropped
- * material event (a legacy-shape open/close, or any unparseable line) silently
- * skews the fold — a plausible-but-wrong NAV, the exact drift class this MVI
- * eliminates — so the fold/ingest paths refuse to run on a partial log rather than
- * degrade gracefully. The quarantine sidecar has already been written by
- * {@link loadEventLog}, so the operator can see every offending line and reason; a
- * legacy open/close is additionally pointed at the one-shot migration. This is the
- * ADR-003 amendment's migration/versioning contract enforced at the read boundary
- * (it reverses the prototype's "a corrupt line degrades gracefully" behavior).
- * `foldEvents` itself stays a pure projection — the loud stop lives here, not in the
- * fold.
- */
-function assertLogFullyLoaded(load: EventLogLoad, logPath: string): void {
-  if (load.quarantined.length === 0) {
-    return;
-  }
-  const detail = load.quarantined
-    .map((entry) => `  line ${entry.lineNumber}: ${entry.reason}`)
-    .join("\n");
-  throw new Error(
-    `Durable log ${logPath} has ${load.quarantined.length} unloadable line(s); refusing to ` +
-      `fold a partial log (it would silently skew NAV). Fix or migrate them, then retry. ` +
-      `Details also written to ${quarantineLogPath(logPath)}:\n${detail}`,
-  );
-}
-
-type ParsedLine =
-  | { ok: true; event: PortfolioEvent }
-  | { ok: false; reason: string };
-
-function parseLogLine(line: string): ParsedLine {
-  let json: unknown;
-  try {
-    json = JSON.parse(line);
-  } catch {
-    return { ok: false, reason: "not valid JSON" };
-  }
-  const result = parseEvent(json);
-  if (result.kind !== "ok") {
-    return { ok: false, reason: `${result.path}: ${result.message}` };
-  }
-  return { ok: true, event: result.value };
-}
-
-/**
- * Write the corrupt lines to the quarantine lane (one JSON record per line) so the
- * bad input is durably surfaced for the user to fix; remove a stale lane when the
- * log reads clean, so a fixed log self-heals. Idempotent: the lane reflects exactly
- * the current read, so repeated reads in one startup converge on the same content.
- */
-async function surfaceQuarantine(logPath: string, quarantined: QuarantinedLine[]): Promise<void> {
-  const lanePath = quarantineLogPath(logPath);
-  if (quarantined.length === 0) {
-    await rm(lanePath, { force: true });
-    return;
-  }
-  await mkdir(dirname(logPath), { recursive: true });
-  const body = `${quarantined.map((entry) => JSON.stringify(entry)).join("\n")}\n`;
-  await writeFile(lanePath, body, "utf8");
 }
 
 /**
@@ -389,17 +248,6 @@ export async function ingestInbox(
   const archivedTo = await archiveInbox(paths, now());
 
   return { newCount: toAppend.length, duplicateCount, archivedTo };
-}
-
-/** Ingest, then fold genesis + log to `asOf` (or current state) for rendering. */
-export async function loadFoldedReview(
-  paths: EventStorePaths,
-  asOf?: string,
-): Promise<FundReviewData> {
-  const genesis = await loadGenesis(paths.genesis);
-  const load = await loadEventLog(paths.log);
-  assertLogFullyLoaded(load, paths.log);
-  return foldEvents(genesis, load.events, asOf);
 }
 
 export interface MigrationReport {
@@ -581,16 +429,5 @@ async function pathExists(filePath: string): Promise<boolean> {
     return true;
   } catch {
     return false;
-  }
-}
-
-async function readOptional(filePath: string): Promise<string | undefined> {
-  try {
-    return await readFile(filePath, "utf8");
-  } catch (error) {
-    if (error instanceof Error && "code" in error && error.code === "ENOENT") {
-      return undefined;
-    }
-    throw error;
   }
 }

--- a/apps/tui/src/ingest-capture-wiring.test.ts
+++ b/apps/tui/src/ingest-capture-wiring.test.ts
@@ -10,7 +10,8 @@ import { tmpdir } from "node:os";
 import { resolve } from "node:path";
 import { formatIngestCommitMessage } from "@numisma/engine";
 import { afterEach, describe, expect, it, vi } from "vitest";
-import { ingestInbox, resolveEventStorePaths } from "./event-store.js";
+import { resolveEventStorePaths } from "@numisma/event-store";
+import { ingestInbox } from "./event-store.js";
 import { GENESIS, git, initGitRepo, MARK } from "./ingest-commit.fixtures.js";
 
 // Each case spawns several real `git` children (plus a workspace-version read); under

--- a/apps/tui/src/migrate-legacy-log.ts
+++ b/apps/tui/src/migrate-legacy-log.ts
@@ -23,7 +23,8 @@
  */
 import { readFile } from "node:fs/promises";
 import type { SuppliedCashLeg } from "@numisma/engine";
-import { migrateLegacyLog, resolveEventStorePaths } from "./event-store.js";
+import { resolveEventStorePaths } from "@numisma/event-store";
+import { migrateLegacyLog } from "./event-store.js";
 
 const MAPPING_PATH = "data/migration-cash-legs.json";
 

--- a/apps/tui/src/position-added-to-reliable.test.ts
+++ b/apps/tui/src/position-added-to-reliable.test.ts
@@ -21,12 +21,12 @@ import { resolve } from "node:path";
 import { tmpdir } from "node:os";
 import { buildCompositionReport } from "@numisma/engine";
 import {
-  ingestInbox,
   loadEventLog,
   loadFoldedReview,
   resolveEventStorePaths,
   type EventStorePaths,
-} from "./event-store.js";
+} from "@numisma/event-store";
+import { ingestInbox } from "./event-store.js";
 import { afterEach, describe, expect, it } from "vitest";
 
 const GENESIS_AS_OF = "2026-06-01";

--- a/apps/tui/src/position-trimmed-reliable.test.ts
+++ b/apps/tui/src/position-trimmed-reliable.test.ts
@@ -12,12 +12,12 @@ import { mkdir, mkdtemp, readFile, rm, stat, writeFile } from "node:fs/promises"
 import { resolve } from "node:path";
 import { tmpdir } from "node:os";
 import {
-  ingestInbox,
   loadEventLog,
   loadFoldedReview,
   resolveEventStorePaths,
   type EventStorePaths,
-} from "./event-store.js";
+} from "@numisma/event-store";
+import { ingestInbox } from "./event-store.js";
 import { buildCompositionReport } from "@numisma/engine";
 import { afterEach, describe, expect, it } from "vitest";
 

--- a/apps/tui/src/report-fold.test.ts
+++ b/apps/tui/src/report-fold.test.ts
@@ -14,7 +14,8 @@ import { mkdir, mkdtemp, rm, writeFile } from "node:fs/promises";
 import { resolve } from "node:path";
 import { tmpdir } from "node:os";
 import { buildCompositionReport, formatCompositionReport } from "@numisma/engine";
-import { ingestInbox, loadFoldedReview, resolveEventStorePaths } from "./event-store.js";
+import { loadFoldedReview, resolveEventStorePaths } from "@numisma/event-store";
+import { ingestInbox } from "./event-store.js";
 import { loadFundReview } from "./review-file.js";
 import { afterEach, describe, expect, it } from "vitest";
 

--- a/apps/tui/src/report.ts
+++ b/apps/tui/src/report.ts
@@ -2,11 +2,8 @@ import {
   buildCompositionReport,
   formatCompositionReport,
 } from "@numisma/engine";
-import {
-  loadFoldedReview,
-  parseAsOfArg,
-  resolveEventStorePaths,
-} from "./event-store.js";
+import { loadFoldedReview, resolveEventStorePaths } from "@numisma/event-store";
+import { parseAsOfArg } from "./event-store.js";
 
 // Single source of truth (ADR-003 slice 4): `pnpm report` renders the FOLD over
 // the durable genesis + event log, the same read model `pnpm dev` (app.ts) and the

--- a/apps/tui/src/smoke-startup-openTui.ts
+++ b/apps/tui/src/smoke-startup-openTui.ts
@@ -27,7 +27,7 @@ import {
   loadFoldedReview,
   resolveEventStorePaths,
   type EventStorePaths,
-} from "./event-store.js"
+} from "@numisma/event-store"
 import { prepareStartup } from "./startup.js"
 
 const FIXED_NOW = "2026-06-29T14:03:22.000Z"

--- a/apps/tui/src/spine-reset.ts
+++ b/apps/tui/src/spine-reset.ts
@@ -22,7 +22,7 @@
 import { readdir, rename, rm, stat } from "node:fs/promises";
 import { join, resolve } from "node:path";
 import { resolveDataDir } from "@numisma/engine";
-import { resolveDataDirDefault, resolveEventStorePaths } from "./event-store.js";
+import { resolveDataDirDefault, resolveEventStorePaths } from "@numisma/event-store";
 
 const dataDir = resolveDataDirDefault();
 // The accumulus default, ignoring any env override: `resolveDataDir` with an empty

--- a/apps/tui/src/spine.ts
+++ b/apps/tui/src/spine.ts
@@ -18,13 +18,8 @@
  * never silent; a malformed value fails loud before anything is ingested.
  */
 import { buildCompositionReport, formatCompositionReport } from "@numisma/engine";
-import {
-  ingestInbox,
-  loadFoldedReview,
-  parseAsOfArg,
-  parseMagnitudeThresholdArg,
-  resolveEventStorePaths,
-} from "./event-store.js";
+import { loadFoldedReview, resolveEventStorePaths } from "@numisma/event-store";
+import { ingestInbox, parseAsOfArg, parseMagnitudeThresholdArg } from "./event-store.js";
 
 try {
   const paths = resolveEventStorePaths();

--- a/apps/tui/src/startup.test.ts
+++ b/apps/tui/src/startup.test.ts
@@ -7,7 +7,7 @@
 import { mkdir, mkdtemp, rm, writeFile } from "node:fs/promises";
 import { resolve } from "node:path";
 import { tmpdir } from "node:os";
-import { resolveEventStorePaths, type EventStorePaths } from "./event-store.js";
+import { resolveEventStorePaths, type EventStorePaths } from "@numisma/event-store";
 import { formatIngestReport, prepareStartup } from "./startup.js";
 import { afterEach, describe, expect, it } from "vitest";
 

--- a/apps/tui/src/startup.ts
+++ b/apps/tui/src/startup.ts
@@ -7,17 +7,13 @@
  * fold loader + source label the renderer mounts.
  *
  * Per ADR-001 this is access-surface orchestration over `@numisma/engine`: the
- * fold and event validation stay in the engine; the IO (`ingestInbox`,
- * `loadFoldedReview`) stays in `event-store.ts`; this only sequences them.
+ * fold and event validation stay in the engine; the write IO (`ingestInbox`)
+ * stays in `event-store.ts` and the read IO (`loadFoldedReview`) in
+ * `@numisma/event-store`; this only sequences them.
  */
 import type { FundReviewData } from "@numisma/engine";
-import {
-  ingestInbox,
-  loadFoldedReview,
-  parseAsOfArg,
-  type EventStorePaths,
-  type IngestReport,
-} from "./event-store.js";
+import { loadFoldedReview, type EventStorePaths } from "@numisma/event-store";
+import { ingestInbox, parseAsOfArg, type IngestReport } from "./event-store.js";
 
 /** What the renderer needs after the startup data path runs. */
 export interface StartupPlan {

--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -19,6 +19,7 @@
   },
   "dependencies": {
     "@numisma/engine": "workspace:*",
+    "@numisma/event-store": "workspace:*",
     "@tanstack/react-query": "5.101.2",
     "@tanstack/react-router": "1.170.17",
     "@tanstack/react-start": "1.168.27",

--- a/apps/web/src/event-store-import-guard.test.ts
+++ b/apps/web/src/event-store-import-guard.test.ts
@@ -1,0 +1,81 @@
+/**
+ * Blast-radius guard (PRD #134 R4). Slice 2 gave `apps/web` a dependency on
+ * `@numisma/event-store` — the read path over the PRIVATE durable log, the whole
+ * event history, everything the fund ever did. The push needs it; nothing else in
+ * the web app does. Today's other tests guard the *payload* (`toProjectionReport`
+ * narrows to `{ totals, dashboard }`, and the client-bundle test scans the built
+ * browser assets), but nothing would stop a route or a render surface importing
+ * the log reader directly and shipping the full event log to a browser.
+ *
+ * So: no source file in `apps/web` outside `apps/web/src/push/` may import
+ * `@numisma/event-store`. The precedent is the client-bundle credential-literal
+ * guard (`client-bundle.integration.test.ts`) — same shape of structural
+ * assertion. UNLIKE that one, this reads the SOURCE TREE rather than a build
+ * output, so it needs no build and MUST NOT self-skip: it runs on every
+ * `pnpm test`, on every machine.
+ */
+import { readFileSync, readdirSync } from "node:fs";
+import { fileURLToPath } from "node:url";
+import { dirname, join, relative, resolve, sep } from "node:path";
+import { describe, expect, it } from "vitest";
+
+const HERE = dirname(fileURLToPath(import.meta.url));
+/** The web app's source root — this file lives at its top level. */
+const SRC_DIR = resolve(HERE);
+/** The ONE directory allowed to read the durable log. */
+const ALLOWED_DIR = join(SRC_DIR, "push");
+
+const PACKAGE = "@numisma/event-store";
+const SOURCE_EXTENSIONS = [".ts", ".tsx", ".js", ".jsx", ".mts", ".cts"];
+
+/** Every file under `dir`, recursively (skipping build/dependency output). */
+function walk(dir: string): string[] {
+  return readdirSync(dir, { withFileTypes: true }).flatMap((entry) => {
+    if (entry.name === "node_modules" || entry.name.startsWith(".")) return [];
+    const full = join(dir, entry.name);
+    return entry.isDirectory() ? walk(full) : [full];
+  });
+}
+
+function sourceFiles(dir: string): string[] {
+  return walk(dir).filter((file) =>
+    SOURCE_EXTENSIONS.some((ext) => file.endsWith(ext)),
+  );
+}
+
+/**
+ * Does this file name the package in an IMPORT POSITION? Matched by syntax
+ * (`from "…"`, `import "…"`, `import("…")`, `require("…")`) rather than by bare
+ * substring, so a file that merely mentions the name in prose or in a constant —
+ * this guard itself, for one — is not a false positive.
+ */
+const IMPORT_RE = new RegExp(
+  `(?:\\bfrom|\\bimport|\\brequire\\s*\\(|\\bimport\\s*\\()\\s*["']${PACKAGE.replace("/", "\\/")}["']`,
+);
+
+function importsEventStore(file: string): boolean {
+  return IMPORT_RE.test(readFileSync(file, "utf-8"));
+}
+
+describe("blast radius: @numisma/event-store is confined to the push path", () => {
+  it("no apps/web source file outside src/push/ imports the durable-log reader", () => {
+    const offenders = sourceFiles(SRC_DIR)
+      .filter((file) => !file.startsWith(`${ALLOWED_DIR}${sep}`))
+      .filter(importsEventStore)
+      .map((file) => relative(SRC_DIR, file));
+
+    expect(
+      offenders,
+      `These files import ${PACKAGE} outside src/push/, which would put the entire ` +
+        `private event log within reach of a render surface:\n${offenders.join("\n")}`,
+    ).toEqual([]);
+  });
+
+  it("guards a tree where the import actually occurs (assertion has teeth)", () => {
+    // Guard against a false pass: if the push path stopped importing the reader
+    // (or the scan stopped matching import syntax), the check above would pass
+    // vacuously while proving nothing.
+    const importers = sourceFiles(ALLOWED_DIR).filter(importsEventStore);
+    expect(importers.length).toBeGreaterThan(0);
+  });
+});

--- a/apps/web/src/push/projection-payload.test.ts
+++ b/apps/web/src/push/projection-payload.test.ts
@@ -29,7 +29,8 @@
  */
 import { describe, expect, it } from "vitest";
 import type { CompositionReport } from "@numisma/engine";
-import { deriveSnapshot, loadFixture } from "./push-core.ts";
+import { deriveSnapshot } from "./push-core.ts";
+import { loadFixture } from "./push-core.fixtures.ts";
 import { toProjectionReport } from "../projection/contract.ts";
 
 /**
@@ -190,7 +191,7 @@ describe("D8 forbidden-key contract (what may not reach the cloud)", () => {
     ]);
   });
 
-  it("narrows the shipped fixture the same way (the real push input)", async () => {
+  it("narrows the shipped fixture the same way (a wide real-shaped report)", async () => {
     const fixture = await loadFixture();
     expect(Object.keys(toProjectionReport(fixture)).sort()).toEqual([
       "dashboard",

--- a/apps/web/src/push/push-core.fixtures.ts
+++ b/apps/web/src/push/push-core.fixtures.ts
@@ -1,0 +1,116 @@
+/**
+ * Test-only fixtures for the push path (the repo's `.fixtures.ts` convention —
+ * cf. `apps/tui/src/ingest-commit.fixtures.ts`; already coverage-excluded).
+ *
+ * Two things live here, and neither is reachable from the push command:
+ *
+ *  - `FIXTURE_PATH` / `loadFixture` — the committed `composition-report.fixture.json`
+ *    the push shell USED to publish. It moved out of `push-core.ts` when the push
+ *    started folding the real durable log (PRD #134 slice 2): after that slice the
+ *    command can only push real data, with no flag, env toggle, or fallback back to
+ *    the fixture. The JSON stays committed and is what it always should have been —
+ *    a *test* fixture, loaded directly by the unit and integration tests.
+ *  - `makeTempStore` — builds a throwaway data dir (genesis seed + an events.jsonl
+ *    of the caller's choosing) so the real-fold tests can exercise
+ *    `loadCurrentReport` over an actual log without touching the operator's store.
+ */
+import { mkdtemp, readFile, writeFile } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { fileURLToPath } from "node:url";
+import { dirname, resolve } from "node:path";
+import type { CompositionReport } from "@numisma/engine";
+import {
+  resolveEventStorePaths,
+  type EventStorePaths,
+} from "@numisma/event-store";
+
+const HERE = dirname(fileURLToPath(import.meta.url));
+
+/** Absolute path to the committed fixture CompositionReport (TEST INPUT ONLY). */
+export const FIXTURE_PATH = resolve(
+  HERE,
+  "../../fixtures/composition-report.fixture.json",
+);
+
+/** Load and parse the fixture CompositionReport from disk (TEST INPUT ONLY). */
+export async function loadFixture(): Promise<CompositionReport> {
+  const raw = await readFile(FIXTURE_PATH, "utf-8");
+  return JSON.parse(raw) as CompositionReport;
+}
+
+/** The genesis seed's t0 date — every temp-store fold starts here. */
+export const TEMP_GENESIS_AS_OF = "2026-06-01";
+
+/** The fund name the temp genesis seed carries (slugged into the row's fund_id). */
+export const TEMP_FUND_NAME = "Accumulus";
+
+/** A small, legible genesis seed: one live position, one reserve, two instruments. */
+export function tempGenesisSeed(): unknown {
+  return {
+    fund: { id: "fund-1", name: TEMP_FUND_NAME, baseCurrency: "USD" },
+    review: { asOf: TEMP_GENESIS_AS_OF, usdMxn: 20 },
+    portfolios: [{ id: "core", name: "Core" }],
+    accounts: [
+      { id: "xtb-usd", name: "Main Broker", platform: "XTB", currency: "USD" },
+    ],
+    instruments: [
+      { id: "aapl-usd", name: "Apple Inc.", symbol: "AAPL", currency: "USD" },
+      { id: "btc-usd", name: "Bitcoin", symbol: "BTC", currency: "USD" },
+    ],
+    reserves: [
+      {
+        id: "cash-core",
+        portfolioId: "core",
+        tempo: "Reserve",
+        executionMode: "live",
+        accountId: "xtb-usd",
+        currency: "USD",
+        amount: 1000,
+      },
+    ],
+    positions: [
+      {
+        id: "aapl-core",
+        portfolioId: "core",
+        tempo: "Capital",
+        executionMode: "live",
+        accountId: "xtb-usd",
+        instrumentId: "aapl-usd",
+        direction: "long",
+        markPrice: 150,
+        currency: "USD",
+        lots: [{ quantity: 2, cost: 100, tier: "c1" }],
+      },
+    ],
+  };
+}
+
+/** A `PriceMarked` event line for the genesis AAPL position, dated `asOf`. */
+export function priceMarkedLine(
+  id: string,
+  asOf: string,
+  price: number,
+): string {
+  return JSON.stringify({
+    id,
+    asOf,
+    type: "PriceMarked",
+    instrumentId: "aapl-usd",
+    price,
+  });
+}
+
+/**
+ * Create a throwaway data dir holding the genesis seed plus `log` as
+ * `events.jsonl`. Returns the resolved paths AND the dir, so a caller can point
+ * `NUMISMA_DATA_DIR` at it and clean it up afterwards.
+ */
+export async function makeTempStore(
+  log: string,
+): Promise<{ dir: string; paths: EventStorePaths }> {
+  const dir = await mkdtemp(resolve(tmpdir(), "numisma-push-"));
+  const paths = resolveEventStorePaths(dir);
+  await writeFile(paths.genesis, JSON.stringify(tempGenesisSeed()), "utf8");
+  await writeFile(paths.log, log, "utf8");
+  return { dir, paths };
+}

--- a/apps/web/src/push/push-core.integration.test.ts
+++ b/apps/web/src/push/push-core.integration.test.ts
@@ -10,6 +10,7 @@
  * `pnpm test` still passes on machines without Postgres. To actually run it:
  *   NUMISMA_TEST_DATABASE_URL=postgres://amet@localhost:5432/numisma pnpm test
  */
+import { rm } from "node:fs/promises";
 import { afterAll, beforeAll, describe, expect, it } from "vitest";
 import type { Pool } from "pg";
 import type { CompositionReport } from "@numisma/engine";
@@ -20,7 +21,16 @@ import {
   TEST_DATABASE_URL_ENV,
   type ThrowawayDb,
 } from "../projection/pg-substrate.testkit.ts";
-import { deriveSnapshot, loadFixture, upsertSnapshot } from "./push-core.ts";
+import {
+  deriveSnapshot,
+  loadCurrentReport,
+  upsertSnapshot,
+} from "./push-core.ts";
+import {
+  loadFixture,
+  makeTempStore,
+  priceMarkedLine,
+} from "./push-core.fixtures.ts";
 
 const runIntegration = hasTestDatabase();
 if (!runIntegration) {
@@ -150,3 +160,83 @@ describe.skipIf(!runIntegration)(
     });
   },
 );
+
+/**
+ * The REAL-FOLD push, proven at the database (PRD #134 slice 2). The block above
+ * pushes the committed fixture; this one folds a throwaway durable log through
+ * `loadCurrentReport` — the exact source the `push` command now uses — and
+ * asserts the two properties the fixture block never did:
+ *
+ *  - R4: the pushed `report` JSONB carries EXACTLY `totals` and `dashboard`. The
+ *    payload's WIDTH, asserted on the stored row rather than on the derivation,
+ *    so the narrowing is proven where it matters — in the cloud.
+ *  - R3: a second push over the SAME unchanged log leaves exactly one row with an
+ *    identical payload; only `pushed_at` moves.
+ */
+describe.skipIf(!runIntegration)("real-fold push (folds the durable log)", () => {
+  let db: ThrowawayDb;
+  let writerPool: Pool;
+  let tempDir: string;
+  const savedDataDir = process.env.NUMISMA_DATA_DIR;
+
+  beforeAll(async () => {
+    db = await createThrowawayDb();
+    const writer = await db.createLoginRole("writer");
+    const reader = await db.createLoginRole("reader");
+    await provisionProjection(db.adminPool, {
+      writerRole: writer.role,
+      readerRole: reader.role,
+    });
+    writerPool = writer.pool();
+
+    const store = await makeTempStore(
+      `${priceMarkedLine("mark-1", "2026-06-05", 160)}\n` +
+        `${priceMarkedLine("mark-2", "2026-06-09", 175)}\n`,
+    );
+    tempDir = store.dir;
+    process.env.NUMISMA_DATA_DIR = store.dir;
+  }, 60_000);
+
+  afterAll(async () => {
+    if (savedDataDir === undefined) {
+      delete process.env.NUMISMA_DATA_DIR;
+    } else {
+      process.env.NUMISMA_DATA_DIR = savedDataDir;
+    }
+    await rm(tempDir, { recursive: true, force: true });
+    await db?.drop();
+  });
+
+  it("R4: the pushed report JSONB carries exactly `totals` and `dashboard`", async () => {
+    const report = await loadCurrentReport();
+    // Sanity: the fold really ran — asOf is the LATER event's date, not genesis.
+    expect(report.dashboard.summary.asOf).toBe("2026-06-09");
+    // And the wide report carries more than the payload is allowed to.
+    expect(Object.keys(report).length).toBeGreaterThan(2);
+
+    const { fundId, asOf } = await upsertSnapshot(writerPool, report);
+    expect(asOf).toBe("2026-06-09");
+
+    const stored = await readRow(writerPool, fundId, asOf);
+    expect(Object.keys(stored.report).sort()).toEqual(["dashboard", "totals"]);
+  });
+
+  it("R3: a second push over the unchanged log — one row, same payload, later pushed_at", async () => {
+    const first = await loadCurrentReport();
+    const { fundId, asOf } = await upsertSnapshot(writerPool, first);
+    expect(await rowCount(writerPool)).toBe(1);
+    const before = await readRow(writerPool, fundId, asOf);
+
+    await new Promise((r) => setTimeout(r, 25));
+
+    // Fold the SAME log again (no new events) and push again.
+    const second = await loadCurrentReport();
+    await upsertSnapshot(writerPool, second);
+
+    expect(await rowCount(writerPool)).toBe(1);
+    const after = await readRow(writerPool, fundId, asOf);
+    expect(after.as_of).toBe(before.as_of);
+    expect(after.report).toEqual(before.report);
+    expect(after.pushed_at.getTime()).toBeGreaterThan(before.pushed_at.getTime());
+  });
+});

--- a/apps/web/src/push/push-core.test.ts
+++ b/apps/web/src/push/push-core.test.ts
@@ -3,10 +3,18 @@
  * `schemaVersion`. This is the DB-independent half of the push shell — the upsert
  * path itself is covered by push-core.integration.test.ts against a real pg.
  */
-import { describe, expect, it } from "vitest";
+import { readFile, rm } from "node:fs/promises";
+import { afterEach, describe, expect, it } from "vitest";
 import type { CompositionReport } from "@numisma/engine";
+import { quarantineLogPath } from "@numisma/event-store";
 import { COMPOSITION_SNAPSHOT_SCHEMA_VERSION } from "../projection/contract.ts";
-import { deriveSnapshot, loadFixture } from "./push-core.ts";
+import { deriveSnapshot, loadCurrentReport } from "./push-core.ts";
+import {
+  loadFixture,
+  makeTempStore,
+  priceMarkedLine,
+  TEMP_GENESIS_AS_OF,
+} from "./push-core.fixtures.ts";
 
 /** Minimal report shaped just enough for the derivation under test. */
 function reportWith(fundName: string, asOf: string): CompositionReport {
@@ -40,7 +48,7 @@ describe("deriveSnapshot (pure fixture → derivation)", () => {
   });
 });
 
-describe("loadFixture → deriveSnapshot (the actual push input, no DB)", () => {
+describe("loadFixture → deriveSnapshot (a TEST input, no longer the push input)", () => {
   it("loads the shipped fixture and derives its identity/version", async () => {
     const report = await loadFixture();
     const { fundId, asOf, schemaVersion } = deriveSnapshot(report);
@@ -49,5 +57,81 @@ describe("loadFixture → deriveSnapshot (the actual push input, no DB)", () => 
       asOf: "2026-05-29",
       schemaVersion: COMPOSITION_SNAPSHOT_SCHEMA_VERSION,
     });
+  });
+});
+
+/**
+ * The real fold over a throwaway durable log — the source line this slice
+ * changed. No DB, no network: genesis seed + an events.jsonl on disk, folded to
+ * CURRENT state (loadCurrentReport takes no date argument by decision — an
+ * `--as-of` fold would write a SECOND row keyed to that date and quietly change
+ * what "latest" means to the reader).
+ */
+describe("loadCurrentReport (the real fold of the durable log)", () => {
+  const dirs: string[] = [];
+  const savedDataDir = process.env.NUMISMA_DATA_DIR;
+
+  afterEach(async () => {
+    if (savedDataDir === undefined) {
+      delete process.env.NUMISMA_DATA_DIR;
+    } else {
+      process.env.NUMISMA_DATA_DIR = savedDataDir;
+    }
+    await Promise.all(
+      dirs.splice(0).map((dir) => rm(dir, { recursive: true, force: true })),
+    );
+  });
+
+  async function useStore(log: string): Promise<{ dir: string; log: string }> {
+    const { dir, paths } = await makeTempStore(log);
+    dirs.push(dir);
+    process.env.NUMISMA_DATA_DIR = dir;
+    return { dir, log: paths.log };
+  }
+
+  it("folds genesis + the log to current state: asOf is the LATER event's date", async () => {
+    await useStore(
+      `${priceMarkedLine("mark-1", "2026-06-05", 160)}\n` +
+        `${priceMarkedLine("mark-2", "2026-06-09", 175)}\n`,
+    );
+
+    const report = await loadCurrentReport();
+
+    // The later of the two events wins — not genesis, not the earlier mark.
+    expect(report.dashboard.summary.asOf).toBe("2026-06-09");
+    expect(report.dashboard.summary.asOf).not.toBe(TEMP_GENESIS_AS_OF);
+    // A real fold, not an empty shell: the marked price reached the totals.
+    expect(report.totals.fundValueUsd).toBeGreaterThan(0);
+  });
+
+  it("supplies the same load-provenance block the TUI's report path supplies", async () => {
+    const { log } = await useStore(
+      `${priceMarkedLine("mark-1", "2026-06-05", 160)}\n`,
+    );
+
+    const report = await loadCurrentReport();
+
+    expect(report.load?.status).toBe("loaded");
+    expect(report.load?.sourcePath).toBe(log);
+    expect(typeof report.load?.loadedAt).toBe("string");
+  });
+
+  it("R1/R2: an unparseable log line throws, and the log stays byte-identical", async () => {
+    const body =
+      `${priceMarkedLine("mark-1", "2026-06-05", 160)}\n` +
+      `{ this is not JSON\n`;
+    const { log } = await useStore(body);
+    const before = await readFile(log);
+
+    await expect(loadCurrentReport()).rejects.toThrow(/unloadable line/i);
+
+    // R2: the durable log itself is never written. (The quarantine SIDECAR
+    // beside it is expected — the read path writes it as a consequence of
+    // reading — and is explicitly not a violation.)
+    const after = await readFile(log);
+    expect(after.equals(before)).toBe(true);
+    await expect(readFile(quarantineLogPath(log), "utf8")).resolves.toContain(
+      "not valid JSON",
+    );
   });
 });

--- a/apps/web/src/push/push-core.ts
+++ b/apps/web/src/push/push-core.ts
@@ -1,17 +1,17 @@
 /**
  * Push core (Deliverable C) — the IMPORTABLE, self-exec-free half of the push
  * shell. `push.ts` is a `main().then(..., process.exit)` script: importing it
- * would run it. This module holds the two pieces worth asserting on their own —
- * the pure fixture→derivation and the real upsert SQL — so a unit test can cover
+ * would run it. This module holds the pieces worth asserting on their own — the
+ * real fold of the durable log, the pure derivation and the real upsert SQL — so
+ * a unit test can cover
  * the derivation without a DB and the integration test can drive the EXACT upsert
  * path (`INSERT ... ON CONFLICT (fund_id, as_of) DO UPDATE`) the script runs, not
  * a copy of it. `push.ts` now just wires argv + credentials around these.
  */
-import { readFile } from "node:fs/promises";
-import { fileURLToPath } from "node:url";
-import { dirname, resolve } from "node:path";
 import type { Pool } from "pg";
 import type { CompositionReport } from "@numisma/engine";
+import { buildCompositionReport } from "@numisma/engine";
+import { loadFoldedReview, resolveEventStorePaths } from "@numisma/event-store";
 import type { ProjectionReport } from "../projection/contract.ts";
 import {
   COMPOSITION_SNAPSHOT_SCHEMA_VERSION,
@@ -19,18 +19,39 @@ import {
   toProjectionReport,
 } from "../projection/contract.ts";
 
-const HERE = dirname(fileURLToPath(import.meta.url));
-
-/** Absolute path to the fixture CompositionReport the push shell projects. */
-export const FIXTURE_PATH = resolve(
-  HERE,
-  "../../fixtures/composition-report.fixture.json",
-);
-
-/** Load and parse the fixture CompositionReport from disk. */
-export async function loadFixture(): Promise<CompositionReport> {
-  const raw = await readFile(FIXTURE_PATH, "utf-8");
-  return JSON.parse(raw) as CompositionReport;
+/**
+ * THE SOURCE of what gets pushed: the real fold of the durable log, in the same
+ * three calls `apps/tui/src/report.ts` makes — resolve the event-store paths
+ * (honoring `NUMISMA_DATA_DIR`), fold genesis + `events.jsonl` to CURRENT state,
+ * build the composition report. This replaced `loadFixture()` (PRD #134 slice 2):
+ * the push shell used to publish a committed JSON fixture, so the row was
+ * well-formed, the reader rendered it, and the number on the phone was not the
+ * fund. There is no `--fixture` flag, no env toggle and no fallback — a flag
+ * would preserve the exact ambiguity this change exists to remove.
+ *
+ * Takes NO date argument, by decision: it always folds current state. An
+ * `--as-of` fold would write a SECOND row keyed to that historical date and
+ * quietly change what "latest" means to the reader.
+ *
+ * FAILS LOUD on a partial log: `loadFoldedReview` asserts the log fully loaded,
+ * so an unparseable or legacy-shape line throws here rather than upserting a
+ * silently-skewed NAV. `push.ts` calls this BEFORE it constructs the Pool, so
+ * that throw happens before any connection or write. It never mutates the log
+ * (only the read path's quarantine sidecar beside it moves).
+ *
+ * The `load` provenance block matches the TUI's report path — and is one of the
+ * keys `toProjectionReport` drops, so it never reaches the cloud.
+ */
+export async function loadCurrentReport(): Promise<CompositionReport> {
+  const paths = resolveEventStorePaths();
+  const data = await loadFoldedReview(paths);
+  return buildCompositionReport(data, {
+    load: {
+      status: "loaded",
+      sourcePath: paths.log,
+      loadedAt: new Date().toISOString(),
+    },
+  });
 }
 
 /** The three projected identity/versioning columns derived from a report. */

--- a/apps/web/src/push/push.ts
+++ b/apps/web/src/push/push.ts
@@ -1,14 +1,16 @@
 /**
  * Push shell (Deliverable C) — headless, price-feed-style script (NOT a package).
  *
- * Loads the fixture CompositionReport and idempotently upserts it into the
- * projection DB using the WRITE credential (PROJECTION_WRITE_DATABASE_URL). The
+ * Folds the REAL durable event log (`NUMISMA_DATA_DIR`) into a CompositionReport
+ * and idempotently upserts it into the projection DB using the WRITE credential
+ * (PROJECTION_WRITE_DATABASE_URL). There is no fixture path and no flag that
+ * restores one: this command can only push real data. The
  * pure derivation and the actual upsert SQL live in `push-core.ts` (importable,
  * unit- and integration-tested); this file is just the argv + credential +
  * process-exit wiring around them, so importing `push-core.ts` never runs the
  * script.
  *
- *   pnpm --filter @numisma/web push            # upsert the fixture snapshot
+ *   pnpm --filter @numisma/web push            # fold the log, upsert the snapshot
  *   pnpm --filter @numisma/web push -- --init  # create table first, then upsert
  *   pnpm --filter @numisma/web db:init         # create table only (no upsert)
  *
@@ -16,7 +18,7 @@
  */
 import { Pool } from "pg";
 import { readSchemaDdl } from "../projection/provision.ts";
-import { loadFixture, upsertSnapshot } from "./push-core.ts";
+import { loadCurrentReport, upsertSnapshot } from "./push-core.ts";
 
 /**
  * Apply the DDL (composition_snapshot table) through the driver for one-command
@@ -37,7 +39,10 @@ async function main(): Promise<void> {
     throw new Error("PROJECTION_WRITE_DATABASE_URL is not set");
   }
 
-  const report = await loadFixture();
+  // Fold BEFORE the Pool exists. A partial/corrupt log throws here, so the
+  // process exits non-zero having opened no connection and written nothing —
+  // including on the `--init` path. Do not move this below `new Pool(...)`.
+  const report = await loadCurrentReport();
 
   const pool = new Pool({ connectionString });
   try {

--- a/docs/coverage-rationale.md
+++ b/docs/coverage-rationale.md
@@ -26,11 +26,12 @@ dishonest.
 | `apps/tui/src/mount-app.ts` | Bun-only openTUI wiring (`@opentui/core` import, keypress subscription, `requestRender`). Never runs under Node. | `pnpm smoke:tui` drives real `j`/`k`/`enter` through it on the real openTUI test renderer. |
 | `apps/tui/src/smoke-openTui.ts` | The keypress Bun smoke harness itself. | It *is* the test; running it (`pnpm smoke:tui`) is the assertion. |
 | `apps/tui/src/smoke-startup-openTui.ts` | The startup Bun smoke harness itself: drives `prepareStartup` + `mountApp` through the real openTUI renderer against an on-disk store. | It *is* the test; running it (`pnpm smoke:startup`) is the assertion. |
-| `apps/tui/src/report.ts` | A `tsx` CLI script: a top-level `try/catch` that folds genesis + log (`loadFoldedReview`) and renders the already-tested composition report. No unit to assert beyond a `process.stdout.write`. | Its constituent functions are unit-tested directly (`event-store.test.ts`, `report-fold.test.ts`, `fund-composition.test.ts`). |
-| `apps/tui/src/spine.ts` | The `tsx` Node tracer (`pnpm spine`): a top-level `try/catch` orchestrating already-tested `ingestInbox` / `loadFoldedReview` / `buildCompositionReport` / `formatCompositionReport`. Same script category — no unit to assert. | Its constituent functions are unit-tested (`event-store.test.ts`, `report-fold.test.ts`); the end-to-end path is also driven by `pnpm spine` / `pnpm smoke:startup`. |
+| `apps/tui/src/report.ts` | A `tsx` CLI script: a top-level `try/catch` that folds genesis + log (`loadFoldedReview`) and renders the already-tested composition report. No unit to assert beyond a `process.stdout.write`. | Its constituent functions are unit-tested directly (`loadFoldedReview` by `packages/event-store/src/event-store.test.ts`, `report-fold.test.ts`, `fund-composition.test.ts`). |
+| `apps/tui/src/spine.ts` | The `tsx` Node tracer (`pnpm spine`): a top-level `try/catch` orchestrating already-tested `ingestInbox` / `loadFoldedReview` / `buildCompositionReport` / `formatCompositionReport`. Same script category — no unit to assert. | Its constituent functions are unit-tested (`ingestInbox` by `apps/tui/src/event-store.test.ts`, `loadFoldedReview` by `packages/event-store/src/event-store.test.ts`, `report-fold.test.ts`); the end-to-end path is also driven by `pnpm spine` / `pnpm smoke:startup`. |
 | `apps/tui/src/spine-reset.ts` | A `tsx` dev iteration helper (`pnpm spine:reset`): clear the log, restore the most recent archived inbox. A throwaway utility, not product behavior — no unit to assert. | Manual: it exists to re-run `pnpm spine` against an edited inbox. |
-| `apps/web/src/push/push.ts` | Self-executing `tsx` script (`pnpm push` / `db:init`): top-level `main().then(..., process.exit)` — argv + credential + `process.exit` wiring only. Importing it runs `main()`, so there is no unit to assert as written. Slice #127 extracted the two pieces worth asserting into the measured `push/push-core.ts` (see below), leaving this a thin wrapper. | `push-core.ts` is measured: `deriveSnapshot` / `loadFixture` by `push-core.test.ts`, the real upsert (`upsertSnapshot`) by the gated `push-core.integration.test.ts`. The DDL `push.ts` applies via `--init` is the tested `readSchemaDdl()` from `provision.ts`. |
-| `apps/web/src/push/push-core.ts` | **Measured**, not excluded — listed here only for the map. The importable, self-exec-free half of the push shell. | `deriveSnapshot` (pure fixture→derivation) and `loadFixture` are unit-tested (`push-core.test.ts`); `upsertSnapshot` (the real `ON CONFLICT ... DO UPDATE`) is exercised by the gated `push-core.integration.test.ts` against a throwaway Postgres. With the test DB present it is 100% covered; without it, `upsertSnapshot`'s `pool.query` shows uncovered (the integration test skips) — flagged honestly, same posture as `provision.ts`. |
+| `apps/web/src/push/push.ts` | Self-executing `tsx` script (`pnpm push` / `db:init`): top-level `main().then(..., process.exit)` — argv + credential + `process.exit` wiring only. Importing it runs `main()`, so there is no unit to assert as written. Slice #127 extracted the two pieces worth asserting into the measured `push/push-core.ts` (see below), leaving this a thin wrapper. PRD #134 slice 2 then moved `push.ts` off the committed fixture onto `loadCurrentReport()` (the real fold of the durable log). | `push-core.ts` is measured: `deriveSnapshot` / `loadCurrentReport` by `push-core.test.ts`, the real upsert (`upsertSnapshot`) by the gated `push-core.integration.test.ts`. The DDL `push.ts` applies via `--init` is the tested `readSchemaDdl()` from `provision.ts`. |
+| `apps/web/src/push/push-core.ts` | **Measured**, not excluded — listed here only for the map. The importable, self-exec-free half of the push shell. | `deriveSnapshot` (pure report→derivation) and `loadCurrentReport` (the real genesis+log fold, via `@numisma/event-store`) are unit-tested (`push-core.test.ts`); `upsertSnapshot` (the real `ON CONFLICT ... DO UPDATE`) is exercised by the gated `push-core.integration.test.ts` against a throwaway Postgres. With the test DB present it is 100% covered; without it, `upsertSnapshot`'s `pool.query` shows uncovered (the integration test skips) — flagged honestly, same posture as `provision.ts`. |
+| `apps/web/src/push/push-core.fixtures.ts` | Test-only fixtures extracted from `push-core.ts` when the push stopped publishing the committed fixture (PRD #134 slice 2): `FIXTURE_PATH` / `loadFixture` (the retired committed fixture, now a test input only) and `makeTempStore` (a throwaway data dir for exercising `loadCurrentReport` over a real log). Excluded via the repo's `**/*.fixtures.ts` glob. | Exercised by `push-core.test.ts` / `push-core.integration.test.ts`, the tests that import it — it is test infrastructure, not product code to measure. |
 | `apps/web/src/projection/provision-projection.ts` | Self-executing `tsx` provisioning CLI (`pnpm db:provision`): top-level `main().then(..., process.exit)` over the tested `provision.ts` builders. Same script category as `push.ts` — no unit to assert as written. | Its pure inputs (`readSchemaDdl`, `buildGrantStatements`, `rolesFromEnv`, `assertValidRoleName`) are unit-tested (`provision.test.ts`); the DB-applying `provisionProjection()` it calls is exercised by the gated integration test (`provision.integration.test.ts`). |
 | `apps/web/src/auth/apply-auth-schema.ts` | Self-executing `tsx` auth-schema applier (`pnpm auth:apply`): top-level `main().then(..., process.exit)` that reads the vendored `better-auth.schema.sql` and applies it idempotently to `AUTH_DATABASE_URL`. Same script category as `push.ts`. | The vendored artifact is generated by the pinned `@better-auth/cli@1.4.21`; idempotency (already-exists → no-op) is demonstrated in the provisioning runbook (`docs/projection-provisioning.md`). |
 | `apps/web/src/auth/seed-account.ts` (slice #125) | Self-executing `tsx` single-tenant seed CLI (`pnpm auth:seed`): top-level `main().then(..., process.exit)` that writes the ONE account through Better Auth's internal adapter (`auth.$context`) keyed on `NUMISMA_SEED_EMAIL` (idempotent — a second run no-ops). Same script category as `apply-auth-schema.ts`; importing it runs `main()`, so there is no unit to assert as written. | The single-tenant invariant it exists to serve — server-side signup disabled (`emailAndPassword.disableSignUp`) with sign-in still enabled — IS asserted (`lib/single-tenant.test.ts`), along with the anonymous-leaks-nothing gate behavior. |
@@ -141,14 +142,23 @@ a regression could break while the suite stayed green. It is now unit-tested:
 What remains uncovered after #72 is only the §2 defensive guards and the §3
 tie-break — each listed there with a concrete reason.
 
-## 5. Event-sourcing spine (ADR-003) — newly added, ~94% lines
+## 5. Event-sourcing spine (ADR-003) — newly added
 
-The engine event modules (`events/*.ts`) and `event-store.ts` (TUI) are the
-persistence spine added in the portfolio-history increment. Both sit at ~94%
-lines, and the remainder is
-**real, reachable behavior that is partially — not yet exhaustively — covered**.
-It is listed here honestly, not dressed up as unreachable; closing it is a
-follow-up, tracked against the spine's reliable-conversion work.
+The engine event modules (`events/*.ts`) and the durable event-store are the
+persistence spine added in the portfolio-history increment, and the remainder
+across both is **real, reachable behavior that is partially — not yet
+exhaustively — covered**. It is listed here honestly, not dressed up as
+unreachable; closing it is a follow-up, tracked against the spine's
+reliable-conversion work.
+
+PRD #134 slice 1 split the event-store's *read path* — path resolution,
+genesis load, log load with quarantine, `loadFoldedReview` — out of
+`apps/tui/src/event-store.ts` into the new **`@numisma/event-store`** package
+(`packages/event-store/src/event-store.ts`), so `apps/web`'s push can fold the
+durable log without depending on the TUI. `apps/tui/src/event-store.ts` now
+holds only the write/ingest half (`ingestInbox`, `migrateLegacyLog`, inbox
+archival, magnitude-threshold env plumbing, `parseAsOfArg`); its read-path unit
+tests moved with the code into `packages/event-store/src/event-store.test.ts`.
 
 - **`packages/engine/src/events/*.ts`** (94% lines) — the covered core is the
   fold itself (`events/fold.ts`) and the ingest cross-reference
@@ -160,13 +170,22 @@ follow-up, tracked against the spine's reliable-conversion work.
   exists yet; plus two real branches in `events/fold.ts` — a `PriceMarked`
   carrying `usdMxn` updating the fold's FX (~L223), and the zero-`totalQuantity`
   guard in the weighted-average helper (~L281).
-- **`apps/tui/src/event-store.ts`** (94% lines) — the covered core is the
-  validated ingest boundary, dedup, atomic append, archive, and quarantine
-  (`event-store.test.ts`). Uncovered: the inbox **invalid-JSON** and
-  **non-array** rejection throws, the `--as-of=<date>` (equals-form) arg variant
-  (the space-separated form is tested), the genesis-validation-failure throw (a
-  corrupt `genesis.json`, defensive), and the `readOptional` non-`ENOENT` rethrow
-  (an unexpected fs error the call path does not otherwise produce — defensive).
+- **`packages/event-store/src/event-store.ts`** (the read path, 96% lines) — the
+  covered core is `loadEventLog`'s quarantine handling and `loadFoldedReview`'s
+  fail-loud fold, exercised by `packages/event-store/src/event-store.test.ts`.
+  Uncovered: `loadGenesis`'s validation-failure throw (a corrupt `genesis.json`,
+  defensive) and `readOptional`'s non-`ENOENT` rethrow (an unexpected fs error
+  the call path does not otherwise produce — defensive).
+- **`apps/tui/src/event-store.ts`** (the write/ingest path, 89% lines) — the
+  covered core is the validated ingest boundary, dedup, atomic append, archive,
+  and quarantine (`event-store.test.ts`). Uncovered: the inbox **invalid-JSON**
+  and **non-array** rejection throws, and the `--as-of=<date>` (equals-form) arg
+  variant (the space-separated form is tested). The file's measured percentage
+  dropped from the pre-split ~94% because the read path it used to also contain
+  was more thoroughly covered; splitting it out left a higher proportion of this
+  file's remaining lines in less-exhaustively-tested rejection branches
+  (`migrateLegacyLog`'s abort paths, the ingest-commit-capture warn branch) —
+  real, reachable behavior, not yet individually itemized here.
 
 `startup.ts` is at 100% (`startup.test.ts`).
 
@@ -218,18 +237,30 @@ for what that number measures.
   (`pg-substrate.testkit.ts`, via the `**/*.testkit.ts` exclude) are excluded per
   §1.
 
-- **`apps/web/src/push/push-core.ts`** (slice #127) — the importable, self-exec-free
-  half of the push shell, extracted from `push.ts` so the derivation and the real
-  upsert are assertable without running the script. `deriveSnapshot` (fixture →
-  `fundId` / `asOf` / `schemaVersion`, delegating to the shared contract) and
-  `loadFixture` are unit-tested (`push-core.test.ts`, no DB). `upsertSnapshot` — the
+- **`apps/web/src/push/push-core.ts`** (slice #127; real fold since PRD #134
+  slice 2) — the importable, self-exec-free half of the push shell, extracted
+  from `push.ts` so the derivation and the real upsert are assertable without
+  running the script. `deriveSnapshot` (report → `fundId` / `asOf` /
+  `schemaVersion`, delegating to the shared contract) is unit-tested
+  (`push-core.test.ts`, no DB). `loadCurrentReport` — the real fold of the
+  durable log (resolve event-store paths via `@numisma/event-store`, fold
+  genesis + `events.jsonl` to current state, `buildCompositionReport`) — is
+  also unit-tested there against a throwaway on-disk store built by the
+  coverage-excluded `push-core.fixtures.ts`; the retired committed fixture
+  (`FIXTURE_PATH` / `loadFixture`) now lives in that same fixtures module as a
+  test input only, no longer read by the push itself. `upsertSnapshot` — the
   exact `INSERT ... ON CONFLICT (fund_id, as_of) DO UPDATE` the script runs — is
   exercised by the gated `push-core.integration.test.ts`: two pushes of the same
   key yield exactly one row with `pushed_at` refreshed and `report` /
   `schema_version` updated (no delete, no duplicate), pushed through the WRITER cred
   on the #123 throwaway-Postgres substrate. With the test DB present, 100% covered;
   without it, `upsertSnapshot`'s `pool.query` shows uncovered (integration test
-  skips) — flagged honestly, same posture as `provision.ts`.
+  skips) — flagged honestly, same posture as `provision.ts`. Measured at 58%
+  lines with the test DB absent (only `upsertSnapshot` uncovered); the blast
+  radius this real fold opens — `apps/web` now depends on `@numisma/event-store`,
+  the reader for the whole private event log — is guarded structurally, not by
+  a coverage number: `apps/web/src/event-store-import-guard.test.ts` asserts no
+  `apps/web` source file outside `src/push/` imports that package.
 
 **Excluded (`.ts` dead weight — see §1 table):** `push/push.ts` (self-executing
 script — now a thin argv/credential wrapper over the measured `push-core.ts`) and

--- a/docs/hosted-cutover-runbook.md
+++ b/docs/hosted-cutover-runbook.md
@@ -200,23 +200,94 @@ says.
 
 ## 8. First real push by hand, then soak
 
-Push real fund data **once, manually**. Look at it on the phone. Live with
-it for a few days before automating anything.
+`pnpm --filter @numisma/web push` folds the durable genesis + event log into
+a `CompositionReport` and upserts it — that is the **only** thing it can do.
+The fixture path has left the command entirely: no `--fixture` flag, no env
+toggle, no fallback. There is no "am I looking at the fixture?" question left
+to resolve at the console. (Step 1's fixture cleanup removed a *database
+row*; the fixture JSON itself remains on disk as a test fixture, loaded only
+by the test suite — the two are unrelated after this step.)
 
 ```sh
 pnpm --filter @numisma/web push
 ```
 
+**Preconditions, as checkable facts, not hopes:**
+
+- `NUMISMA_DATA_DIR` points at the real durable-data store (the accumulus
+  checkout), not a scratch or test directory.
+- `PROJECTION_WRITE_DATABASE_URL` (the no-DELETE writer credential) is set in
+  the shell the push runs from.
+- The durable log is well-formed. A corrupt, partial, or legacy-shape log
+  line makes the push **fail loud**: non-zero exit, no database write. That
+  failure is the system working as designed — the fix is the log (re-run
+  ingest, repair the offending line), never the push. Do not work around a
+  failed push here; find out why the log is malformed first.
+
+**Where `asOf` comes from.** The pushed row's `asOf` is the **last applied
+event's date** (seeded from genesis), never the date the push happens to run
+on. Three consequences follow directly, and an operator should expect all
+three rather than treat any of them as a bug:
+
+- **One row per `asOf`.** A second push the same day updates that same row —
+  `report` and `schema_version` refresh, `pushed_at` bumps — it does not add
+  a row.
+- **A quiet day refreshes yesterday's row, not today's.** If no new marks
+  landed since the last push, `asOf` is unchanged, so the push refreshes the
+  *previous* date's row rather than creating a new one — and the dashboard
+  correctly continues to show that earlier date. This is expected on a
+  weekend or a market holiday, not a fault to chase.
+- **Staleness on the reader is version-mismatch only — there is no age
+  check.** The dashboard's `stale` state fires only when a stored row's
+  schema version disagrees with what the reader expects. An `asOf` that
+  hasn't moved in days is not staleness; it renders exactly as "ok" as a
+  same-day push does.
+
 **Why here, and why not automated yet:** doing the first real push and
 wiring it into a schedule at the same time means a broken push either
 silently overwrites a good snapshot on a timer, or starts publishing before
-a real fund has ever been seen to render correctly. The first real push is
-the moment the ADR-007 gate actually closes — it deserves direct attention,
-not cron.
+a real fund has ever been seen to render correctly (Decision D10). The first
+real push must be manual, watched, and lived with before step 9 is even
+considered.
 
-**Verify:** the deployed dashboard shows real composition data, correctly,
-on a phone — not the fixture, not a stale/empty state, and the numbers match
-the local fold.
+**Two success signals — do not report one for the other.**
+
+1. **Push-side (code half):** the command exits `0` and prints
+   `fundId=<slug> asOf=<the log's last event date> schemaVersion=2`; exactly
+   one row exists for that `(fund_id, as_of)`; the row's `report` JSONB
+   carries exactly the two keys `totals` and `dashboard`. This is verifiable
+   from the shell alone and says nothing about what a browser shows.
+2. **Gate-closing (the actual signal, map 8.1):** the deployed URL, opened on
+   the phone away from the desk, shows that same composition with that same
+   `asOf`. This depends on the console/cutover track completing in
+   parallel — step 1's fixture-row deletion, step 2's owner-credential
+   rotation, step 4's deploy, step 5's auth schema, step 6's password
+   rotation — and cannot happen from the push command alone. Exit `0` on
+   the push is **not** the gate closing; only the phone check is.
+
+**The soak — a condition to check, not a mood.** After the first push
+verifies clean (both signals above), keep running the push **by hand, once a
+day** — the cadence step 9 will eventually automate — and watch the dashboard
+for **at least one week** spanning at least one weekend:
+
+- Each day's `asOf` matches the durable log's actual last-event date — never
+  the run date, never frozen on a stale value while the log keeps growing.
+- A weekend or no-new-marks day shows the previous trading day's `asOf`
+  unchanged, per the second bullet above, and this is *not* logged as an
+  incident.
+- No push during the week fails, and no push writes more than one row per
+  day.
+- The numbers on the phone match the local fold by hand-checking at least
+  once mid-week.
+
+Only once all four hold across the full week does step 9 become something to
+consider — the soak is the acceptance gate step 9 is conditioned on, not a
+suggestion to automate immediately after the first clean push.
+
+**Verify:** record both signals from the section above, separately, with
+their dates — the push-side signal after each manual push during the soak
+week, and the gate-closing signal (phone, away from the desk) at least once
+after the console/cutover track has completed.
 
 ## 9. Automate the push into the existing daily schedule
 

--- a/package.json
+++ b/package.json
@@ -19,7 +19,7 @@
     "push": "tsx apps/web/src/push/push.ts",
     "db:init": "tsx apps/web/src/push/push.ts --init",
     "db:provision": "tsx apps/web/src/projection/provision-projection.ts",
-    "typecheck": "pnpm --filter @numisma/engine run typecheck && pnpm --filter @numisma/price-feed run typecheck && pnpm --filter @numisma/tui run typecheck && pnpm --filter @numisma/web run typecheck",
+    "typecheck": "pnpm --filter @numisma/engine run typecheck && pnpm --filter @numisma/event-store run typecheck && pnpm --filter @numisma/price-feed run typecheck && pnpm --filter @numisma/tui run typecheck && pnpm --filter @numisma/web run typecheck",
     "test": "vitest run",
     "coverage": "vitest run --coverage"
   },

--- a/packages/event-store/package.json
+++ b/packages/event-store/package.json
@@ -1,0 +1,16 @@
+{
+  "name": "@numisma/event-store",
+  "version": "0.7.3",
+  "private": true,
+  "type": "module",
+  "exports": {
+    ".": "./src/index.ts"
+  },
+  "types": "./src/index.ts",
+  "dependencies": {
+    "@numisma/engine": "workspace:*"
+  },
+  "scripts": {
+    "typecheck": "tsc --noEmit -p tsconfig.json"
+  }
+}

--- a/packages/event-store/src/event-store.test.ts
+++ b/packages/event-store/src/event-store.test.ts
@@ -1,0 +1,168 @@
+// Read-path tests for the durable log, moved verbatim out of the TUI's
+// `event-store.test.ts` when the read path was extracted into this package. The
+// engine owns the validation logic (parseEvent); this suite locks the read
+// boundary's contract: a corrupt line is quarantined and durably surfaced rather
+// than aborting the load, the fold path REFUSES a partial log (never a silently
+// skewed NAV), and a fixed log self-heals its stale quarantine lane. A small
+// explicit genesis fixture makes the cases legible.
+import { mkdir, mkdtemp, readFile, rm, stat, writeFile } from "node:fs/promises";
+import { resolve } from "node:path";
+import { tmpdir } from "node:os";
+import {
+  loadEventLog,
+  loadFoldedReview,
+  quarantineLogPath,
+  resolveEventStorePaths,
+  type EventStorePaths,
+} from "./event-store.js";
+import { afterEach, describe, expect, it } from "vitest";
+
+const GENESIS_AS_OF = "2026-06-01";
+
+function genesisSeed() {
+  return {
+    fund: { id: "fund-1", name: "Accumulus", baseCurrency: "USD" },
+    review: { asOf: GENESIS_AS_OF, usdMxn: 20 },
+    portfolios: [{ id: "core", name: "Core" }],
+    accounts: [{ id: "xtb-usd", name: "Main Broker", platform: "XTB", currency: "USD" }],
+    instruments: [
+      { id: "aapl-usd", name: "Apple Inc.", symbol: "AAPL", currency: "USD" },
+      { id: "btc-usd", name: "Bitcoin", symbol: "BTC", currency: "USD" },
+    ],
+    reserves: [
+      {
+        id: "cash-core",
+        portfolioId: "core",
+        tempo: "Reserve",
+        executionMode: "live",
+        accountId: "xtb-usd",
+        currency: "USD",
+        amount: 1000,
+      },
+    ],
+    positions: [
+      {
+        id: "aapl-core",
+        portfolioId: "core",
+        tempo: "Capital",
+        executionMode: "live",
+        accountId: "xtb-usd",
+        instrumentId: "aapl-usd",
+        direction: "long",
+        markPrice: 150,
+        currency: "USD",
+        lots: [{ quantity: 2, cost: 100, tier: "c1" }],
+      },
+    ],
+  };
+}
+
+const DECISION = {
+  entryThesis: "thesis",
+  invalidationCondition: "invalidation",
+  riskBudget: "1R",
+  plannedHoldingHorizon: "weeks",
+  strategy: "trend",
+};
+
+function openBtc(id = "open-btc") {
+  return {
+    id,
+    asOf: "2026-06-05",
+    type: "PositionOpened",
+    position: {
+      id: "btc-core",
+      portfolioId: "core",
+      tempo: "Liquid",
+      executionMode: "live",
+      accountId: "xtb-usd",
+      instrumentId: "btc-usd",
+      direction: "long",
+      currency: "USD",
+      lots: [{ quantity: 1, cost: 100, tier: "c1" }],
+    },
+    decision: DECISION,
+    funding: { reserveId: "cash-core", amount: 100 },
+  };
+}
+
+function markAapl(price: number, id = "mark-aapl") {
+  return { id, asOf: "2026-06-06", type: "PriceMarked", instrumentId: "aapl-usd", price };
+}
+
+const createdDirs: string[] = [];
+
+afterEach(async () => {
+  await Promise.all(createdDirs.map((dir) => rm(dir, { recursive: true, force: true })));
+  createdDirs.length = 0;
+});
+
+/** Build a temp data dir with genesis + optional pre-existing log and inbox. */
+async function makeStore(options: {
+  inbox?: unknown;
+  log?: string;
+}): Promise<EventStorePaths> {
+  const dir = await mkdtemp(resolve(tmpdir(), "numisma-ingest-"));
+  createdDirs.push(dir);
+  const paths = resolveEventStorePaths(dir);
+  await writeFile(paths.genesis, JSON.stringify(genesisSeed()), "utf8");
+  if (options.log !== undefined) {
+    await writeFile(paths.log, options.log, "utf8");
+  }
+  if (options.inbox !== undefined) {
+    await mkdir(resolve(dir, "inbox"), { recursive: true });
+    await writeFile(paths.inbox, JSON.stringify(options.inbox), "utf8");
+  }
+  return paths;
+}
+
+async function exists(path: string): Promise<boolean> {
+  try {
+    await stat(path);
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+describe("loadEventLog — log-line quarantine", () => {
+  it("quarantines one corrupt line, loads the rest, and surfaces the bad line", async () => {
+    const good = JSON.stringify(openBtc());
+    const later = JSON.stringify(markAapl(160));
+    const log = `${good}\nthis is not json\n${later}\n`;
+    const paths = await makeStore({ log });
+
+    const { events, quarantined } = await loadEventLog(paths.log);
+
+    expect(events.map((event) => event.id)).toEqual(["open-btc", "mark-aapl"]);
+    expect(quarantined).toHaveLength(1);
+    expect(quarantined[0]).toMatchObject({ lineNumber: 2, line: "this is not json" });
+    // The bad line is durably surfaced to the side lane for the user to fix.
+    const lane = await readFile(quarantineLogPath(paths.log), "utf8");
+    expect(lane).toContain("this is not json");
+  });
+
+  it("fails loud on the fold path when any line is unloadable (never a partial fold)", async () => {
+    // ADR-003 amendment (M1): the fold/ingest read no longer degrades gracefully —
+    // a dropped line would silently skew NAV, so loadFoldedReview refuses to fold a
+    // partial log. The quarantine side lane is still surfaced for diagnostics.
+    const log = `${JSON.stringify(openBtc())}\n{ broken\n`;
+    const paths = await makeStore({ log });
+
+    await expect(loadFoldedReview(paths)).rejects.toThrow(/unloadable line/i);
+
+    // The bad line is still surfaced to the side lane for the operator to fix.
+    const lane = await readFile(quarantineLogPath(paths.log), "utf8");
+    expect(lane).toContain("{ broken");
+  });
+
+  it("self-heals: a clean log removes a stale quarantine lane", async () => {
+    const paths = await makeStore({ log: `${JSON.stringify(openBtc())}\n` });
+    await writeFile(quarantineLogPath(paths.log), "stale\n", "utf8");
+
+    const { quarantined } = await loadEventLog(paths.log);
+
+    expect(quarantined).toHaveLength(0);
+    expect(await exists(quarantineLogPath(paths.log))).toBe(false);
+  });
+});

--- a/packages/event-store/src/event-store.ts
+++ b/packages/event-store/src/event-store.ts
@@ -1,0 +1,213 @@
+/**
+ * The durable log's READ path — lifted verbatim out of `apps/tui/src/event-store.ts`
+ * so both runnable surfaces can fold the same log. The TUI reads it to render; the
+ * web push reads it to publish. ADR-001 keeps this file IO OUT of `@numisma/engine`
+ * (which stays I/O-free); the pure fold + event validation live there
+ * (`foldEvents` / `parseEvent`), and this package is the thin IO shell around them.
+ *
+ * Deliberately app-free: plain `node:fs`, no Bun, no terminal, no git, no argv. The
+ * write half (inbox ingest, atomic append, archival, the one-shot legacy migration,
+ * git capture) stays in the TUI app.
+ *
+ * Durable truth on disk this path reads:
+ *   - data/genesis.json            immutable t0 seed (a FundReviewData shape)
+ *   - data/events.jsonl            append-only log, one JSON event per line
+ *   - data/events.jsonl.quarantine the lane for surfaced corrupt log lines
+ *
+ * DURABILITY (reliable conversion, ADR-003 slice 3):
+ *   - A corrupt log line is quarantined to a side lane and surfaced; the rest of
+ *     the log still loads. The fold path then refuses to run on a partial log.
+ */
+import { mkdir, readFile, rm, writeFile } from "node:fs/promises";
+import { dirname, join, resolve } from "node:path";
+import {
+  foldEvents,
+  parseEvent,
+  parseFundReview,
+  resolveDataDir,
+  type FundReviewData,
+  type PortfolioEvent,
+} from "@numisma/engine";
+
+export interface EventStorePaths {
+  genesis: string;
+  log: string;
+  inbox: string;
+  ingestedDir: string;
+}
+
+/** A log line that failed to parse, diverted to the quarantine lane on read. */
+export interface QuarantinedLine {
+  lineNumber: number;
+  line: string;
+  reason: string;
+}
+
+/** The result of reading the append-only log: the good events plus any corrupt
+ * lines that were quarantined rather than aborting the load. */
+export interface EventLogLoad {
+  events: PortfolioEvent[];
+  quarantined: QuarantinedLine[];
+}
+
+/**
+ * Resolve the default dataDir root honoring the `NUMISMA_DATA_DIR` env var — the
+ * SINGLE knob that moves EVERY plane. The resolution rule (env override with an
+ * absolute, homedir-derived accumulus default; relative values rejected) is the
+ * pure engine `resolveDataDir`; this thin wrapper keeps the public name the tui
+ * callers already use.
+ */
+export function resolveDataDirDefault(): string {
+  return resolveDataDir();
+}
+
+/** The quarantine lane sits beside the log it shadows. */
+export function quarantineLogPath(logPath: string): string {
+  return `${logPath}.quarantine`;
+}
+
+export function resolveEventStorePaths(dataDir = resolveDataDirDefault()): EventStorePaths {
+  const base = resolve(dataDir);
+  return {
+    genesis: join(base, "genesis.json"),
+    log: join(base, "events.jsonl"),
+    inbox: join(base, "inbox", "transactions.json"),
+    ingestedDir: join(base, "ingested"),
+  };
+}
+
+/** Read and structurally validate the immutable genesis seed. */
+export async function loadGenesis(genesisPath: string): Promise<FundReviewData> {
+  const raw = await readFile(genesisPath, "utf8");
+  const parsed = parseFundReview(raw);
+  if (parsed.kind !== "ok") {
+    throw new Error(`Genesis seed failed validation (${parsed.kind}) at ${genesisPath}.`);
+  }
+  return parsed.value;
+}
+
+/**
+ * Read the append-only log, validating each line into a typed event. A line that
+ * fails to parse is diverted to the quarantine lane (returned, and surfaced to a
+ * durable `events.jsonl.quarantine` sidecar) instead of aborting the load, so a
+ * single corrupt line degrades gracefully rather than bricking startup. The rest
+ * of the log still loads. The log file itself is never mutated on read.
+ */
+export async function loadEventLog(logPath: string): Promise<EventLogLoad> {
+  const raw = await readOptional(logPath);
+  const events: PortfolioEvent[] = [];
+  const quarantined: QuarantinedLine[] = [];
+  if (raw !== undefined) {
+    for (const [index, line] of raw.split("\n").entries()) {
+      const trimmed = line.trim();
+      if (!trimmed) {
+        continue;
+      }
+      const parsed = parseLogLine(trimmed);
+      if (parsed.ok) {
+        events.push(parsed.event);
+      } else {
+        quarantined.push({ lineNumber: index + 1, line: trimmed, reason: parsed.reason });
+      }
+    }
+  }
+  await surfaceQuarantine(logPath, quarantined);
+  return { events, quarantined };
+}
+
+/**
+ * Fail loud when the durable log holds any line that would not load. A dropped
+ * material event (a legacy-shape open/close, or any unparseable line) silently
+ * skews the fold — a plausible-but-wrong NAV, the exact drift class this MVI
+ * eliminates — so the fold/ingest paths refuse to run on a partial log rather than
+ * degrade gracefully. The quarantine sidecar has already been written by
+ * {@link loadEventLog}, so the operator can see every offending line and reason; a
+ * legacy open/close is additionally pointed at the one-shot migration. This is the
+ * ADR-003 amendment's migration/versioning contract enforced at the read boundary
+ * (it reverses the prototype's "a corrupt line degrades gracefully" behavior).
+ * `foldEvents` itself stays a pure projection — the loud stop lives here, not in the
+ * fold.
+ *
+ * Exported because the TUI's `ingestInbox` guards its read of the existing log with
+ * exactly this assertion; the package owns the single definition.
+ */
+export function assertLogFullyLoaded(load: EventLogLoad, logPath: string): void {
+  if (load.quarantined.length === 0) {
+    return;
+  }
+  const detail = load.quarantined
+    .map((entry) => `  line ${entry.lineNumber}: ${entry.reason}`)
+    .join("\n");
+  throw new Error(
+    `Durable log ${logPath} has ${load.quarantined.length} unloadable line(s); refusing to ` +
+      `fold a partial log (it would silently skew NAV). Fix or migrate them, then retry. ` +
+      `Details also written to ${quarantineLogPath(logPath)}:\n${detail}`,
+  );
+}
+
+type ParsedLine =
+  | { ok: true; event: PortfolioEvent }
+  | { ok: false; reason: string };
+
+function parseLogLine(line: string): ParsedLine {
+  let json: unknown;
+  try {
+    json = JSON.parse(line);
+  } catch {
+    return { ok: false, reason: "not valid JSON" };
+  }
+  const result = parseEvent(json);
+  if (result.kind !== "ok") {
+    return { ok: false, reason: `${result.path}: ${result.message}` };
+  }
+  return { ok: true, event: result.value };
+}
+
+/**
+ * Write the corrupt lines to the quarantine lane (one JSON record per line) so the
+ * bad input is durably surfaced for the user to fix; remove a stale lane when the
+ * log reads clean, so a fixed log self-heals. Idempotent: the lane reflects exactly
+ * the current read, so repeated reads in one startup converge on the same content.
+ */
+async function surfaceQuarantine(logPath: string, quarantined: QuarantinedLine[]): Promise<void> {
+  const lanePath = quarantineLogPath(logPath);
+  if (quarantined.length === 0) {
+    await rm(lanePath, { force: true });
+    return;
+  }
+  await mkdir(dirname(logPath), { recursive: true });
+  const body = `${quarantined.map((entry) => JSON.stringify(entry)).join("\n")}\n`;
+  await writeFile(lanePath, body, "utf8");
+}
+
+/**
+ * Load genesis + the durable log, assert the log fully loaded, then fold to `asOf`
+ * (or current state) for rendering. A pure READ: it does NOT ingest — the inbox is
+ * never consulted and the durable log is never written (only `loadEventLog`'s
+ * quarantine sidecar moves).
+ */
+export async function loadFoldedReview(
+  paths: EventStorePaths,
+  asOf?: string,
+): Promise<FundReviewData> {
+  const genesis = await loadGenesis(paths.genesis);
+  const load = await loadEventLog(paths.log);
+  assertLogFullyLoaded(load, paths.log);
+  return foldEvents(genesis, load.events, asOf);
+}
+
+/**
+ * Read a file that may not exist, mapping ENOENT to `undefined` and rethrowing every
+ * other IO error. Exported: the TUI's ingest and migration paths read the inbox and
+ * the log through the same helper, so this package owns the single definition.
+ */
+export async function readOptional(filePath: string): Promise<string | undefined> {
+  try {
+    return await readFile(filePath, "utf8");
+  } catch (error) {
+    if (error instanceof Error && "code" in error && error.code === "ENOENT") {
+      return undefined;
+    }
+    throw error;
+  }
+}

--- a/packages/event-store/src/index.ts
+++ b/packages/event-store/src/index.ts
@@ -1,0 +1,13 @@
+export {
+  assertLogFullyLoaded,
+  loadEventLog,
+  loadFoldedReview,
+  loadGenesis,
+  quarantineLogPath,
+  readOptional,
+  resolveDataDirDefault,
+  resolveEventStorePaths,
+  type EventLogLoad,
+  type EventStorePaths,
+  type QuarantinedLine,
+} from "./event-store.js";

--- a/packages/event-store/tsconfig.json
+++ b/packages/event-store/tsconfig.json
@@ -1,0 +1,4 @@
+{
+  "extends": "../../tsconfig.json",
+  "include": ["src/**/*.ts", "tests/**/*.ts"]
+}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -38,6 +38,9 @@ importers:
       '@numisma/engine':
         specifier: workspace:*
         version: link:../../packages/engine
+      '@numisma/event-store':
+        specifier: workspace:*
+        version: link:../../packages/event-store
       '@opentui/core':
         specifier: 0.2.15
         version: 0.2.15(typescript@5.9.3)(web-tree-sitter@0.25.10)
@@ -47,6 +50,9 @@ importers:
       '@numisma/engine':
         specifier: workspace:*
         version: link:../../packages/engine
+      '@numisma/event-store':
+        specifier: workspace:*
+        version: link:../../packages/event-store
       '@tanstack/react-query':
         specifier: 5.101.2
         version: 5.101.2(react@19.2.7)
@@ -92,6 +98,12 @@ importers:
         version: 7.3.6(@types/node@24.12.4)(jiti@2.7.0)(lightningcss@1.32.0)(tsx@4.22.3)
 
   packages/engine: {}
+
+  packages/event-store:
+    dependencies:
+      '@numisma/engine':
+        specifier: workspace:*
+        version: link:../engine
 
 packages:
 


### PR DESCRIPTION
Closes #135
Closes #136
Closes #137
Closes #134

## Summary

Three slices, landed as one increment:

- **#135** — extracts the durable log's read path (`resolveEventStorePaths`, `loadGenesis`, `loadEventLog`, `loadFoldedReview`, `readOptional`, `assertLogFullyLoaded`, the quarantine helpers) out of `apps/tui/src/event-store.ts` into a new shared `@numisma/event-store` package, so the web push can fold the same log the TUI does. Behavior-preserving move, not a rewrite — the moved tests move unchanged.
- **#136** — the web push now folds the durable log via `loadCurrentReport()` instead of reading a fixture. Same derivation, same `{ totals, dashboard }` narrowing, same `(fund_id, as_of)` upsert, no schema-version bump. The fixture path is gone from the command with no flag, env toggle, or fallback. The fold runs before the pool is constructed, so a corrupt or partial log exits non-zero having written nothing.
- **#137** — rewrites the runbook's first-real-push step around real data and `asOf` semantics: what the push publishes, its preconditions, where `asOf` comes from and its operator-visible consequences, and keeps the soak as its own gating condition separate from the push-side signal.

Plus a doc reconciliation: `apps/tui/README.md` and `docs/coverage-rationale.md` updated to match the new package layout, with coverage numbers re-measured against this branch rather than estimated.

## Verified

- `pnpm typecheck` — exit 0
- `pnpm test` — 578 passed / 13 skipped / 0 failed (baseline before this increment: 573/11/0)
- `pnpm --filter @numisma/web build` — clean
- End-to-end against a throwaway Postgres: one push produces one row with `report` JSONB carrying exactly `totals` and `dashboard`; a second run leaves one row (upsert, not insert); a corrupt log line produces exit 1, no write, and a byte-identical `events.jsonl`.
- The structural import guard confining `@numisma/event-store` to `apps/web/src/push/` was verified negatively with a probe file outside that directory.

`pnpm smoke:startup` fails on this branch, but it fails identically on pristine HEAD before this work (its own inbox fixture is legacy-shape) — pre-existing, out of scope, not a regression.

## Follow-ups

`readOptional` still has a second byte-identical copy at `apps/price-feed/src/rejection-check.ts:359` — left deliberately for issue #110 rather than drawing a new package edge here.