### PR TITLE
docs(adr-011): amend the claims executing the cutover falsified

### DIFF
--- a/apps/web/.env.example
+++ b/apps/web/.env.example
@@ -1,5 +1,22 @@
 # @numisma/web environment. Copy to apps/web/.env (git-ignored) for local dev.
 # Never commit a real .env. Local throwaway values are enough to boot the app.
+#
+# --- HOSTED values are NOT sourced from here, and NOT readable from Vercel ----
+# Vercel Production env vars are SENSITIVE BY DEFAULT: injected into deployments
+# but never readable back. `vercel env pull` returns them as EMPTY STRINGS,
+# silently — so it cannot be used to source credentials for `auth:apply` or
+# `push`, and the failure looks local (psql falls back to a unix socket and
+# reports `database "<you>" does not exist`). Operator credentials live in
+# git-ignored `.env.*.local` files and a password manager. See
+# docs/hosted-cutover-runbook.md step 0.
+#
+# --- sslmode: a scheduled semantic change, not a preference -------------------
+# Hosted strings use `?sslmode=require`. TODAY `pg` treats 'prefer'/'require'/
+# 'verify-ca' as aliases for 'verify-full' (full cert + hostname validation) and
+# warns on every run. In pg-connection-string v3 / pg v9 they adopt libpq
+# semantics, which are WEAKER — `require` will stop validating the certificate.
+# On that upgrade, change hosted strings to `sslmode=verify-full` explicitly, or
+# they silently weaken with no error and no test failure.
 
 # --- Projection DB (ADR-007 read-projection) -------------------------------
 # READ-ONLY credential used by the web app's dashboard server function. Behind

--- a/apps/web/src/client-bundle.integration.test.ts
+++ b/apps/web/src/client-bundle.integration.test.ts
@@ -53,9 +53,18 @@ if (!hasBuild) {
  * asset, whatever a future refactor does.
  *
  * DELIBERATELY NOT LISTED: `VITE_NEON_AUTH_URL`. Its `VITE_` prefix means Vite
- * INLINES it into the client bundle by design — it is a URL, not a credential,
- * and it is EXPECTED to ship. Adding it here would assert against a working
- * feature. What must not ship is a credential, which is what this list names.
+ * would INLINE it into the client bundle by design — it is a URL, not a
+ * credential — so listing it here would assert against Vite's documented
+ * behavior rather than against a leak. What must not ship is a credential,
+ * which is what this list names.
+ *
+ * As of 2026-07-25 the variable no longer exists in any environment: it was one
+ * of the 18 auto-injected by the Neon Marketplace integration, which was
+ * DISCONNECTED from this project (ADR-011 amendment, D9). Nothing in this app
+ * ever read it — there is no Neon Auth feature here; auth is Better Auth
+ * (ADR-010) against a separate `numisma_auth` DB. The exclusion is kept as a
+ * standing rule in case a `VITE_`-prefixed var is ever added, not because a
+ * feature depends on one shipping.
  *
  * DELIBERATELY REDUNDANT: matching is by `includes()`, so the bare `DATABASE_URL`
  * added for the Neon set already subsumes `PROJECTION_DATABASE_URL`,

--- a/apps/web/src/lib/auth.ts
+++ b/apps/web/src/lib/auth.ts
@@ -66,9 +66,24 @@ export const auth = betterAuth({
   // single-tenant; if a second tenant is ever added, revisit it.
   //
   // ACCEPTED COST: DB-backed limiting writes to Neon on every auth attempt,
-  // including rejected ones — attack traffic costs money. That is bounded
-  // out-of-band by an explicit Neon spend threshold (D6), which prefers an
-  // outage over a surprise bill.
+  // including rejected ones — attack traffic costs money. D6 says that is
+  // bounded by an explicit Neon spend threshold, which prefers an outage over a
+  // surprise bill.
+  //
+  // WHAT ACTUALLY BOUNDS IT TODAY (verified 2026-07-25, ADR-011 amendment):
+  // the Neon FREE plan's hard caps — 100 CU-hrs compute, 0.5 GB storage, 5 GB
+  // transfer — which suspend the database rather than billing past it. There is
+  // NO spend threshold, and none can be set: `vercel integration balance neon`
+  // reports no balance to attach one to on Free. The outage-over-bill posture
+  // holds, but structurally rather than by the configured control D6 names.
+  //
+  // THE TRIGGER TO WATCH: upgrading the Neon plan. A paid plan replaces hard
+  // caps with billable usage, so upgrading WITHOUT setting a threshold silently
+  // converts D6's deliberate choice into the alternative it rejected — an
+  // unbounded bill under sustained attack. Read `create-threshold` carefully if
+  // that day comes: its args are (resource, minimum, spend, limit) and it
+  // configures AUTO-RECHARGE — buying capacity to stay up — which is the
+  // opposite of what D6 wants unless `limit` is doing the work.
   //
   // Verified by attack, not by inspection: `pnpm --filter @numisma/web
   // auth:verify-limit` (src/auth/verify-rate-limit.ts). Configuration alone

--- a/context/adr/ADR-011-single-tenant-hosted-security-posture.md
+++ b/context/adr/ADR-011-single-tenant-hosted-security-posture.md
@@ -2,7 +2,7 @@
 
 _Made during: MVI — hosted security pass (`~/Dev/notes/numisma/2026-07-24-hosted-security-pass-grill.md`), the operational-hardening follow-on ADR-007 explicitly gated ("the concrete pre-deploy security controls … are a **required follow-on this ADR gates**"). Also resolves the "N/A until a hosted surface exists" deferral parked in `2026-07-03-credentials-secrets-grill`, since that surface now exists._
 _Scope: product_
-_Status: accepted_
+_Status: accepted (amended 2026-07-25 — see "Amendment: what executing the cutover falsified" below)_
 
 ADR-007 ratified the hosted-projection regime and gated real fund data on a
 dedicated security pass. This ADR is that pass's record. Most of what the pass
@@ -89,7 +89,9 @@ onboarding, no second tenant.
   owner's door. `apps/web/src/lib/auth.ts` carries this reasoning inline so
   the "why is there no lockout" question is answered where the config is
   read, not only here.
-- **Cost over availability, explicitly (D6).** A spend threshold
+- **Cost over availability, explicitly (D6).** **⚠ See the 2026-07-25
+  amendment — the mechanism named here is not available on the current plan;
+  the intent holds by a different means.** A spend threshold
   (`vercel integration-resource create-threshold`) means sustained attack
   traffic does not run up a bill — it **suspends the database**, taking the
   fund view offline. This was chosen deliberately: *"I prefer non
@@ -115,15 +117,18 @@ onboarding, no second tenant.
   Auth session). It would also couple fund availability to the same Vercel
   account that holds all five app secrets, so one compromise takes both door
   and keys, and it would hollow out the portfolio-visibility driver. The
-  five app secrets (`BETTER_AUTH_URL`, `BETTER_AUTH_SECRET`,
-  `AUTH_DATABASE_URL`, `PROJECTION_DATABASE_URL`,
-  `PROJECTION_WRITE_DATABASE_URL`) are scoped Production-only and verified
+  app secrets (`BETTER_AUTH_URL`, `BETTER_AUTH_SECRET`, `AUTH_DATABASE_URL`,
+  `PROJECTION_DATABASE_URL` — **four, not five; see the 2026-07-25 amendment
+  on `PROJECTION_WRITE_DATABASE_URL`**) are scoped Production-only and verified
   unresolvable on Preview, so the protection spend goes where it is needed:
   the auto-generated preview URLs built from code that reads
   `PROJECTION_DATABASE_URL`, which nobody watches.
 - **Rate limiting is DB-backed, not in-memory (D5).** See Considered Options.
   The accepted cost — every auth attempt, including rejected ones, writes to
   `numisma_auth` — is bounded by D6's spend threshold rather than left open.
+  **⚠ Amended 2026-07-25: that bound is currently the Neon Free plan's hard
+  caps, not a threshold. It disappears on upgrade to a paid plan unless a
+  threshold is set then.**
 - **Rotation is trigger-based, never calendar-based (D9).** `neondb_owner`
   rotates once, mandatorily, after the Neon auto-injected owner-credential
   set is removed from Vercel env (a bypass of the structural one-way
@@ -161,3 +166,91 @@ onboarding, no second tenant.
   (bounded spend, but an outage on attack) vs. no cap (always available, but
   an unbounded bill) was chosen explicitly by the operator, against the
   instinctive default of "keep it up at any cost."
+
+## Amendment: what executing the cutover falsified
+
+_Amended 2026-07-25, while executing `docs/hosted-cutover-runbook.md` end to
+end. **No decision below is reversed.** Each intent stands; what changed is
+that three of the named mechanisms were found not to work as written, and one
+credential was found in a place this ADR said it belonged and ADR-007 says it
+must not. Recorded here rather than silently corrected in place, because the
+gap between "the decision" and "the mechanism that implements it" is exactly
+where a future reader would otherwise trust a claim that no longer holds._
+
+**D6's spend threshold does not exist and cannot be set on the current plan.**
+`vercel integration balance neon` reports `No balance information found for
+this integration` — the Neon resource is on the **Free** plan, which has no
+prepaid balance to attach a threshold to. Worse, the command's real signature
+is `create-threshold <resource> <minimum> <spend> <limit>`: it configures
+**auto-recharge** (when the balance drops below `minimum`, purchase `spend`
+more, up to `limit`), which buys capacity to keep the database *up* — close to
+the opposite of the outage-over-bill posture D6 chose.
+
+**The intent survives on the Free plan by a different mechanism.** Free
+enforces hard caps (100 CU-hrs compute, 0.5 GB storage, 5 GB transfer) and
+suspends rather than billing past them. That is precisely D6's stated
+preference — an outage, noticed and actionable — delivered structurally and
+for free. **The consequence is that D6 becomes load-bearing only on
+upgrade:** a paid plan replaces hard caps with billable usage, so moving off
+Free without setting a threshold silently converts the deliberate
+outage-over-bill choice into its rejected alternative. Treat "upgrade the Neon
+plan" as the trigger that re-activates D6, and note that the auto-recharge
+semantics above mean the threshold must be read carefully rather than set
+reflexively.
+
+This also re-bases D5's accepted cost. Every auth attempt writing to
+`numisma_auth` is bounded today by the Free caps, **not** by a threshold, and
+`apps/web/src/lib/auth.ts` has been corrected to say so where the config is
+read.
+
+**D9's rotation sequence is self-defeating.** D9 has `neondb_owner` rotating
+"once, mandatorily, after the Neon auto-injected owner-credential set is
+removed from Vercel env." Executing that order proved the two halves cancel:
+**rotating the password is itself a Neon-side change, which re-triggers the
+Marketplace integration's sync and re-injects all 18 variables — carrying the
+new password.** Deleting the variables is not a durable fix at all; the
+integration recreates them within minutes of any Neon-side change.
+
+The mechanism that does work is severing the link:
+`vercel integration-resource disconnect <resource> <project>` (which is **not**
+`integration-resource remove`, the command that deletes the resource and its
+data). Two further facts belong with it: `vercel env ls` shows only *stored*
+variables, so the owner credential remained visible only in a resolved
+`vercel env pull`; and Vercel bakes env into a deployment at build time, so
+**the removal is inert at runtime until the next deploy.** D9's underlying
+principle — rotation is trigger-based, never calendar-based — is unaffected,
+and rotation remains correct for a *suspected leak*. It is simply not the
+control that removes an injected credential from the runtime.
+
+**D2 listed a credential that must not be in the web project.** D2's "five app
+secrets" included `PROJECTION_WRITE_DATABASE_URL`. That is the projection
+**write** credential, and ADR-007's structural one-way guarantee — enforced by
+split creds, "read-only web cred vs. sole write-cred on the local push job" —
+requires the running web service never to hold it.
+`docs/web-deploy-runbook.md` already said so explicitly ("they belong to the
+push shell and one-shot provisioning, local/operator only, never the deployed
+app"); this ADR contradicted it. Found live in the project's Production
+environment and removed 2026-07-25. The web project now holds **four** app
+secrets. This was a genuine violation of the parent ADR's central invariant,
+not a documentation preference.
+
+**A control this ADR relies on was unusable when tested.** D7's 30-day rolling
+session is justified on the grounds that revocation works and is findable in
+under a minute (`DELETE FROM session`). It was not: Vercel Production
+environment variables are **sensitive by default** and cannot be read back —
+`vercel env pull` returns them as **empty strings, silently** — so no
+credential on the operator's machine could reach `numisma_auth`, and the owner
+password had been rotated and discarded. Pulling the lever would have required
+a Neon console password reset first, plus a Vercel update and a redeploy.
+Resolved by giving the operator credentials a documented home (runbook step 0)
+and recording them in a password manager. **The D7 trade-off is only sound
+while that custody holds**, which is now a written prerequisite rather than an
+assumption.
+
+**Verified, not merely asserted.** Two claims this ADR makes structurally were
+confirmed against the live database for the first time during the same pass:
+the grant split (`numisma_push` INSERT/SELECT/UPDATE with **no DELETE**;
+`numisma_web` SELECT-only), and D5's DB-backed property — after a 150-attempt
+attack, the counter was present as a single row in `numisma_auth."rateLimit"`,
+which is the one thing `auth:verify-limit` prints a caveat saying it cannot
+prove on its own.


### PR DESCRIPTION
## What

Comments and docs only — no behaviour change. Typecheck clean; full suite passes (**580 passed, 13 skipped**; the 2 skipped files are the build-gated and DB-gated integration tests).

Follow-up to #142. That PR rebuilt the runbook; this one fixes the claims the same walkthrough falsified **in code and in ADR-011**, which #142 deliberately left alone to keep the diff reviewable.

## Why this isn't cosmetic

Three of these were assertions a future reader would have trusted:

| Claim | Reality | Where it lived |
| --- | --- | --- |
| Attack-traffic cost is "bounded by an explicit Neon spend threshold (D6)" | **No threshold exists or can be set** — Free plan has no balance. Bounded by Free's hard caps instead, and **that bound vanishes on upgrade** | `auth.ts:68-71`, ADR-011 D5/D6 |
| `neondb_owner` rotates "after the injected set is removed" | Rotating **re-triggers the sync and re-injects all 18 vars** — the two halves cancel | ADR-011 D9 |
| Five app secrets in the web project, incl. `PROJECTION_WRITE_DATABASE_URL` | That's the **write** credential; ADR-007 forbids the web runtime holding it. Found live in Production, removed. Four secrets | ADR-011 D2 |
| D7's 30-day session is safe because revocation is pullable in under a minute | It **wasn't** — no credential on the machine could reach `numisma_auth`; `vercel env pull` returns sensitive vars as empty strings, silently | ADR-011 D7 |

**No decision is reversed.** Each intent stands; the amendment records the gap between a decision and the mechanism claimed to implement it — which is exactly where stale documentation does damage.

## Approach

ADR-011 is **amended, not rewritten**, following ADR-007's existing convention (`## Amendment: …`, status line updated). Inline `⚠` markers at D2, D5, and D6 point at the amendment so a reader landing mid-document doesn't miss it.

## Also

- `.env.example` gains two notes **next to the connection strings**: hosted values aren't sourceable from Vercel (and the failure is silent), and `pg` v9 will **weaken** `sslmode=require`, which today aliases `verify-full`. That one has no test and no error — the strings just stop validating certificates.
- `client-bundle.integration.test.ts`'s `VITE_NEON_AUTH_URL` exclusion is re-justified: it was defended as shipping for "a working feature" that never existed, and the variable is now gone entirely.

## Test plan

`pnpm --filter @numisma/web typecheck` and `pnpm test`. Nothing else — every change is a comment or a markdown document.