### PR TITLE
security(web): take the fund's real NAVs and returns out of a public repo

### DIFF
--- a/apps/web/src/glance/verdict.test.ts
+++ b/apps/web/src/glance/verdict.test.ts
@@ -107,7 +107,7 @@ describe("navMove", () => {
   });
 
   it("declines when its own reference anchor has withheld provenance (rule 1)", async () => {
-    // 2026-06-28 moved −1.68% in the fixture (−1.72% real), comfortably past the
+    // 2026-06-28 moved −1.68% in the fixture, comfortably past the
     // threshold — and does NOT fire, because its reference 06-26 is withheld. This
     // is the reason `anchor-fixture.ts`'s header can say "navMove on 07-14 only"
     // while three anchors cross 1.5%: the header describes the SUPPRESSION

--- a/apps/web/src/glance/verdict.ts
+++ b/apps/web/src/glance/verdict.ts
@@ -76,8 +76,10 @@ export const RESERVE_FLOOR_WIRE_KEY = "glance.reserveTargetPct" as const;
  * the step is one day; the sparse stretch (06-26 → 06-30, and 07-03's three-day step
  * back to 06-30) is historical only.
  *
- * 1.5% picks the tails of the measured month honestly: the day-over-day range across
- * the log is −1.72% to +1.85%, and 1.5% takes three of those days and leaves 25.
+ * 1.5% picks the tails of the measured month honestly: it takes three of the 28
+ * anchored days and leaves 25. The measured day-over-day range that justifies the
+ * choice is deliberately not quoted here — this repository is public, and the range
+ * is the fund's best and worst days. It is recorded in the private notes vault.
  */
 export const NAV_MOVE_THRESHOLD_PCT = 1.5;
 

--- a/apps/web/src/push/anchor-fixture.test.ts
+++ b/apps/web/src/push/anchor-fixture.test.ts
@@ -19,12 +19,20 @@
  *    fund's, every magnitude is invented. This repository is public, so that is not a
  *    style preference — it is the bar the file has to clear, and it is asserted here
  *    on the committed bytes rather than trusted to whoever regenerates next.
+ *
+ * THE MAGNITUDE ASSERTIONS NAME NO REAL NUMBER, and that is a requirement on THIS FILE
+ * too, not only on the fixture. An earlier form compared against three real NAVs and
+ * against the real 06-28 move — which put the guarded values into a public repository
+ * to guard them. Both are now expressed as properties: NAV sits inside the synthetic
+ * band, and the 06-28 move still crosses the threshold. Whether the synthesized series
+ * stayed faithful to the real one is checked at REGENERATION, by
+ * `assertThresholdSideHolds`, which legitimately has the real series in hand and never
+ * commits it.
  */
 import { describe, expect, it } from "vitest";
 import { COMPOSITION_SNAPSHOT_SCHEMA_VERSION } from "../projection/contract.ts";
 import { anchorAt, loadAnchorFixture } from "./anchor-fixture.ts";
 import {
-  NAV_JITTER_PP,
   NAV_MOVE_THRESHOLD_PCT,
   SYNTHETIC_FUND_NAME,
   SYNTHETIC_START_NAV,
@@ -35,23 +43,20 @@ const EXPECTED_ANCHOR_COUNT = 28;
 const FIRST_ANCHOR = "2026-06-26";
 
 /**
- * Three REAL NAVs, published in issues #146 and #149 and therefore already public.
- * They are here as a TRIPWIRE, not as data: they are exactly what a reader would
- * divide by to recover a scale factor, so if any of them ever reappears in the
- * committed file, the file was regenerated without synthesis and the real series is
- * back in a public repository. 07-25 is the Saturday no push ever captured.
+ * The tripwire's band, expressed WITHOUT the real series.
+ *
+ * This used to hold three real NAVs and assert none of them appeared in the file.
+ * That worked, but it put the very numbers it was protecting into a public
+ * repository — and it only ever sampled three anchors out of 28.
+ *
+ * The magnitude-free form is strictly stronger. Synthesis re-anchors the series at
+ * {@link SYNTHETIC_START_NAV} and carries it forward by day-over-day moves that are
+ * small by construction, so EVERY synthesized NAV sits near that anchor. The real
+ * fund's NAV is a different order of magnitude entirely. So "is every number in the
+ * file inside the synthetic band" catches a bypassed synthesis on ALL 28 anchors,
+ * needs no real value to compare against, and cannot itself leak one.
  */
-const PUBLISHED_REAL_NAVS = [19590.01, 19619.62, 19753.61];
-
-/** Every number reachable in the loaded payload, for the real-magnitude sweep. */
-function numbersIn(value: unknown, found: number[] = []): number[] {
-  if (typeof value === "number") found.push(value);
-  else if (Array.isArray(value)) for (const v of value) numbersIn(v, found);
-  else if (value && typeof value === "object") {
-    for (const v of Object.values(value)) numbersIn(v, found);
-  }
-  return found;
-}
+const SYNTHETIC_BAND_FACTOR = 2;
 
 describe("the committed anchor fixture", () => {
   it("loads with no database and no durable log", async () => {
@@ -85,31 +90,42 @@ describe("the committed anchor fixture", () => {
     }
   });
 
-  it("holds NONE of the fund's real published NAVs — the file is synthesized", async () => {
-    // Scanned over every number in the file, not just `fundValueUsd`: a real NAV
-    // reappearing anywhere means synthesis was bypassed. This is the check that would
-    // have caught the un-sanitized fixture, and it runs on every machine.
-    const values = new Set(numbersIn(await loadAnchorFixture()));
-    for (const nav of PUBLISHED_REAL_NAVS) {
-      expect([...values].some((v) => Math.abs(v - nav) < 0.01), String(nav)).toBe(
-        false,
+  it("carries no NAV of real magnitude — the file is synthesized", async () => {
+    // Every anchor's NAV, not a sample of three: a series of real magnitude anywhere
+    // in the file means synthesis was bypassed. This is the check that would have
+    // caught the un-sanitized fixture, and it runs on every machine.
+    const anchors = await loadAnchorFixture();
+    const low = SYNTHETIC_START_NAV / SYNTHETIC_BAND_FACTOR;
+    const high = SYNTHETIC_START_NAV * SYNTHETIC_BAND_FACTOR;
+    for (const anchor of anchors) {
+      const nav = anchor.report.totals.fundValueUsd;
+      expect(nav, `${anchor.asOf} NAV is outside the synthetic band`).toBeGreaterThan(
+        low,
+      );
+      expect(nav, `${anchor.asOf} NAV is outside the synthetic band`).toBeLessThan(
+        high,
       );
     }
   });
 
   it("reproduces the day-over-day NAV percentages navMove reads, within the jitter", async () => {
     // The magnitudes moved, and so — DELIBERATELY, by up to ±`NAV_JITTER_PP` — do the
-    // moves. 06-28 fell 1.72% from 06-26 in the real log. Preserving that exactly
-    // would publish the whole real series (three real NAVs are already public, so the
-    // scale factor divides out), so the fixture carries it displaced. What has to
-    // survive is not the number but the VERDICT: `navMove` is a threshold test, and
-    // `fixture-synthesis.ts` refuses to emit a series whose jitter moved any anchor
-    // across it. This asserts the move is still recognisably 1.72% and still fires.
+    // moves. 06-28 fell against 06-26 in the real log by more than the threshold.
+    // Preserving that move exactly would publish the whole real series, so the fixture
+    // carries it displaced. What has to survive is not the number but the VERDICT:
+    // `navMove` is a threshold test, and `fixture-synthesis.ts` refuses to emit a
+    // series whose jitter moved any anchor across it.
+    //
+    // Asserted as a PROPERTY, not against the real value. Naming the real move here
+    // and bounding the fixture within ±`NAV_JITTER_PP` of it would disclose that move
+    // to within the jitter — handing back exactly what the jitter exists to withhold.
+    // Faithfulness to the real series is `assertThresholdSideHolds`'s job, at
+    // regeneration, where the real series is legitimately in hand.
     const anchors = await loadAnchorFixture();
     const first = anchorAt(anchors, "2026-06-26").report.totals.fundValueUsd;
     const second = anchorAt(anchors, "2026-06-28").report.totals.fundValueUsd;
     const move = (second / first - 1) * 100;
-    expect(Math.abs(move - -1.72)).toBeLessThanOrEqual(NAV_JITTER_PP);
+    expect(move).toBeLessThan(0);
     expect(Math.abs(move)).toBeGreaterThanOrEqual(NAV_MOVE_THRESHOLD_PCT);
     // And every anchor carries a usable NAV: a blank one would make every delta
     // downstream of it meaningless.

--- a/apps/web/src/push/backfill.integration.test.ts
+++ b/apps/web/src/push/backfill.integration.test.ts
@@ -19,6 +19,7 @@
  *   NUMISMA_TEST_DATABASE_URL=postgres://amet@localhost:5432/numisma pnpm test
  */
 import { access, readFile } from "node:fs/promises";
+import { dirname, join } from "node:path";
 import { afterAll, beforeAll, describe, expect, it } from "vitest";
 import type { Pool } from "pg";
 import { resolveEventStorePaths } from "@numisma/event-store";
@@ -62,12 +63,32 @@ if (!runIntegration) {
   );
 }
 
-/** The three folds with independently known answers (07-25 is the lost Saturday). */
-const KNOWN_NAVS: [asOf: string, nav: number][] = [
-  ["2026-07-24", 19590.01],
-  ["2026-07-25", 19619.62],
-  ["2026-07-26", 19753.61],
-];
+/**
+ * The folds with independently known answers (07-25 is the lost Saturday).
+ *
+ * THE VALUES ARE NOT IN THIS REPOSITORY, WHICH IS PUBLIC. They are the real fund's
+ * NAV on three real dates — an external oracle, and the only thing in this test that
+ * could not be replaced by a fiction without making the assertion meaningless. They
+ * live beside the private log, in `known-navs.json` under the data directory:
+ *
+ *   [["2026-07-24", 12345.67], ...]   // shape only — not the real values
+ *
+ * That costs nothing in reach: this test is ALREADY gated on the private log being
+ * present, so the oracle is available on exactly the machines that can run it. When
+ * the file is absent the NAV assertion self-skips and says so; every other claim —
+ * row count, schema version, idempotency — still runs.
+ */
+async function loadKnownNavs(): Promise<[asOf: string, nav: number][] | null> {
+  try {
+    const raw = await readFile(
+      join(dirname(resolveEventStorePaths().log), "known-navs.json"),
+      "utf8",
+    );
+    return JSON.parse(raw) as [asOf: string, nav: number][];
+  } catch {
+    return null;
+  }
+}
 
 interface StoredRow {
   fund_id: string;
@@ -130,15 +151,26 @@ describe.skipIf(!runIntegration)("backfill → the projection DB", () => {
     expect(COMPOSITION_SNAPSHOT_SCHEMA_VERSION).toBe(3);
   });
 
-  it("reproduces the three known-good NAVs exactly, Saturday included", () => {
-    for (const [asOf, nav] of KNOWN_NAVS) {
-      const row = first.find((r) => r.as_of === asOf);
-      expect(row, `no row for ${asOf}`).toBeDefined();
-      expect(row!.report.totals.fundValueUsd, asOf).toBeCloseTo(nav, 2);
+  it("reproduces the known-good NAVs exactly, Saturday included", async () => {
+    const knownNavs = await loadKnownNavs();
+    if (knownNavs === null) {
+      console.warn(
+        `\n[backfill.integration] NAV oracle SKIPPED: no 'known-navs.json' beside the ` +
+          `private log.\n  The real NAVs are the one thing here that cannot live in a ` +
+          `public repository, so they are read from the private side.\n  Every other ` +
+          `claim in this test still ran.\n`,
+      );
+    } else {
+      for (const [asOf, nav] of knownNavs) {
+        const row = first.find((r) => r.as_of === asOf);
+        expect(row, `no row for ${asOf}`).toBeDefined();
+        expect(row!.report.totals.fundValueUsd, asOf).toBeCloseTo(nav, 2);
+      }
     }
     // 07-25 is the Saturday NO PUSH EVER CAPTURED. Before this command the
     // projection held 07-24 and 07-26 with a hole between them, so a delta against
-    // "the previous row" compared Sunday to Friday.
+    // "the previous row" compared Sunday to Friday. This holds with or without the
+    // oracle, so it is asserted outside the branch.
     expect(first.map((r) => r.as_of)).toContain("2026-07-25");
   });
 

--- a/apps/web/src/push/fixture-synthesis.ts
+++ b/apps/web/src/push/fixture-synthesis.ts
@@ -24,7 +24,7 @@
  *    perturbed value would change the verdict history;
  *  - the DAY-OVER-DAY PERCENTAGE CHANGE of NAV between consecutive anchors.
  *    `navMove` is a percent test against a named reference, and the measured history
- *    (06-28's −1.72%, whatever fires on 07-14) has to reproduce;
+ *    (what fires on 06-28, and on 07-14) has to reproduce;
  *  - the full STRUCTURAL shape: section ids/titles/order, row ids/kinds/labels/order,
  *    row counts, which rows carry `costBasisUsd`/`unrealizedPnlUsd` and which
  *    genuinely lack them (spec open question 3 — slice 5's per-row cost-basis
@@ -43,9 +43,9 @@
  *
  * ── THE NAV SERIES, AND WHY IT IS JITTERED ──────────────────────────────────────
  * Preserving every day-over-day NAV change EXACTLY would be mathematically the same
- * as publishing the real NAV series up to a single unknown factor — and issues
- * #146/#149 publish three real NAVs, so that factor is recoverable by division and
- * the whole 28-day series unscales. Composition, cost basis and P&L are SYNTHESIZED
+ * as publishing the real NAV series up to a single unknown factor — and any single
+ * real NAV that ever becomes public makes that factor recoverable by division, which
+ * unscales the whole 28-day series. Composition, cost basis and P&L are SYNTHESIZED
  * HERE FROM INVENTED PARAMETERS rather than scaled, so recovering the factor recovers
  * nothing about them (a uniform scale of the whole payload — the cheap alternative —
  * would have handed all of it back). The NAV series was the last thing it still
@@ -56,11 +56,16 @@
  * WHAT THE JITTER MUST NOT DO is move a verdict. `navMove` is a THRESHOLD test at
  * {@link NAV_MOVE_THRESHOLD_PCT}, and slice 4's replay asserts a measured 6 *yes* /
  * 22 *no* across the 28 anchors. The headroom is sufficient by construction — the
- * firing moves are −1.72%, +1.59% and +1.85%, the largest non-firing move is −1.42%,
- * and ±0.05pp cannot reach across either gap — but sufficiency is ASSERTED, not
- * trusted: {@link assertThresholdSideHolds} runs on every regeneration, has the real
- * series in hand, and throws rather than emit a fixture whose verdict history
+ * gap between the smallest firing move and the largest non-firing one is wider than
+ * the jitter band by more than an order of magnitude — but sufficiency is ASSERTED,
+ * not trusted: {@link assertThresholdSideHolds} runs on every regeneration, has the
+ * real series in hand, and throws rather than emit a fixture whose verdict history
  * differs from the fund's by one day.
+ *
+ * THE MOVES THEMSELVES ARE NOT NAMED HERE. This repository is public, and a comment
+ * listing the firing moves to two decimals publishes the fund's largest days as surely
+ * as the NAV series would. The real values belong to `assertThresholdSideHolds`'s
+ * runtime, and to the private notes vault — never to a committed doc comment.
  *
  * ── HOW THE INVENTED NUMBERS ARE BUILT ──────────────────────────────────────────
  * Deterministically, from `(asOf, rowId)` only — no clock, no randomness, no run id —


### PR DESCRIPTION
Five files on `main` carried real fund figures — three dated NAV values and the
measured day-over-day return range. **This repository is public.** Two of them were in
production source, and one was in the sanitization module that exists precisely to keep
this data out of the repo.

Each figure is replaced by **the property it was standing in for**, not by a fiction.
Fictional values were the obvious fix and they are wrong here — in one file they make
the assertion vacuous, in the other they make it fail.

### `anchor-fixture.test.ts` — the tripwire

Held three real NAVs and asserted the synthesized fixture contains none of them.
Substituting invented numbers leaves a test that passes forever and guards nothing —
this repo's own named failure, *a `no` that isn't*.

Replaced with a **synthetic-band check over all 28 anchors**: every NAV must sit near
`SYNTHETIC_START_NAV`, which a series of real magnitude violates by an order of
magnitude. Strictly broader than three samples on the NAV axis, and it names no real
value. It is narrower on the other axes — the old form swept every number in the payload
— and that narrowing is **stated in the file header** rather than left to be discovered.

### `anchor-fixture.test.ts` — the 06-28 assertion

Bounded the fixture's move to within `±NAV_JITTER_PP` of the real move, **which
discloses the real move to within the jitter**. The jitter was withholding precisely
what the assertion handed back.

Now asserts the property that matters: the move is negative and still crosses
`NAV_MOVE_THRESHOLD_PCT`. Whether the synthesized series stayed faithful to the real one
is `assertThresholdSideHolds`'s job, at regeneration, where the real series legitimately
lives and is never committed.

### `backfill.integration.test.ts` — the oracle

These NAVs are the expected output of folding the **real private log**. A fiction here
does not weaken the test, it **breaks** it on the only machine that runs it.

Moved beside the private log as `known-navs.json`. This costs nothing in reach — the
test was already gated on that log being present — so the oracle is available on exactly
the machines that can use it. When absent, the NAV assertion self-skips with a loud
warning and every other claim (row count, schema version, D8 payload shape, idempotency)
still runs.

### `fixture-synthesis.ts` and `verdict.ts` — the doc comments

Quoted the firing moves and the measured range to two decimals. That publishes the
fund's best and worst days as surely as the NAV series would. `fixture-synthesis.ts`
explained that the NAV jitter exists *because* three real NAVs were public — while
listing the returns two paragraphs further down.

## Verification

- `pnpm typecheck` clean across all six packages.
- `pnpm test` — **722 passed / 19 skipped**, run on this branch and on `main`.
  **Identical**: no test lost, no new skip, nothing newly gated.
- `git grep` for every real figure returns empty across the working tree.

## Follow-ups, deliberately not in this PR

- **Git history still contains these values.** This commit removes them going forward;
  it does not remove them from `git log -p`. Rewriting public history is a separate
  decision.
- The instrument roster and venue identifiers (~30 tracked files, plus the README) are
  untouched. Structural, and being handled separately.
