### PR TITLE
fix(engine,tui): unify reserve attribution and admit partial fills on Bitget import

### DIFF
--- a/apps/tui/src/event-store.test.ts
+++ b/apps/tui/src/event-store.test.ts
@@ -22,7 +22,25 @@ import {
   SPINE_MAGNITUDE_THRESHOLD_ENV,
 } from "./event-store.js";
 import type { SuppliedCashLeg } from "@numisma/engine";
-import { afterEach, describe, expect, it } from "vitest";
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+// Every case here is FILESYSTEM-bound: each one builds a real temp store (mkdir +
+// writes), folds it, and ingests — and the archive cases ingest twice. Under
+// `pnpm test` this file is scheduled alongside the real-`git`-subprocess suites
+// (ingest-commit-hardening, go-back-invariant, ingest-commit), whose individual
+// cases run 3–9s of subprocess and disk work. Measured on this tree: the archive
+// case ("never clobbers a prior archive…") costs ~540ms run in isolation and
+// 1.2–1.9s under full-suite load — a ~3x amplification that leaves the 5s vitest
+// DEFAULT under 3x of headroom. #178 saw it cross that line twice on a busier
+// machine, timing out the whole suite while passing in isolation.
+//
+// So the number is not a tolerance for slow code; it is headroom over scheduler
+// contention we do not control. 30_000 matches what the git-heavy tui suites
+// already set for the same reason — one convention, not a new number. Nothing
+// here awaits an unbounded operation (the archive's collision-suffix loop is
+// bounded by the first free name), so a case that actually reaches 30s is a real
+// hang and should be read as a defect, not raised again.
+vi.setConfig({ testTimeout: 30_000 });
 
 const GENESIS_AS_OF = "2026-06-01";
 

--- a/apps/tui/src/import-orders-cli.ts
+++ b/apps/tui/src/import-orders-cli.ts
@@ -41,6 +41,14 @@ if (!csvPath) {
     });
     if (outcome.status === "rejected") {
       process.exitCode = 1;
+    } else if (outcome.status === "imported-partial") {
+      // HANDLED, AND DELIBERATELY 0 (`D3`, #177). Lines WERE written, so exiting 1 would
+      // tell a caller the run failed when it partly succeeded — replacing one
+      // overstatement with another. The flow is interactive, and the operator's line
+      // (which opens on the unread rows and names the money direction) is the real
+      // channel. If this import is ever automated or piped, the exit code becomes the only
+      // surface left and this branch must be revisited — that is #183.
+      process.exitCode = 0;
     }
   } catch (error) {
     process.stderr.write(`${error instanceof Error ? error.message : String(error)}\n`);

--- a/apps/tui/src/import-orders-cli.ts
+++ b/apps/tui/src/import-orders-cli.ts
@@ -28,10 +28,12 @@ if (!csvPath) {
         ordersPath: resolveOrdersPath(),
         loadOrders,
         appendOrders,
-        reserveBalances: async () => {
-          const data = await loadFoldedReview(resolveEventStorePaths());
-          return data.reserves.map((reserve) => ({ id: reserve.id, amount: reserve.amount }));
-        },
+        // The folded review goes over WHOLE. This used to map `data.reserves` into
+        // `{ id, amount }` pairs here — three lines that quietly gave the `O1` guard a
+        // different reserve set than the rendered report reads, and stripped the
+        // currency it needed to refuse a cross-currency rung (#172). Admission is the
+        // engine's policy, not this wiring's.
+        fundReview: () => loadFoldedReview(resolveEventStorePaths()),
         ask: (question) => rl.question(question),
         out: (message) => process.stdout.write(message),
         err: (message) => process.stderr.write(`${message}\n`),

--- a/apps/tui/src/import-orders.test.ts
+++ b/apps/tui/src/import-orders.test.ts
@@ -15,7 +15,8 @@ import { appendOrders, loadOrders, resolveOrdersPath } from "@numisma/preference
 import {
   BITGET_OPEN_ORDERS_HEADER,
   parseBitgetOpenOrdersCsv,
-  type ReserveBalance,
+  parseFundReview,
+  type FundReviewData,
 } from "@numisma/engine";
 import { afterEach, describe, expect, it } from "vitest";
 import { importBitgetOpenOrders, type OrdersImportIo } from "./import-orders.js";
@@ -82,7 +83,36 @@ interface HarnessOptions {
    * with the operator answering the same way both times.
    */
   answers?: string[];
-  balances?: ReserveBalance[];
+  /**
+   * The LIVE reserves the folded fund carries, as `{ id, amount }` — synthesized into a
+   * real `FundReviewData` by {@link syntheticFund}, because the guard takes the fund now
+   * and derives its own reserve set from it (#172). A harness can no longer hand the
+   * guard a reserve list the rendered report would reject.
+   */
+  reserves?: { id: string; amount: number }[];
+}
+
+/** A minimal folded fund carrying the given LIVE, USD reserves. Round fakes only (`O7`). */
+function syntheticFund(reserves: { id: string; amount: number }[]): FundReviewData {
+  const parsed = parseFundReview({
+    fund: { id: "synthetic-fund", name: "Synthetic Fund", baseCurrency: "USD" },
+    review: { asOf: "2026-01-31", usdMxn: 20 },
+    portfolios: [{ id: "core", name: "Core" }],
+    accounts: [{ id: "venue-usd", name: "Synthetic Venue", platform: "BITGET", currency: "USD" }],
+    instruments: [{ id: "test-usd", name: "Test Asset", symbol: "XYZ", currency: "USD" }],
+    reserves: reserves.map((reserve) => ({
+      id: reserve.id,
+      portfolioId: "core",
+      tempo: "Capital",
+      executionMode: "live",
+      accountId: "venue-usd",
+      currency: "USD",
+      amount: reserve.amount,
+    })),
+    positions: [],
+  });
+  if (parsed.kind !== "ok") throw new Error(`fixture must parse, got ${parsed.kind}`);
+  return parsed.value;
 }
 
 async function harness(options: HarnessOptions = {}): Promise<Harness> {
@@ -106,7 +136,7 @@ async function harness(options: HarnessOptions = {}): Promise<Harness> {
       ordersPath,
       loadOrders: (path) => loadOrders(path, { warn: () => {} }),
       appendOrders,
-      reserveBalances: async () => options.balances ?? [{ id: "reserve-a", amount: 1000 }],
+      fundReview: async () => syntheticFund(options.reserves ?? [{ id: "reserve-a", amount: 1000 }]),
       ask: async (question) => {
         asked.push(question);
         if (answers.length === 0) {
@@ -194,7 +224,7 @@ describe("`O1` — the over-commitment reject (testing decision 6)", () => {
   it("refuses loudly and leaves the sidecar untouched when it does not yet exist", async () => {
     const { csvPath, io, ordersPath, errors } = await harness({
       // A balance far below the synthetic ladder's committed sum.
-      balances: [{ id: "reserve-a", amount: 10 }],
+      reserves: [{ id: "reserve-a", amount: 10 }],
     });
 
     const outcome = await importBitgetOpenOrders({ csvPath, io });
@@ -219,7 +249,7 @@ describe("`O1` — the over-commitment reject (testing decision 6)", () => {
 
   it("counts the orders ALREADY on file toward the reserve, not just the new batch", async () => {
     // Each half fits the balance alone; together they do not.
-    const first = await harness({ balances: [{ id: "reserve-a", amount: 250 }] });
+    const first = await harness({ reserves: [{ id: "reserve-a", amount: 250 }] });
     await importBitgetOpenOrders({ csvPath: first.csvPath, io: first.io });
     const before = await readFile(first.ordersPath, "utf8");
 
@@ -257,7 +287,7 @@ describe("the declared half — one field, once per batch", () => {
   it("lets ONE rung be overridden, keeping the batch answer for the rest", async () => {
     const { csvPath, io, ordersPath } = await harness({
       answers: ["reserve-a", "y", "", "reserve-b"],
-      balances: [
+      reserves: [
         { id: "reserve-a", amount: 1000 },
         { id: "reserve-b", amount: 1000 },
       ],

--- a/apps/tui/src/import-orders.test.ts
+++ b/apps/tui/src/import-orders.test.ts
@@ -100,6 +100,8 @@ interface Harness {
   ordersPath: string;
   asked: string[];
   errors: string[];
+  /** Everything the flow told the OPERATOR on the normal channel — merges included. */
+  outputs: string[];
 }
 
 interface HarnessOptions {
@@ -150,6 +152,7 @@ async function harness(options: HarnessOptions = {}): Promise<Harness> {
 
   const asked: string[] = [];
   const errors: string[] = [];
+  const outputs: string[] = [];
   const script = options.answers ?? ["reserve-a", "n"];
   let answers = [...script];
 
@@ -158,6 +161,7 @@ async function harness(options: HarnessOptions = {}): Promise<Harness> {
     ordersPath,
     asked,
     errors,
+    outputs,
     io: {
       readExport: (path) => readFile(path, "utf8"),
       ordersPath,
@@ -171,7 +175,9 @@ async function harness(options: HarnessOptions = {}): Promise<Harness> {
         }
         return answers.shift() ?? "";
       },
-      out: () => {},
+      out: (message) => {
+        outputs.push(message);
+      },
       err: (message) => {
         errors.push(message);
       },
@@ -249,6 +255,97 @@ describe("importBitgetOpenOrders — deterministic ids (testing decision 5)", ()
     expect(load.status).toBe("loaded");
     if (load.status !== "loaded") return;
     expect(load.records.map((record) => record.currency)).toEqual(["USD", "USD"]);
+  });
+});
+
+describe("one id identifies exactly ONE claim (#174)", () => {
+  /** Two rows the venue rendered identically in every id component: same second, same price. */
+  const COLLIDING_LADDER = ladder(
+    rung("1000", "1", "2020-01-01 10:00:00"),
+    rung("1000", "2", "2020-01-01 10:00:00"),
+  );
+
+  it("SUMS two rows colliding on one id into a single claim, and appends one line", async () => {
+    const { csvPath, io, ordersPath } = await harness({
+      csv: COLLIDING_LADDER,
+      reserves: [{ id: "reserve-a", amount: 5000 }],
+    });
+    const outcome = await importBitgetOpenOrders({ csvPath, io });
+
+    expect(outcome).toMatchObject({ status: "imported", appended: 1, alreadyKnown: 0 });
+    // ONE line, under ONE id, claiming the SUM. Dropping either row would be a guess;
+    // two lines under one id would make the second unreachable to the selector.
+    expect(await idsOnDisk(ordersPath)).toHaveLength(1);
+    expect(await remainingOnDisk(ordersPath)).toEqual([3]);
+  });
+
+  it("REPORTS the merge to the operator, naming both quantities and the total", async () => {
+    const { csvPath, io, outputs } = await harness({
+      csv: COLLIDING_LADDER,
+      reserves: [{ id: "reserve-a", amount: 5000 }],
+    });
+    await importBitgetOpenOrders({ csvPath, io });
+
+    const merge = outputs.find((message) => message.toLowerCase().includes("merged"));
+    expect(merge).toBeDefined();
+    const text = merge ?? "";
+    expect(text).toContain("1000"); // the price
+    expect(text).toContain("2020-01-01T10:00:00"); // the second
+    expect(text).toContain("1"); // the first quantity
+    expect(text).toContain("2"); // the second quantity
+    expect(text).toContain("3"); // the merged total
+    // And how to keep two genuinely separate rungs distinct next time.
+    expect(text).toContain("tick");
+  });
+
+  it("puts the SUMMED claim in front of `O1`, so an over-committed batch is caught", async () => {
+    // The balance covers ONE of the two colliding rows and not both. Deduping by id
+    // instead of summing would hide the second row from the guard entirely.
+    const { csvPath, io, ordersPath } = await harness({
+      csv: COLLIDING_LADDER,
+      reserves: [{ id: "reserve-a", amount: 1500 }],
+    });
+    const outcome = await importBitgetOpenOrders({ csvPath, io });
+
+    expect(outcome).not.toMatchObject({ status: "imported" });
+    expect(outcome).toMatchObject({ status: "rejected", reason: "over-committed" });
+    expect(await readOrDefault(ordersPath, "<<absent>>")).toBe("<<absent>>");
+  });
+
+  it("REFUSES an amended row — same id, different quantity — instead of calling it known", async () => {
+    const first = await harness({ reserves: [{ id: "reserve-a", amount: 5000 }] });
+    await importBitgetOpenOrders({ csvPath: first.csvPath, io: first.io });
+    const before = await readFile(first.ordersPath, "utf8");
+
+    // The SAME rung by every id component, re-exported with a different size. There is
+    // no verb for "this claim changed" yet, and a second placement line is ignored by
+    // the selector by construction — so it is refused, loudly, and nothing is written.
+    const amended = ladder(
+      rung("1000", "0.5", "2020-01-01 10:00:00"),
+      rung("900", "0.1", "2020-01-01 10:00:01"),
+    );
+    await writeFile(first.csvPath, amended, "utf8");
+    const outcome = await importBitgetOpenOrders({ csvPath: first.csvPath, io: first.io });
+
+    expect(outcome).toMatchObject({ status: "rejected", reason: "changed-claim" });
+    // NEVER counted as already known: it is a change, not a re-sighting.
+    expect(outcome).not.toMatchObject({ status: "imported" });
+    expect(first.errors.join("\n")).toContain("REFUSED");
+    expect(await readFile(first.ordersPath, "utf8")).toBe(before);
+  });
+
+  it("REFUSES a rung whose observed partial moved, rather than silently keeping the old one", async () => {
+    const partial = ladder(partlyFilledRung("100", "10", "6", "2020-01-01 10:00:00"));
+    const first = await harness({ csv: partial });
+    await importBitgetOpenOrders({ csvPath: first.csvPath, io: first.io });
+    const before = await readFile(first.ordersPath, "utf8");
+
+    const filledMore = ladder(partlyFilledRung("100", "10", "8", "2020-01-01 10:00:00"));
+    await writeFile(first.csvPath, filledMore, "utf8");
+    const outcome = await importBitgetOpenOrders({ csvPath: first.csvPath, io: first.io });
+
+    expect(outcome).toMatchObject({ status: "rejected", reason: "changed-claim" });
+    expect(await readFile(first.ordersPath, "utf8")).toBe(before);
   });
 });
 

--- a/apps/tui/src/import-orders.test.ts
+++ b/apps/tui/src/import-orders.test.ts
@@ -84,6 +84,15 @@ function partlyFilledRung(
   return BITGET_OPEN_ORDERS_HEADER.map((column) => fields[column] ?? "").join(",");
 }
 
+/**
+ * One synthetic rung the venue shows as FULLY filled — nothing still claimed, so the
+ * parser reports it as `not-resting` rather than admitting it (#173). This is the
+ * ordinary case of a rung filling between the export and the import (#184).
+ */
+function filledRung(price: string, quantity: string, at: string): string {
+  return partlyFilledRung(price, quantity, quantity, at);
+}
+
 function ladder(...rows: string[]): string {
   return [HEADER, ...rows, ""].join("\n");
 }
@@ -549,6 +558,60 @@ describe("a partial export imports, and every surface says it was partial", () =
     const { csvPath, io } = await harness();
     const outcome = await importBitgetOpenOrders({ csvPath, io });
     expect(outcome).toMatchObject({ status: "imported", appended: 2, alreadyKnown: 0 });
+  });
+});
+
+/**
+ * #184 — a `not-resting` skip is a WEIGHED rung, not an unread one.
+ *
+ * `parsed.skips` is heterogeneous: three of the four `BitgetRowProblem` members mean the
+ * row might still be claiming capital and we cannot say how much, while `not-resting`
+ * means the parser reached a POSITIVE finding — the encumbrance is zero. Summing all four
+ * into the INCOMPLETE line fires a money-direction alarm on the ordinary event of a rung
+ * filling between the export and the import, which is how that alarm becomes noise.
+ */
+describe("a rung that filled before the import is not a gap in the read", () => {
+  it("keeps the CLEAN status and line when the only skip is not-resting", async () => {
+    const csv = ladder(
+      rung("1000", "0.1", "2020-01-01 10:00:00"),
+      rung("900", "0.1", "2020-01-01 10:00:01"),
+      filledRung("1100", "0.1", "2020-01-01 10:00:02"),
+    );
+    const { csvPath, io, outputs, errors } = await harness({ csv });
+    const outcome = await importBitgetOpenOrders({ csvPath, io });
+
+    expect(outcome).toMatchObject({ status: "imported", appended: 2, alreadyKnown: 0 });
+    if (outcome.status !== "imported") throw new Error("expected a clean import");
+    expect(outputs.some((message) => message.includes("INCOMPLETE"))).toBe(false);
+    expect(
+      outputs.some((message) => message.startsWith(`Imported ${csvPath}: 2 order(s) appended, 0 already known.`)),
+    ).toBe(true);
+    // The skip is still CARRIED and still REPORTED — only the discrimination changed.
+    expect(outcome.skips).toHaveLength(1);
+    expect(errors.some((message) => message.includes("not a resting order"))).toBe(true);
+  });
+
+  it("counts only the UNWEIGHED skips in the INCOMPLETE line of a mixed export", async () => {
+    const csv = ladder(
+      rung("1000", "0.1", "2020-01-01 10:00:00"),
+      rung("900", "0.1", "2020-01-01 10:00:01"),
+      rung("not-a-price", "0.1", "2020-01-01 10:00:02"),
+      filledRung("1100", "0.1", "2020-01-01 10:00:03"),
+    );
+    const { csvPath, io, outputs, errors } = await harness({ csv });
+    const outcome = await importBitgetOpenOrders({ csvPath, io });
+
+    expect(outcome).toMatchObject({ status: "imported-partial", appended: 2, alreadyKnown: 0 });
+    if (outcome.status !== "imported-partial") throw new Error("expected a partial import");
+    const line = outputs.find((message) => message.includes("could not be read"));
+    expect(line).toBeDefined();
+    // ONE row could not be read — the malformed price. The filled rung was read fully.
+    expect(line).toContain("1 row(s)");
+    expect(line).not.toContain("2 row(s)");
+    // Both skips still ride the outcome and both are still on the error channel.
+    expect(outcome.skips).toHaveLength(2);
+    expect(errors.some((message) => message.includes("price must be a positive decimal"))).toBe(true);
+    expect(errors.some((message) => message.includes("not a resting order"))).toBe(true);
   });
 });
 

--- a/apps/tui/src/import-orders.test.ts
+++ b/apps/tui/src/import-orders.test.ts
@@ -16,6 +16,7 @@ import {
   BITGET_OPEN_ORDERS_HEADER,
   parseBitgetOpenOrdersCsv,
   parseFundReview,
+  pickRestingOrdersAsOf,
   type FundReviewData,
 } from "@numisma/engine";
 import { afterEach, describe, expect, it } from "vitest";
@@ -52,6 +53,32 @@ function rung(price: string, quantity: string, at: string): string {
     total_quantity: quantity,
     filled_percent: "0.00%",
     status: "Unfilled",
+    action: "Cancel",
+  };
+  return BITGET_OPEN_ORDERS_HEADER.map((column) => fields[column] ?? "").join(",");
+}
+
+/** One synthetic rung the venue shows as PARTIALLY FILLED, with a remainder still open. */
+function partlyFilledRung(
+  price: string,
+  quantity: string,
+  filled: string,
+  at: string,
+): string {
+  const fields: Record<string, string> = {
+    timestamp: at,
+    pair: "XYZ/USDT",
+    time_in_force: "GTC",
+    order_type: "Limit",
+    side: "Buy",
+    price,
+    quantity,
+    trigger_price: "-- / --",
+    order_value: "0",
+    filled_quantity: filled,
+    total_quantity: quantity,
+    filled_percent: "60.00%",
+    status: "PartiallyFilled",
     action: "Cancel",
   };
   return BITGET_OPEN_ORDERS_HEADER.map((column) => fields[column] ?? "").join(",");
@@ -165,6 +192,13 @@ async function idsOnDisk(path: string): Promise<string[]> {
   return load.status === "loaded" ? load.records.map((record) => record.id) : [];
 }
 
+/** What each rung on disk STILL CLAIMS, through the selector rather than by hand. */
+async function remainingOnDisk(path: string): Promise<number[]> {
+  const load = await loadOrders(path, { warn: () => {} });
+  if (load.status !== "loaded") return [];
+  return pickRestingOrdersAsOf(load.records).map((order) => order.remainingQuantity);
+}
+
 describe("importBitgetOpenOrders — deterministic ids (testing decision 5)", () => {
   it("appends the ladder once and ZERO lines on a re-import of the same export", async () => {
     const first = await harness();
@@ -179,6 +213,33 @@ describe("importBitgetOpenOrders — deterministic ids (testing decision 5)", ()
     // The file is BYTE-IDENTICAL: not merely "no new orders", but no new lines at all.
     expect(await readFile(first.ordersPath, "utf8")).toBe(afterFirst);
     expect(await idsOnDisk(first.ordersPath)).toHaveLength(2);
+  });
+
+  it("stays idempotent over a PARTIALLY-FILLED rung — no double-counted partial", async () => {
+    // #173. The partial rides on the placement line, so a re-import is the same
+    // deterministic id and appends nothing. If it were a synthesized `orderFilled` line
+    // instead, the second import would subtract the same 6 units a second time and the
+    // rung would read 8 remaining of a 10-unit claim — free capital that does not exist.
+    const partial = ladder(partlyFilledRung("100", "10", "6", "2020-01-01 10:00:00"));
+    const first = await harness({ csv: partial });
+    expect(await importBitgetOpenOrders({ csvPath: first.csvPath, io: first.io })).toMatchObject({
+      status: "imported",
+      appended: 1,
+    });
+    const afterFirst = await readFile(first.ordersPath, "utf8");
+    expect(await remainingOnDisk(first.ordersPath)).toEqual([4]);
+
+    const again = await importBitgetOpenOrders({ csvPath: first.csvPath, io: first.io });
+    expect(again).toMatchObject({ status: "imported", appended: 0, alreadyKnown: 1 });
+
+    // Byte-identical, and the remainder is unmoved: counted once, on both readings.
+    expect(await readFile(first.ordersPath, "utf8")).toBe(afterFirst);
+    expect(await remainingOnDisk(first.ordersPath)).toEqual([4]);
+    // And no `orderFilled` line was ever synthesized — which would also read as a torn
+    // fill act, since no lot in `events.jsonl` answers for it.
+    const load = await loadOrders(first.ordersPath, { warn: () => {} });
+    if (load.status !== "loaded") throw new Error("expected a loaded sidecar");
+    expect(load.records.map((record) => record.kind)).toEqual(["orderPlaced"]);
   });
 
   it("carries the pair's quote currency onto every record, explicitly", async () => {

--- a/apps/tui/src/import-orders.test.ts
+++ b/apps/tui/src/import-orders.test.ts
@@ -497,3 +497,81 @@ describe("the export is refused whole when it is not an open-orders export", () 
     expect(await readFile(ordersPath, "utf8")).toBe("{not json}\n");
   });
 });
+
+/**
+ * `D2`/`D3` (#177 item 4) — a partial export STILL imports, and says so as a gap.
+ *
+ * The two partial-read policies stay ASYMMETRIC on purpose. Appending over a partially
+ * read SIDECAR asserts something false: `known` is built only from readable lines, so a
+ * row whose sidecar line was unreadable looks FRESH and appends a second time, and
+ * `detectChangedClaims` goes blind over that region. Skipping an unparseable EXPORT row
+ * asserts nothing — it omits, it cannot duplicate, it is reported with a line and a
+ * reason, and the next export carries the same rung again. What it must NOT do is read as
+ * an unqualified success on any of the three surfaces: the status, the operator's line, or
+ * the exit code.
+ */
+describe("a partial export imports, and every surface says it was partial", () => {
+  /** One readable rung and one whose price no build can read — a real, reported skip. */
+  const PARTLY_READABLE_LADDER = ladder(
+    rung("1000", "0.1", "2020-01-01 10:00:00"),
+    rung("not-a-price", "0.1", "2020-01-01 10:00:01"),
+  );
+
+  it("DISCRIMINATES in the status rather than hiding the gap in a second field", async () => {
+    const { csvPath, io } = await harness({ csv: PARTLY_READABLE_LADDER });
+    const outcome = await importBitgetOpenOrders({ csvPath, io });
+    expect(outcome).toMatchObject({ status: "imported-partial", appended: 1, alreadyKnown: 0 });
+    if (outcome.status !== "imported-partial") throw new Error("expected a partial import");
+    expect(outcome.skips).toHaveLength(1);
+  });
+
+  it("LEADS the operator's line with the unread rows and names the money DIRECTION", async () => {
+    const { csvPath, io, outputs } = await harness({ csv: PARTLY_READABLE_LADDER });
+    await importBitgetOpenOrders({ csvPath, io });
+
+    const line = outputs.find((message) => message.includes("could not be read"));
+    expect(line).toBeDefined();
+    // The gap OPENS the line — not a suffix after two success numbers.
+    expect(line?.startsWith("INCOMPLETE")).toBe(true);
+    expect(line).toContain("1 row(s)");
+    expect(line).toContain("available reads HIGH");
+    // The counts still follow, after the qualifier rather than before it.
+    expect(line).toContain("1 order(s) appended");
+  });
+
+  it("still WRITES the readable rungs — the skip omits, it does not refuse", async () => {
+    const { csvPath, io, ordersPath } = await harness({ csv: PARTLY_READABLE_LADDER });
+    await importBitgetOpenOrders({ csvPath, io });
+    expect(await idsOnDisk(ordersPath)).toHaveLength(1);
+  });
+
+  it("keeps a CLEAN export on the unqualified status", async () => {
+    const { csvPath, io } = await harness();
+    const outcome = await importBitgetOpenOrders({ csvPath, io });
+    expect(outcome).toMatchObject({ status: "imported", appended: 2, alreadyKnown: 0 });
+  });
+});
+
+/**
+ * #177 item 5 — a failed sidecar write returns through the refusal contract.
+ *
+ * `appendOrders` is atomic (temp + rename), so a rejection means nothing landed; the
+ * operator is owed the flow's own `REFUSED — ... Nothing was written` line rather than a
+ * bare stack from the CLI's outer catch. The precedent is `record-fill.ts`, which has
+ * carried a `write-failed` member for exactly this case all along.
+ */
+describe("a failed sidecar write is a refusal, not a thrown error", () => {
+  it("returns write-failed instead of throwing out of the flow", async () => {
+    const { csvPath, io, errors } = await harness();
+    io.appendOrders = async () => {
+      throw new Error("synthetic sidecar write failure");
+    };
+
+    const outcome = await importBitgetOpenOrders({ csvPath, io });
+
+    expect(outcome).toMatchObject({ status: "rejected", reason: "write-failed" });
+    if (outcome.status !== "rejected") throw new Error("expected a rejection");
+    expect(outcome.message).toContain("synthetic sidecar write failure");
+    expect(errors.some((message) => message.startsWith("REFUSED —"))).toBe(true);
+  });
+});

--- a/apps/tui/src/import-orders.ts
+++ b/apps/tui/src/import-orders.ts
@@ -24,7 +24,7 @@ import {
   type BitgetRowSkip,
   type OrderPlacedRecord,
   type OrderRecord,
-  type ReserveBalance,
+  type FundReviewData,
 } from "@numisma/engine";
 import type { OrdersLoad } from "@numisma/preferences";
 
@@ -36,8 +36,17 @@ export interface OrdersImportIo {
   ordersPath: string;
   loadOrders: (path: string) => Promise<OrdersLoad>;
   appendOrders: (path: string, records: OrderRecord[]) => Promise<void>;
-  /** The reserves as the FOLD reports them: value, untouched by any order. */
-  reserveBalances: () => Promise<ReserveBalance[]>;
+  /**
+   * The FOLDED fund review — the whole thing, not a reserve list derived from it.
+   *
+   * This used to be `reserveBalances: () => Promise<ReserveBalance[]>`, and the CLI
+   * satisfied it with `data.reserves.map(...)` — every reserve the fold emitted, with no
+   * currency. That mapping was the bug (#172): it handed the guard reserves the rendered
+   * report refuses to place, so a ladder could be FUNDABLE at import and UNPLACEABLE in
+   * the report. The admission policy belongs to the engine, so the fund goes over
+   * whole and this shell derives nothing.
+   */
+  fundReview: () => Promise<FundReviewData>;
   /** Ask the operator one question; the answer is returned trimmed by the caller. */
   ask: (question: string) => Promise<string>;
   out: (message: string) => void;
@@ -52,6 +61,7 @@ export type OrdersImportRejection =
   | "unreadable-sidecar-lines"
   | "no-reserve-declared"
   | "unknown-reserve"
+  | "currency-mismatch"
   | "over-committed";
 
 export type OrdersImportOutcome =
@@ -193,12 +203,29 @@ export async function importBitgetOpenOrders(
   // this batch — because a reserve funds every claim against it, not one import's slice.
   // The selector dedupes by id, so a re-import does not double-count the same rung.
   const resting = pickRestingOrdersAsOf([...existingRecords, ...records]);
-  const coverage = checkFundingCoverage(resting, await io.reserveBalances());
+  const coverage = checkFundingCoverage(resting, await io.fundReview());
   if (coverage.status === "unknown-reserve") {
     return reject(
       io,
       "unknown-reserve",
-      `no such reserve: ${coverage.fundingReserveIds.join(", ")}`,
+      `no such fundable reserve: ${coverage.fundingReserveIds.join(", ")}. A reserve the ` +
+        `fold excluded — paper execution mode, an unsupported currency, a dangling ` +
+        `account reference — cannot fund a live order either, and the available-capital ` +
+        `report would not be able to place it`,
+    );
+  }
+  if (coverage.status === "currency-mismatch") {
+    // Cross-currency funding is not designed; it is refused, here and in the report.
+    // Accepting it would sum a quote-denominated committed into a native balance and
+    // report free capital that does not exist.
+    const detail = coverage.rungs
+      .map((rung) => `${rung.orderId} (${rung.currency}) against ${rung.fundingReserveId}`)
+      .join("; ");
+    return reject(
+      io,
+      "currency-mismatch",
+      `these rungs are quoted in a currency their declared reserve does not hold — ` +
+        `${detail}. Cross-currency funding is not supported; fix the declaration`,
     );
   }
   if (coverage.status === "over-committed") {

--- a/apps/tui/src/import-orders.ts
+++ b/apps/tui/src/import-orders.ts
@@ -76,22 +76,42 @@ export type OrdersImportRejection =
   | "changed-claim"
   | "unknown-reserve"
   | "currency-mismatch"
-  | "over-committed";
+  | "over-committed"
+  /**
+   * The sidecar append itself failed (#177 item 5). `appendOrders` builds a full next
+   * image and renames, so a failure means NOTHING landed and the flow's own refusal
+   * contract is the honest report — not a bare stack out of the CLI's outer catch.
+   */
+  | "write-failed";
+
+/** What an import that WROTE reports, in the two shapes it can honestly take. */
+interface OrdersImportWrite {
+  /** Lines actually appended. ZERO when the same export is imported twice. */
+  appended: number;
+  /**
+   * Rungs already in the sidecar under the same synthesized id AND saying the same
+   * thing about it — the id components plus `quantity` and the observed partial. A
+   * row that differs never reaches this count; it refuses the batch as
+   * `changed-claim` (#174).
+   */
+  alreadyKnown: number;
+  /** The export rows this build could not read. EMPTY on `imported`, by construction. */
+  skips: BitgetRowSkip[];
+}
 
 export type OrdersImportOutcome =
-  | {
-      status: "imported";
-      /** Lines actually appended. ZERO when the same export is imported twice. */
-      appended: number;
-      /**
-       * Rungs already in the sidecar under the same synthesized id AND saying the same
-       * thing about it — the id components plus `quantity` and the observed partial. A
-       * row that differs never reaches this count; it refuses the batch as
-       * `changed-claim` (#174).
-       */
-      alreadyKnown: number;
-      skips: BitgetRowSkip[];
-    }
+  /** Every row of the export was read. The unqualified success, and the only one. */
+  | ({ status: "imported" } & OrdersImportWrite)
+  /**
+   * The readable rungs were written and at least one row was NOT read (`D3`, #177).
+   *
+   * A DISTINCT MEMBER, not `imported` carrying a non-empty `skips`. The risk is real —
+   * an unread rung is `committed` that nobody counted, so `available` reads HIGH, the
+   * direction that costs money — and a shape that forces every reader to open a second
+   * field to discover the first was qualified is a type that lies to the reader who does
+   * not. It is still a SUCCESS: lines were written, and the CLI exits 0 (`D3`).
+   */
+  | ({ status: "imported-partial" } & OrdersImportWrite)
   | { status: "rejected"; reason: OrdersImportRejection; message: string };
 
 export interface OrdersImportOptions {
@@ -325,17 +345,42 @@ export async function importBitgetOpenOrders(
 
   const known = new Set(existingRecords.map((record) => record.id));
   const fresh: OrderPlacedRecord[] = records.filter((record) => !known.has(record.id));
-  await io.appendOrders(io.ordersPath, fresh);
+  try {
+    await io.appendOrders(io.ordersPath, fresh);
+  } catch (error) {
+    // The write is a temp file plus a rename, so a failure here landed NOTHING — the
+    // refusal contract's "Nothing was written" is literally true, and the operator gets
+    // it instead of a stack trace from the CLI's outer catch (#177 item 5).
+    const detail = error instanceof Error ? error.message : String(error);
+    return reject(io, "write-failed", `could not append to ${io.ordersPath}: ${detail}`);
+  }
 
+  const counts =
+    `${fresh.length} order(s) appended, ${records.length - fresh.length} already known`;
+  if (parsed.skips.length === 0) {
+    io.out(`Imported ${csvPath}: ${counts}.\n`);
+    return {
+      status: "imported",
+      appended: fresh.length,
+      alreadyKnown: records.length - fresh.length,
+      skips: parsed.skips,
+    };
+  }
+
+  // THE GAP OPENS THE LINE, AND IN MONEY TERMS (`D3`, #177). It used to be a suffix after
+  // two success numbers — `..., 1 row(s) skipped.` — in exactly the position an operator
+  // skims past. An unread row is a rung resting at the venue that no committed sum
+  // includes, so the figure this import feeds reads HIGH; naming that direction is what
+  // makes it a risk rather than a statistic.
   io.out(
-    `Imported ${csvPath}: ${fresh.length} order(s) appended, ` +
-      `${records.length - fresh.length} already known` +
-      (parsed.skips.length > 0 ? `, ${parsed.skips.length} row(s) skipped` : "") +
-      `.\n`,
+    `INCOMPLETE — ${parsed.skips.length} row(s) of ${csvPath} could not be read, so that ` +
+      `many rung(s) resting at the venue are NOT counted as committed and available reads ` +
+      `HIGH by whatever they encumber. Imported ${csvPath}: ${counts}. Re-export and ` +
+      `re-import to pick the missing rung(s) up; the reasons are on the error channel above.\n`,
   );
 
   return {
-    status: "imported",
+    status: "imported-partial",
     appended: fresh.length,
     alreadyKnown: records.length - fresh.length,
     skips: parsed.skips,

--- a/apps/tui/src/import-orders.ts
+++ b/apps/tui/src/import-orders.ts
@@ -19,6 +19,7 @@ import {
   buildOrderPlacedRecords,
   checkFundingCoverage,
   detectChangedClaims,
+  leavesRungUnweighed,
   mergeCollidingClaims,
   parseBitgetOpenOrdersCsv,
   pickRestingOrdersAsOf,
@@ -357,7 +358,13 @@ export async function importBitgetOpenOrders(
 
   const counts =
     `${fresh.length} order(s) appended, ${records.length - fresh.length} already known`;
-  if (parsed.skips.length === 0) {
+  // NOT `parsed.skips.length` (#184). `skips` is heterogeneous, and a `not-resting` row
+  // was read COMPLETELY — the parser's finding about it is that nothing is still claimed.
+  // The gap this line warns about is rungs we could not weigh, so both the discrimination
+  // and the count below run through the engine's predicate rather than the raw total.
+  // `outcome.skips` still carries every skip and stderr still reports every one of them.
+  const unweighed = parsed.skips.filter((entry) => leavesRungUnweighed(entry.problem));
+  if (unweighed.length === 0) {
     io.out(`Imported ${csvPath}: ${counts}.\n`);
     return {
       status: "imported",
@@ -373,7 +380,7 @@ export async function importBitgetOpenOrders(
   // includes, so the figure this import feeds reads HIGH; naming that direction is what
   // makes it a risk rather than a statistic.
   io.out(
-    `INCOMPLETE — ${parsed.skips.length} row(s) of ${csvPath} could not be read, so that ` +
+    `INCOMPLETE — ${unweighed.length} row(s) of ${csvPath} could not be read, so that ` +
       `many rung(s) resting at the venue are NOT counted as committed and available reads ` +
       `HIGH by whatever they encumber. Imported ${csvPath}: ${counts}. Re-export and ` +
       `re-import to pick the missing rung(s) up; the reasons are on the error channel above.\n`,

--- a/apps/tui/src/import-orders.ts
+++ b/apps/tui/src/import-orders.ts
@@ -8,8 +8,8 @@
  * Every IO dependency is injected, so the whole flow — including the prompt and the
  * `O1` reject — is testable without a terminal, a real export or the real data dir.
  *
- * THE ORDERING IS THE CONTRACT: parse → load the sidecar → prompt → check coverage →
- * append. The coverage check is the LAST thing before the only write, and every refusal
+ * THE ORDERING IS THE CONTRACT: parse → merge id collisions → load the sidecar → refuse
+ * changed claims → prompt → check coverage → append. The coverage check is the LAST thing before the only write, and every refusal
  * before it returns having written nothing at all. `orders.jsonl` is append-only, so a
  * wrong claim written here is not edited away later — it costs a compensating line
  * forever, and that asymmetry is why the refusals are loud and total rather than
@@ -18,10 +18,13 @@
 import {
   buildOrderPlacedRecords,
   checkFundingCoverage,
+  detectChangedClaims,
+  mergeCollidingClaims,
   parseBitgetOpenOrdersCsv,
   pickRestingOrdersAsOf,
   type BitgetOpenOrder,
   type BitgetRowSkip,
+  type MergedOrderClaim,
   type OrderPlacedRecord,
   type OrderRecord,
   type FundReviewData,
@@ -60,6 +63,17 @@ export type OrdersImportRejection =
   | "unreadable-sidecar"
   | "unreadable-sidecar-lines"
   | "no-reserve-declared"
+  /**
+   * A row names a claim already on file but says something DIFFERENT about it (#174).
+   *
+   * Refused rather than recorded, and this is the ONE place the "proceed with the
+   * arithmetic" reasoning behind the within-batch merge does not extend. Recording a
+   * change needs a verb this build does not have: a second `orderPlaced` line is ignored
+   * by `pickRestingOrdersAsOf` by construction (that guard is what makes re-import
+   * idempotent), and an observation verb is a later design that must not be pre-empted
+   * by one invented here, in an append-only file, to get past this import.
+   */
+  | "changed-claim"
   | "unknown-reserve"
   | "currency-mismatch"
   | "over-committed";
@@ -69,7 +83,12 @@ export type OrdersImportOutcome =
       status: "imported";
       /** Lines actually appended. ZERO when the same export is imported twice. */
       appended: number;
-      /** Rungs already in the sidecar under the same synthesized id. */
+      /**
+       * Rungs already in the sidecar under the same synthesized id AND saying the same
+       * thing about it — the id components plus `quantity` and the observed partial. A
+       * row that differs never reaches this count; it refuses the batch as
+       * `changed-claim` (#174).
+       */
       alreadyKnown: number;
       skips: BitgetRowSkip[];
     }
@@ -89,6 +108,24 @@ function reject(
   // be able to mistake a refusal for a quiet no-op.
   io.err(`REFUSED — ${message}\nNothing was written to ${io.ordersPath}.`);
   return { status: "rejected", reason, message };
+}
+
+/**
+ * The operator-facing line for one merged claim — FIRST-CLASS output, not an aside.
+ *
+ * Two rows the venue rendered under one id have been summed, and the operator is owed
+ * the whole arithmetic: which rung, at what second, both sizes, the total that will be
+ * written, and the remedy if the two were meant to stay distinct claims.
+ */
+function describeMerge(merge: MergedOrderClaim): string {
+  return (
+    `MERGED — ${merge.symbol} ${merge.side} at ${merge.price}, submitted ${merge.observedAt}: ` +
+    `${merge.quantities.length} rows sharing one id (${merge.quantities.join(" + ")}) were ` +
+    `summed into ONE claim of ${merge.mergedQuantity}. The venue's export carries no order ` +
+    `id, and these rows agree on every field identity is built from, so the sum is the only ` +
+    `reading that neither invents a second claim nor frees committed capital. To keep two ` +
+    `rungs distinct, re-place one a tick apart so their prices differ.`
+  );
 }
 
 /** How one rung is shown when the operator asks to override it. */
@@ -175,6 +212,15 @@ export async function importBitgetOpenOrders(
     return reject(io, "no-orders", `${csvPath} contains no resting orders this build can read`);
   }
 
+  // ONE ID, ONE CLAIM (#174). Rows of this batch colliding on the synthesized id are
+  // SUMMED before anything else sees them, so the guard below weighs the whole claim and
+  // the append writes one line for it. Told to the operator on the normal channel: this
+  // is arithmetic that was applied, not a warning about something skipped.
+  const { orders, merges } = mergeCollidingClaims(parsed.orders);
+  for (const merge of merges) {
+    io.out(`${describeMerge(merge)}\n`);
+  }
+
   const existing = await io.loadOrders(io.ordersPath);
   if (existing.status === "unreadable") {
     // "There are no orders" and "I could not read the orders" are opposite facts about
@@ -192,12 +238,44 @@ export async function importBitgetOpenOrders(
   }
   const existingRecords: OrderRecord[] = existing.status === "loaded" ? existing.records : [];
 
-  const declaration = await declareFunding(io, parsed.orders);
+  // A row that names a known claim and DISAGREES with it is refused BEFORE the prompt and
+  // before the guard — the guard would read the claim's size off the file, not off this
+  // row (a repeat placement is ignored by the selector), so proceeding would check
+  // coverage against a book the export no longer describes.
+  const changed = detectChangedClaims(
+    existingRecords.filter(
+      (record): record is OrderPlacedRecord => record.kind === "orderPlaced",
+    ),
+    orders,
+  );
+  if (changed.length > 0) {
+    const detail = changed
+      .map(
+        (claim) =>
+          `${claim.id} (` +
+          claim.differences
+            .map((difference) => `${difference.field} ${difference.known} → ${difference.observed}`)
+            .join(", ") +
+          `)`,
+      )
+      .join("; ");
+    return reject(
+      io,
+      "changed-claim",
+      `${csvPath} re-states a claim already on file with different terms — ${detail}. An id ` +
+        `identifies exactly one claim, and this build has no verb for "the claim changed": a ` +
+        `second placement line would be ignored by the selector, and calling this row ALREADY ` +
+        `KNOWN would leave the wrong size committed. Cancel the rung at the venue and record ` +
+        `the cancellation, or re-place it at a different price so it arrives as a new claim`,
+    );
+  }
+
+  const declaration = await declareFunding(io, orders);
   if (declaration === undefined) {
     return reject(io, "no-reserve-declared", "no funding reserve was declared for this batch");
   }
 
-  const records = buildOrderPlacedRecords(parsed.orders, declaration);
+  const records = buildOrderPlacedRecords(orders, declaration);
 
   // `O1`. Coverage is checked over the WHOLE resting book — what is already on file plus
   // this batch — because a reserve funds every claim against it, not one import's slice.

--- a/apps/tui/src/record-fill.test.ts
+++ b/apps/tui/src/record-fill.test.ts
@@ -89,6 +89,8 @@ class Harness {
   failWrite: "log" | "orders" | "orders-and-rollback" | undefined;
   readonly out: string[] = [];
   readonly err: string[] = [];
+  /** Every question the flow put to the operator, in order — the prompt TEXT matters. */
+  readonly asked: string[] = [];
   private readonly answers: string[];
 
   constructor(options: {
@@ -145,7 +147,10 @@ class Harness {
       loadGenesis: async () => genesisSeed(),
       loadLogEvents: async () => this.logEvents(),
       loadFolded: async () => foldEvents(genesisSeed(), this.logEvents()),
-      ask: async () => this.answers.shift() ?? "",
+      ask: async (question) => {
+        this.asked.push(question);
+        return this.answers.shift() ?? "";
+      },
       out: (message) => this.out.push(message),
       err: (message) => this.err.push(message),
     };
@@ -428,6 +433,169 @@ describe("monotonicity refuses BEFORE any write", () => {
     expect(outcome.reason).toBe("impossible-verdict");
     expect(harness.ordersImage).toBe(ordersBefore);
     expect(harness.logImage).toBeUndefined();
+  });
+});
+
+// #176. `ObservedRungState.filledQuantity` is CUMULATIVE-SINCE-PLACEMENT, so this flow
+// must supply that basis for BOTH the rung it is recording and the rungs it asks about —
+// and the guard must compare it against the rung's ORIGINAL quantity.
+describe("`filled_quantity observed` is the venue's CUMULATIVE figure", () => {
+  /** rung-300 with 7 of its 10 already recorded as filled, and the lot that answers for it. */
+  function ladderWithRecordedPartial(): { records: OrderRecord[]; events: PortfolioEvent[] } {
+    return {
+      records: [
+        ...ladderRecords(),
+        {
+          id: "rung-300",
+          observedAt: "2026-01-03T09:00:00",
+          kind: "orderFilled",
+          currency: "USD",
+          filledQuantity: 7,
+        },
+      ],
+      events: [
+        {
+          id: "fill:rung-300@2026-01-03T09:00:00",
+          asOf: "2026-01-03",
+          type: "PositionOpened",
+          position: {
+            id: "position-synthetic",
+            portfolioId: "portfolio-synthetic",
+            tempo: "Capital",
+            executionMode: "live",
+            accountId: "account-synthetic",
+            instrumentId: "instrument-synthetic",
+            direction: "long",
+            currency: "USD",
+            lots: [{ quantity: 7, cost: 300, tier: "c1" }],
+          },
+          decision: {
+            entryThesis: "synthetic entry thesis",
+            invalidationCondition: "synthetic invalidation condition",
+            riskBudget: "synthetic risk budget",
+            plannedHoldingHorizon: "synthetic horizon",
+            strategy: "synthetic strategy",
+          },
+          funding: { reserveId: "reserve-synthetic", amount: 2100 },
+        } as PortfolioEvent,
+      ],
+    };
+  }
+
+  it("records an UNRELATED rung's fill while rung-300 reads its honest cumulative 7", async () => {
+    // rung-300 was placed for 10 and 7 are recorded, so it still claims 3. The operator
+    // honestly reports the venue's cumulative 7 for it while recording a fill on rung-400.
+    // Compared against the REMAINDER that would be `7 > 3` — an "arithmetic, not policy"
+    // refusal that discredits the whole book and refuses the operator's unrelated act.
+    const { records, events } = ladderWithRecordedPartial();
+    const harness = new Harness({
+      records,
+      events,
+      answers: [
+        "rung-400", // which rung filled
+        "2026-01-05T12:00:00", // fill timestamp
+        "", // filled quantity — the whole remaining claim, so rung-400 leaves the book
+        "t", // rung-300 touched
+        "7", //   filled_quantity observed — the venue's CUMULATIVE figure
+        "r", // rung-200 still resting untouched
+        "y", // confirm the derived verdicts
+        "", // append this lot to the ladder's existing Position
+        "", // cash debited — accept price x quantity
+        "y", // write BOTH
+      ],
+    });
+
+    const outcome = await recordFill(harness.io);
+
+    expectRecorded(outcome);
+    expect(reconcileFillActs(harness.logEvents(), harness.orderRecords())).toEqual([]);
+  });
+
+  it("pushes the rung's own state as a CUMULATIVE total, never as this fill's delta", async () => {
+    // rung-400 was placed for 10 with 4 already recorded, so it still claims 6. A further
+    // fill of 2 leaves it on the book: the venue's cumulative reading is 6, not 2.
+    const harness = new Harness({
+      records: [
+        ...ladderRecords(),
+        {
+          id: "rung-400",
+          observedAt: "2026-01-03T09:00:00",
+          kind: "orderFilled",
+          currency: "USD",
+          filledQuantity: 4,
+        },
+      ],
+      events: [
+        {
+          id: "fill:rung-400@2026-01-03T09:00:00",
+          asOf: "2026-01-03",
+          type: "PositionOpened",
+          position: {
+            id: "position-synthetic",
+            portfolioId: "portfolio-synthetic",
+            tempo: "Capital",
+            executionMode: "live",
+            accountId: "account-synthetic",
+            instrumentId: "instrument-synthetic",
+            direction: "long",
+            currency: "USD",
+            lots: [{ quantity: 4, cost: 400, tier: "c1" }],
+          },
+          decision: {
+            entryThesis: "synthetic entry thesis",
+            invalidationCondition: "synthetic invalidation condition",
+            riskBudget: "synthetic risk budget",
+            plannedHoldingHorizon: "synthetic horizon",
+            strategy: "synthetic strategy",
+          },
+          funding: { reserveId: "reserve-synthetic", amount: 1600 },
+        } as PortfolioEvent,
+      ],
+      answers: [
+        "rung-400",
+        "2026-01-05T12:00:00",
+        "2", // a partial — the rung keeps resting with 4 still claimed
+        "r", // rung-300 untouched
+        "r", // rung-200 untouched
+        "y",
+        "", // append to the ladder's existing Position
+        "", // cash debited
+        "y",
+      ],
+    });
+
+    expectRecorded(await recordFill(harness.io));
+    // The evidence the operator is shown is the CUMULATIVE reading, so it is the same
+    // number they can check against the venue's own column.
+    expect(harness.out.join("")).toContain("filled_quantity 6");
+    expect(harness.out.join("")).not.toContain("filled_quantity 2");
+  });
+
+  it("names the basis in the prompt, so the operator reads the right column", async () => {
+    const harness = new Harness({
+      answers: [
+        "rung-400",
+        "2026-01-05T12:00:00",
+        "", // the whole claim — rung-400 leaves the book
+        "t", // rung-300 touched, which is what triggers the quantity prompt
+        "5",
+        "r", // rung-200 untouched
+        "y",
+        "position-synthetic",
+        "",
+        "synthetic entry thesis",
+        "synthetic invalidation condition",
+        "synthetic risk budget",
+        "synthetic horizon",
+        "synthetic strategy",
+        "",
+        "y",
+      ],
+    });
+    await recordFill(harness.io);
+    const prompt = harness.asked.find((question) => question.includes("filled_quantity"));
+    expect(prompt).toBeDefined();
+    expect(prompt?.toLowerCase()).toContain("cumulative");
   });
 });
 

--- a/apps/tui/src/record-fill.test.ts
+++ b/apps/tui/src/record-fill.test.ts
@@ -599,6 +599,123 @@ describe("`filled_quantity observed` is the venue's CUMULATIVE figure", () => {
   });
 });
 
+// #175. `observeBook` decides which rungs to ASK about; `proposeFillVerdicts` must then
+// reason over THAT SAME SET. When the caller handed it the whole resting book instead,
+// every rung the questions had skipped arrived as an ABSENCE — which is exactly the input
+// `D12` forbids reading as a fill. Plus #177 item 2: an unparseable observed quantity was
+// coerced to `0`, the encoding for UNTOUCHED, so a typo SUPPRESSED the impossible-book
+// detection instead of tripping it.
+describe("the proposal reasons over the same book the questions observed (#175)", () => {
+  /** A second synthetic ladder on a DIFFERENT instrument, against the same reserve. */
+  function otherLadderRecords(): OrderRecord[] {
+    return [900, 800].map((price) => ({
+      id: `other-${price}`,
+      observedAt: "2026-01-02T09:00:00",
+      kind: "orderPlaced" as const,
+      currency: "USD" as const,
+      symbol: "OTHER/USD",
+      side: "buy" as const,
+      price,
+      quantity: 1,
+      fundingReserveId: "reserve-synthetic",
+    }));
+  }
+
+  /** The proposal block alone — NOT the resting-rung listing, which names every rung. */
+  function verdictBlock(harness: Harness): string {
+    const block = harness.out.find((message) => message.startsWith("Proposed verdicts"));
+    if (block === undefined) {
+      throw new Error(`no proposal was printed; out was ${JSON.stringify(harness.out)}`);
+    }
+    return block;
+  }
+
+  it("proposes NO verdict for any rung of a second ladder on another symbol", async () => {
+    const harness = new Harness({
+      records: [...ladderRecords(), ...otherLadderRecords()],
+      answers: openTopRungAnswers(),
+    });
+
+    expectRecorded(await recordFill(harness.io));
+
+    // The other ladder was never asked about, so it must not arrive at the reasoning as an
+    // absence — which is what turned four untouched rungs into four proposed purchases.
+    expect(verdictBlock(harness)).not.toContain("other-900");
+    expect(verdictBlock(harness)).not.toContain("other-800");
+  });
+
+  it("records the fill with a second ladder open — no phantom FILLED to walk past", async () => {
+    const harness = new Harness({
+      records: [...ladderRecords(), ...otherLadderRecords()],
+      answers: openTopRungAnswers(),
+    });
+
+    const outcome = await recordFill(harness.io);
+
+    expect(outcome.status).toBe("recorded");
+    expect(harness.out.join("")).not.toContain("also derive");
+    expect(reconcileFillActs(harness.logEvents(), harness.orderRecords())).toEqual([]);
+  });
+
+  it("backdates a fill onto a ladder that has SINCE gained a rung", async () => {
+    // rung-500 was placed on the 9th; the fill being recorded happened on the 5th. It was
+    // not on the book at that moment, so it is not evidence about it — and asking about it
+    // put a rung into the observation that condition 1 then refused to know.
+    const harness = new Harness({
+      records: [
+        ...ladderRecords(),
+        {
+          id: "rung-500",
+          observedAt: "2026-01-09T09:00:00",
+          kind: "orderPlaced",
+          currency: "USD",
+          symbol: "TEST/USD",
+          side: "buy",
+          price: 500,
+          quantity: 10,
+          fundingReserveId: "reserve-synthetic",
+        },
+      ],
+      answers: openTopRungAnswers(),
+    });
+
+    const outcome = await recordFill(harness.io);
+
+    expect(outcome.status).toBe("recorded");
+    // Never asked about...
+    expect(harness.asked.some((question) => question.includes("rung-500"))).toBe(false);
+    // ...and NAMED, so its absence from the reasoning is visible rather than assumed.
+    expect(harness.out.join("")).toContain("excluded from the reasoning: rung-500");
+    expect(harness.err.join("")).not.toContain("no simultaneously-resting book");
+  });
+});
+
+// #177 item 2.
+describe("an unparseable `filled_quantity observed` is REFUSED, never read as zero", () => {
+  it("refuses instead of recording a `0` — which is the encoding for UNTOUCHED", async () => {
+    const harness = new Harness({
+      answers: [
+        "rung-400",
+        "2026-01-05T12:00:00",
+        "5", // a partial, so rung-400 stays on the book
+        "t", // rung-300 touched
+        "not-a-number", //   ...and the operator fat-fingers the figure
+      ],
+    });
+    const ordersBefore = harness.ordersImage;
+
+    const outcome = await recordFill(harness.io);
+
+    expect(outcome.status).toBe("rejected");
+    if (outcome.status !== "rejected") throw new Error("expected a rejection");
+    expect(outcome.reason).toBe("bad-quantity");
+    expect(outcome.message).toContain("not-a-number");
+    expect(outcome.message).toContain("rung-300");
+    expect(harness.ordersImage).toBe(ordersBefore);
+    expect(harness.logImage).toBeUndefined();
+  });
+});
+
 describe("the named crash window is DETECTABLE", () => {
   it("finds a lot whose orderFilled line never landed", async () => {
     const harness = new Harness({ answers: openTopRungAnswers(), failWrite: "orders" });

--- a/apps/tui/src/record-fill.test.ts
+++ b/apps/tui/src/record-fill.test.ts
@@ -850,3 +850,80 @@ describe("the named crash window is DETECTABLE", () => {
     expect(outcome.reason).toBe("torn-fill-act");
   });
 });
+
+/**
+ * `D1` (#177 item 1) — the ACT is exempt, the OVERRIDE is guarded.
+ *
+ * The arithmetic: recording a fill of `Q` at `P` with cash debited `D` drops `committed`
+ * by `P x Q` and drops `value` by `D`, so `available` moves by `P x Q - D`. The default
+ * answer is `D = P x Q`, exactly available-neutral by construction — so the only input
+ * that can drive a reserve below the `available >= 0` invariant is an operator overriding
+ * the cash-debited figure UPWARD. That EXCESS is what is weighed here, and nothing else.
+ *
+ * Synthetic throughout (`O7`): reserve 10000, three rungs of 10 at 400/300/200 committing
+ * 9000, so available is a round 1000 before the act.
+ */
+describe("the cash-debited override is weighed against the reserve's available", () => {
+  /** The answer sequence with the `Cash debited` prompt answered explicitly. */
+  function answersWithCash(cash: string, answers = openTopRungAnswers()): string[] {
+    answers[answers.length - 2] = cash;
+    return answers;
+  }
+
+  it("refuses an override whose EXCESS over price x quantity exceeds available", async () => {
+    // available is 10000 - 9000 = 1000; the excess asked for is 1001.
+    const harness = new Harness({ answers: answersWithCash(String(400 * 10 + 1001)) });
+    const ordersBefore = harness.ordersImage;
+    const logBefore = harness.logImage;
+
+    const outcome = await recordFill(harness.io);
+
+    expect(outcome.status).toBe("rejected");
+    if (outcome.status !== "rejected") throw new Error("expected a rejection");
+    expect(outcome.reason).toBe("uncovered-override");
+    expect(harness.ordersImage).toBe(ordersBefore);
+    expect(harness.logImage).toBe(logBefore);
+  });
+
+  it("admits an override whose excess FITS inside available", async () => {
+    const harness = new Harness({ answers: answersWithCash(String(400 * 10 + 500)) });
+    const outcome = expectRecorded(await recordFill(harness.io));
+    expect(outcome.act.event.funding.amount).toBe(400 * 10 + 500);
+  });
+
+  it("admits a DOWNWARD correction, which frees available rather than spending it", async () => {
+    const harness = new Harness({ answers: answersWithCash(String(400 * 10 - 500)) });
+    const outcome = expectRecorded(await recordFill(harness.io));
+    expect(outcome.act.event.funding.amount).toBe(400 * 10 - 500);
+  });
+
+  it("records the DEFAULT answer over a book whose available is ALREADY negative", async () => {
+    // The guard is phrased over the EXCESS, not over "post-act available >= 0". A book that
+    // is already over-committed from some other cause must not have its fills bricked: the
+    // default answer moves available by exactly zero, so it has nothing to answer for.
+    const overCommitted: OrderRecord[] = [
+      ...ladderRecords(),
+      {
+        id: "rung-100",
+        observedAt: "2026-01-02T09:00:00",
+        kind: "orderPlaced",
+        currency: "USD",
+        symbol: "TEST/USD",
+        side: "buy",
+        price: 100,
+        quantity: 60,
+        fundingReserveId: "reserve-synthetic",
+      },
+    ];
+    const answers = openTopRungAnswers();
+    answers.splice(5, 0, "r"); // the extra rung below is resting untouched too
+    const harness = new Harness({ answers, records: overCommitted });
+
+    // 15000 committed against a balance of 10000 — available is -5000 before the act.
+    expect(harness.reserveAmount("reserve-synthetic") - harness.committedFor("reserve-synthetic"))
+      .toBeLessThan(0);
+
+    const outcome = expectRecorded(await recordFill(harness.io));
+    expect(outcome.act.event.funding.amount).toBe(400 * 10);
+  });
+});

--- a/apps/tui/src/record-fill.test.ts
+++ b/apps/tui/src/record-fill.test.ts
@@ -691,7 +691,7 @@ describe("the proposal reasons over the same book the questions observed (#175)"
 });
 
 // #177 item 2.
-describe("an unparseable `filled_quantity observed` is REFUSED, never read as zero", () => {
+describe("`filled_quantity observed` refuses anything `<= 0`, never reads it as untouched", () => {
   it("refuses instead of recording a `0` — which is the encoding for UNTOUCHED", async () => {
     const harness = new Harness({
       answers: [
@@ -711,6 +711,67 @@ describe("an unparseable `filled_quantity observed` is REFUSED, never read as ze
     expect(outcome.reason).toBe("bad-quantity");
     expect(outcome.message).toContain("not-a-number");
     expect(outcome.message).toContain("rung-300");
+    expect(harness.ordersImage).toBe(ordersBefore);
+    expect(harness.logImage).toBeUndefined();
+  });
+
+  // A LITERAL `0` IS THE SAME DEFECT THROUGH THE FRONT DOOR. The typo case above was
+  // refused because reading it as 0 would contradict the `t` just answered — so typing
+  // the 0 outright has to be refused for that same reason, or the argument is only half
+  // applied. It is also what the `[r]` answer already produces, so this path never needs
+  // it, and admitting it skips `filled-quantity-exceeds-order`: 0 exceeds nothing.
+  it("refuses a literal `0` — the `[r]` answer is what legitimately produces one", async () => {
+    const harness = new Harness({
+      answers: [
+        "rung-400",
+        "2026-01-05T12:00:00",
+        "5", // a partial, so rung-400 stays on the book
+        "t", // rung-300 touched
+        "0", //   ...and then the figure that means untouched
+      ],
+    });
+    const ordersBefore = harness.ordersImage;
+
+    const outcome = await recordFill(harness.io);
+
+    expect(outcome.status).toBe("rejected");
+    if (outcome.status !== "rejected") throw new Error("expected a rejection");
+    expect(outcome.reason).toBe("bad-quantity");
+    expect(outcome.message).toContain("rung-300");
+    expect(harness.ordersImage).toBe(ordersBefore);
+    expect(harness.logImage).toBeUndefined();
+  });
+
+  it("refuses a negative — finite is not the same test as readable", async () => {
+    const harness = new Harness({
+      answers: ["rung-400", "2026-01-05T12:00:00", "5", "t", "-5"],
+    });
+    const ordersBefore = harness.ordersImage;
+
+    const outcome = await recordFill(harness.io);
+
+    expect(outcome.status).toBe("rejected");
+    if (outcome.status !== "rejected") throw new Error("expected a rejection");
+    expect(outcome.reason).toBe("bad-quantity");
+    expect(outcome.message).toContain("-5");
+    expect(harness.ordersImage).toBe(ordersBefore);
+    expect(harness.logImage).toBeUndefined();
+  });
+
+  // BLANK IS NOT A DEFAULT HERE. `Number("")` is `0` — finite, and the same UNTOUCHED
+  // encoding through a third door. This prompt advertises no `[default]`, and in this
+  // file a bracketless prompt refuses on blank (the five decision fields are the rule).
+  it("refuses a blank answer — this prompt advertises no default", async () => {
+    const harness = new Harness({
+      answers: ["rung-400", "2026-01-05T12:00:00", "5", "t", ""],
+    });
+    const ordersBefore = harness.ordersImage;
+
+    const outcome = await recordFill(harness.io);
+
+    expect(outcome.status).toBe("rejected");
+    if (outcome.status !== "rejected") throw new Error("expected a rejection");
+    expect(outcome.reason).toBe("bad-quantity");
     expect(harness.ordersImage).toBe(ordersBefore);
     expect(harness.logImage).toBeUndefined();
   });

--- a/apps/tui/src/record-fill.ts
+++ b/apps/tui/src/record-fill.ts
@@ -251,9 +251,15 @@ async function observeBook(
         )
       ).trim();
       const quantity = Number(rawQuantity);
-      if (rawQuantity === "" || !Number.isFinite(quantity)) {
-        // NOT a neutral default. `0` means UNTOUCHED, and the operator has just said the
-        // opposite; reading their typo as untouched is what would hide an impossible book.
+      if (rawQuantity === "" || !Number.isFinite(quantity) || quantity <= 0) {
+        // THE BOUNDARY IS `<= 0`, NOT MERELY UNPARSEABLE — and a literal `0` is refused
+        // for the same reason a typo is, not as an afterthought. `0` is the encoding for
+        // UNTOUCHED, which is the opposite of the `[t]ouched` just answered, and it is
+        // byte-identical to what the `[r]` answer produces below: this path never needs
+        // to emit it. Admitting it also skips `filled-quantity-exceeds-order`
+        // (`monotonicity.ts`), since 0 exceeds nothing — the one geometry where the
+        // defect is silent rather than loud. Blank refuses too: this prompt advertises
+        // no `[default]`, and in this file that is what a bracketless prompt means.
         return { status: "bad-quantity", orderId: rung.orderId, answer: rawQuantity };
       }
       present.push({ orderId: rung.orderId, filledQuantity: quantity });
@@ -394,8 +400,9 @@ export async function recordFill(io: RecordFillIo): Promise<RecordFillOutcome> {
     return reject(
       io,
       "bad-quantity",
-      `'${observed.answer}' is not a filled_quantity for rung '${observed.orderId}'; reading it ` +
-        `as 0 would record that rung as UNTOUCHED, which is the opposite of what you just said`,
+      `'${observed.answer}' is not a positive filled_quantity for rung '${observed.orderId}'; ` +
+        `0 or blank is the encoding for UNTOUCHED, which is the opposite of the 'touched' ` +
+        `you just answered`,
     );
   }
   const proposal = proposeFillVerdicts(scoped.sameSymbol, observed.observation);

--- a/apps/tui/src/record-fill.ts
+++ b/apps/tui/src/record-fill.ts
@@ -62,6 +62,7 @@ import {
   proposeFillVerdicts,
   reconcileFillActs,
   resolveLadderPosition,
+  scopeBookForFill,
   type BookObservation,
   type CapitalTier,
   type CommittedRung,
@@ -174,12 +175,30 @@ function describeVerdict(verdict: ProposedVerdict): string {
 }
 
 /**
+ * Either the look at the book, or the refusal that a figure in it could not be read.
+ *
+ * The observation cannot just "do its best": a quantity nobody could parse used to become
+ * `0`, which is the encoding for UNTOUCHED and the very input `fill-below-untouched-rung`
+ * fires on — so a typo SUPPRESSED the impossible-book detection instead of tripping it
+ * (#177). It refuses instead, exactly as the sibling `Filled quantity` prompt does.
+ */
+type BookObservationResult =
+  | { status: "observed"; observation: BookObservation }
+  | { status: "bad-quantity"; orderId: string; answer: string };
+
+/**
  * Ask the operator what the venue shows for every OTHER rung of the ladder.
  *
  * This is the evidence monotonicity reasons over, and it is gathered interactively rather
  * than parsed because the fills export is deferred and `T6`'s interactive path is
  * PERMANENT. The default is `resting` — the conservative answer, since claiming a rung
  * was touched is what would license a fill verdict.
+ *
+ * `rungs` IS ALREADY THE SCOPED SET — `scopeBookForFill`'s `observable` — and this function
+ * does no scoping of its own. That is the whole correction of #175: whatever set the
+ * questions cover is the set the proposal reasons over, so nothing this function declined
+ * to ask about can reach `proposeFillVerdicts` as an ABSENCE. Restating the rule here as a
+ * second filter is how the two drifted apart in the first place.
  *
  * EVERY QUANTITY HERE IS CUMULATIVE SINCE PLACEMENT — the one meaning `ObservedRungState.
  * filledQuantity` has (#176). Both producers in this function supply that basis: the
@@ -192,7 +211,7 @@ async function observeBook(
   filled: CommittedRung,
   filledQuantity: number,
   observedAt: string,
-): Promise<BookObservation> {
+): Promise<BookObservationResult> {
   const present: ObservedRungState[] = [];
 
   // The rung being recorded needs no question: the operator just answered it. It leaves
@@ -208,7 +227,9 @@ async function observeBook(
   }
 
   for (const rung of rungs) {
-    if (rung.orderId === filled.orderId || rung.symbol !== filled.symbol) {
+    // The ONLY rung skipped here is the one being recorded, which the operator has already
+    // answered for. Symbol and moment were settled by `scopeBookForFill` before this ran.
+    if (rung.orderId === filled.orderId) {
       continue;
     }
     const answer = (
@@ -223,24 +244,25 @@ async function observeBook(
       // The BASIS is named in the prompt, because the operator is reading a column and
       // only they can tell which number they are reading. Asking for "filled_quantity"
       // bare is what let a delta and a running total mean the same field (#176).
-      const quantity = Number(
-        (
-          await io.ask(
-            `      filled_quantity observed — the venue's CUMULATIVE total for this rung ` +
-              `since it was placed, not just this session's: `,
-          )
-        ).trim(),
-      );
-      present.push({
-        orderId: rung.orderId,
-        filledQuantity: Number.isFinite(quantity) ? quantity : 0,
-      });
+      const rawQuantity = (
+        await io.ask(
+          `      filled_quantity observed — the venue's CUMULATIVE total for this rung ` +
+            `since it was placed, not just this session's: `,
+        )
+      ).trim();
+      const quantity = Number(rawQuantity);
+      if (rawQuantity === "" || !Number.isFinite(quantity)) {
+        // NOT a neutral default. `0` means UNTOUCHED, and the operator has just said the
+        // opposite; reading their typo as untouched is what would hide an impossible book.
+        return { status: "bad-quantity", orderId: rung.orderId, answer: rawQuantity };
+      }
+      present.push({ orderId: rung.orderId, filledQuantity: quantity });
       continue;
     }
     present.push({ orderId: rung.orderId, filledQuantity: 0 });
   }
 
-  return { observedAt, present };
+  return { status: "observed", observation: { observedAt, present } };
 }
 
 /** The five authored decision fields. All required; a blank one abandons the act. */
@@ -350,10 +372,33 @@ export async function recordFill(io: RecordFillIo): Promise<RecordFillOutcome> {
     );
   }
 
-  // ---- 4. monotonicity PROPOSES ----
+  // ---- 4. monotonicity PROPOSES, over the SAME book the questions observed (#175) ----
+  //
+  // ONE rung set, computed once and used twice: the operator is asked about `observable`,
+  // and `sameSymbol` — that plus the rungs placed after this moment — is what reaches the
+  // proposal. Handing over the whole `resting` book instead made every rung the questions
+  // had skipped arrive as an ABSENCE, and an absence with nothing untouched above it
+  // derives FILLED: a second open ladder proposed as a purchase, and a rung placed after
+  // the fill answered for and then refused as `unknown-rung`. A later rung now surfaces
+  // where it belongs, in `excluded`, named rather than reasoned over.
+  const scoped = scopeBookForFill(resting, filled.symbol, observedAt);
   io.out("What does the venue show for the rest of this ladder?\n");
-  const observation = await observeBook(io, rungs, filled, filledQuantity, observedAt);
-  const proposal = proposeFillVerdicts(resting, observation);
+  const observed = await observeBook(
+    io,
+    committedRungs(scoped.observable),
+    filled,
+    filledQuantity,
+    observedAt,
+  );
+  if (observed.status === "bad-quantity") {
+    return reject(
+      io,
+      "bad-quantity",
+      `'${observed.answer}' is not a filled_quantity for rung '${observed.orderId}'; reading it ` +
+        `as 0 would record that rung as UNTOUCHED, which is the opposite of what you just said`,
+    );
+  }
+  const proposal = proposeFillVerdicts(scoped.sameSymbol, observed.observation);
   if (proposal.status === "impossible") {
     return reject(
       io,

--- a/apps/tui/src/record-fill.ts
+++ b/apps/tui/src/record-fill.ts
@@ -54,6 +54,7 @@ import {
   buildEventReference,
   buildFillAct,
   committedRungs,
+  composeAvailableCapital,
   crossReferenceEvent,
   deriveFundingTier,
   isObservedAtStamp,
@@ -113,6 +114,13 @@ export type RecordFillRejection =
   | "unknown-instrument"
   | "ambiguous-ladder-position"
   | "ambiguous-tier"
+  /**
+   * The operator overrode `Cash debited` UPWARD by more than the funding reserve has
+   * available (`D1`, #177). Only the excess over `price × quantity` is weighed: the fill's
+   * own arithmetic is available-neutral, so the default answer and every downward
+   * correction pass this guard by construction.
+   */
+  | "uncovered-override"
   | "incomplete-decision"
   | "duplicate-fill-act"
   | "invalid-event"
@@ -554,6 +562,60 @@ export async function recordFill(io: RecordFillIo): Promise<RecordFillOutcome> {
   const fundingAmount = fundingAnswer === "" ? proposedFunding : Number(fundingAnswer);
   if (!Number.isFinite(fundingAmount) || fundingAmount <= 0) {
     return reject(io, "bad-quantity", `'${fundingAnswer}' is not a positive cash amount`);
+  }
+
+  // `D1` (#177) — THE ACT IS EXEMPT; THE OVERRIDE IS GUARDED, and only upward.
+  //
+  // The arithmetic decides where the guard goes. `available = value − committed`, and this
+  // act moves BOTH terms: the `orderFilled` line drops `committed` by `price × quantity`
+  // and the cash leg drops `value` by the amount debited. So
+  //
+  //     Δavailable = price × quantity − cash debited
+  //
+  // and the DEFAULT answer — `proposedFunding`, the two multiplied — is exactly
+  // available-neutral BY CONSTRUCTION. The fill itself therefore cannot break the
+  // `available ≥ 0` invariant no matter what shape the book is in, which is why this flow
+  // does NOT call `checkFundingCoverage`: that guard weighs the WHOLE book and returns on
+  // the first `unknown-reserve` anywhere in it (#179), so one stale `fundingReserveId` on
+  // an unrelated rung would refuse a fill that really happened at the venue. A fill is an
+  // observed fact; the flow does not get to disbelieve it.
+  //
+  // The override is not an observed fact. It is the operator asserting a figure nothing at
+  // the venue vouches for, and it is the ONLY input in this act that can drive a reserve
+  // negative. What is weighed is the EXCESS over the neutral figure — never "post-act
+  // available ≥ 0", which would brick every fill, neutral ones included, on any book that
+  // already sits negative from some other cause. A downward correction FREES availability
+  // and never reaches this branch.
+  const excess = fundingAmount - proposedFunding;
+  if (excess > 0) {
+    // The report's own arithmetic, over the report's own admission policy — not a second
+    // implementation of `value − committed` that could drift from the rendered figure.
+    const capital = composeAvailableCapital(folded, resting);
+    const funder = capital.reserves.find((entry) => entry.reserveId === reserve.id);
+    if (!funder) {
+      return reject(
+        io,
+        "uncovered-override",
+        `you asked to debit ${fundingAmount} against '${reserve.id}' — ${excess} more than the ` +
+          `${proposedFunding} this fill accounts for — but the available-capital report does ` +
+          `not place that reserve (paper execution mode, an unsupported currency, a dangling ` +
+          `account reference), so the excess cannot be weighed against anything. The fill ` +
+          `itself is recordable at the default figure`,
+      );
+    }
+    if (excess > funder.available) {
+      return reject(
+        io,
+        "uncovered-override",
+        `you asked to debit ${fundingAmount} against '${reserve.id}', ${excess} more than the ` +
+          `${proposedFunding} this fill accounts for, and '${reserve.id}' has only ` +
+          `${funder.available} available (${funder.value} balance less ${funder.committed} ` +
+          `committed). The fill's own arithmetic is available-neutral; only the extra is ` +
+          `spending capital that is not there, and a negative available is an IMPOSSIBLE ` +
+          `state rather than a warning. Record the fill at ${proposedFunding}, or record the ` +
+          `fee or funding difference as its own act`,
+      );
+    }
   }
 
   const fundingTier = deriveFundingTier(reserve);

--- a/apps/tui/src/record-fill.ts
+++ b/apps/tui/src/record-fill.ts
@@ -180,6 +180,11 @@ function describeVerdict(verdict: ProposedVerdict): string {
  * than parsed because the fills export is deferred and `T6`'s interactive path is
  * PERMANENT. The default is `resting` — the conservative answer, since claiming a rung
  * was touched is what would license a fill verdict.
+ *
+ * EVERY QUANTITY HERE IS CUMULATIVE SINCE PLACEMENT — the one meaning `ObservedRungState.
+ * filledQuantity` has (#176). Both producers in this function supply that basis: the
+ * prompt names it, and the rung being recorded pushes its running TOTAL rather than this
+ * fill's delta. They used to disagree, a few lines apart.
  */
 async function observeBook(
   io: RecordFillIo,
@@ -193,8 +198,13 @@ async function observeBook(
   // The rung being recorded needs no question: the operator just answered it. It leaves
   // the book only when the fill exhausts what was still claimed; a partial keeps resting
   // with its remainder, which is condition 2 expressed as state rather than as a rule.
+  //
+  // What is pushed is the CUMULATIVE total, not `filledQuantity` alone: everything already
+  // netted out of the remainder, plus this fill. That is the same number the venue's own
+  // column would show, which is the whole point of having one basis (#176).
   if (filledQuantity < filled.remainingQuantity) {
-    present.push({ orderId: filled.orderId, filledQuantity });
+    const cumulative = filled.quantity - filled.remainingQuantity + filledQuantity;
+    present.push({ orderId: filled.orderId, filledQuantity: cumulative });
   }
 
   for (const rung of rungs) {
@@ -210,7 +220,17 @@ async function observeBook(
       continue; // absent from the observation = disappeared
     }
     if (answer === "t" || answer === "touched") {
-      const quantity = Number((await io.ask(`      filled_quantity observed: `)).trim());
+      // The BASIS is named in the prompt, because the operator is reading a column and
+      // only they can tell which number they are reading. Asking for "filled_quantity"
+      // bare is what let a delta and a running total mean the same field (#176).
+      const quantity = Number(
+        (
+          await io.ask(
+            `      filled_quantity observed — the venue's CUMULATIVE total for this rung ` +
+              `since it was placed, not just this session's: `,
+          )
+        ).trim(),
+      );
       present.push({
         orderId: rung.orderId,
         filledQuantity: Number.isFinite(quantity) ? quantity : 0,

--- a/packages/engine/src/index.ts
+++ b/packages/engine/src/index.ts
@@ -148,10 +148,19 @@ export type {
   ObservedOpenOrder,
   OrderIdentity,
   OrderAttribution,
-  ReserveBalance,
   FundingShortfall,
   FundingCoverage,
 } from "./orders/ingest.js";
+// The ONE reserve admission policy and rung-placement rule, shared by the `O1` guard and
+// the available-capital report. `FundableReserve` replaces the old `ReserveBalance`: it
+// carries `currency`, and only `fundableReserves(data)` can produce one (#172).
+export type {
+  FundableReserve,
+  RungAttribution,
+  UnmatchedReason,
+  UnmatchedRung,
+} from "./orders/attribution.js";
+export { fundableReserves, attributeRungs } from "./orders/attribution.js";
 export {
   canonicalDecimal,
   synthesizeOrderId,
@@ -176,12 +185,9 @@ export {
 // `CompositionRow` are untouched by this slice.
 export type { CommittedRung } from "./orders/committed.js";
 export { committedRungs, committedByReserve, isNegativeSlack, SLACK_EPSILON } from "./orders/committed.js";
-export type {
-  ReserveCapital,
-  UnmatchedReason,
-  UnmatchedRung,
-  AvailableCapitalReport,
-} from "./orders/available.js";
+// `UnmatchedReason`/`UnmatchedRung` are exported once, above, from the module that owns
+// them (`./orders/attribution.js`); `available.ts` re-exports them for its own readers.
+export type { ReserveCapital, AvailableCapitalReport } from "./orders/available.js";
 export { composeAvailableCapital } from "./orders/available.js";
 // `S8` — the fill act. Monotonicity PROPOSES a verdict (stamped `derived`, carrying its
 // evidence) and refuses on an impossible one; it never writes, and being pure it cannot.

--- a/packages/engine/src/index.ts
+++ b/packages/engine/src/index.ts
@@ -183,6 +183,7 @@ export type {
 export {
   BITGET_OPEN_ORDERS_HEADER,
   BITGET_RESTING_STATUS,
+  leavesRungUnweighed,
   parseBitgetOpenOrdersCsv,
 } from "./orders/bitget.js";
 // `S7` — committed vs available. The ONE committed formula (`./orders/committed.js`)

--- a/packages/engine/src/index.ts
+++ b/packages/engine/src/index.ts
@@ -200,8 +200,9 @@ export type {
   ProposedVerdict,
   MonotonicityContradiction,
   MonotonicityProposal,
+  ScopedBook,
 } from "./orders/monotonicity.js";
-export { proposeFillVerdicts } from "./orders/monotonicity.js";
+export { proposeFillVerdicts, scopeBookForFill } from "./orders/monotonicity.js";
 export type {
   TornFillAct,
   LadderPosition,

--- a/packages/engine/src/index.ts
+++ b/packages/engine/src/index.ts
@@ -166,6 +166,13 @@ export {
   synthesizeOrderId,
   buildOrderPlacedRecords,
   checkFundingCoverage,
+  mergeCollidingClaims,
+  detectChangedClaims,
+} from "./orders/ingest.js";
+export type {
+  MergedOrderClaim,
+  ChangedClaim,
+  ClaimDifference,
 } from "./orders/ingest.js";
 export type {
   BitgetOpenOrder,

--- a/packages/engine/src/orders-not-events.test.ts
+++ b/packages/engine/src/orders-not-events.test.ts
@@ -86,6 +86,7 @@ describe("`S8` — the fill act introduces NO eleventh verb", () => {
       symbol: "TEST/USD",
       side: "buy",
       price: 100,
+      quantity: 1,
       remainingQuantity: 1,
       fundingReserveId: "reserve-synthetic",
       committed: 100,

--- a/packages/engine/src/orders/attribution.ts
+++ b/packages/engine/src/orders/attribution.ts
@@ -1,0 +1,137 @@
+/**
+ * THE ONE RESERVE ADMISSION POLICY, and the one rule for placing a rung against it.
+ *
+ * `./committed.ts` owns the one committed FORMULA. This module owns its ARGUMENTS: which
+ * reserves may fund anything at all, and which rung belongs to which of them. Both
+ * questions are answered here, once, for both surfaces — the `O1` import guard
+ * (`./ingest.ts`) and the rendered available-capital report (`./available.ts`).
+ *
+ * WHY IT IS A MODULE AND NOT A CONVENTION. The two surfaces already shared the formula
+ * and still disagreed, because they were handed different arguments (#172): the guard
+ * took `data.reserves` straight off the fold via the import CLI, the report took
+ * `buildCanonicalState(...).reserveReconciliation`. So a rung against a PAPER-mode or
+ * UNSUPPORTED-CURRENCY reserve was FUNDABLE at the import boundary and UNPLACEABLE in the
+ * report: the import said yes, and the rendered figure showed the capital as free. Worse,
+ * the guard's reserve type carried no currency at all, so it summed a quote-denominated
+ * `committed` into a native balance and found slack that does not exist.
+ *
+ * The fix is structural, not a second check bolted onto the guard: `attributeRungs` takes
+ * the FUND, derives the admitted reserves itself, and is the only way either surface
+ * learns what a fundable reserve is. There is no reserve-list parameter left for a
+ * caller to get wrong — which is the point, because the previous defect was introduced
+ * by a caller, not by either surface.
+ *
+ * ADMISSION IS DELEGATED, NOT RESTATED. The policy is `buildCanonicalState`'s: live
+ * execution mode, supported currency, resolvable account reference. A second copy of
+ * those rules here would be the same defect one layer down, so this module reads the
+ * canonical state's reconciliation lines and adds nothing to them.
+ *
+ * PURE (ADR-001): no IO, no clock.
+ */
+import type { Currency, FundReviewData } from "../contracts.js";
+import { buildCanonicalState } from "../compose/canonical.js";
+import { committedRungs, type CommittedRung } from "./committed.js";
+import type { RestingOrder } from "./select.js";
+
+/**
+ * A reserve that may fund a resting claim: admitted by the canonical state, and carrying
+ * the CURRENCY it is denominated in.
+ *
+ * The currency is the field whose absence was the money-losing half of #172. It is not
+ * optional and there is no constructor for this type outside {@link fundableReserves} —
+ * a reserve nobody admitted cannot be spelled into existence by a caller.
+ */
+export interface FundableReserve {
+  reserveId: string;
+  /** The venue label the reconciliation line already uses, so the two read alike. */
+  venueLabel: string;
+  currency: Currency;
+  /** The native balance exactly as the fold reported it. Untouched, NAV-safe. */
+  balance: number;
+  /** The same balance in USD, as `reserveReconciliation` reports it. */
+  usdValue: number;
+}
+
+/** Why a resting rung could not be placed against any fundable reserve. */
+export type UnmatchedReason = "unknown-reserve" | "currency-mismatch";
+
+/**
+ * A rung that cannot be placed. Surfaced rather than dropped: a silently ignored rung is
+ * capital reported as free that is not — and, at the import boundary, an accepted write
+ * into an append-only file that the report will never be able to substantiate.
+ */
+export interface UnmatchedRung {
+  rung: CommittedRung;
+  reason: UnmatchedReason;
+}
+
+/** Every resting rung placed against the reserves that may fund it, or refused. */
+export interface RungAttribution {
+  /** The admitted reserves, in canonical (genesis insertion) order. */
+  reserves: FundableReserve[];
+  /** Placed rungs, keyed by `reserveId`. A reserve with no rungs is simply absent. */
+  rungsByReserve: Map<string, CommittedRung[]>;
+  unmatched: UnmatchedRung[];
+}
+
+/**
+ * The reserves that may fund a resting claim — the canonical state's reconciliation
+ * lines, and nothing else.
+ *
+ * A paper reserve, an unsupported currency or a dangling account reference is excluded
+ * here for exactly the reasons it is excluded from the composition, with no second
+ * admission policy to keep in step.
+ */
+export function fundableReserves(data: FundReviewData): FundableReserve[] {
+  return buildCanonicalState(data).reserveReconciliation.map((line) => ({
+    reserveId: line.reserveId,
+    venueLabel: line.venueLabel,
+    currency: line.currency,
+    balance: line.balance,
+    usdValue: line.usdValue,
+  }));
+}
+
+/**
+ * Place every resting BUY rung against the reserve it DECLARES, or refuse it with the
+ * reason.
+ *
+ * A rung matches only if its declared `fundingReserveId` names an admitted reserve AND
+ * the currencies agree. The currency check is not ceremony: `committed` is denominated in
+ * the rung's QUOTE currency, and adding a differently-denominated sum into a native
+ * balance would produce a confidently wrong number rather than an obviously missing one.
+ * Cross-currency funding is not designed; it is refused, identically, on both sides.
+ *
+ * Rung order is preserved within a reserve, and the refusal order is the rungs' own, so
+ * the guard's error message and the report's list name the same rungs in the same order.
+ */
+export function attributeRungs(
+  data: FundReviewData,
+  resting: readonly RestingOrder[],
+): RungAttribution {
+  const reserves = fundableReserves(data);
+  const currencyOf = new Map(reserves.map((entry) => [entry.reserveId, entry.currency]));
+
+  const rungsByReserve = new Map<string, CommittedRung[]>();
+  const unmatched: UnmatchedRung[] = [];
+
+  for (const rung of committedRungs(resting)) {
+    const currency = currencyOf.get(rung.fundingReserveId);
+    if (currency === undefined) {
+      // An unadmitted or unknown id is refused rather than read as a zero balance: a
+      // typo'd id would otherwise render the whole ladder as "over-committed", or worse,
+      // silently attribute it to a reserve nobody can see.
+      unmatched.push({ rung, reason: "unknown-reserve" });
+      continue;
+    }
+    if (currency !== rung.currency) {
+      unmatched.push({ rung, reason: "currency-mismatch" });
+      continue;
+    }
+    const existing = rungsByReserve.get(rung.fundingReserveId);
+    if (existing) existing.push(rung);
+    else rungsByReserve.set(rung.fundingReserveId, [rung]);
+  }
+
+  return { reserves, rungsByReserve, unmatched };
+}

--- a/packages/engine/src/orders/available.test.ts
+++ b/packages/engine/src/orders/available.test.ts
@@ -262,26 +262,28 @@ describe("`T4`'s invariant, in its corrected form — `slack = value − committ
 describe("`slack < 0` REJECTS — and the report cannot disagree with the guard that rejects", () => {
   it("the import-boundary guard rejects a reserve that cannot fund its ladder (`O1`)", () => {
     const resting = pickRestingOrdersAsOf(ladder());
-    const coverage = checkFundingCoverage(resting, [
-      { id: CAPITAL_RESERVE, amount: LADDER_VALUE - RUNG_VALUE },
-    ]);
+    const coverage = checkFundingCoverage(resting, syntheticFund(LADDER_VALUE - RUNG_VALUE));
     expect(coverage.status).toBe("over-committed");
     if (coverage.status !== "over-committed") throw new Error("unreachable");
     expect(coverage.shortfalls[0]?.slack).toBeLessThan(0);
   });
 
   it("ONE committed formula: the guard's committed and the report's committed agree", () => {
-    // This is the anti-drift test the whole slice turns on. A rendered `available` that
-    // disagreed with the guard which ACCEPTED the orders would be worse than today's
-    // honest silence, so both sides are computed from `committedByReserve` and this
-    // asserts they cannot part company — including in the over-committed case, where a
-    // second formula would be most likely to differ.
+    // This is the anti-drift test for the FORMULA. A rendered `available` that disagreed
+    // with the guard which ACCEPTED the orders would be worse than today's honest
+    // silence, so both sides are computed from the shared committed formula and this
+    // asserts they cannot part company about the arithmetic — including in the
+    // over-committed case, where a second formula would be most likely to differ.
+    //
+    // It is NOT the anti-drift test for the ARGUMENTS, and it never was: it used to
+    // hand-build the guard's balance array to agree with the fixture fund, which is
+    // exactly how #172 stayed invisible. Both sides now take the SAME fund value, and
+    // `funding-parity.test.ts` covers the argument divergences this file cannot see.
     const shortBalance = LADDER_VALUE - RUNG_VALUE;
+    const fund = syntheticFund(shortBalance);
     const resting = pickRestingOrdersAsOf(ladder());
-    const coverage = checkFundingCoverage(resting, [
-      { id: CAPITAL_RESERVE, amount: shortBalance },
-    ]);
-    const { capital } = capitalOf(ladder(), syntheticFund(shortBalance));
+    const coverage = checkFundingCoverage(resting, fund);
+    const { capital } = capitalOf(ladder(), fund);
 
     if (coverage.status !== "over-committed") throw new Error("fixture must over-commit");
     expect(coverage.shortfalls[0]?.committed).toBe(capital.committed);
@@ -310,7 +312,7 @@ describe("`slack < 0` REJECTS — and the report cannot disagree with the guard 
     expect(Math.abs(capital.available)).toBeLessThan(SLACK_EPSILON);
 
     // The guard ACCEPTS it …
-    expect(checkFundingCoverage(resting, [{ id: CAPITAL_RESERVE, amount: balance }]).status).toBe("ok");
+    expect(checkFundingCoverage(resting, syntheticFund(balance)).status).toBe("ok");
     // … so the report must not call the same book an impossible state.
     const rendered = formatAvailableCapital(
       composeAvailableCapital(syntheticFund(balance), resting),

--- a/packages/engine/src/orders/available.ts
+++ b/packages/engine/src/orders/available.ts
@@ -48,10 +48,22 @@ export interface ReserveCapital {
    * operator reads it by; the invariant is that it is `≥ 0`, ALWAYS, and the direction
    * carries the meaning: a negative value is an IMPOSSIBLE state, not a warning. The
    * venue would not have accepted orders the account could not fund, so it means the
-   * attribution is wrong. It is REJECTED at the import boundary (`checkFundingCoverage`,
-   * the only path that writes) rather than here — this module renders what is, and a
-   * renderer that quietly clamped a negative to zero would hide the very defect the
-   * invariant exists to expose.
+   * attribution is wrong.
+   *
+   * IT IS REJECTED AT THE WRITE BOUNDARIES, NOT HERE. There are TWO of them, with stated
+   * scopes, and neither lives in this module (#177):
+   *
+   *   - `checkFundingCoverage` guards the ORDER IMPORT, over the WHOLE resting book —
+   *     what is on file plus the batch — because that write adds `committed`.
+   *   - the fill act (`record-fill.ts`) guards ONE input, the operator's upward override
+   *     of the cash debited, over the ONE reserve funding the rung. The act moves both
+   *     terms at once (`Δavailable = price × quantity − cash debited`), so the default
+   *     figure is available-neutral by construction and the EXCESS is the only part that
+   *     can spend availability. The fill itself is deliberately unguarded: it records
+   *     something that already happened at the venue.
+   *
+   * This module renders what IS, and a renderer that quietly clamped a negative to zero
+   * would hide the very defect the invariant exists to expose.
    */
   available: number;
   /**

--- a/packages/engine/src/orders/available.ts
+++ b/packages/engine/src/orders/available.ts
@@ -20,9 +20,11 @@
  * files are joined HERE, at read time, and never merged.
  */
 import type { Currency, FundReviewData } from "../contracts.js";
-import { buildCanonicalState } from "../compose/canonical.js";
-import { committedRungs, type CommittedRung } from "./committed.js";
+import { attributeRungs, type UnmatchedRung } from "./attribution.js";
+import type { CommittedRung } from "./committed.js";
 import type { RestingOrder } from "./select.js";
+
+export type { UnmatchedReason, UnmatchedRung } from "./attribution.js";
 
 /** The three numbers, for one live reserve, plus what substantiates the middle one. */
 export interface ReserveCapital {
@@ -62,17 +64,10 @@ export interface ReserveCapital {
   rungs: CommittedRung[];
 }
 
-/** Why a resting rung could not be placed against any live reserve. */
-export type UnmatchedReason = "unknown-reserve" | "currency-mismatch";
-
-/**
- * A rung the fold cannot place. Surfaced rather than dropped: a silently ignored rung
- * is capital reported as free that is not, which is the exact defect of today.
- */
-export interface UnmatchedRung {
-  rung: CommittedRung;
-  reason: UnmatchedReason;
-}
+// `UnmatchedReason` and `UnmatchedRung` are RE-EXPORTED from `./attribution.js` (see the
+// import above) rather than declared here. They are the vocabulary of the placement
+// rule, and that rule is now shared with the import guard — two declarations of the same
+// two reasons is exactly the drift #172 was about.
 
 export interface AvailableCapitalReport {
   /** One entry per LIVE reserve the canonical state admitted, in its order. */
@@ -81,47 +76,23 @@ export interface AvailableCapitalReport {
 }
 
 /**
- * Compose the three numbers, per reserve, over `buildCanonicalState`.
+ * Compose the three numbers, per reserve, over the SHARED attribution (`./attribution.js`).
  *
- * Reserves come from the canonical state's reconciliation lines, which are the live,
- * post-fold, validated reserves — so a paper reserve, an unsupported currency or a
- * dangling account reference is excluded here for exactly the reasons it is excluded
- * from the composition, with no second admission policy to keep in step.
+ * Neither the reserve set nor the placement rule lives here any more. Both come from
+ * `attributeRungs`, which the `O1` import guard also calls — so the report cannot admit a
+ * reserve the guard would refuse, and cannot refuse a rung the guard would fund. That
+ * symmetry used to be a claim in a docstring; it is now the only code path there is.
  *
- * A rung is matched to a reserve by its declared `fundingReserveId` and only if the
- * currencies agree. The currency check is not ceremony: `committed` is denominated in
- * the rung's quote currency, and adding a differently-denominated sum into a native
- * balance would produce a confidently wrong `available` rather than an obviously
- * missing one. Cross-currency funding is not designed; it is refused and reported.
+ * What remains here is the ARITHMETIC and the rendering shape: value, committed,
+ * available, and the rungs that substantiate the middle one.
  */
 export function composeAvailableCapital(
   data: FundReviewData,
   resting: readonly RestingOrder[],
 ): AvailableCapitalReport {
-  const { reserveReconciliation } = buildCanonicalState(data);
+  const { reserves: fundable, rungsByReserve, unmatched } = attributeRungs(data, resting);
 
-  const rungsByReserve = new Map<string, CommittedRung[]>();
-  const unmatched: UnmatchedRung[] = [];
-  const reserveCurrency = new Map(
-    reserveReconciliation.map((line) => [line.reserveId, line.currency]),
-  );
-
-  for (const rung of committedRungs(resting)) {
-    const currency = reserveCurrency.get(rung.fundingReserveId);
-    if (currency === undefined) {
-      unmatched.push({ rung, reason: "unknown-reserve" });
-      continue;
-    }
-    if (currency !== rung.currency) {
-      unmatched.push({ rung, reason: "currency-mismatch" });
-      continue;
-    }
-    const existing = rungsByReserve.get(rung.fundingReserveId);
-    if (existing) existing.push(rung);
-    else rungsByReserve.set(rung.fundingReserveId, [rung]);
-  }
-
-  const reserves = reserveReconciliation.map((line) => {
+  const reserves = fundable.map((line) => {
     const rungs = rungsByReserve.get(line.reserveId) ?? [];
     // Summed from the rung rows themselves, so the list the operator reads and the
     // figure above it are the same arithmetic, not two agreeing implementations.

--- a/packages/engine/src/orders/bitget-ingest.test.ts
+++ b/packages/engine/src/orders/bitget-ingest.test.ts
@@ -20,8 +20,39 @@ import {
   synthesizeOrderId,
 } from "./ingest.js";
 import { pickRestingOrdersAsOf } from "./select.js";
+import { parseFixture } from "../fund-composition.fixtures.js";
+import type { FundReviewData } from "../contracts.js";
 
 const HEADER = BITGET_OPEN_ORDERS_HEADER.join(",");
+
+/**
+ * A fund carrying ONE live USD reserve with the given balance.
+ *
+ * The guard takes the FUND, not a balance array, so its reserve set is derived by the
+ * same admission policy the rendered report uses and a test cannot hand it a reserve the
+ * report would reject (#172). Balances here remain invented round numbers (`O7`).
+ */
+function fundWith(amount: number, reserveId = "reserve-a"): FundReviewData {
+  return parseFixture({
+    fund: { id: "synthetic-fund", name: "Synthetic Fund", baseCurrency: "USD" },
+    review: { asOf: "2026-01-31", usdMxn: 20 },
+    portfolios: [{ id: "core", name: "Core" }],
+    accounts: [{ id: "venue-usd", name: "Synthetic Venue", platform: "BITGET", currency: "USD" }],
+    instruments: [{ id: "test-usd", name: "Test Asset", symbol: "XYZ", currency: "USD" }],
+    reserves: [
+      {
+        id: reserveId,
+        portfolioId: "core",
+        tempo: "Capital",
+        executionMode: "live",
+        accountId: "venue-usd",
+        currency: "USD",
+        amount,
+      },
+    ],
+    positions: [],
+  });
+}
 
 /**
  * One synthetic rendered row. Defaults are deliberately obvious fakes: the pair is
@@ -210,12 +241,12 @@ describe("checkFundingCoverage — `O1`, and slack >= 0", () => {
   it("accepts a batch the declared reserve can fund", () => {
     // 0.1 @ 1000 + 0.1 @ 900 = 190 committed against a 1000 balance.
     const resting = restingFrom(csv(row({ price: "1000" }), row({ price: "900" })), "reserve-a");
-    expect(checkFundingCoverage(resting, [{ id: "reserve-a", amount: 1000 }]).status).toBe("ok");
+    expect(checkFundingCoverage(resting, fundWith(1000)).status).toBe("ok");
   });
 
   it("REJECTS a batch whose committed sum exceeds the declared reserve", () => {
     const resting = restingFrom(csv(row({ price: "1000", quantity: "1" })), "reserve-a");
-    const coverage = checkFundingCoverage(resting, [{ id: "reserve-a", amount: 100 }]);
+    const coverage = checkFundingCoverage(resting, fundWith(100));
     expect(coverage.status).toBe("over-committed");
     if (coverage.status !== "over-committed") return;
     expect(coverage.shortfalls).toHaveLength(1);
@@ -226,12 +257,12 @@ describe("checkFundingCoverage — `O1`, and slack >= 0", () => {
 
   it("holds slack >= 0 at exact equality rather than tripping on IEEE noise", () => {
     const resting = restingFrom(csv(row({ price: "0.1", quantity: "3" })), "reserve-a");
-    expect(checkFundingCoverage(resting, [{ id: "reserve-a", amount: 0.3 }]).status).toBe("ok");
+    expect(checkFundingCoverage(resting, fundWith(0.3)).status).toBe("ok");
   });
 
   it("rejects a declared reserve that does not exist, rather than reading it as zero", () => {
     const resting = restingFrom(csv(row()), "reserve-ghost");
-    const coverage = checkFundingCoverage(resting, [{ id: "reserve-a", amount: 1000 }]);
+    const coverage = checkFundingCoverage(resting, fundWith(1000));
     expect(coverage.status).toBe("unknown-reserve");
     if (coverage.status !== "unknown-reserve") return;
     expect(coverage.fundingReserveIds).toEqual(["reserve-ghost"]);

--- a/packages/engine/src/orders/bitget-ingest.test.ts
+++ b/packages/engine/src/orders/bitget-ingest.test.ts
@@ -16,6 +16,7 @@ import {
 } from "./bitget.js";
 import {
   buildOrderPlacedRecords,
+  canonicalDecimal,
   checkFundingCoverage,
   synthesizeOrderId,
 } from "./ingest.js";
@@ -257,6 +258,33 @@ describe("the null sentinel and the authoritative column (testing decision 4)", 
     // The drifting column is not carried at all — there is nothing to reconcile against.
     expect(order).not.toHaveProperty("orderValue");
     expect(JSON.stringify(order)).not.toContain("99.96");
+  });
+});
+
+describe("`canonicalDecimal` refuses ambiguous comma placement (#177)", () => {
+  it("refuses a token whose comma is not in a thousands position", () => {
+    // A decimal comma, not a group separator. Stripping it read `10,50` as `1050` — a
+    // silent 100x error, baked into a durable id and into the committed sum.
+    expect(canonicalDecimal("10,50")).toBeUndefined();
+    expect(canonicalDecimal("1,00")).toBeUndefined();
+    expect(canonicalDecimal("1000,5")).toBeUndefined();
+    // No comma may follow the decimal point either.
+    expect(canonicalDecimal("1.000,50")).toBeUndefined();
+  });
+
+  it("still accepts valid thousands grouping and the plain spelling", () => {
+    expect(canonicalDecimal("1,000.50")).toBe("1000.5");
+    expect(canonicalDecimal("10.50")).toBe("10.5");
+    expect(canonicalDecimal("1,234,567")).toBe("1234567");
+    expect(canonicalDecimal("-1,000")).toBe("-1000");
+  });
+
+  it("skips the row whose price carries an ambiguous comma rather than reading it 100x", () => {
+    const parsed = parseBitgetOpenOrdersCsv(csv(row({ price: '"10,50"' })));
+    expect(parsed.status).toBe("ok");
+    if (parsed.status !== "ok") return;
+    expect(parsed.orders).toHaveLength(0);
+    expect(parsed.skips.map((skip) => skip.problem)).toEqual(["malformed"]);
   });
 });
 

--- a/packages/engine/src/orders/bitget-ingest.test.ts
+++ b/packages/engine/src/orders/bitget-ingest.test.ts
@@ -19,6 +19,8 @@ import {
   checkFundingCoverage,
   synthesizeOrderId,
 } from "./ingest.js";
+import { committedRungs } from "./committed.js";
+import { parseOrderRecord, serializeOrderRecord } from "./records.js";
 import { pickRestingOrdersAsOf } from "./select.js";
 import { parseFixture } from "../fund-composition.fixtures.js";
 import type { FundReviewData } from "../contracts.js";
@@ -131,12 +133,106 @@ describe("parseBitgetOpenOrdersCsv — the 14-column rendered table", () => {
     expect(parseBitgetOpenOrdersCsv("").status).toBe("unrecognized-header");
   });
 
-  it("is closed at the reader on status — one observed value, everything else skipped", () => {
-    const parsed = parseBitgetOpenOrdersCsv(csv(row({ status: "PartiallyFilled" })));
+  it("is closed at the reader on status — a word outside the vocabulary is skipped", () => {
+    const parsed = parseBitgetOpenOrdersCsv(csv(row({ status: "Expired" })));
     expect(parsed.status).toBe("ok");
     if (parsed.status !== "ok") return;
     expect(parsed.orders).toHaveLength(0);
     expect(parsed.skips.map((skip) => skip.problem)).toEqual(["unknown-status"]);
+  });
+});
+
+// #173. The status word used to be the ADMISSION GATE, and the defect ran both ways: a
+// row the venue printed as `unfilled` was admitted with its partial silently dropped
+// (committed OVERSTATED), while a row printed as partially filled was skipped whole
+// (committed UNDERSTATED and its capital reported FREE — the direction that costs money).
+// The REMAINDER is the gate now; the status word is only a vocabulary check.
+describe("#173 — the venue's filled_quantity is carried, and the REMAINDER decides resting", () => {
+  it("admits a partially-filled row with its remainder still open", () => {
+    const parsed = parseBitgetOpenOrdersCsv(
+      csv(row({ status: "PartiallyFilled", quantity: "10", filled_quantity: "6" })),
+    );
+    expect(parsed.status).toBe("ok");
+    if (parsed.status !== "ok") return;
+    // Not an `unknown-status` skip any more, and not a skip at all.
+    expect(parsed.skips).toEqual([]);
+    expect(parsed.orders).toHaveLength(1);
+    expect(parsed.orders[0]?.quantity).toBe(10);
+    expect(parsed.orders[0]?.filledQuantity).toBe(6);
+  });
+
+  it("leaves a row with NO remainder out — it is not resting", () => {
+    const parsed = parseBitgetOpenOrdersCsv(
+      csv(row({ status: "PartiallyFilled", quantity: "10", filled_quantity: "10" })),
+    );
+    expect(parsed.status).toBe("ok");
+    if (parsed.status !== "ok") return;
+    expect(parsed.orders).toHaveLength(0);
+    expect(parsed.skips.map((skip) => skip.problem)).toEqual(["not-resting"]);
+  });
+
+  it("carries the partial through to `remainingQuantity` = quantity − filled_quantity", () => {
+    const records = buildOrderPlacedRecords(
+      okOrders(csv(row({ price: "100", quantity: "10", filled_quantity: "6" }))),
+      { fundingReserveId: "reserve-a" },
+    );
+    const resting = pickRestingOrdersAsOf(records);
+    expect(resting).toHaveLength(1);
+    expect(resting[0]?.remainingQuantity).toBe(4);
+  });
+
+  it("encumbers `price × remainder`, asserted through the ONE committed formula", () => {
+    // 10 units at 100 with 6 filled truly encumbers 400. Dropping the partial read 1,000.
+    const rungs = committedRungs(
+      pickRestingOrdersAsOf(
+        buildOrderPlacedRecords(
+          okOrders(csv(row({ price: "100", quantity: "10", filled_quantity: "6" }))),
+          { fundingReserveId: "reserve-a" },
+        ),
+      ),
+    );
+    expect(rungs).toHaveLength(1);
+    expect(rungs[0]?.committed).toBe(400);
+    // The ORIGINAL size is still carried beside the remainder — it is what the cumulative
+    // venue reading is compared against (#176).
+    expect(rungs[0]?.quantity).toBe(10);
+    expect(rungs[0]?.remainingQuantity).toBe(4);
+  });
+
+  it("stays IDEMPOTENT on a re-import: the partial is counted once, not twice", () => {
+    const text = csv(row({ price: "100", quantity: "10", filled_quantity: "6" }));
+    const first = buildOrderPlacedRecords(okOrders(text), { fundingReserveId: "reserve-a" });
+    const second = buildOrderPlacedRecords(okOrders(text), { fundingReserveId: "reserve-a" });
+    expect(second).toEqual(first);
+    // The partial rides on the PLACEMENT line, which the selector dedupes by id — there is
+    // no second `orderFilled` line for a replay to subtract twice.
+    const resting = pickRestingOrdersAsOf([...first, ...second]);
+    expect(resting).toHaveLength(1);
+    expect(resting[0]?.remainingQuantity).toBe(4);
+    expect([...first, ...second].filter((record) => record.kind !== "orderPlaced")).toEqual([]);
+  });
+
+  it("round-trips the partial through the record contract byte-for-byte", () => {
+    const [record] = buildOrderPlacedRecords(
+      okOrders(csv(row({ price: "100", quantity: "10", filled_quantity: "6" }))),
+      { fundingReserveId: "reserve-a" },
+    );
+    if (!record) throw new Error("expected one record");
+    const line = serializeOrderRecord(record);
+    const parsed = parseOrderRecord(JSON.parse(line));
+    expect(parsed.status).toBe("ok");
+    if (parsed.status !== "ok") return;
+    expect(serializeOrderRecord(parsed.record)).toBe(line);
+    expect(pickRestingOrdersAsOf([parsed.record])[0]?.remainingQuantity).toBe(4);
+  });
+
+  it("writes NO extra key when there is nothing filled, so existing lines are unchanged", () => {
+    const [record] = buildOrderPlacedRecords(okOrders(csv(row({ filled_quantity: "0" }))), {
+      fundingReserveId: "reserve-a",
+    });
+    if (!record) throw new Error("expected one record");
+    expect(record).not.toHaveProperty("observedFilledQuantity");
+    expect(serializeOrderRecord(record)).not.toContain("observedFilledQuantity");
   });
 });
 

--- a/packages/engine/src/orders/bitget.ts
+++ b/packages/engine/src/orders/bitget.ts
@@ -206,6 +206,34 @@ export type BitgetRowProblem =
   | "not-resting"
   | "unknown-quote-currency";
 
+/**
+ * Does this problem leave a rung UNWEIGHED — a row that might still be claiming capital
+ * where we cannot say how much? That is the whole rule, and it lives here beside the
+ * taxonomy it reads rather than at the consumer, so a fifth `BitgetRowProblem` cannot be
+ * added without deciding which side of the alarm it falls on (#184).
+ *
+ * `unknown-status` and `unknown-quote-currency` fail the test on the SAFE side: we do not
+ * know those rows are not resting, so they count. `not-resting` is excluded because it is
+ * the one class where we DO know — the parser reached a positive finding about the row's
+ * encumbrance, and the finding is zero. Nothing is left claimed, so no committed sum is
+ * missing it and no `available` figure reads high because of it. Counting it would fire a
+ * money-direction alarm on the ordinary event of a rung filling between the operator's
+ * export and their import.
+ *
+ * The switch is EXHAUSTIVE with no `default` on purpose: a new member must fail
+ * `pnpm typecheck` rather than silently default into or out of the alarm.
+ */
+export function leavesRungUnweighed(problem: BitgetRowProblem): boolean {
+  switch (problem) {
+    case "malformed":
+    case "unknown-status":
+    case "unknown-quote-currency":
+      return true;
+    case "not-resting":
+      return false;
+  }
+}
+
 /** One row that did not become an order, reported rather than swallowed. */
 export interface BitgetRowSkip {
   /** 1-based line number in the file, so the operator can go look at it. */

--- a/packages/engine/src/orders/bitget.ts
+++ b/packages/engine/src/orders/bitget.ts
@@ -52,12 +52,35 @@ export const BITGET_OPEN_ORDERS_HEADER = [
 ] as const;
 
 /**
- * The one status value ever observed in this export. OPEN AT THE WIRE, CLOSED AT THE
- * READER: a row carrying any other status is skipped and reported rather than assumed to
- * be resting, because every other member of the vocabulary would be a guess — and
- * guessing here means a claim on capital that the venue never confirmed.
+ * The status value observed on an UNTOUCHED resting row. OPEN AT THE WIRE, CLOSED AT THE
+ * READER: a word outside the vocabulary below is still skipped and reported rather than
+ * assumed to be resting, because an unknown word would be a guess — and guessing here
+ * means a claim on capital the venue never confirmed.
+ *
+ * IT IS NO LONGER THE ADMISSION GATE (#173). It used to be, and the defect ran both ways:
+ * a row printed `unfilled` was admitted with its partial dropped (committed OVERSTATED),
+ * while a row printed as partially filled was skipped whole — the rung vanished from the
+ * book and the capital it encumbers was reported FREE, which is the direction that costs
+ * money. The REMAINDER decides now; the word only has to be one this reader knows.
  */
 export const BITGET_RESTING_STATUS = "unfilled";
+
+/**
+ * The spellings that mean PARTIALLY FILLED. Separators and case are normalized away, so
+ * `Partially Filled`, `partially_filled` and `PartiallyFilled` are one word.
+ *
+ * THE SPELLING IS UNVERIFIED and named as such: no real export has yet shown a partial, so
+ * this list is what a rendered table plausibly prints. It costs little if it is wrong — an
+ * unrecognized word still lands in `unknown-status` where the operator can see it, which
+ * is the same place it landed before. What is NOT a guess is the rule underneath: a row
+ * with a remainder open is resting, and `filled_quantity` is what says so.
+ */
+export const BITGET_PARTIAL_STATUSES = ["partiallyfilled", "partialfilled", "partial"] as const;
+
+/** Case- and separator-insensitive, because a rendered cell is styled for a human. */
+function normalizeStatus(value: string): string {
+  return value.trim().toLowerCase().replace(/[\s_\-/]/g, "");
+}
 
 /** The venue's identifier, and the first component of every id synthesized from it. */
 const VENUE = "bitget";
@@ -165,12 +188,23 @@ export interface BitgetOpenOrder extends ObservedOpenOrder {
   orderType: string;
   /** `null` when the venue rendered the `-- / --` sentinel — never that string. */
   triggerPrice: number | null;
-  /** May be `0`. The honest partial-fill test is this, never a status word. */
+  /**
+   * The venue's CUMULATIVE filled quantity for this row; may be `0`. This — not a status
+   * word — is what decides whether the row still claims anything: a row is admitted when
+   * `quantity − filledQuantity > 0` and skipped as `not-resting` when it is not. It is
+   * carried onto the placement record's `observedFilledQuantity` (`./ingest.js`), so the
+   * rung rests for its REMAINDER rather than for its full size (#173).
+   */
   filledQuantity: number;
   totalQuantity: number;
 }
 
-export type BitgetRowProblem = "malformed" | "unknown-status" | "unknown-quote-currency";
+export type BitgetRowProblem =
+  | "malformed"
+  | "unknown-status"
+  /** The venue shows nothing still claimed — correctly out of the resting book (#173). */
+  | "not-resting"
+  | "unknown-quote-currency";
 
 /** One row that did not become an order, reported rather than swallowed. */
 export interface BitgetRowSkip {
@@ -235,13 +269,21 @@ export function parseBitgetOpenOrdersCsv(csv: string): BitgetOpenOrdersParse {
       continue;
     }
 
-    if (column(fields, "status").trim().toLowerCase() !== BITGET_RESTING_STATUS) {
+    // VOCABULARY CHECK, NOT AN ADMISSION GATE. A word this reader does not know is still
+    // refused; a word it knows only gets the row as far as the remainder test below.
+    const status = normalizeStatus(column(fields, "status"));
+    const known =
+      status === BITGET_RESTING_STATUS ||
+      (BITGET_PARTIAL_STATUSES as readonly string[]).includes(status);
+    if (!known) {
       skips.push(
         skip(
           lineNumber,
           "unknown-status",
           `status ${JSON.stringify(column(fields, "status").trim())} is outside the observed ` +
-            `vocabulary; only ${JSON.stringify(BITGET_RESTING_STATUS)} is known to mean resting`,
+            `vocabulary; ${JSON.stringify(BITGET_RESTING_STATUS)} and ` +
+            `[${BITGET_PARTIAL_STATUSES.join(", ")}] are the words known to mean a row that ` +
+            `may still be resting`,
         ),
       );
       continue;
@@ -289,6 +331,22 @@ export function parseBitgetOpenOrdersCsv(csv: string): BitgetOpenOrdersParse {
     const filledQuantity = canonicalDecimal(column(fields, "filled_quantity"));
     if (filledQuantity === undefined || Number(filledQuantity) < 0) {
       skips.push(skip(lineNumber, "malformed", "filled_quantity must be a non-negative decimal"));
+      continue;
+    }
+
+    // THE ADMISSION GATE (#173). A row still claims capital exactly when something is left
+    // unfilled, whichever of the known words the venue printed. Nothing left is not a
+    // claim: it is correctly out of the resting book, and reported so it is not silent.
+    const remainder = Number(quantity) - Number(filledQuantity);
+    if (remainder <= 0) {
+      skips.push(
+        skip(
+          lineNumber,
+          "not-resting",
+          `the venue shows ${filledQuantity} of ${quantity} filled, so nothing is still ` +
+            `claimed; this row is not a resting order`,
+        ),
+      );
       continue;
     }
 

--- a/packages/engine/src/orders/committed.ts
+++ b/packages/engine/src/orders/committed.ts
@@ -77,6 +77,13 @@ export interface CommittedRung {
   symbol: string;
   side: OrderSide;
   price: number;
+  /**
+   * The size the rung was PLACED for, before anything filled against it. Carried beside
+   * the remainder because a CUMULATIVE venue reading is compared against this and never
+   * against the remainder — the two are on different bases, and conflating them is what
+   * #176 was.
+   */
+  quantity: number;
   /** What is STILL claimed: `quantity − filled_quantity`, per `./select.ts`. */
   remainingQuantity: number;
   fundingReserveId: string;
@@ -87,12 +94,22 @@ export interface CommittedRung {
 /**
  * The encumbrance of ONE resting claim: `price × (quantity − filled_quantity)`.
  *
- * UNVERIFIED, and named as such (spec Open Questions): the remainder rule is believed
- * right but nothing has partially filled yet, so it has never been checked against a
- * real venue's behaviour. The first real partial is the verification event. It is
- * written this way rather than `price × quantity` because the alternative is knowably
- * wrong in the direction that matters — it would over-state committed and under-state
- * available, i.e. hide capital the fund actually has.
+ * THE REMAINDER RULE IS NOW WHAT ACTUALLY RUNS ON EVERY PATH, AND SAYING SO IS THE
+ * CORRECTION (#173). An earlier version of this docstring named the remainder rule as the
+ * correction to `price × quantity` while the import path computed `price × quantity` — the
+ * venue's `filled_quantity` was parsed, validated and then dropped, so no imported rung
+ * could satisfy `remainingQuantity`'s own definition. The file named its own defect and
+ * did not have it. It has it now: the partial rides on the placement line
+ * (`OrderPlacedRecord.observedFilledQuantity`) and `pickRestingOrdersAsOf` nets it out
+ * before anything reaches here.
+ *
+ * STILL UNVERIFIED AGAINST THE REAL VENUE, and that part stands (spec Open Questions):
+ * nothing has partially filled yet, so the rule has never been checked against a real
+ * venue's behaviour — including whether its own partial spelling is one this build reads.
+ * The first real partial is the verification event. The rule is written this way rather
+ * than `price × quantity` because the alternative is knowably wrong in the direction that
+ * matters — it would over-state committed and under-state available, i.e. hide capital the
+ * fund actually has.
  */
 function encumbranceOf(order: RestingOrder): number {
   return order.placed.price * order.remainingQuantity;
@@ -118,6 +135,7 @@ export function committedRungs(resting: readonly RestingOrder[]): CommittedRung[
       symbol: order.placed.symbol,
       side: order.placed.side,
       price: order.placed.price,
+      quantity: order.placed.quantity,
       remainingQuantity: order.remainingQuantity,
       fundingReserveId: order.placed.fundingReserveId,
       committed: encumbranceOf(order),

--- a/packages/engine/src/orders/committed.ts
+++ b/packages/engine/src/orders/committed.ts
@@ -10,7 +10,23 @@
  * be worse than today's honest silence: today the fund is quietly wrong about free cash
  * and everyone knows the number is unexamined, whereas two disagreeing figures would
  * each look examined. So there is exactly one place the arithmetic happens, and
- * `available.test.ts` asserts the two callers cannot part company.
+ * `available.test.ts` asserts the two callers cannot part company ABOUT THE ARITHMETIC.
+ *
+ * THIS FILE DOES NOT OWN THE ARGUMENTS, AND SAYING SO IS THE CORRECTION. An earlier
+ * version of this docstring claimed the two callers simply "cannot part company". That
+ * was false, and #172 is what it cost: the two shared this formula and were handed
+ * DIFFERENT reserve sets — the guard `data.reserves` straight off the fold, the report
+ * only the reserves `buildCanonicalState` admits — and the guard's reserve type carried
+ * no currency at all. Same formula, divergent arguments, a rung fundable at import and
+ * unplaceable in the report.
+ *
+ * WHICH SURFACE OWNS THE DERIVATION: `./attribution.js`, and neither caller. It answers
+ * both argument questions — which reserves may fund anything (delegated to
+ * `buildCanonicalState`, never restated), and which rung is placed against which — and
+ * the guard and the report each call it rather than deriving anything themselves. The
+ * pairing is the invariant: this module is the one FORMULA, `./attribution.js` is the one
+ * ARGUMENT SET, and `funding-parity.test.ts` drives BOTH surfaces from a single fund
+ * fixture so neither claim can rot into prose again.
  *
  * PURE (ADR-001): no IO, no clock. The input is what `pickRestingOrdersAsOf` returned.
  */

--- a/packages/engine/src/orders/fill.test.ts
+++ b/packages/engine/src/orders/fill.test.ts
@@ -26,6 +26,7 @@ const RUNG: CommittedRung = {
   symbol: "TEST/USD",
   side: "buy",
   price: 400,
+  quantity: 10,
   remainingQuantity: 10,
   fundingReserveId: "reserve-synthetic",
   committed: 4000,

--- a/packages/engine/src/orders/funding-parity.test.ts
+++ b/packages/engine/src/orders/funding-parity.test.ts
@@ -1,0 +1,201 @@
+/**
+ * THE ANTI-DRIFT TEST FOR THE GUARD'S ARGUMENTS.
+ *
+ * `available.test.ts` proves the two surfaces share the committed FORMULA. It cannot
+ * prove they share its ARGUMENTS, because it hand-builds the guard's reserve list to
+ * agree with the fixture fund — so it can only ever show that one shared function
+ * returns one value. This file removes that freedom: BOTH surfaces are derived from a
+ * SINGLE fund fixture, with no hand-built balance array anywhere, and every case asserts
+ * the guard's verdict and the report's `unmatched`/`available` say the same thing about
+ * the same rung.
+ *
+ * The four cases are the four ways the two used to part company:
+ *   1. a live, matching reserve            — both place the rung
+ *   2. a PAPER-mode reserve                — the report cannot place it; the guard must refuse
+ *   3. an UNSUPPORTED-CURRENCY reserve     — likewise
+ *   4. a CROSS-CURRENCY rung               — the money-losing direction: a quote-denominated
+ *                                            committed summed into a native balance
+ *
+ * EVERY FIGURE IS SYNTHETIC (`O7`). Round, obviously-fake numbers; no real balance,
+ * price, quantity or rung appears here and none may ever be added.
+ */
+import { describe, expect, it } from "vitest";
+import { parseFixture } from "../fund-composition.fixtures.js";
+import type { FundReviewData } from "../contracts.js";
+import { composeAvailableCapital } from "./available.js";
+import { checkFundingCoverage } from "./ingest.js";
+import type { OrderRecord } from "./records.js";
+import { pickRestingOrdersAsOf } from "./select.js";
+
+const LIVE_USD = "reserve-live-usd";
+const PAPER_USD = "reserve-paper-usd";
+const ODD_CURRENCY = "reserve-odd-currency";
+const LIVE_MXN = "reserve-live-mxn";
+
+/** Obviously-fake round numbers: two rungs of 100 × 2 = 400 against a balance of 1000. */
+const RUNG_PRICE = 100;
+const RUNG_QUANTITY = 2;
+const RUNG_COUNT = 2;
+const LADDER_VALUE = RUNG_PRICE * RUNG_QUANTITY * RUNG_COUNT; // 400
+const BALANCE = 1000;
+
+/**
+ * One fund carrying all four reserve shapes, so a single fixture feeds both surfaces.
+ *
+ * `PAPER_USD` and `ODD_CURRENCY` are exactly the reserves `buildCanonicalState` refuses
+ * to admit — non-live execution mode, and a currency outside the supported set. They
+ * exist in `data.reserves` (which is what the import CLI used to hand the guard) and are
+ * absent from `reserveReconciliation` (which is what the report reads). That gap IS the
+ * defect under test.
+ */
+function parityFund(): FundReviewData {
+  return parseFixture({
+    fund: { id: "synthetic-fund", name: "Synthetic Fund", baseCurrency: "USD" },
+    review: { asOf: "2026-01-31", usdMxn: 20 },
+    portfolios: [{ id: "core", name: "Core" }],
+    accounts: [
+      { id: "venue-usd", name: "Synthetic Venue", platform: "BITGET", currency: "USD" },
+      { id: "venue-mxn", name: "Other Venue", platform: "XTB", currency: "MXN" },
+    ],
+    instruments: [{ id: "test-usd", name: "Test Asset", symbol: "TEST", currency: "USD" }],
+    reserves: [
+      reserve(LIVE_USD, { executionMode: "live", currency: "USD", accountId: "venue-usd" }),
+      reserve(PAPER_USD, { executionMode: "paper", currency: "USD", accountId: "venue-usd" }),
+      reserve(ODD_CURRENCY, { executionMode: "live", currency: "EUR", accountId: "venue-usd" }),
+      reserve(LIVE_MXN, { executionMode: "live", currency: "MXN", accountId: "venue-mxn" }),
+    ],
+    positions: [],
+  });
+}
+
+function reserve(
+  id: string,
+  overrides: { executionMode: string; currency: string; accountId: string },
+) {
+  return {
+    id,
+    portfolioId: "core",
+    tempo: "Capital",
+    amount: BALANCE,
+    ...overrides,
+  };
+}
+
+/** `RUNG_COUNT` synthetic BUY rungs, all resting, all declaring `reserveId`. */
+function ladder(reserveId: string, currency: "USD" | "MXN" = "USD"): OrderRecord[] {
+  return Array.from({ length: RUNG_COUNT }, (_unused, index) => ({
+    id: `rung-${reserveId}-${index}`,
+    observedAt: `2026-01-0${index + 1}T10:00:00`,
+    kind: "orderPlaced" as const,
+    currency,
+    symbol: "TEST/USD",
+    side: "buy" as const,
+    price: RUNG_PRICE,
+    quantity: RUNG_QUANTITY,
+    fundingReserveId: reserveId,
+  })) as OrderRecord[];
+}
+
+/**
+ * Drive BOTH surfaces off ONE fund. The guard takes the fund itself, so there is no
+ * argument left for a caller to get wrong — which is the fix this file locks.
+ */
+function bothSurfaces(records: OrderRecord[], data = parityFund()) {
+  const resting = pickRestingOrdersAsOf(records);
+  return {
+    coverage: checkFundingCoverage(resting, data),
+    report: composeAvailableCapital(data, resting),
+  };
+}
+
+describe("the guard and the report admit the SAME reserves (one admission policy)", () => {
+  it("both place a ladder against a live, currency-matching reserve", () => {
+    const { coverage, report } = bothSurfaces(ladder(LIVE_USD));
+
+    expect(coverage.status).toBe("ok");
+    expect(report.unmatched).toEqual([]);
+    const placed = report.reserves.find((entry) => entry.reserveId === LIVE_USD);
+    expect(placed?.committed).toBe(LADDER_VALUE);
+    expect(placed?.available).toBe(BALANCE - LADDER_VALUE);
+  });
+
+  it("both REFUSE a rung funded by a PAPER-mode reserve", () => {
+    // Before the fix the guard said `ok` here — `data.reserves` carries the paper
+    // reserve — while the report listed the rung as `unknown-reserve` and encumbered
+    // nothing. The import said yes and the rendered figure showed the capital as free.
+    const { coverage, report } = bothSurfaces(ladder(PAPER_USD));
+
+    expect(coverage.status).toBe("unknown-reserve");
+    if (coverage.status !== "unknown-reserve") throw new Error("unreachable");
+    expect(coverage.fundingReserveIds).toEqual([PAPER_USD]);
+    expect(report.unmatched.map((entry) => entry.reason)).toEqual(
+      Array.from({ length: RUNG_COUNT }, () => "unknown-reserve"),
+    );
+    expect(report.reserves.some((entry) => entry.reserveId === PAPER_USD)).toBe(false);
+  });
+
+  it("both REFUSE a rung funded by an UNSUPPORTED-CURRENCY reserve", () => {
+    const { coverage, report } = bothSurfaces(ladder(ODD_CURRENCY));
+
+    expect(coverage.status).toBe("unknown-reserve");
+    if (coverage.status !== "unknown-reserve") throw new Error("unreachable");
+    expect(coverage.fundingReserveIds).toEqual([ODD_CURRENCY]);
+    expect(report.unmatched.map((entry) => entry.reason)).toEqual(
+      Array.from({ length: RUNG_COUNT }, () => "unknown-reserve"),
+    );
+  });
+});
+
+describe("the guard and the report treat CURRENCY the same way", () => {
+  it("both REFUSE a rung quoted in a currency the reserve does not hold", () => {
+    // THE MONEY-LOSING DIRECTION. The rungs are quoted in USD and the reserve holds MXN.
+    // Before the fix `ReserveBalance` carried no currency at all, so the guard summed a
+    // quote-denominated committed straight into a native balance, found slack, and
+    // accepted — while the report refused the identical rung as `currency-mismatch`.
+    const { coverage, report } = bothSurfaces(ladder(LIVE_MXN, "USD"));
+
+    expect(coverage.status).toBe("currency-mismatch");
+    if (coverage.status !== "currency-mismatch") throw new Error("unreachable");
+    expect(coverage.rungs.map((rung) => rung.fundingReserveId)).toEqual(
+      Array.from({ length: RUNG_COUNT }, () => LIVE_MXN),
+    );
+    expect(report.unmatched.map((entry) => entry.reason)).toEqual(
+      Array.from({ length: RUNG_COUNT }, () => "currency-mismatch"),
+    );
+    // And the reserve is reported UNENCUMBERED, which is only honest because the import
+    // that would have encumbered it was refused.
+    const mxn = report.reserves.find((entry) => entry.reserveId === LIVE_MXN);
+    expect(mxn?.committed).toBe(0);
+    expect(mxn?.available).toBe(BALANCE);
+  });
+
+  it("accepts the same rungs once they are quoted in the reserve's own currency", () => {
+    // The mirror of the case above: nothing about cross-currency FUNDING is being
+    // designed here, so the only thing that makes the ladder placeable is quoting it in
+    // the currency the reserve actually holds.
+    const { coverage, report } = bothSurfaces(ladder(LIVE_MXN, "MXN"));
+
+    expect(coverage.status).toBe("ok");
+    expect(report.unmatched).toEqual([]);
+    expect(report.reserves.find((entry) => entry.reserveId === LIVE_MXN)?.committed).toBe(
+      LADDER_VALUE,
+    );
+  });
+});
+
+describe("no verdict the guard accepts leaves the report with an unplaceable rung", () => {
+  it("holds across every reserve in the fixture, one ladder at a time", () => {
+    // The property, not four hand-picked cases: for EVERY reserve the fund declares —
+    // admitted or not — an accepted import must leave the report with nothing unmatched,
+    // and a refused import must be refused for the reason the report gives.
+    for (const reserveId of [LIVE_USD, PAPER_USD, ODD_CURRENCY, LIVE_MXN]) {
+      const { coverage, report } = bothSurfaces(ladder(reserveId));
+      if (coverage.status === "ok") {
+        expect(report.unmatched).toEqual([]);
+      } else {
+        expect(report.unmatched.length).toBeGreaterThan(0);
+        expect(coverage.status).toBe(report.unmatched[0]?.reason);
+      }
+    }
+  });
+});

--- a/packages/engine/src/orders/ingest.ts
+++ b/packages/engine/src/orders/ingest.ts
@@ -30,6 +30,12 @@ export interface ObservedOpenOrder {
   side: OrderSide;
   price: number;
   quantity: number;
+  /**
+   * The venue's CUMULATIVE filled quantity for this row, `0` or absent when untouched. A
+   * venue that does not report one may omit it; a venue that does must not have it
+   * dropped, which is exactly what #173 was.
+   */
+  filledQuantity?: number;
 }
 
 /**
@@ -111,6 +117,13 @@ export interface OrderAttribution {
  * first fill, so naming one here would be the repo's first unresolvable id) and a
  * ladder/batch id (that join is parked on a fills header nobody has, and designing a key
  * for it blind, into an append-only file, is the more expensive mistake).
+ *
+ * The venue's `filled_quantity` IS carried, onto the placement line's
+ * `observedFilledQuantity` and only when it is positive — #173. It used to be parsed,
+ * validated and then dropped here, which made every imported rung rest at its full
+ * quantity forever and put `CommittedRung.remainingQuantity` beyond the reach of its own
+ * definition. The mechanism (a field, never a synthesized `orderFilled` line) is argued in
+ * full on the field itself in `./records.ts`.
  */
 export function buildOrderPlacedRecords(
   orders: readonly ObservedOpenOrder[],
@@ -125,6 +138,11 @@ export function buildOrderPlacedRecords(
     side: order.side,
     price: order.price,
     quantity: order.quantity,
+    // Omitted rather than written as `0`, so an untouched rung serializes to exactly the
+    // bytes it always did and no existing line in the append-only file is re-shaped.
+    ...(order.filledQuantity !== undefined && order.filledQuantity > 0
+      ? { observedFilledQuantity: order.filledQuantity }
+      : {}),
     fundingReserveId: attribution.overrides?.[order.id] ?? attribution.fundingReserveId,
   }));
 }

--- a/packages/engine/src/orders/ingest.ts
+++ b/packages/engine/src/orders/ingest.ts
@@ -10,8 +10,9 @@
  * happens to look like" and "what an observed open order IS". A second venue owes a
  * second parser and nothing here.
  */
-import type { Currency } from "../contracts.js";
-import { committedByReserve, isNegativeSlack } from "./committed.js";
+import type { Currency, FundReviewData } from "../contracts.js";
+import { attributeRungs } from "./attribution.js";
+import { isNegativeSlack, type CommittedRung } from "./committed.js";
 import type { OrderPlacedRecord, OrderSide } from "./records.js";
 import type { RestingOrder } from "./select.js";
 
@@ -128,11 +129,15 @@ export function buildOrderPlacedRecords(
   }));
 }
 
-/** A reserve's balance as the fold reports it — the value half, untouched by any order. */
-export interface ReserveBalance {
-  id: string;
-  amount: number;
-}
+/**
+ * `ReserveBalance` USED TO LIVE HERE — `{ id, amount }`, built by the caller. It is gone
+ * on purpose (#172). It carried no currency, so this guard summed a quote-denominated
+ * `committed` into a native balance; and because the CALLER built it, the import CLI
+ * handed over `data.reserves` straight off the fold, including reserves the report
+ * refuses to place. The successor is `FundableReserve` in `./attribution.js`, which
+ * carries `currency` and which only `fundableReserves(data)` can produce. This guard
+ * takes the FUND now, so there is no list left to hand it wrongly.
+ */
 
 /** One reserve that cannot fund what has been attributed to it. */
 export interface FundingShortfall {
@@ -143,10 +148,17 @@ export interface FundingShortfall {
   slack: number;
 }
 
+/**
+ * The two REFUSAL arms are, deliberately, the two `UnmatchedReason`s the report already
+ * uses — same names, same meanings. A rung the report would list as `unknown-reserve`
+ * refuses the import as `unknown-reserve`; likewise `currency-mismatch`. The parity is
+ * legible in the type rather than asserted in prose.
+ */
 export type FundingCoverage =
   | { status: "ok" }
   | { status: "over-committed"; shortfalls: FundingShortfall[] }
-  | { status: "unknown-reserve"; fundingReserveIds: string[] };
+  | { status: "unknown-reserve"; fundingReserveIds: string[] }
+  | { status: "currency-mismatch"; rungs: CommittedRung[] };
 
 /**
  * `O1` — no order may encumber a reserve that cannot fund it.
@@ -163,31 +175,46 @@ export type FundingCoverage =
  * encumbers only its remainder. Re-importing an unchanged export changes nothing here:
  * the ids are deterministic, so the selector counts each rung once.
  *
- * Committed comes from the SHARED formula in `./committed.ts` — the same call the
- * rendered available-capital report makes. This guard and that report must never be
- * able to disagree about how much of a reserve is encumbered: a rendered `available`
- * that contradicted the check which ACCEPTED the orders would be worse than the fund's
- * present honest silence. Only BUY claims encumber a cash reserve, and that rule lives
- * there too rather than being restated here.
+ * Committed comes from the SHARED formula in `./committed.ts`, and its ARGUMENTS — which
+ * reserves may fund anything, and which rung belongs to which — from the SHARED
+ * attribution in `./attribution.js`. Both are the same calls the rendered
+ * available-capital report makes. Sharing only the formula was not enough and is the
+ * defect this signature exists to close (#172): the guard took a reserve list from its
+ * CALLER, and the caller handed it reserves the report refuses to place, plus no
+ * currency to check against. It takes the FUND now. There is no list to get wrong.
+ *
+ * A rendered `available` that contradicted the check which ACCEPTED the orders would be
+ * worse than the fund's present honest silence. Only BUY claims encumber a cash reserve,
+ * and that rule lives in `./committed.ts` rather than being restated here.
  */
 export function checkFundingCoverage(
   resting: readonly RestingOrder[],
-  balances: readonly ReserveBalance[],
+  data: FundReviewData,
 ): FundingCoverage {
-  const balanceById = new Map(balances.map((balance) => [balance.id, balance.amount]));
+  const { reserves, rungsByReserve, unmatched } = attributeRungs(data, resting);
 
-  const committedById = committedByReserve(resting);
-
-  const unknown = [...committedById.keys()].filter((id) => !balanceById.has(id));
+  // Refuse before summing anything. An unplaceable rung has no honest balance to be
+  // compared against — reading it as a zero balance would render the ladder as
+  // "over-committed" on a typo, and summing it into a foreign-denominated balance would
+  // produce the confidently wrong slack that #172 was about.
+  const unknown = unmatched.filter((entry) => entry.reason === "unknown-reserve");
   if (unknown.length > 0) {
-    // An unknown reserve is refused rather than read as a zero balance: a typo'd id
-    // would otherwise render as "everything is over-committed" or, worse, silently
-    // attribute the ladder to a reserve nobody can see.
-    return { status: "unknown-reserve", fundingReserveIds: unknown };
+    return {
+      status: "unknown-reserve",
+      fundingReserveIds: [...new Set(unknown.map((entry) => entry.rung.fundingReserveId))],
+    };
+  }
+  const mismatched = unmatched.filter((entry) => entry.reason === "currency-mismatch");
+  if (mismatched.length > 0) {
+    return { status: "currency-mismatch", rungs: mismatched.map((entry) => entry.rung) };
   }
 
+  const balanceById = new Map(reserves.map((reserve) => [reserve.reserveId, reserve.balance]));
   const shortfalls: FundingShortfall[] = [];
-  for (const [fundingReserveId, committed] of committedById) {
+  for (const [fundingReserveId, rungs] of rungsByReserve) {
+    // Summed from the same rung rows the report lists, so the figure in the refusal
+    // message and the figure the operator reads afterwards are one arithmetic.
+    const committed = rungs.reduce((total, rung) => total + rung.committed, 0);
     const balance = balanceById.get(fundingReserveId) ?? 0;
     const slack = balance - committed;
     if (isNegativeSlack(slack)) {

--- a/packages/engine/src/orders/ingest.ts
+++ b/packages/engine/src/orders/ingest.ts
@@ -380,6 +380,44 @@ export type FundingCoverage =
  * A rendered `available` that contradicted the check which ACCEPTED the orders would be
  * worse than the fund's present honest silence. Only BUY claims encumber a cash reserve,
  * and that rule lives in `./committed.ts` rather than being restated here.
+ *
+ * SCOPE — THE GUARD WEIGHS THE RUNGS IT IS HANDED (#183). `resting` is not a sample of
+ * the venue's book; it IS this function's scope. The question answered is "are THESE
+ * rungs covered?", and over the rungs handed in, `ok` is honest. Whether that set is the
+ * WHOLE book is the CALLER's to own, and the caller cannot always say yes: a row the
+ * export's parser skipped never became a record, so it never reaches `resting` and is
+ * never in `committed`. The guard cannot see it and does not claim to. The surface that
+ * carries that gap is the import boundary's `imported-partial` outcome
+ * (`apps/tui/src/import-orders.ts`), whose operator line names the money direction —
+ * rungs nobody could weigh make `available` read HIGH — and whose count runs through
+ * `leavesRungUnweighed` so a `not-resting` row, read completely and found to encumber
+ * nothing, raises no false alarm (#184).
+ *
+ * The verdict is deliberately NOT qualified with that gap, and #183 decided so against
+ * its own leading candidate. This is a pure function of its arguments: the incompleteness
+ * lives in the ARGUMENT, not in the verdict, and a fifth arm apologizing for the caller's
+ * inputs moves the caller's problem into the callee's type. It would harden `ok` against
+ * a caller that does not exist — one non-test call site, and `record-fill.ts` names this
+ * function only in a comment saying why it deliberately does not call it. It would also
+ * break #172's parity property in TWO places: `funding-parity.test.ts:197`'s token
+ * equality against `UnmatchedReason`, and `:193`'s `if (coverage.status === "ok")
+ * expect(report.unmatched).toEqual([])`, where a fifth arm falls to the `else` and
+ * asserts a non-empty unmatched list against an empty one — on the ACCEPT path, which is
+ * the path a qualified verdict lives on.
+ *
+ * KNOWINGLY OPEN, tracked on #183 — A SKIPPED EXPORT ROW IS NEVER PERSISTED. `OrderRecord`
+ * is exactly three kinds — `orderPlaced`, `orderCancelled`, `orderFilled`
+ * (`./records.ts:132`) — and `appendOrders` (`packages/preferences/src/orders.ts:244`)
+ * writes only fresh `orderPlaced` rows. There is no record for "line N of the export
+ * could not be read": the skip reaches stderr and the returned outcome, then dies with
+ * the process. So `orders.jsonl` carries no trace that the rung exists, and every later
+ * reader — tomorrow's available-capital report, any adherence question about that date —
+ * sees a book that looks complete, with nothing to warn it otherwise. Persisting the gap
+ * was CONSIDERED AND REJECTED: a skipped row has no id, because the id is synthesized
+ * from venue, pair, side, price and submitted-at (`synthesizeOrderId`, :119) and those
+ * are the very tokens that failed to parse. An un-idable durable "something was here"
+ * could never be matched to a later import and so could never be RETIRED — a permanent
+ * blot on every future report with no verb to close it.
  */
 export function checkFundingCoverage(
   resting: readonly RestingOrder[],

--- a/packages/engine/src/orders/ingest.ts
+++ b/packages/engine/src/orders/ingest.ts
@@ -64,9 +64,37 @@ export interface OrderIdentity {
  * than through `Number(...).toString()` keeps the id exact for sizes the venue quotes
  * well past float's comfortable range, and keeps a rounding change in the runtime from
  * silently re-identifying every resting order in the file.
+ *
+ * A COMMA IS A GROUP SEPARATOR OR IT IS NOTHING (#177). Every comma used to be stripped
+ * before the shape test ran, so `10,50` — a decimal comma, which is how half the world
+ * writes ten and a half — canonicalized to `1050`: a silent 100x error, and one baked
+ * permanently into a synthesized order id and into the committed sum computed from it.
+ * The grouping must be VALID (first group 1-3 digits, every later group exactly 3, no
+ * comma anywhere after the decimal point) or the token is refused, and the row carrying
+ * it is skipped and reported. Guessing which spelling the operator meant is exactly the
+ * guess an append-only file cannot afford.
  */
+const THOUSANDS_GROUPED = /^\d{1,3}(,\d{3})+$/;
+
 export function canonicalDecimal(token: string): string | undefined {
-  const cleaned = token.trim().replace(/[\s,]/g, "").replace(/^\+/, "");
+  const signed = token.trim().replace(/\s/g, "").replace(/^\+/, "");
+  const isNegative = signed.startsWith("-");
+  const unsigned = isNegative ? signed.slice(1) : signed;
+  const [rawWholePart = "", rawFractionPart = "", ...surplus] = unsigned.split(".");
+  if (surplus.length > 0 || rawFractionPart.includes(",")) {
+    return undefined;
+  }
+  let wholePart = rawWholePart;
+  if (wholePart.includes(",")) {
+    if (!THOUSANDS_GROUPED.test(wholePart)) {
+      return undefined;
+    }
+    wholePart = wholePart.replace(/,/g, "");
+  }
+  const cleaned =
+    (isNegative ? "-" : "") +
+    wholePart +
+    (unsigned.includes(".") ? `.${rawFractionPart}` : "");
   if (!/^-?(\d+(\.\d*)?|\.\d+)$/.test(cleaned)) {
     return undefined;
   }
@@ -96,6 +124,154 @@ export function synthesizeOrderId(identity: OrderIdentity): string {
     identity.price,
     identity.observedAt,
   ].join(":");
+}
+
+/**
+ * Two or more rows of ONE batch that the venue rendered under the same synthesized id,
+ * summed into one claim. Reported so the operator sees the arithmetic that was applied.
+ */
+export interface MergedOrderClaim {
+  id: string;
+  price: number;
+  observedAt: string;
+  symbol: string;
+  side: OrderSide;
+  /** Every row's quantity, in the order the export rendered them. */
+  quantities: number[];
+  /** Their sum — what the single surviving claim encumbers. */
+  mergedQuantity: number;
+}
+
+/**
+ * Collapse rows of ONE batch that collide on the synthesized id into one claim each,
+ * SUMMING their sizes (#174).
+ *
+ * The export has no total discriminator: a venue-split order's children share every
+ * parsed field, so identity by content cannot be made total by widening the id (adding
+ * `quantity` would be worse than useless — a claim rests until something explicitly
+ * retires it, so the second sighting of a re-sized rung would become a second claim
+ * resting forever). What IS certain is the arithmetic: two claims at the same price
+ * against the same reserve encumber their SUM. Summing is therefore the only reading
+ * that is not a guess — dropping one row would silently free capital that is committed,
+ * and appending two lines under one id would leave the second unreachable to
+ * `pickRestingOrdersAsOf`, which ignores a repeat placement of a known id by design.
+ *
+ * The merge is RETURNED, never whispered: the caller owes the operator a first-class
+ * line naming both sizes and the total, because the remedy — re-place one rung a tick
+ * apart so the two get distinct prices — is the operator's to apply, not ours.
+ */
+export function mergeCollidingClaims<T extends ObservedOpenOrder>(
+  orders: readonly T[],
+): { orders: T[]; merges: MergedOrderClaim[] } {
+  const byId = new Map<string, { order: T; quantities: number[] }>();
+  for (const order of orders) {
+    const seen = byId.get(order.id);
+    if (seen === undefined) {
+      byId.set(order.id, { order, quantities: [order.quantity] });
+      continue;
+    }
+    seen.quantities.push(order.quantity);
+    seen.order = {
+      ...seen.order,
+      quantity: seen.order.quantity + order.quantity,
+      // The venue's cumulative fill for each child is a fill of the merged claim too, so
+      // the remainder the merged rung rests for stays honest.
+      ...(seen.order.filledQuantity !== undefined || order.filledQuantity !== undefined
+        ? { filledQuantity: (seen.order.filledQuantity ?? 0) + (order.filledQuantity ?? 0) }
+        : {}),
+    };
+  }
+
+  const merges: MergedOrderClaim[] = [];
+  for (const { order, quantities } of byId.values()) {
+    if (quantities.length > 1) {
+      merges.push({
+        id: order.id,
+        price: order.price,
+        observedAt: order.observedAt,
+        symbol: order.symbol,
+        side: order.side,
+        quantities,
+        mergedQuantity: order.quantity,
+      });
+    }
+  }
+
+  return { orders: [...byId.values()].map((entry) => entry.order), merges };
+}
+
+/** One field of a known claim that the venue is now rendering differently. */
+export interface ClaimDifference {
+  field: "quantity" | "observedFilledQuantity";
+  known: number;
+  observed: number;
+}
+
+/** A row that names a claim already on file, but does NOT say the same thing about it. */
+export interface ChangedClaim {
+  id: string;
+  differences: ClaimDifference[];
+}
+
+/**
+ * Rows of this batch that name a claim already on file while DIFFERING from it (#174).
+ *
+ * `alreadyKnown` means byte-identical in the fields that matter — the id components plus
+ * the size and the observed partial. Anything else is a CHANGE to a known claim, and a
+ * change is not a re-sighting: folding it into `alreadyKnown` reported "nothing to do"
+ * about a rung whose size on file is now wrong, which is exactly the silence #174 names.
+ *
+ * KNOWN LIMIT, stated rather than papered over: the sidecar persists neither
+ * `orderType`, `timeInForce` nor `triggerPrice` — `KEY_ORDER.orderPlaced` in `records.ts`
+ * is ten fields and none of them is a descriptor — so a change confined to those cannot be
+ * detected here. There is nothing on file to compare against.
+ *
+ * Accepted for increment two, deliberately: no descriptor moves the encumbrance, which is
+ * `price * quantity`, so the funding guard stays correct across such a change. Closing it
+ * means WIDENING the durable record, and that is not free — every line already on file
+ * carries no descriptors, so every re-imported row would differ from its known claim and an
+ * UNCHANGED batch would refuse on every rung until a migration rewrote an append-only file.
+ * That widening belongs with the observation verb #181 designs, which is the next thing to
+ * decide what a later sighting of a known rung may carry. When these fields are persisted,
+ * compare them here too.
+ */
+export function detectChangedClaims(
+  known: readonly OrderPlacedRecord[],
+  observed: readonly ObservedOpenOrder[],
+): ChangedClaim[] {
+  const placedById = new Map<string, OrderPlacedRecord>();
+  for (const record of known) {
+    // FIRST placement wins, matching `pickRestingOrdersAsOf`: a repeat placement line is
+    // ignored there, so it must not be what a change is measured against here.
+    if (!placedById.has(record.id)) {
+      placedById.set(record.id, record);
+    }
+  }
+
+  const changed: ChangedClaim[] = [];
+  for (const order of observed) {
+    const placed = placedById.get(order.id);
+    if (placed === undefined) {
+      continue;
+    }
+    const differences: ClaimDifference[] = [];
+    if (placed.quantity !== order.quantity) {
+      differences.push({ field: "quantity", known: placed.quantity, observed: order.quantity });
+    }
+    const knownFilled = placed.observedFilledQuantity ?? 0;
+    const observedFilled = order.filledQuantity ?? 0;
+    if (knownFilled !== observedFilled) {
+      differences.push({
+        field: "observedFilledQuantity",
+        known: knownFilled,
+        observed: observedFilled,
+      });
+    }
+    if (differences.length > 0) {
+      changed.push({ id: order.id, differences });
+    }
+  }
+  return changed;
 }
 
 /**

--- a/packages/engine/src/orders/monotonicity.test.ts
+++ b/packages/engine/src/orders/monotonicity.test.ts
@@ -157,7 +157,7 @@ describe("an IMPOSSIBLE verdict fails loud rather than being normalized", () => 
     expect(proposal).not.toHaveProperty("verdicts");
   });
 
-  it("refuses a filled quantity larger than the claim itself", () => {
+  it("refuses a filled quantity larger than the rung was ever PLACED for", () => {
     const proposal = proposeFillVerdicts([rung(400)], observe([[400, 99]]));
     expect(proposal.status).toBe("impossible");
     if (proposal.status !== "impossible") throw new Error("expected impossible");
@@ -172,6 +172,39 @@ describe("an IMPOSSIBLE verdict fails loud rather than being normalized", () => 
     expect(proposal.status).toBe("impossible");
     if (proposal.status !== "impossible") throw new Error("expected impossible");
     expect(proposal.contradictions[0]?.kind).toBe("unknown-rung");
+  });
+});
+
+// `ObservedRungState.filledQuantity` is CUMULATIVE-SINCE-PLACEMENT (#176). It used to be
+// compared against `remainingQuantity`, which `pickRestingOrdersAsOf` has ALREADY taken
+// the recorded fills out of — so the two sides of the comparison were on different bases
+// and an honest venue reading contradicted itself past the halfway point.
+describe("`filledQuantity` is cumulative, and the check compares it with like", () => {
+  /** rung-400 placed for 10, with 7 already recorded as filled: 3 is still claimed. */
+  const partlyFilled: RestingOrder = { ...rung(400), remainingQuantity: 3 };
+
+  it("does NOT contradict an honest cumulative reading above the remaining claim", () => {
+    // The venue honestly shows 7 filled of the 10 the rung was placed for. 7 exceeds the
+    // 3 still claimed, and that is not a contradiction — it is the same 7 counted once.
+    const proposal = proposeFillVerdicts(
+      [partlyFilled, rung(300)],
+      observe([[400, 7], [300, 0]]),
+    );
+    expect(proposal.status).toBe("proposed");
+    expect(verdictFor(proposal, 400).verdict).toBe("touched");
+    expect(verdictFor(proposal, 400).evidence.observedFilledQuantity).toBe(7);
+    // And the unrelated rung below still gets its own verdict rather than being
+    // discredited along with the whole book.
+    expect(verdictFor(proposal, 300).verdict).toBe("resting");
+  });
+
+  it("still trips on a reading larger than the rung was EVER placed for", () => {
+    // 11 of a rung placed for 10. Genuinely impossible on any basis — the check is
+    // corrected, not weakened.
+    const proposal = proposeFillVerdicts([partlyFilled], observe([[400, 11]]));
+    expect(proposal.status).toBe("impossible");
+    if (proposal.status !== "impossible") throw new Error("expected impossible");
+    expect(proposal.contradictions[0]?.kind).toBe("filled-quantity-exceeds-order");
   });
 });
 

--- a/packages/engine/src/orders/monotonicity.test.ts
+++ b/packages/engine/src/orders/monotonicity.test.ts
@@ -12,7 +12,7 @@
 // EVERY FIXTURE IS A SYNTHETIC LADDER (`O7`). Round numbers, invented symbol, no real
 // price, size, balance or rung anywhere in this file.
 import { describe, expect, it } from "vitest";
-import { proposeFillVerdicts, type BookObservation } from "./monotonicity.js";
+import { proposeFillVerdicts, scopeBookForFill, type BookObservation } from "./monotonicity.js";
 import type { OrderPlacedRecord } from "./records.js";
 import type { RestingOrder } from "./select.js";
 
@@ -239,6 +239,49 @@ describe("a fill on one symbol implies nothing about a rung on another", () => {
     });
     // The untouched higher-priced rung on the OTHER symbol must not veto the top rung's
     // proposed fill on this one.
+    expect(verdictFor(proposal, 400).verdict).toBe("filled");
+  });
+});
+
+// #175. The scope a caller must gather evidence over is the same scope the proposal
+// reasons over, so it is computed HERE and once rather than restated at each call site.
+describe("`scopeBookForFill` — the one rung set both halves of the act use", () => {
+  const other = rung(900, { id: "other-900", symbol: "OTHER/USD" });
+  const later = rung(500, { id: "rung-500", observedAt: "2026-01-09T09:00:00" });
+  const sell = rung(600, { id: "sell-600", side: "sell" });
+
+  it("keeps only the fill's own symbol — the other ladder is not evidence at all", () => {
+    const scoped = scopeBookForFill([other, sell, later, ...LADDER], "TEST/USD", OBSERVED);
+    expect(scoped.sameSymbol.map((entry) => entry.placed.id)).not.toContain("other-900");
+    expect(scoped.observable.map((entry) => entry.placed.id)).not.toContain("other-900");
+  });
+
+  it("carries a LATER rung in `sameSymbol` but not in `observable`", () => {
+    // It must reach the proposal — so it is NAMED in `excluded` — while never being asked
+    // about, since an answer would put a rung condition 1 refuses to know into the book.
+    const scoped = scopeBookForFill([later, ...LADDER], "TEST/USD", OBSERVED);
+    expect(scoped.sameSymbol.map((entry) => entry.placed.id)).toContain("rung-500");
+    expect(scoped.observable.map((entry) => entry.placed.id)).not.toContain("rung-500");
+  });
+
+  it("leaves resting SELLS out of what is asked about", () => {
+    const scoped = scopeBookForFill([sell, ...LADDER], "TEST/USD", OBSERVED);
+    expect(scoped.observable.map((entry) => entry.placed.id)).not.toContain("sell-600");
+  });
+
+  it("agrees with the proposal: what it scopes out never arrives as an ABSENCE", () => {
+    const scoped = scopeBookForFill([other, later, ...LADDER], "TEST/USD", OBSERVED);
+    // The operator is asked about every `observable` rung except the one that filled, and
+    // answers "gone" for it — so the observation names the rest.
+    const proposal = proposeFillVerdicts(scoped.sameSymbol, {
+      observedAt: OBSERVED,
+      present: scoped.observable
+        .filter((entry) => entry.placed.id !== "rung-400")
+        .map((entry) => ({ orderId: entry.placed.id, filledQuantity: 0 })),
+    });
+    if (proposal.status !== "proposed") throw new Error(`expected a proposal: ${proposal.status}`);
+    expect(proposal.verdicts.map((entry) => entry.orderId)).not.toContain("other-900");
+    expect(proposal.excluded).toEqual(["rung-500"]);
     expect(verdictFor(proposal, 400).verdict).toBe("filled");
   });
 });

--- a/packages/engine/src/orders/monotonicity.ts
+++ b/packages/engine/src/orders/monotonicity.ts
@@ -155,12 +155,77 @@ export type MonotonicityProposal =
   | { status: "impossible"; contradictions: MonotonicityContradiction[] };
 
 /**
+ * CONDITION 1, as ONE predicate rather than two that have to be kept in step. A rung
+ * placed after the moment being reasoned about was not on the book then and cannot be
+ * evidence about it. Both the proposal below and {@link scopeBookForFill} — which is what
+ * a caller gathers its evidence over — partition with this, so "asked about" and
+ * "reasoned over" cannot drift apart (#175).
+ */
+function partitionByMoment(
+  resting: readonly RestingOrder[],
+  observedAt: string,
+): { simultaneous: RestingOrder[]; later: RestingOrder[] } {
+  const simultaneous: RestingOrder[] = [];
+  const later: RestingOrder[] = [];
+  for (const order of resting) {
+    // Sells are out of scope and out of the reasoning: a resting sell encumbers the ASSET,
+    // and the ladder monotonicity argument is about a descending buy ladder.
+    if (order.placed.side !== "buy") {
+      continue;
+    }
+    (order.placed.observedAt <= observedAt ? simultaneous : later).push(order);
+  }
+  return { simultaneous, later };
+}
+
+/** The one rung set an act observes AND reasons over, split by what may be asked about. */
+export interface ScopedBook {
+  /**
+   * Every BUY rung on the fill's own symbol, LATER ONES INCLUDED — the argument list for
+   * {@link proposeFillVerdicts}. A later rung belongs here so it surfaces in `excluded`,
+   * named, rather than being silently dropped.
+   */
+  sameSymbol: RestingOrder[];
+  /**
+   * Of those, the ones actually resting at the moment: the ONLY rungs there is any point
+   * asking the operator about. Asking about a later one puts a rung into the observation
+   * that condition 1 then refuses to know — `unknown-rung`, on a truthful answer.
+   */
+  observable: RestingOrder[];
+}
+
+/**
+ * The rung set ONE fill act is about: same instrument, resting at the fill's moment.
+ *
+ * This exists because the two halves of the act used to disagree. The caller asked the
+ * operator about same-symbol rungs and then handed the WHOLE resting book to the proposal,
+ * so every rung it had declined to ask about arrived as an ABSENCE — and an absence with
+ * nothing untouched above it derives `filled`. A second open ladder was therefore proposed
+ * as a purchase, which is precisely the conversion of cancellations into phantom purchases
+ * `D12` refuses to make (#175). The scope is computed once, here, and both halves take it.
+ */
+export function scopeBookForFill(
+  resting: readonly RestingOrder[],
+  symbol: string,
+  observedAt: string,
+): ScopedBook {
+  const sameSymbol = resting.filter((order) => order.placed.symbol === symbol);
+  return { sameSymbol, observable: partitionByMoment(sameSymbol, observedAt).simultaneous };
+}
+
+/**
  * Propose a verdict for every simultaneously-resting BUY rung, or refuse.
  *
  * Sells are out of scope and out of the reasoning: a resting sell encumbers the asset,
- * and the ladder monotonicity argument is about a descending buy ladder. Reasoning is
- * grouped per `symbol`, because a fill on one instrument implies nothing whatever about a
- * rung on another.
+ * and the ladder monotonicity argument is about a descending buy ladder.
+ *
+ * WHAT IS GROUPED PER `symbol` IS THE `above` COMPARISON, AND ONLY THAT. This function
+ * reasons over exactly the book it is handed: every buy rung in `resting` that was resting
+ * at `observation.observedAt` gets a verdict, whatever instrument it names. So a caller
+ * that wants "a fill on one instrument implies nothing whatever about a rung on another"
+ * must hand over one instrument's rungs — {@link scopeBookForFill} is that, and the
+ * observation must be gathered over the same set. Handing over more than was asked about
+ * is #175, and it was the whole defect: absence is the input `D12` forbids inferring from.
  */
 export function proposeFillVerdicts(
   resting: readonly RestingOrder[],
@@ -168,15 +233,10 @@ export function proposeFillVerdicts(
 ): MonotonicityProposal {
   const contradictions: MonotonicityContradiction[] = [];
 
-  // CONDITION 1, enforced rather than assumed. A rung placed after the observation was
-  // not on the book at that moment and cannot be evidence about it. Excluded rungs are
-  // returned by id so the operator sees WHAT the reasoning did not consider.
-  const simultaneous = resting.filter(
-    (order) => order.placed.side === "buy" && order.placed.observedAt <= observation.observedAt,
-  );
-  const excluded = resting
-    .filter((order) => order.placed.side === "buy" && order.placed.observedAt > observation.observedAt)
-    .map((order) => order.placed.id);
+  // CONDITION 1, enforced rather than assumed. Excluded rungs are returned by id so the
+  // operator sees WHAT the reasoning did not consider.
+  const { simultaneous, later } = partitionByMoment(resting, observation.observedAt);
+  const excluded = later.map((order) => order.placed.id);
 
   const present = new Map(observation.present.map((state) => [state.orderId, state]));
   const known = new Set(simultaneous.map((order) => order.placed.id));

--- a/packages/engine/src/orders/monotonicity.ts
+++ b/packages/engine/src/orders/monotonicity.ts
@@ -46,9 +46,28 @@ const QUANTITY_EPSILON = 1e-9;
 export interface ObservedRungState {
   orderId: string;
   /**
-   * The venue's `filled_quantity` for this rung, `0` when untouched. This is the honest
-   * test and the ONLY one: a `status` column reading `Filled` is a venue's summary of
-   * this number, and summarizing it is where partials get rounded up into whole fills.
+   * CUMULATIVE SINCE THE RUNG WAS PLACED — the venue's running `filled_quantity` total for
+   * it, `0` when untouched. NOT the quantity filled since the last record; NOT a delta.
+   * ONE basis, stated here rather than left to each caller (#176).
+   *
+   * CUMULATIVE, because that is the only basis a producer can honestly supply. The venue
+   * prints a running total in its own column, and an operator reading it off the screen
+   * cannot compute a delta without knowing what this file already recorded. Asking for a
+   * number nobody can look up is how the two bases got mixed in the first place: the
+   * prompt asked for the venue's column while the rung being recorded pushed its own
+   * fill's delta, a few lines apart in the same function.
+   *
+   * WHAT IT IS COMPARED AGAINST, AND WHY THAT IS NOT `remainingQuantity`. A cumulative
+   * total belongs beside the rung's ORIGINAL `placed.quantity`. `RestingOrder.
+   * remainingQuantity` has already had every recorded fill netted out of it (`./select.ts`
+   * — and, since #173, the placement line's own `observedFilledQuantity` too), so
+   * comparing the two subtracts the same fills twice: a rung placed for 10 with 7 recorded
+   * shows a remainder of 3, and an honest venue reading of 7 would read as `7 > 3` — an
+   * "arithmetic, not policy" contradiction raised against the truth.
+   *
+   * It is still the honest partial-fill test and the ONLY one: a `status` column reading
+   * `Filled` is a venue's summary of this number, and summarizing it is where partials get
+   * rounded up into whole fills.
    */
   filledQuantity: number;
 }
@@ -113,7 +132,12 @@ export interface MonotonicityContradiction {
      * leaving a higher buy limit untouched.
      */
     | "fill-below-untouched-rung"
-    /** The venue reports more filled than the rung still claims. Arithmetic, not policy. */
+    /**
+     * The venue reports more filled than the rung was EVER PLACED FOR. Arithmetic, not
+     * policy — and measured against the original quantity, because the observation is a
+     * cumulative total. It used to be measured against `remainingQuantity`, which is net
+     * of the very fills the cumulative figure counts (#176).
+     */
     | "filled-quantity-exceeds-order"
     /** The observation names a rung that was not resting — nothing to reason over. */
     | "unknown-rung";
@@ -170,13 +194,17 @@ export function proposeFillVerdicts(
 
   for (const order of simultaneous) {
     const state = present.get(order.placed.id);
-    if (state && state.filledQuantity > order.remainingQuantity + QUANTITY_EPSILON) {
+    // LIKE WITH LIKE. `state.filledQuantity` is cumulative since placement, so the only
+    // number it can contradict is what the rung was placed for. Against
+    // `remainingQuantity` — already net of those same fills — an honest reading past the
+    // halfway point would refuse the operator's whole act.
+    if (state && state.filledQuantity > order.placed.quantity + QUANTITY_EPSILON) {
       contradictions.push({
         kind: "filled-quantity-exceeds-order",
         orderId: order.placed.id,
         message:
-          `rung '${order.placed.id}' is observed with filled_quantity ${state.filledQuantity} ` +
-          `against a remaining claim of ${order.remainingQuantity}`,
+          `rung '${order.placed.id}' is observed with a cumulative filled_quantity of ` +
+          `${state.filledQuantity} against the ${order.placed.quantity} it was placed for`,
       });
     }
   }

--- a/packages/engine/src/orders/records.ts
+++ b/packages/engine/src/orders/records.ts
@@ -97,9 +97,11 @@ export interface OrderPlacedRecord extends OrderRecordBase {
    *
    * KNOWN LIMIT, named rather than papered over: the id is synthesized from the venue's
    * SUBMISSION stamp, so a later export showing the same rung further filled arrives under
-   * the same id and is skipped as already known. The partial observed at FIRST import is
-   * the one carried. The error direction is conservative — committed reads high, available
-   * reads low — which is the direction that does not cost money.
+   * the same id. It USED TO BE SKIPPED AS ALREADY KNOWN, silently keeping the partial
+   * observed at first import; since #174 it is REFUSED as a `changed-claim` instead —
+   * loudly, with nothing written — because recording it needs an observation verb this
+   * build does not have and a second placement line would be ignored by the selector.
+   * Until that verb exists the operator records the fill, or cancels and re-places.
    */
   observedFilledQuantity?: number;
   /**

--- a/packages/engine/src/orders/records.ts
+++ b/packages/engine/src/orders/records.ts
@@ -74,6 +74,35 @@ export interface OrderPlacedRecord extends OrderRecordBase {
    */
   quantity: number;
   /**
+   * The venue's `filled_quantity` for this rung AS OF `observedAt` — CUMULATIVE since the
+   * rung was placed, and ABSENT rather than `0` when nothing had filled (#173).
+   *
+   * WHY IT IS A FIELD ON THE PLACEMENT LINE AND NOT A SYNTHESIZED `orderFilled`. The
+   * append-only file makes this shape permanent, so the reasoning is recorded here:
+   *
+   *   - AN `orderFilled` LINE IS HALF OF A FILL ACT. `reconcileFillActs` pairs every one
+   *     of them with a `PositionOpened`/`PositionAddedTo` in `events.jsonl` by a derived
+   *     id. A line synthesized at import has no lot answering for it, so it would read as
+   *     a permanent `fill-without-lot` TORN ACT — and `recordFill` refuses to record
+   *     anything while one is outstanding. Importing any partial would brick the fill flow.
+   *   - IDEMPOTENCY COMES FREE HERE AND NOWHERE ELSE. Both the import's append filter and
+   *     `pickRestingOrdersAsOf` dedupe by ORDER ID, so a re-import of the same export
+   *     lands nothing twice. `orderFilled` lines are SUBTRACTED unconditionally
+   *     (`./select.ts`), so two identical ones would double-count the partial — and a
+   *     dedupe rule for them would be indistinguishable from a genuine second real
+   *     partial at the same second.
+   *   - THE TWO FACTS ARE DIFFERENT. `orderFilled` is something the FUND did, with a lot
+   *     and a cash leg behind it. This is something the venue SHOWED about the row at the
+   *     moment it was observed. Collapsing them into one verb would lose that.
+   *
+   * KNOWN LIMIT, named rather than papered over: the id is synthesized from the venue's
+   * SUBMISSION stamp, so a later export showing the same rung further filled arrives under
+   * the same id and is skipped as already known. The partial observed at FIRST import is
+   * the one carried. The error direction is conservative — committed reads high, available
+   * reads low — which is the direction that does not cost money.
+   */
+  observedFilledQuantity?: number;
+  /**
    * The one DECLARED field at placement (`Q9`): which reserve the claim encumbers. The
    * venue has never heard of a Reserve, so this cannot be observed. Notably absent: a
    * target `positionId` (the Position cannot exist until the first fill, so naming it
@@ -165,6 +194,9 @@ const KEY_ORDER: Record<OrderKind, readonly string[]> = {
     "side",
     "price",
     "quantity",
+    // Absent when nothing had filled: `JSON.stringify` drops an `undefined` value, so a
+    // rung with no partial serializes to exactly the bytes it always did.
+    "observedFilledQuantity",
     "fundingReserveId",
   ],
   orderCancelled: ["id", "observedAt", "kind", "currency"],
@@ -263,6 +295,23 @@ export function parseOrderRecord(value: unknown): OrderRecordParse {
           message: "fundingReserveId must be a non-empty string",
         };
       }
+      // Optional and NON-NEGATIVE. Absent is the common case and reads as nothing filled;
+      // a value at or above `quantity` would leave nothing resting, and the selector — not
+      // this reader — is where "nothing still claimed stops resting" is decided.
+      if (
+        value.observedFilledQuantity !== undefined &&
+        !(
+          typeof value.observedFilledQuantity === "number" &&
+          Number.isFinite(value.observedFilledQuantity) &&
+          value.observedFilledQuantity >= 0
+        )
+      ) {
+        return {
+          status: "skip",
+          problem: "malformed",
+          message: "observedFilledQuantity must be a non-negative number when present",
+        };
+      }
       return {
         status: "ok",
         record: {
@@ -272,6 +321,9 @@ export function parseOrderRecord(value: unknown): OrderRecordParse {
           side: value.side,
           price: value.price,
           quantity: value.quantity,
+          ...(value.observedFilledQuantity !== undefined && value.observedFilledQuantity > 0
+            ? { observedFilledQuantity: value.observedFilledQuantity }
+            : {}),
           fundingReserveId: value.fundingReserveId,
         },
       };

--- a/packages/engine/src/orders/select.ts
+++ b/packages/engine/src/orders/select.ts
@@ -15,6 +15,12 @@ import type { OrderPlacedRecord, OrderRecord } from "./records.js";
  * One claim still resting at the as-of boundary, with the size that is STILL claimed.
  * A partially-filled rung encumbers only its unfilled remainder, so the remainder is
  * carried here rather than left for each caller to recompute from the fill lines.
+ *
+ * `remainingQuantity` is NET OF EVERYTHING OBSERVED: the placement line's own
+ * `observedFilledQuantity` (what the venue already showed filled when the rung was
+ * imported) and every `orderFilled` line since. The ORIGINAL size stays on
+ * `placed.quantity`, and that distinction is load-bearing — a cumulative venue reading is
+ * compared against the original, never against this (#176).
  */
 export interface RestingOrder {
   placed: OrderPlacedRecord;
@@ -61,9 +67,17 @@ export function pickRestingOrdersAsOf(records: OrderRecord[], asOf?: string): Re
       case "orderPlaced": {
         // A repeat placement of a known id is the same claim observed twice (ingest ids
         // are deterministic), not a second claim. Ignoring it keeps a re-import from
-        // double-counting the ladder.
+        // double-counting the ladder — and it is what makes the partial carried ON this
+        // line idempotent, where a synthesized `orderFilled` line would be subtracted
+        // once per copy (#173).
         if (!resting.has(record.id)) {
-          resting.set(record.id, { placed: record, remainingQuantity: record.quantity });
+          // A rung the venue already showed partly filled at placement rests only for its
+          // REMAINDER. Nothing still claimed means it is not resting at all — a fully
+          // filled row is not a claim on capital.
+          const remaining = record.quantity - (record.observedFilledQuantity ?? 0);
+          if (remaining > 0) {
+            resting.set(record.id, { placed: record, remainingQuantity: remaining });
+          }
         }
         break;
       }


### PR DESCRIPTION
## Summary

Increment two continues `Order`, Bitget ingest, and available capital (increment one, #163) by unifying reserve attribution between the funding guard and the available-capital report, and by fixing partial-fill handling on import.

- **Reserve attribution unification** (72dec2f): the O1 import guard and the available-capital report computed committed reserves via the same formula but different call sites — the guard read `data.reserves` off the fold directly, the report read `buildCanonicalState(...).reserveReconciliation`, and the guard's reserve type carried no currency. New `packages/engine/src/orders/attribution.ts` is now the single owner of the admission policy and placement rule; `checkFundingCoverage` takes the fund itself instead of a reserve list a caller could get wrong; `ReserveBalance` is replaced by `FundableReserve` (carries currency, only producible via `fundableReserves(data)`). This is a breaking change to `@numisma/engine`'s public `checkFundingCoverage` signature.
- **Partial-fill admission on import** (a4ee60f): the venue's `filled_quantity` was parsed but dropped by `buildOrderPlacedRecords`, so every imported rung started at full quantity forever, and `BITGET_RESTING_STATUS = "unfilled"` gated admission so partially-filled rows were skipped and their encumbered capital reported as free. `observedFilledQuantity` is now an optional field on `OrderPlacedRecord`; admission is `quantity - filled_quantity > 0`; status is a vocabulary check, not the gate. Also unifies `ObservedRungState.filledQuantity` to one cumulative-since-placement meaning across producers. The durable format stays backward compatible (field serialized only when > 0).
- **Test hardening** (7d5672c): raises `event-store.test.ts`'s timeout to 30s to match five sibling TUI test files, giving headroom against shared-worker contention with `ingest-commit-hardening.test.ts`'s real git subprocesses. Honesty note carried from the commit: no actual timeout was reproduced across 8 full test runs — this is headroom (~2.6x → ~15x), not a proven root-cause fix.
- **One synthesized order id identifies exactly one claim** (d56c69b): `quantity` stays out of the synthesized id; the id keeps meaning the rung as the venue submitted it. What changes is that a repeat sighting differing in a non-id field now has a stated meaning. Two rows of one batch colliding on an id are summed into one claim, because two claims at the same price against the same reserve encumber their sum — arithmetic, not a guess. Previously both were appended (`known` is built from the sidecar, never from the batch) while the selector rested only the first, so the second line was unreachable forever and the funding guard was evaluated over an understated committed; the merge is now reported as a first-class operator line naming price, second, both quantities, the total, and the tick-apart remedy. A row naming a known claim but differing from it is refused via a new `changed-claim` member of `OrdersImportRejection`, returned through the existing `reject(...)` path — not recorded, because recording it needs a verb that does not exist (#181 designs it in increment four). `canonicalDecimal` (#177 item 3) no longer strips every comma before its shape test; commas must form valid thousands grouping or the token is refused and the row skipped — it rode in this commit because its return feeds `price` into `synthesizeOrderId`. Named narrowing: the sidecar persists no `orderType`, `timeInForce` or `triggerPrice`, so a descriptor-only change is undetectable — accepted for increment two and left to #181.

Closes #172
Closes #173
Closes #174
Closes #175
Closes #176
Closes #177
Closes #178
Closes #184
Closes #183

## Remaining in this increment

No open PRD/spec issue currently tracks #172–#177 as an umbrella (increment one, #163, was the last such issue and is closed). Tracking the remaining work here directly:

- [x] #174 — Makes a synthesized order id identify exactly one claim
- [x] #175 — Reasons over the same book it observed
- [x] #177 — Closes five refusal gaps in the order write paths (items 2 and 3 closed alongside the issues they collide with; items 1, 4, 5 close in this PR's final commit)

#179 and #180 (increment three) and #181 (increment four) were also filed from this branch's work, but they're out of scope for this PR and will land on their own branch.

## Build order

- The sequence completed as planned: #174's identity decision (decision only, no code) → #175 → #174's implementation → #177 remains, with only #177's outstanding items left.
- #177 stayed a single issue, not split — but two of its five items closed as a side effect of the issues they collided with:
  - Item 2 (the `Number.isFinite(quantity) ? quantity : 0` coercion at `record-fill.ts:236`) closed with #175, in the same edit — it sat inside the `for (const rung of rungs)` loop at `record-fill.ts:210-213` that #175 re-scoped.
  - Item 3 (`canonicalDecimal`'s comma handling at `ingest.ts:63`) closed together with #174's identity decision — its return feeds `price` into `synthesizeOrderId` at `ingest.ts:96`, so changing what tokens it accepts was itself an id-identity change.
  - Items 1, 4, and 5 remain as a clean three-item pass.

## The identity decision (#174, criterion 1)

**`quantity` stays OUT of the id.** A synthesized id keeps identifying the rung as the venue submitted it — venue, symbol, side, price, submitted-at. A row that names a known claim while differing from it in a non-id field is a CHANGE to that claim, never an `alreadyKnown` re-sighting.

The alternative — `quantity` joins the id components — was rejected on one fact: a placement rests forever until something explicit retires it, and absence from a later export retires nothing. An amended rung would synthesize a new id while the old claim rested at its old size forever, so the guard would refuse every future batch as over-committed and advise the operator to fix a declaration that was never wrong. It also does not close the within-batch collision, since two identical split children collide under it exactly as they do today.

**Within-batch collisions are summed, not refused.** The house reflex is to refuse loudly, and it applies to proceeding on an unverified assumption. A sum is not one: two claims at the same price against the same reserve encumber their total whether they are venue-split children or a double-submit. Refusing instead would block every import until the operator cancelled and re-placed at the venue — a dead end on an input they may not be able to change. Deciding they are "one order seen twice" and dropping one would be the guess.

**A detected change is refused, not recorded** — the one place the proceed-with-arithmetic reasoning does not extend. Recording it would need either a verb the log does not have or a rewrite of an append-only line; #181 introduces that verb in increment four and upgrades this refusal into a recorded observation.

**Recorded narrowing.** `alreadyKnown` was decided as byte-identical in the id components plus `quantity`, `observedFilledQuantity` and the descriptors `orderType`, `timeInForce`, `triggerPrice`. It shipped without the descriptors, deliberately: `KEY_ORDER.orderPlaced` persists none of the three, so there is nothing on file to compare against. No descriptor moves the encumbrance — that is `price * quantity` — so the funding guard stays correct across such a change, and widening the durable record would make every line already on file differ from every re-imported row, refusing an unchanged batch on every rung until a migration rewrote an append-only file. The limit is written onto `detectChangedClaims` and filed as a comment on #181.

## Why the two partial-read policies stay asymmetric

A partially readable sidecar is still refused whole; a partially readable export still imports. The risk direction is the same for both — `committed` is under-counted, so `available` reads HIGH — but what PROCEEDING ASSERTS is not. Appending over an unreadable sidecar asserts something false: `known` is built only from readable lines, so a row whose sidecar line was unreadable looks FRESH and appends a second time (the #174 defect arriving through another door), and `detectChangedClaims` goes blind over that region, so a changed claim appends as fresh instead of refusing. Skipping an unparseable export row asserts nothing: it omits, it cannot duplicate, it is visible with a line number and a reason, and it self-corrects on the next export. Refusing the export was considered and rejected — it blocks on the venue's own file, which the operator cannot change, so one weird token would block a ladder that is otherwise entirely readable.

`imported-partial`'s exit code stays 0 because lines were written. That decision has a recorded reopen trigger: if this import is ever automated or piped, the exit code becomes the only surface left and 0-on-partial must be revisited — tracked as #183.

## Regression fixed before merge (#184)

#184 was a regression this PR itself introduced, in the #177 item 4 work: `import-orders.ts` discriminated a partial import on the raw skip count, but `BitgetRowSkip` is heterogeneous — a not-resting row (`quantity - filled_quantity <= 0`) is read completely and claims nothing still outstanding. An export whose only skip was a rung that filled between export and import was reported as INCOMPLETE with a money-direction warning that was false in every clause, on an entirely ordinary event. Fixed here before merge: the partial-import alarm now counts only skips that leave a rung unweighed, via a new exhaustive `leavesRungUnweighed(problem)` predicate, so a rung filling between export and import no longer triggers a false money-direction warning.

## #183 decided (docs only)

#183's reopen trigger — recorded above — was decided this session, and the outcome is documentation only: `checkFundingCoverage`'s public type is deliberately unchanged. Its docstring now states the guard's verdict scope directly — `resting` is the function's whole input, `ok` is honest over exactly that set, and whether the set is the whole book is the caller's to own — and records why qualifying the verdict was rejected, plus the one blind spot left knowingly open (a skipped export row is never persisted, so no reader can see the gap). See `packages/engine/src/orders/ingest.ts`.

## Gates

- `pnpm typecheck`: clean
- `pnpm test`: 986 passed / 19 skipped / 0 failed

## Why draft

Increment two is five of six issues done. Parking this now, before travel, so the finished work is legible from a phone while only #177's items 1, 4, and 5 remain open.

**Update:** #177's remaining items (1, 4, 5) are now done; the branch is out of draft and ready for review.



