### PR TITLE
Detect a day the price feed did not run, and say so where you will see it

### DIFF
--- a/apps/tui/src/app.ts
+++ b/apps/tui/src/app.ts
@@ -3,6 +3,7 @@ import { resolveEventStorePaths } from "@numisma/event-store";
 import { loadOrders, resolveOrdersPath } from "@numisma/preferences";
 import { loadAvailableCapital } from "./available-capital.js";
 import { prepareStartup, type StartupPlan } from "./startup.js";
+import { loadGapLines } from "./gap-lines.js";
 
 // PROTOTYPE (mvi 2026-06-29-portfolio-persistence): the real TUI surface now
 // renders the FOLD over the event log, not a single hand-edited snapshot. On
@@ -42,6 +43,11 @@ async function runStartup(): Promise<StartupPlan> {
   try {
     return await prepareStartup(paths, process.argv, {
       emit: (line) => process.stderr.write(`${line}\n`),
+      // THE ONLY ENTRY POINT THAT ASKS. `report`, `spine` and the openTUI smoke
+      // harness omit this, so they stay silent by construction rather than by a
+      // flag. Lost days land on the same pre-alternate-screen channel as the ingest
+      // report — the surface that reaches you without you going to look for it.
+      gapLines: () => loadGapLines(paths, { now: new Date() }),
     });
   } catch (error) {
     failStartup(error);

--- a/apps/tui/src/app.ts
+++ b/apps/tui/src/app.ts
@@ -3,7 +3,7 @@ import { resolveEventStorePaths } from "@numisma/event-store";
 import { loadOrders, resolveOrdersPath } from "@numisma/preferences";
 import { loadAvailableCapital } from "./available-capital.js";
 import { prepareStartup, type StartupPlan } from "./startup.js";
-import { loadGapLines } from "./gap-lines.js";
+import { loadLivenessLines } from "./liveness-lines.js";
 
 // PROTOTYPE (mvi 2026-06-29-portfolio-persistence): the real TUI surface now
 // renders the FOLD over the event log, not a single hand-edited snapshot. On
@@ -45,9 +45,10 @@ async function runStartup(): Promise<StartupPlan> {
       emit: (line) => process.stderr.write(`${line}\n`),
       // THE ONLY ENTRY POINT THAT ASKS. `report`, `spine` and the openTUI smoke
       // harness omit this, so they stay silent by construction rather than by a
-      // flag. Lost days land on the same pre-alternate-screen channel as the ingest
-      // report — the surface that reaches you without you going to look for it.
-      gapLines: () => loadGapLines(paths, { now: new Date() }),
+      // flag. The job heartbeat and the lost days land on the same
+      // pre-alternate-screen channel as the ingest report — the surface that
+      // reaches you without you going to look for it.
+      livenessLines: () => loadLivenessLines(paths, new Date()),
     });
   } catch (error) {
     failStartup(error);

--- a/apps/tui/src/gap-lines.test.ts
+++ b/apps/tui/src/gap-lines.test.ts
@@ -1,0 +1,100 @@
+/**
+ * The gap-line loader — the half of #185's TUI surface that was untestable as
+ * written. The prototype reached `apps/web`'s derivation through a COMPUTED
+ * specifier (`new URL(...).href`) precisely so `tsc` could not follow it, which
+ * left the edge untypechecked and the loader undrivable. With the derivation in
+ * `@numisma/event-store` — which `apps/tui` already declares — it is an ordinary
+ * import and an ordinary function, so it gets ordinary tests.
+ *
+ * Synthetic events in a throwaway store. No real log is read.
+ */
+import { mkdtemp, rm, writeFile } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { resolve } from "node:path";
+import type { PortfolioEvent } from "@numisma/engine";
+import { resolveEventStorePaths, type EventStorePaths } from "@numisma/event-store";
+import { afterEach, describe, expect, it } from "vitest";
+import { loadGapLines } from "./gap-lines.js";
+
+const created: string[] = [];
+
+afterEach(async () => {
+  await Promise.all(created.map((dir) => rm(dir, { recursive: true, force: true })));
+  created.length = 0;
+});
+
+async function storeWithLog(lines: readonly string[]): Promise<EventStorePaths> {
+  const dir = await mkdtemp(resolve(tmpdir(), "numisma-gap-lines-"));
+  created.push(dir);
+  const paths = resolveEventStorePaths(dir);
+  await writeFile(paths.log, lines.map((line) => `${line}\n`).join(""), "utf8");
+  return paths;
+}
+
+function mark(date: string, instrumentId = "cx-a"): PortfolioEvent {
+  return { id: `pm-${instrumentId}-${date}`, asOf: date, type: "PriceMarked", instrumentId, price: 100 };
+}
+
+function deposit(date: string): PortfolioEvent {
+  return { id: `dep-${date}`, asOf: date, type: "Deposit", reserveId: "cash-core", amount: 500, tier: "c1" };
+}
+
+const NOW = new Date("2026-08-05T12:00:00Z"); // 06:00 CDMX; yesterday = 2026-08-04
+
+describe("loadGapLines", () => {
+  it("SAYS NOTHING when every day in the window carried a mark", async () => {
+    // Silence is the feature. A startup channel that speaks on a healthy log is a
+    // startup channel you learn to scroll past.
+    const paths = await storeWithLog([JSON.stringify(mark("2026-08-04"))]);
+    const lines = await loadGapLines(paths, { since: "2026-08-04", now: NOW });
+    expect(lines).toEqual([]);
+  });
+
+  it("names each lost day, one line per day", async () => {
+    const paths = await storeWithLog([
+      JSON.stringify(mark("2026-08-02")),
+      JSON.stringify(deposit("2026-08-03")),
+    ]);
+    const lines = await loadGapLines(paths, { since: "2026-08-02", now: NOW });
+    expect(lines).toEqual([
+      "Numisma: 2026-08-03 — NO MARKS. The day is anchored but no price mark landed on it; the day is lost.",
+      "Numisma: 2026-08-04 — NO DATA. No event of any kind carries this date; the day is lost.",
+    ]);
+  });
+
+  it("never names today, however late in the day the TUI is started", async () => {
+    const paths = await storeWithLog([JSON.stringify(mark("2026-08-04"))]);
+    // 23:59 CDMX on 2026-08-05 — the ceiling is still yesterday.
+    const lines = await loadGapLines(paths, {
+      since: "2026-08-04",
+      now: new Date("2026-08-06T05:59:00Z"),
+    });
+    expect(lines.join("\n")).not.toContain("2026-08-05");
+  });
+
+  it("SAYS SO — non-fatally — when the report cannot be derived", async () => {
+    // A liveness report that can brick the dashboard is worse than none, so this
+    // never throws. But it must not go SILENT either: a detector that says nothing
+    // when it is broken is indistinguishable from a detector saying "all clear",
+    // which is the whole failure this increment exists to remove.
+    const dir = await mkdtemp(resolve(tmpdir(), "numisma-gap-lines-"));
+    created.push(dir);
+    const paths = resolveEventStorePaths(dir);
+    await writeFile(paths.log, `${JSON.stringify(mark("2026-08-04"))}\n{ not an event }\n`, "utf8");
+
+    const lines = await loadGapLines(paths, { since: "2026-08-04", now: NOW });
+    expect(lines).toHaveLength(1);
+    expect(lines[0]).toMatch(/^Numisma: lost days were NOT checked/);
+    expect(lines[0]).toMatch(/quarantine/i);
+  });
+
+  it("reports an absent log as lost days rather than as a failure", async () => {
+    const dir = await mkdtemp(resolve(tmpdir(), "numisma-gap-lines-"));
+    created.push(dir);
+    const paths = resolveEventStorePaths(dir);
+    const lines = await loadGapLines(paths, { since: "2026-08-04", now: NOW });
+    expect(lines).toEqual([
+      "Numisma: 2026-08-04 — NO DATA. No event of any kind carries this date; the day is lost.",
+    ]);
+  });
+});

--- a/apps/tui/src/gap-lines.ts
+++ b/apps/tui/src/gap-lines.ts
@@ -1,0 +1,58 @@
+/**
+ * The lost-day lines the TUI prints on its pre-alternate-screen startup channel —
+ * the surface that reaches you WITHOUT YOU GOING TO LOOK FOR IT.
+ *
+ * WHY THE TUI AND NOT THE DASHBOARD. The dashboard's freshness verdict is
+ * derivation-correct and delivery-broken: on the day this was investigated it
+ * would have fired at four stale days and nobody saw it, because it speaks only
+ * when a human opens the dashboard. Its own comment predicted exactly that — "this
+ * fires only when the job dies, which is precisely when it is needed and precisely
+ * when nobody has seen it work." The TUI is the surface already opened daily.
+ *
+ * NO BRIDGE, AND NO HAND-WRITTEN INTERFACE. The prototype put this derivation in
+ * `apps/web` and reached it from here through a COMPUTED specifier so `tsc` could
+ * not follow the edge — an app importing an app, with a hand-maintained structural
+ * interface standing in for a contract the compiler should have known. Both are
+ * gone: the derivation lives in `@numisma/event-store`, which this app already
+ * declares, so this is an ordinary import with a real type. That is also what makes
+ * "no `pg` in the TUI's module graph" true BY CONSTRUCTION rather than by care —
+ * asserted in `module-graph.test.ts`.
+ *
+ * ── IT NEVER THROWS, AND IT IS NEVER SILENT ABOUT BEING BROKEN ────────────────
+ * A liveness report that can brick the dashboard is worse than none, so a failure
+ * to derive is caught here and returned as a line. But it is NOT swallowed: a
+ * detector that says nothing when it is broken is indistinguishable from a detector
+ * saying "all clear", which is the precise failure this whole increment exists to
+ * remove. A clean window prints nothing; a BROKEN check says so.
+ */
+import {
+  formatGapReport,
+  loadGapReport,
+  type EventStorePaths,
+  type GapWindow,
+} from "@numisma/event-store";
+
+/** The one wording for "the check itself did not run." Shared with `startup.ts`. */
+export function formatGapCheckFailure(error: unknown): string {
+  const detail = error instanceof Error ? error.message : String(error);
+  return `Numisma: lost days were NOT checked (${detail}).`;
+}
+
+/**
+ * Derive the lost days and render them.
+ *
+ * EMPTY MEANS CLEAN — the caller stays quiet, which is the whole point of putting
+ * this on a channel the operator sees every single day. The window's floor defaults
+ * to the launchd era and its ceiling is pinned to yesterday by the derivation, so
+ * this can never accuse the day still in progress.
+ */
+export async function loadGapLines(
+  paths: EventStorePaths,
+  window: GapWindow,
+): Promise<string[]> {
+  try {
+    return formatGapReport(await loadGapReport(paths, window));
+  } catch (error) {
+    return [formatGapCheckFailure(error)];
+  }
+}

--- a/apps/tui/src/liveness-lines.test.ts
+++ b/apps/tui/src/liveness-lines.test.ts
@@ -1,0 +1,116 @@
+/**
+ * The composed liveness channel: the job heartbeat and the lost days, in the order
+ * an operator needs them, on the one pre-alternate-screen surface.
+ *
+ * Synthetic events and synthetic breadcrumbs in a throwaway store.
+ */
+import { mkdtemp, rm, writeFile } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { resolve } from "node:path";
+import type { PortfolioEvent } from "@numisma/engine";
+import { heartbeatPath, resolveEventStorePaths, type EventStorePaths } from "@numisma/event-store";
+import { afterEach, describe, expect, it } from "vitest";
+import { loadLivenessLines } from "./liveness-lines.js";
+
+const created: string[] = [];
+
+afterEach(async () => {
+  await Promise.all(created.map((dir) => rm(dir, { recursive: true, force: true })));
+  created.length = 0;
+});
+
+const NOW = new Date("2026-08-05T12:00:00Z"); // ceiling = 2026-08-04
+
+function mark(date: string): PortfolioEvent {
+  return { id: `pm-cx-a-${date}`, asOf: date, type: "PriceMarked", instrumentId: "cx-a", price: 100 };
+}
+
+/** A heartbeat in the wrapper's exact printf shape. `day` is the CDMX run day. */
+function heartbeat(day: string, exitCode: number, lastStep: string): string {
+  const utcStamp = `${new Date(Date.parse(`${day}T00:00:00Z`) + 86_400_000).toISOString().slice(0, 10)}T00:05:00Z`;
+  return (
+    `{\n  "schemaVersion": 1,\n  "startedAt": "${utcStamp}",\n` +
+    `  "finishedAt": "${utcStamp}",\n  "exitCode": ${exitCode},\n  "lastStep": "${lastStep}"\n}\n`
+  );
+}
+
+async function store(options: { events?: readonly PortfolioEvent[]; heartbeat?: string }) {
+  const dir = await mkdtemp(resolve(tmpdir(), "numisma-liveness-"));
+  created.push(dir);
+  const paths: EventStorePaths = resolveEventStorePaths(dir);
+  await writeFile(
+    paths.log,
+    (options.events ?? []).map((event) => `${JSON.stringify(event)}\n`).join(""),
+    "utf8",
+  );
+  if (options.heartbeat !== undefined) {
+    await writeFile(heartbeatPath(paths), options.heartbeat, "utf8");
+  }
+  return paths;
+}
+
+describe("loadLivenessLines", () => {
+  it("says NOTHING when the job ran clean and no day is lost", async () => {
+    const paths = await store({
+      events: [mark("2026-08-04")],
+      heartbeat: heartbeat("2026-08-04", 0, "complete"),
+    });
+    expect(await loadLivenessLines(paths, NOW, { since: "2026-08-04" })).toEqual([]);
+  });
+
+  it("puts the heartbeat FIRST — the cause before the effect", async () => {
+    // A failed run is why the days are lost. Reading the consequence first and the
+    // reason last is the wrong way round on a channel you scan in two seconds.
+    const paths = await store({
+      events: [mark("2026-08-02")],
+      heartbeat: heartbeat("2026-08-04", 127, "resolve-tools"), // ran, and failed
+    });
+    const lines = await loadLivenessLines(paths, NOW, { since: "2026-08-02" });
+    expect(lines[0]).toContain("FAILED");
+    expect(lines[0]).toContain("exit 127");
+    expect(lines.slice(1)).toHaveLength(2); // 08-03 and 08-04
+    expect(lines.slice(1).every((line) => line.includes("the day is lost"))).toBe(true);
+  });
+
+  it("keeps every heartbeat line ahead of the gap lines when the run is also stale", async () => {
+    // A run that failed AND has not run since is two facts, so the heartbeat
+    // contributes two lines. BOTH still precede the lost days.
+    const paths = await store({
+      events: [mark("2026-08-02")],
+      heartbeat: heartbeat("2026-08-02", 127, "resolve-tools"),
+    });
+    const lines = await loadLivenessLines(paths, NOW, { since: "2026-08-02" });
+    expect(lines).toHaveLength(4);
+    expect(lines[0]).toContain("FAILED");
+    expect(lines[1]).toContain("has not completed since");
+    expect(lines.slice(2).every((line) => line.includes("the day is lost"))).toBe(true);
+  });
+
+  it("still names lost days when no heartbeat was ever written", async () => {
+    // The backstop that makes heartbeat silence safe: no breadcrumb, but the marks
+    // stopped landing, so the gap report speaks.
+    const paths = await store({ events: [mark("2026-08-02")] });
+    const lines = await loadLivenessLines(paths, NOW, { since: "2026-08-02" });
+    expect(lines).toHaveLength(2);
+    expect(lines.every((line) => line.includes("the day is lost"))).toBe(true);
+  });
+
+  it("still speaks for a failed job on a day whose marks did land", async () => {
+    // The complement: the fetch succeeded and the run died later (step 3 or 4), so
+    // the log looks perfect and only the heartbeat knows.
+    const paths = await store({
+      events: [mark("2026-08-04")],
+      heartbeat: heartbeat("2026-08-04", 1, "post-check"),
+    });
+    const lines = await loadLivenessLines(paths, NOW, { since: "2026-08-04" });
+    expect(lines).toEqual([
+      "Numisma: the daily price job FAILED on 2026-08-04 — exit 1 at step 'post-check'. " +
+        "Nothing pushed this to you; that is why it is here.",
+    ]);
+  });
+
+  it("never throws, whatever it finds on disk", async () => {
+    const paths = await store({ events: [mark("2026-08-04")], heartbeat: "{ truncat" });
+    await expect(loadLivenessLines(paths, NOW, { since: "2026-08-04" })).resolves.toEqual([]);
+  });
+});

--- a/apps/tui/src/liveness-lines.ts
+++ b/apps/tui/src/liveness-lines.ts
@@ -1,0 +1,43 @@
+/**
+ * The one liveness channel the TUI prints before the alternate screen takes over:
+ * **did the job run**, then **which days are lost**.
+ *
+ * TWO SIGNALS, ONE SURFACE, AND NEITHER SUBSUMES THE OTHER. They fail in opposite
+ * directions, which is exactly why both are here:
+ *
+ *   - The job dies before fetching → no marks land → the GAP REPORT sees it, and
+ *     the heartbeat says why.
+ *   - The job fetches cleanly and then dies at the commit or the post-check → the
+ *     log looks perfect and the gap report is silent → only the HEARTBEAT knows.
+ *   - The machine never hosted the job → no heartbeat at all → silence is correct,
+ *     and the gap report remains the backstop if marks ever stop landing.
+ *
+ * ORDER IS THE CAUSE, THEN THE EFFECT. A failed run is why the days went missing;
+ * reading the consequence first and the reason last is the wrong way round on a
+ * channel scanned in two seconds.
+ *
+ * EMPTY MEANS HEALTHY. Both halves are silent when there is nothing to say, and
+ * neither can throw — a liveness report that stops the dashboard mounting is worse
+ * than no liveness report at all.
+ */
+import { loadHeartbeatLines, type EventStorePaths, type GapWindow } from "@numisma/event-store";
+import { loadGapLines } from "./gap-lines.js";
+
+/**
+ * The heartbeat lines followed by the lost-day lines, for one instant.
+ *
+ * `now` is passed ONCE and shared: the heartbeat's staleness threshold and the gap
+ * report's ceiling are the same rule (`dueThrough`), so evaluating them against two
+ * different clock reads is the one way they could contradict each other.
+ */
+export async function loadLivenessLines(
+  paths: EventStorePaths,
+  now: Date,
+  window: Omit<GapWindow, "now"> = {},
+): Promise<string[]> {
+  const [heartbeat, gaps] = await Promise.all([
+    loadHeartbeatLines(paths, now),
+    loadGapLines(paths, { ...window, now }),
+  ]);
+  return [...heartbeat, ...gaps];
+}

--- a/apps/tui/src/module-graph.test.ts
+++ b/apps/tui/src/module-graph.test.ts
@@ -177,18 +177,18 @@ describe("the TUI's module graph", () => {
     expect(GRAPH.unresolved).toEqual([]);
   });
 
-  it("ONLY `pnpm dev` asks for the gap lines — silence elsewhere is structural", () => {
+  it("ONLY `pnpm dev` asks for the liveness lines — silence elsewhere is structural", () => {
     // The behavioural half is in `startup.test.ts` (omitting `gapLines` emits
     // nothing). This is the other half: no OTHER entry point supplies it, so
     // `report`, `spine` and the smoke harness cannot start speaking by accident.
     const speaking = tuiSources()
-      .filter((file) => /\bgapLines\s*:/.test(readFileSync(file, "utf8")))
+      .filter((file) => /\blivenessLines\s*:/.test(readFileSync(file, "utf8")))
       .map((file) => relative(REPO_ROOT, file));
     expect(speaking).toEqual(["apps/tui/src/app.ts"]);
 
     // And the entry points that must stay quiet do not even reach the loader.
     for (const quiet of ["report.ts", "spine.ts", "spine-reset.ts", "smoke-startup-openTui.ts"]) {
-      expect(readFileSync(join(HERE, quiet), "utf8")).not.toMatch(/loadGapLines/);
+      expect(readFileSync(join(HERE, quiet), "utf8")).not.toMatch(/loadGapLines|loadLivenessLines/);
     }
   });
 
@@ -198,6 +198,8 @@ describe("the TUI's module graph", () => {
     const reached = [...GRAPH.files].map((file) => relative(REPO_ROOT, file));
     expect(reached).toContain("apps/tui/src/app.ts");
     expect(reached).toContain("apps/tui/src/gap-lines.ts");
+    expect(reached).toContain("apps/tui/src/liveness-lines.ts");
+    expect(reached).toContain("packages/event-store/src/heartbeat.ts");
     expect(reached).toContain("packages/event-store/src/gap-report-io.ts");
     expect(GRAPH.files.size).toBeGreaterThan(20);
   });

--- a/apps/tui/src/module-graph.test.ts
+++ b/apps/tui/src/module-graph.test.ts
@@ -1,0 +1,204 @@
+/**
+ * NO `pg` IN THE TUI'S MODULE GRAPH — and no app importing an app.
+ *
+ * WHY THIS IS A GRAPH TEST AND NOT AN ENVIRONMENT TEST. The AAR's claim that the
+ * gap detector was independent of the projection was true of the ENVIRONMENT and
+ * false of the MODULE GRAPH: the prototype's TUI bridge reached into
+ * `apps/web/src/push/gap-report-core.ts`, and that file's neighbourhood imports
+ * the `pg` driver. Asserting `process.env.DATABASE_URL` is unset would have passed
+ * the whole time. So this follows the imports instead — from every non-test file
+ * in `apps/tui/src`, transitively through the workspace packages, and reports what
+ * the TUI can actually reach.
+ *
+ * The prototype hid that edge behind a COMPUTED specifier (`new URL(...).href`) so
+ * `tsc` could not follow it; a regex walker cannot be dodged the same way, because
+ * a computed specifier that this walker cannot resolve shows up as an unresolved
+ * import and fails the last assertion rather than passing silently.
+ */
+import { readFileSync, readdirSync, existsSync } from "node:fs";
+import { dirname, join, relative, resolve } from "node:path";
+import { fileURLToPath } from "node:url";
+import { describe, expect, it } from "vitest";
+
+const HERE = dirname(fileURLToPath(import.meta.url));
+// HERE = apps/tui/src → the repo root is three levels up.
+const REPO_ROOT = resolve(HERE, "../../..");
+
+/** Every workspace package: name → its directory and `exports` map. */
+function workspacePackages(): Map<string, { dir: string; exports: unknown }> {
+  const found = new Map<string, { dir: string; exports: unknown }>();
+  for (const group of ["packages", "apps"]) {
+    for (const entry of readdirSync(join(REPO_ROOT, group), { withFileTypes: true })) {
+      if (!entry.isDirectory()) {
+        continue;
+      }
+      const dir = join(REPO_ROOT, group, entry.name);
+      const manifestPath = join(dir, "package.json");
+      if (!existsSync(manifestPath)) {
+        continue;
+      }
+      const manifest = JSON.parse(readFileSync(manifestPath, "utf8")) as {
+        name?: string;
+        exports?: unknown;
+      };
+      if (manifest.name !== undefined) {
+        found.set(manifest.name, { dir, exports: manifest.exports });
+      }
+    }
+  }
+  return found;
+}
+
+const PACKAGES = workspacePackages();
+
+/** A source file for `specifier`, or undefined when it is not ours to follow. */
+function resolveSpecifier(specifier: string, fromFile: string): string | undefined {
+  if (specifier.startsWith(".")) {
+    const base = resolve(dirname(fromFile), specifier);
+    // The TUI is NodeNext (`./x.js`); apps/web is Bundler (`./x.ts`). Try both.
+    for (const candidate of [base, base.replace(/\.js$/, ".ts"), `${base}.ts`, join(base, "index.ts")]) {
+      if (existsSync(candidate) && !candidate.endsWith("/")) {
+        return candidate;
+      }
+    }
+    return undefined;
+  }
+  const packageName = specifier.startsWith("@")
+    ? specifier.split("/").slice(0, 2).join("/")
+    : (specifier.split("/")[0] as string);
+  const pkg = PACKAGES.get(packageName);
+  if (pkg === undefined) {
+    return undefined; // a real external (node_modules) — recorded, not followed
+  }
+  const subpath = specifier === packageName ? "." : `.${specifier.slice(packageName.length)}`;
+  const exports = pkg.exports as Record<string, string> | undefined;
+  const target = exports?.[subpath];
+  if (target === undefined) {
+    // A workspace package reached through an entry point it does not export —
+    // e.g. one app deep-importing another's source. Surfaced, never silently ok.
+    return join(pkg.dir, `UNRESOLVED:${subpath}`);
+  }
+  return resolve(pkg.dir, target);
+}
+
+interface Graph {
+  files: Set<string>;
+  externals: Set<string>;
+  workspacePackagesReached: Set<string>;
+  unresolved: string[];
+}
+
+/** Walk every import — static and dynamic — reachable from `entries`. */
+function walkGraph(entries: readonly string[]): Graph {
+  const graph: Graph = {
+    files: new Set(),
+    externals: new Set(),
+    workspacePackagesReached: new Set(),
+    unresolved: [],
+  };
+  const queue = [...entries];
+  while (queue.length > 0) {
+    const file = queue.pop() as string;
+    if (graph.files.has(file)) {
+      continue;
+    }
+    graph.files.add(file);
+    const source = readFileSync(file, "utf8");
+    const specifiers = [
+      ...[...source.matchAll(/from\s*["']([^"']+)["']/g)].map((m) => m[1] as string),
+      ...[...source.matchAll(/import\s*\(\s*["']([^"']+)["']\s*\)/g)].map((m) => m[1] as string),
+    ];
+    for (const specifier of specifiers) {
+      if (specifier.startsWith("node:")) {
+        continue;
+      }
+      if (!specifier.startsWith(".")) {
+        const packageName = specifier.startsWith("@")
+          ? specifier.split("/").slice(0, 2).join("/")
+          : (specifier.split("/")[0] as string);
+        if (PACKAGES.has(packageName)) {
+          graph.workspacePackagesReached.add(packageName);
+        } else {
+          graph.externals.add(packageName);
+          continue;
+        }
+      }
+      const resolved = resolveSpecifier(specifier, file);
+      if (resolved === undefined || resolved.includes("UNRESOLVED:")) {
+        graph.unresolved.push(`${relative(REPO_ROOT, file)} → ${specifier}`);
+        continue;
+      }
+      queue.push(resolved);
+    }
+  }
+  return graph;
+}
+
+/** Every non-test source file the TUI ships. */
+function tuiSources(): string[] {
+  return readdirSync(HERE)
+    .filter((name) => /\.tsx?$/.test(name) && !/\.test\.tsx?$/.test(name))
+    .map((name) => join(HERE, name));
+}
+
+const GRAPH = walkGraph(tuiSources());
+
+describe("the TUI's module graph", () => {
+  it("reaches no database driver — `pg` is not in it, at any depth", () => {
+    // The assertion that would have failed on the prototype's bridge.
+    expect([...GRAPH.externals].filter((name) => /^pg($|-)/.test(name))).toEqual([]);
+    for (const file of GRAPH.files) {
+      expect(readFileSync(file, "utf8")).not.toMatch(/from\s*["']pg["']/);
+    }
+  });
+
+  it("reaches exactly one external package, and it is the renderer", () => {
+    // Exact, like the gap-report CLI's specifier assertion: a NEW external
+    // dependency in the TUI's reach has to be looked at, not absorbed.
+    expect([...GRAPH.externals].sort()).toEqual(["@opentui/core"]);
+  });
+
+  it("NO APP IMPORTS AN APP — only the three workspace packages are reached", () => {
+    expect([...GRAPH.workspacePackagesReached].sort()).toEqual([
+      "@numisma/engine",
+      "@numisma/event-store",
+      "@numisma/preferences",
+    ]);
+    const otherApps = [...GRAPH.files]
+      .map((file) => relative(REPO_ROOT, file))
+      .filter((file) => file.startsWith("apps/") && !file.startsWith("apps/tui/"));
+    expect(otherApps).toEqual([]);
+  });
+
+  it("resolves every import it follows — a computed specifier cannot hide an edge", () => {
+    // The prototype's bridge used `new URL(...).href` precisely so `tsc` could not
+    // follow the edge. Anything this walker cannot resolve is reported here rather
+    // than quietly skipped, so hiding an edge fails the test instead of passing it.
+    expect(GRAPH.unresolved).toEqual([]);
+  });
+
+  it("ONLY `pnpm dev` asks for the gap lines — silence elsewhere is structural", () => {
+    // The behavioural half is in `startup.test.ts` (omitting `gapLines` emits
+    // nothing). This is the other half: no OTHER entry point supplies it, so
+    // `report`, `spine` and the smoke harness cannot start speaking by accident.
+    const speaking = tuiSources()
+      .filter((file) => /\bgapLines\s*:/.test(readFileSync(file, "utf8")))
+      .map((file) => relative(REPO_ROOT, file));
+    expect(speaking).toEqual(["apps/tui/src/app.ts"]);
+
+    // And the entry points that must stay quiet do not even reach the loader.
+    for (const quiet of ["report.ts", "spine.ts", "spine-reset.ts", "smoke-startup-openTui.ts"]) {
+      expect(readFileSync(join(HERE, quiet), "utf8")).not.toMatch(/loadGapLines/);
+    }
+  });
+
+  it("actually walked the graph — the guard is not passing on an empty set", () => {
+    // Without this, every assertion above would pass on a walker that returned
+    // nothing. It must have reached the app entry point and the derivation.
+    const reached = [...GRAPH.files].map((file) => relative(REPO_ROOT, file));
+    expect(reached).toContain("apps/tui/src/app.ts");
+    expect(reached).toContain("apps/tui/src/gap-lines.ts");
+    expect(reached).toContain("packages/event-store/src/gap-report-io.ts");
+    expect(GRAPH.files.size).toBeGreaterThan(20);
+  });
+});

--- a/apps/tui/src/startup.test.ts
+++ b/apps/tui/src/startup.test.ts
@@ -183,7 +183,7 @@ describe("prepareStartup — ingests, surfaces the report, and wires the fold lo
 
     await prepareStartup(paths, ["node", "app"], {
       emit: (line) => emitted.push(line),
-      gapLines: () => Promise.resolve(["Numisma: 2026-08-03 — NO MARKS. …"]),
+      livenessLines: () => Promise.resolve(["Numisma: 2026-08-03 — NO MARKS. …"]),
     });
 
     // After the ingest report, deliberately: the ingest may have just added the
@@ -201,15 +201,15 @@ describe("prepareStartup — ingests, surfaces the report, and wires the fold lo
     await prepareStartup(paths, ["node", "app"], {
       emit: (line) => emitted.push(line),
       // A clean report yields no lines at all — not an "all clear" line.
-      gapLines: () => Promise.resolve([]),
+      livenessLines: () => Promise.resolve([]),
     });
 
     expect(emitted).toEqual(["Numisma: 1 new transaction(s) ingested, 0 duplicate(s) skipped."]);
   });
 
-  it("SILENCE, HALF TWO: an entry point that supplies no gapLines never checks at all", async () => {
+  it("SILENCE, HALF TWO: an entry point that supplies no livenessLines never checks at all", async () => {
     // The half a "lost days print" test cannot catch. `report`, `spine` and the
-    // smoke harness omit `gapLines`, so startup must not reach for the derivation
+    // smoke harness omit `livenessLines`, so startup must not reach for the derivation
     // on its own — a default would make every entry point speak.
     const paths = await makeStore({ inbox: [openBtc()] });
     const emitted: string[] = [];
@@ -225,7 +225,7 @@ describe("prepareStartup — ingests, surfaces the report, and wires the fold lo
 
     const plan = await prepareStartup(paths, ["node", "app"], {
       emit: (line) => emitted.push(line),
-      gapLines: () => Promise.reject(new Error("derivation exploded")),
+      livenessLines: () => Promise.reject(new Error("derivation exploded")),
     });
 
     // Startup completes and the renderer still gets its plan.

--- a/apps/tui/src/startup.test.ts
+++ b/apps/tui/src/startup.test.ts
@@ -175,6 +175,67 @@ describe("prepareStartup — ingests, surfaces the report, and wires the fold lo
     expect(emitted).toEqual([]);
   });
 
+  // ── The gap lines, and the two halves of silence ──────────────────────────
+
+  it("prints the lost days after the ingest report, on the same channel", async () => {
+    const paths = await makeStore({ inbox: [openBtc()] });
+    const emitted: string[] = [];
+
+    await prepareStartup(paths, ["node", "app"], {
+      emit: (line) => emitted.push(line),
+      gapLines: () => Promise.resolve(["Numisma: 2026-08-03 — NO MARKS. …"]),
+    });
+
+    // After the ingest report, deliberately: the ingest may have just added the
+    // very events the report is about.
+    expect(emitted).toEqual([
+      "Numisma: 1 new transaction(s) ingested, 0 duplicate(s) skipped.",
+      "Numisma: 2026-08-03 — NO MARKS. …",
+    ]);
+  });
+
+  it("SILENCE, HALF ONE: a clean window adds nothing to the channel", async () => {
+    const paths = await makeStore({ inbox: [openBtc()] });
+    const emitted: string[] = [];
+
+    await prepareStartup(paths, ["node", "app"], {
+      emit: (line) => emitted.push(line),
+      // A clean report yields no lines at all — not an "all clear" line.
+      gapLines: () => Promise.resolve([]),
+    });
+
+    expect(emitted).toEqual(["Numisma: 1 new transaction(s) ingested, 0 duplicate(s) skipped."]);
+  });
+
+  it("SILENCE, HALF TWO: an entry point that supplies no gapLines never checks at all", async () => {
+    // The half a "lost days print" test cannot catch. `report`, `spine` and the
+    // smoke harness omit `gapLines`, so startup must not reach for the derivation
+    // on its own — a default would make every entry point speak.
+    const paths = await makeStore({ inbox: [openBtc()] });
+    const emitted: string[] = [];
+
+    await prepareStartup(paths, ["node", "app"], { emit: (line) => emitted.push(line) });
+
+    expect(emitted).toEqual(["Numisma: 1 new transaction(s) ingested, 0 duplicate(s) skipped."]);
+  });
+
+  it("does not let a gap-line failure take the dashboard down with it", async () => {
+    const paths = await makeStore({ inbox: [openBtc()] });
+    const emitted: string[] = [];
+
+    const plan = await prepareStartup(paths, ["node", "app"], {
+      emit: (line) => emitted.push(line),
+      gapLines: () => Promise.reject(new Error("derivation exploded")),
+    });
+
+    // Startup completes and the renderer still gets its plan.
+    expect(plan.sourcePath).toBe(paths.log);
+    expect(emitted).toEqual([
+      "Numisma: 1 new transaction(s) ingested, 0 duplicate(s) skipped.",
+      "Numisma: lost days were NOT checked (derivation exploded).",
+    ]);
+  });
+
   it("propagates a fail-loud ingest rejection without emitting a count", async () => {
     const paths = await makeStore({ inbox: [openBtc()] });
     const emitted: string[] = [];

--- a/apps/tui/src/startup.ts
+++ b/apps/tui/src/startup.ts
@@ -14,6 +14,7 @@
 import type { FundReviewData } from "@numisma/engine";
 import { loadFoldedReview, type EventStorePaths } from "@numisma/event-store";
 import { ingestInbox, parseAsOfArg, type IngestReport } from "./event-store.js";
+import { formatGapCheckFailure } from "./gap-lines.js";
 
 /** What the renderer needs after the startup data path runs. */
 export interface StartupPlan {
@@ -31,6 +32,15 @@ export interface StartupDeps {
   emit: (line: string) => void;
   /** The inbox ingest. Defaults to the real {@link ingestInbox}. */
   ingest?: (paths: EventStorePaths) => Promise<IngestReport>;
+  /**
+   * The lost-day lines, when this entry point wants them. **OMITTED MEANS SILENT,
+   * AND THERE IS DELIBERATELY NO DEFAULT.** Only `pnpm dev` supplies it; `report`,
+   * `spine` and the openTUI smoke harness leave it out, so they never reach for the
+   * derivation at all. A default here would make every entry point speak, which is
+   * the difference between a startup channel you read and one you learn to scroll
+   * past.
+   */
+  gapLines?: (() => Promise<string[]>) | undefined;
 }
 
 /**
@@ -72,6 +82,22 @@ export async function prepareStartup(
   const ingest = deps.ingest ?? ingestInbox;
   const report = await ingest(paths);
   deps.emit(formatIngestReport(report));
+  // AFTER the ingest report, deliberately: the ingest may have just appended the
+  // very events the gap report is about, so it must run against the log as it now
+  // stands. And guarded, because a liveness line must never be able to stop the
+  // dashboard from mounting — `loadGapLines` already catches its own failures; this
+  // is the seam refusing to trust that any injected adapter does.
+  if (deps.gapLines !== undefined) {
+    let lines: string[];
+    try {
+      lines = await deps.gapLines();
+    } catch (error) {
+      lines = [formatGapCheckFailure(error)];
+    }
+    for (const line of lines) {
+      deps.emit(line);
+    }
+  }
   const sourcePath = asOf ? `${paths.log} as-of ${asOf}` : paths.log;
   return {
     asOf,

--- a/apps/tui/src/startup.ts
+++ b/apps/tui/src/startup.ts
@@ -33,14 +33,14 @@ export interface StartupDeps {
   /** The inbox ingest. Defaults to the real {@link ingestInbox}. */
   ingest?: (paths: EventStorePaths) => Promise<IngestReport>;
   /**
-   * The lost-day lines, when this entry point wants them. **OMITTED MEANS SILENT,
-   * AND THERE IS DELIBERATELY NO DEFAULT.** Only `pnpm dev` supplies it; `report`,
-   * `spine` and the openTUI smoke harness leave it out, so they never reach for the
-   * derivation at all. A default here would make every entry point speak, which is
-   * the difference between a startup channel you read and one you learn to scroll
-   * past.
+   * The liveness lines — the job heartbeat and the lost days — when this entry
+   * point wants them. **OMITTED MEANS SILENT, AND THERE IS DELIBERATELY NO
+   * DEFAULT.** Only `pnpm dev` supplies it; `report`, `spine` and the openTUI smoke
+   * harness leave it out, so they never reach for the derivation at all. A default
+   * here would make every entry point speak, which is the difference between a
+   * startup channel you read and one you learn to scroll past.
    */
-  gapLines?: (() => Promise<string[]>) | undefined;
+  livenessLines?: (() => Promise<string[]>) | undefined;
 }
 
 /**
@@ -87,10 +87,10 @@ export async function prepareStartup(
   // stands. And guarded, because a liveness line must never be able to stop the
   // dashboard from mounting — `loadGapLines` already catches its own failures; this
   // is the seam refusing to trust that any injected adapter does.
-  if (deps.gapLines !== undefined) {
+  if (deps.livenessLines !== undefined) {
     let lines: string[];
     try {
-      lines = await deps.gapLines();
+      lines = await deps.livenessLines();
     } catch (error) {
       lines = [formatGapCheckFailure(error)];
     }

--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -9,6 +9,7 @@
     "start": "node .output/server/index.mjs",
     "typecheck": "tsc --noEmit -p tsconfig.json",
     "push": "tsx src/push/push.ts",
+    "gap-report": "tsx src/push/gap-report.ts",
     "backfill": "tsx src/push/backfill.ts",
     "db:init": "tsx src/push/push.ts --init-only",
     "db:provision": "tsx src/projection/provision-projection.ts",

--- a/apps/web/src/calendar-contract.test.ts
+++ b/apps/web/src/calendar-contract.test.ts
@@ -1,0 +1,156 @@
+/**
+ * Guards the ONE home of the `as-of` calendar arithmetic (`addDays`,
+ * `daysBetween`) — the exact class of de-duplication ADR-001's *Realized* note
+ * records for the shared formatters, and the same guard shape as
+ * `apps/tui/src/format-contract.test.ts`.
+ *
+ * WHY A CONTRACT TEST AND NOT A CODE REVIEW. These eight lines had already been
+ * copied once: `apps/web/src/projection/as-of.ts` held the validated, documented
+ * pair and `apps/web/src/push/glance.ts` held a private, undocumented `addDays`
+ * with the validation dropped. A package cannot import from an app, so the next
+ * consumer would have written a THIRD copy. The single home is
+ * `packages/engine/src/calendar.ts`; this test fails the moment a private copy
+ * reappears ANYWHERE in the repo, which is what makes "zero private copies
+ * repo-wide" a fact rather than a claim.
+ *
+ * The UTC-throughout docstring is asserted too, because it is load-bearing: the
+ * defect it names (`new Date("2026-07-26")` renders in LOCAL time and lands west
+ * of Greenwich on the previous day) is what would let a liveness detector call a
+ * Monday a Sunday.
+ */
+import { readFileSync, readdirSync } from "node:fs";
+import { dirname, join, relative, resolve } from "node:path";
+import { fileURLToPath } from "node:url";
+import * as engine from "@numisma/engine";
+import * as calendar from "@numisma/engine/calendar";
+import { describe, expect, it } from "vitest";
+
+const SHARED_DATE_HELPERS = ["addDays", "daysBetween"] as const;
+
+const HERE = dirname(fileURLToPath(import.meta.url));
+// HERE = apps/web/src → the repo root is three levels up.
+const REPO_ROOT = resolve(HERE, "../../..");
+const SINGLE_HOME = "packages/engine/src/calendar.ts";
+
+const SKIPPED_DIRS = new Set([
+  "node_modules",
+  ".git",
+  ".vercel",
+  ".output",
+  ".nitro",
+  "dist",
+  "coverage",
+]);
+
+/** Every non-vendored TypeScript source in the repo, repo-root-relative. */
+function typescriptSources(dir: string, found: string[] = []): string[] {
+  for (const entry of readdirSync(dir, { withFileTypes: true })) {
+    if (entry.isDirectory()) {
+      if (!SKIPPED_DIRS.has(entry.name)) {
+        typescriptSources(join(dir, entry.name), found);
+      }
+    } else if (/\.tsx?$/.test(entry.name)) {
+      found.push(relative(REPO_ROOT, join(dir, entry.name)));
+    }
+  }
+  return found;
+}
+
+/** Files that DECLARE a helper of this name (a `function` or a `const` arrow). */
+function declarersOf(name: string): string[] {
+  const declaration = new RegExp(
+    `(?:function\\s+${name}\\b|(?:const|let|var)\\s+${name}\\s*[:=][^=]*=>)`,
+  );
+  return typescriptSources(REPO_ROOT).filter((file) =>
+    declaration.test(readFileSync(join(REPO_ROOT, file), "utf8")),
+  );
+}
+
+const asOfSource = readFileSync(join(REPO_ROOT, "apps/web/src/projection/as-of.ts"), "utf8");
+const glanceSource = readFileSync(join(REPO_ROOT, "apps/web/src/push/glance.ts"), "utf8");
+const calendarSource = readFileSync(join(REPO_ROOT, SINGLE_HOME), "utf8");
+
+/**
+ * The names a module pulls out of any `@numisma/engine[...]` entry point. A
+ * re-export (`export { addDays } from "@numisma/engine/calendar"`) counts — it is
+ * an import that also forwards, which is exactly what `as-of.ts` does so the
+ * projection's as-of vocabulary still reads as one module.
+ */
+function engineImports(source: string): string {
+  return [
+    ...source.matchAll(
+      /(?:import|export)\s*\{([^}]*)\}\s*from\s*["']@numisma\/engine[^"']*["']/g,
+    ),
+  ]
+    .map((match) => match[1])
+    .join(",");
+}
+
+describe("as-of calendar arithmetic contract", () => {
+  it("exports every shared date helper from @numisma/engine", () => {
+    for (const name of SHARED_DATE_HELPERS) {
+      expect(
+        typeof (engine as Record<string, unknown>)[name],
+        `@numisma/engine must export ${name}`,
+      ).toBe("function");
+    }
+  });
+
+  it("exports them from the browser-safe @numisma/engine/calendar subpath too", () => {
+    // `as-of.ts` is reached from the BROWSER (glance/verdict.ts), so it cannot
+    // value-import the engine root — that pulls `node:os`/`node:path` (data-dir)
+    // into the client bundle. Same reason `@numisma/engine/format` exists.
+    for (const name of SHARED_DATE_HELPERS) {
+      expect(
+        typeof (calendar as Record<string, unknown>)[name],
+        `@numisma/engine/calendar must export ${name}`,
+      ).toBe("function");
+    }
+  });
+
+  it("is the same function through both entry points", () => {
+    for (const name of SHARED_DATE_HELPERS) {
+      expect((engine as Record<string, unknown>)[name]).toBe(
+        (calendar as Record<string, unknown>)[name],
+      );
+    }
+  });
+
+  it("imports both helpers into the web projection's as-of module from the engine", () => {
+    const imported = engineImports(asOfSource);
+    for (const name of SHARED_DATE_HELPERS) {
+      expect(
+        new RegExp(`\\b${name}\\b`).test(imported),
+        `as-of.ts must import ${name} from the engine`,
+      ).toBe(true);
+    }
+  });
+
+  it("imports addDays into the push glance module from the engine", () => {
+    expect(
+      /\baddDays\b/.test(engineImports(glanceSource)),
+      "push/glance.ts must import addDays from the engine",
+    ).toBe(true);
+  });
+
+  it("keeps ZERO private copies repo-wide — one declaring file, and it is the engine's", () => {
+    for (const name of SHARED_DATE_HELPERS) {
+      expect(declarersOf(name), `${name} must be declared once, in ${SINGLE_HOME}`).toEqual([
+        SINGLE_HOME,
+      ]);
+    }
+  });
+
+  it("carries the UTC-throughout rationale over intact", () => {
+    // The defect the docstring names is why the helper is UTC-only; losing the
+    // note is how a future edit reintroduces a local-time `new Date(asOf)`.
+    expect(calendarSource).toContain("LOCAL");
+    expect(calendarSource).toMatch(/previous day/);
+    expect(calendarSource).toMatch(/Monday a Sunday/);
+  });
+
+  it("keeps the validation both helpers were documented to have", () => {
+    expect(() => calendar.addDays("not-a-date", 1)).toThrow(/addDays/);
+    expect(() => calendar.daysBetween("2026-07-26", "not-a-date")).toThrow(/daysBetween/);
+  });
+});

--- a/apps/web/src/calendar-contract.test.ts
+++ b/apps/web/src/calendar-contract.test.ts
@@ -9,9 +9,15 @@
  * pair and `apps/web/src/push/glance.ts` held a private, undocumented `addDays`
  * with the validation dropped. A package cannot import from an app, so the next
  * consumer would have written a THIRD copy. The single home is
- * `packages/engine/src/calendar.ts`; this test fails the moment a private copy
- * reappears ANYWHERE in the repo, which is what makes "zero private copies
- * repo-wide" a fact rather than a claim.
+ * `packages/engine/src/calendar.ts`; this test sweeps every non-vendored source in
+ * the repo and fails the moment a second file DECLARES one of these two names.
+ *
+ * Its guarantee is NAME-SCOPED, and knowing that is what keeps it honest: it greps
+ * for `addDays` and `daysBetween` literally, so a re-implementation under another
+ * name is invisible to it. `packages/engine/src/price-feed/derive.ts`'s
+ * `calendarDaysBetween` is the live example — a duplicate of `daysBetween` that
+ * survived this sweep purely because of what it is called. Folding it in is its own
+ * change; what this file promises is that THESE TWO NAMES have one home.
  *
  * The UTC-throughout docstring is asserted too, because it is load-bearing: the
  * defect it names (`new Date("2026-07-26")` renders in LOCAL time and lands west
@@ -56,14 +62,20 @@ function typescriptSources(dir: string, found: string[] = []): string[] {
   return found;
 }
 
+// The repo walk and every read happen ONCE, hoisted for the same reason the three
+// sources below are: `declarersOf` is called per helper name, and re-walking 200-odd
+// files per name buys nothing.
+const SOURCES = typescriptSources(REPO_ROOT).map((file) => ({
+  file,
+  text: readFileSync(join(REPO_ROOT, file), "utf8"),
+}));
+
 /** Files that DECLARE a helper of this name (a `function` or a `const` arrow). */
 function declarersOf(name: string): string[] {
   const declaration = new RegExp(
     `(?:function\\s+${name}\\b|(?:const|let|var)\\s+${name}\\s*[:=][^=]*=>)`,
   );
-  return typescriptSources(REPO_ROOT).filter((file) =>
-    declaration.test(readFileSync(join(REPO_ROOT, file), "utf8")),
-  );
+  return SOURCES.filter(({ text }) => declaration.test(text)).map(({ file }) => file);
 }
 
 const asOfSource = readFileSync(join(REPO_ROOT, "apps/web/src/projection/as-of.ts"), "utf8");

--- a/apps/web/src/projection/as-of.ts
+++ b/apps/web/src/projection/as-of.ts
@@ -37,33 +37,18 @@ export function asOfSortKey(asOf: string): number {
 }
 
 /**
- * The `YYYY-MM-DD` date `delta` days from `asOf`, read and written in UTC.
+ * `addDays` / `daysBetween` moved to `@numisma/engine`'s calendar module — the ONE
+ * home for this arithmetic, next to the `asOf` convention `tradingDayAsOf` owns.
+ * They were born here and the push glance builder had copied them privately; a
+ * package cannot import from an app, so a third consumer would have written a
+ * third copy. Re-exported so this module still reads as the projection's whole
+ * as-of vocabulary, and so the UTC-throughout rationale has exactly one place to
+ * live. Guarded by `apps/web/src/calendar-contract.test.ts`.
  *
- * UTC THROUGHOUT, deliberately. `new Date("2026-07-26")` parses as UTC midnight and
- * then renders in LOCAL time, which west of Greenwich lands on the previous day —
- * enough to call a Monday a Sunday. The push side makes the same choice for the same
- * reason (`push/glance.ts`).
+ * The subpath, not the engine root: `glance/verdict.ts` reaches this module from
+ * the BROWSER, and the root pulls `node:os`/`node:path` (data-dir) into its reach.
  */
-export function addDays(asOf: string, delta: number): string {
-  const date = new Date(`${asOf}T00:00:00Z`);
-  if (Number.isNaN(date.getTime())) {
-    throw new Error(`addDays: ${JSON.stringify(asOf)} is not a calendar date`);
-  }
-  date.setUTCDate(date.getUTCDate() + delta);
-  return date.toISOString().slice(0, 10);
-}
-
-/** Whole calendar days from `from` to `to`, in UTC. Negative when `to` precedes `from`. */
-export function daysBetween(from: string, to: string): number {
-  const start = Date.parse(`${from}T00:00:00Z`);
-  const end = Date.parse(`${to}T00:00:00Z`);
-  if (Number.isNaN(start) || Number.isNaN(end)) {
-    throw new Error(
-      `daysBetween: ${JSON.stringify(from)} → ${JSON.stringify(to)} is not a date range`,
-    );
-  }
-  return Math.round((end - start) / 86_400_000);
-}
+export { addDays, daysBetween } from "@numisma/engine/calendar";
 
 /** The UTC calendar date a wall clock is currently on. */
 export function calendarDateOf(now: Date): string {

--- a/apps/web/src/push/gap-report-core.test.ts
+++ b/apps/web/src/push/gap-report-core.test.ts
@@ -1,0 +1,279 @@
+/**
+ * The gap-report CLI's FIRST test file. The command had none.
+ *
+ * Most of what is asserted here is ordinary argument hygiene. One case is not:
+ * `--since 2026-02-30`. Left to `Date` that input rolls silently to March 2 and
+ * the report answers a question nobody asked, IN THE SAME SHAPE AS A CORRECT
+ * ANSWER — a detector whose entire value is trust cannot have a failure mode that
+ * looks like success. It is why this slice exists at this size, and it is tested
+ * by name.
+ *
+ * The log fixtures are synthetic — invented instrument ids and round numbers,
+ * written into a throwaway temp dir. No test here reads the real data store.
+ */
+import { mkdtemp, rm, writeFile } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { isAbsolute, join } from "node:path";
+import type { PortfolioEvent } from "@numisma/engine";
+import { resolveEventStorePaths, type EventStorePaths } from "@numisma/event-store";
+import { afterEach, describe, expect, it } from "vitest";
+import {
+  MAX_WINDOW_DAYS,
+  parseGapReportArgs,
+  resolveGapReportPaths,
+  runGapReport,
+} from "./gap-report-core.ts";
+
+const created: string[] = [];
+const savedEnv = { ...process.env };
+
+afterEach(async () => {
+  await Promise.all(created.map((dir) => rm(dir, { recursive: true, force: true })));
+  created.length = 0;
+  process.env = { ...savedEnv };
+});
+
+function mark(date: string, instrumentId: string): PortfolioEvent {
+  return {
+    id: `pm-${instrumentId}-${date}`,
+    asOf: date,
+    type: "PriceMarked",
+    instrumentId,
+    price: 100,
+  };
+}
+
+function deposit(date: string): PortfolioEvent {
+  return { id: `dep-${date}`, asOf: date, type: "Deposit", reserveId: "cash-core", amount: 500, tier: "c1" };
+}
+
+/** A throwaway store holding exactly these events. */
+async function storeWith(events: readonly PortfolioEvent[]): Promise<EventStorePaths> {
+  const dataDir = await mkdtemp(join(tmpdir(), "numisma-gap-cli-"));
+  created.push(dataDir);
+  const paths = resolveEventStorePaths(dataDir);
+  await writeFile(paths.log, events.map((event) => `${JSON.stringify(event)}\n`).join(""), "utf8");
+  return paths;
+}
+
+const NOW = new Date("2026-08-05T12:00:00Z"); // 06:00 CDMX on 2026-08-05
+const YESTERDAY = "2026-08-04";
+const TODAY_CDMX = "2026-08-05";
+
+describe("parseGapReportArgs — refusing an input it cannot answer correctly", () => {
+  it("rejects --since 2026-02-30 rather than rolling it forward to March 2", () => {
+    // The whole reason for this slice. `2026-02-30` satisfies /\d{4}-\d{2}-\d{2}/
+    // and is still not a date; `new Date("2026-02-30")` yields 2026-03-02 and the
+    // report would look exactly like a correct one.
+    expect(() => parseGapReportArgs(["--since", "2026-02-30"])).toThrow(
+      /2026-02-30.*not a real calendar date/,
+    );
+  });
+
+  it("rejects other calendar-shaped non-dates for the same reason", () => {
+    expect(() => parseGapReportArgs(["--until", "2026-13-01"])).toThrow(/not a real calendar date/);
+    expect(() => parseGapReportArgs(["--since", "2027-02-29"])).toThrow(/not a real calendar date/);
+    // …and accepts a real leap day, so the check is a calendar check, not a blocklist.
+    expect(parseGapReportArgs(["--since", "2028-02-29"]).since).toBe("2028-02-29");
+  });
+
+  it("rejects a date that is not strict zero-padded YYYY-MM-DD", () => {
+    expect(() => parseGapReportArgs(["--since", "2026-7-3"])).toThrow(/YYYY-MM-DD/);
+    expect(() => parseGapReportArgs(["--since", "07/03/2026"])).toThrow(/YYYY-MM-DD/);
+    expect(() => parseGapReportArgs(["--since", "2026-07-03T00:00:00Z"])).toThrow(/YYYY-MM-DD/);
+  });
+
+  it("rejects a flag consumed as a value: --since --write errors at parse", () => {
+    // Not deep inside date arithmetic, where the message would be about a date.
+    expect(() => parseGapReportArgs(["--since", "--write"])).toThrow(
+      /--since expects a date.*got the flag '--write'/s,
+    );
+  });
+
+  it("rejects --until as the final argv token instead of falling back to the default ceiling", () => {
+    // Silently falling back is how a typo turns into a differently-scoped report
+    // that still looks right.
+    expect(() => parseGapReportArgs(["--write", "--until"])).toThrow(/--until expects a date/);
+    expect(() => parseGapReportArgs(["--since"])).toThrow(/--since expects a date/);
+  });
+
+  it("rejects an unrecognized argument rather than ignoring it", () => {
+    expect(() => parseGapReportArgs(["--sicne", "2026-07-03"])).toThrow(/unrecognized/i);
+    expect(() => parseGapReportArgs(["2026-07-03"])).toThrow(/unrecognized/i);
+  });
+
+  it("ignores the bare `--` separator that `pnpm gap-report -- …` passes through", () => {
+    // Caught by running the real command, not by a unit test: pnpm forwards the
+    // literal `--` into argv, so a parser strict enough to reject unknown tokens
+    // rejects the documented invocation itself. The looser `argv.includes(...)`
+    // parsing in `push.ts` / `backfill.ts` never had to notice.
+    expect(parseGapReportArgs(["--", "--since", "2026-07-03"])).toEqual({
+      since: "2026-07-03",
+      until: undefined,
+      write: false,
+    });
+    // Still not a date, though — `--` after a date flag is a missing value.
+    expect(() => parseGapReportArgs(["--since", "--"])).toThrow(/--since expects a date/);
+  });
+
+  it("accepts the flags it documents, in any order", () => {
+    expect(parseGapReportArgs([])).toEqual({ since: undefined, until: undefined, write: false });
+    expect(parseGapReportArgs(["--write", "--since", "2026-07-03", "--until", "2026-07-31"])).toEqual({
+      since: "2026-07-03",
+      until: "2026-07-31",
+      write: true,
+    });
+  });
+});
+
+describe("runGapReport — the window's bounds", () => {
+  it("refuses a window wider than MAX_WINDOW_DAYS rather than printing one line per calendar day", async () => {
+    const paths = await storeWith([mark(YESTERDAY, "cx-a")]);
+    await expect(
+      runGapReport({ argv: ["--since", "1970-01-01"], now: NOW, paths }),
+    ).rejects.toThrow(new RegExp(`window .*${MAX_WINDOW_DAYS}`));
+  });
+
+  it("accepts a window exactly at the bound", async () => {
+    const paths = await storeWith([mark(YESTERDAY, "cx-a")]);
+    // MAX_WINDOW_DAYS days inclusive ends on the ceiling.
+    const since = new Date(Date.parse(`${YESTERDAY}T00:00:00Z`) - (MAX_WINDOW_DAYS - 1) * 86_400_000)
+      .toISOString()
+      .slice(0, 10);
+    const run = await runGapReport({ argv: ["--since", since], now: NOW, paths });
+    expect(run.exitCode).toBe(0);
+  });
+
+  it("clamps a far-future --until to yesterday, so it cannot run away", async () => {
+    const paths = await storeWith([mark(YESTERDAY, "cx-a")]);
+    const run = await runGapReport({
+      argv: ["--since", YESTERDAY, "--until", "2099-12-31"],
+      now: NOW,
+      paths,
+    });
+    expect(run.report.until).toBe(YESTERDAY);
+    expect(run.report.calendarDays).toBe(1);
+  });
+
+  it("--until with today's date still produces a report ending yesterday", async () => {
+    // The seam with #187: the clamp lives in `computeGapReport` and is NOT
+    // re-implemented here. This asserts the CLI cannot defeat it.
+    const paths = await storeWith([mark(YESTERDAY, "cx-a")]);
+    const run = await runGapReport({
+      argv: ["--since", YESTERDAY, "--until", TODAY_CDMX],
+      now: NOW,
+      paths,
+    });
+    expect(run.report.until).toBe(YESTERDAY);
+    expect(run.lines.join("\n")).not.toContain(TODAY_CDMX);
+  });
+});
+
+describe("runGapReport — the exit contract", () => {
+  it("exits 0 when days are lost", async () => {
+    // A lost day is PERMANENT and unfixable. Gating the job's exit on it means a
+    // permanently red job, and a permanently red job is one nobody reads.
+    // A lost day is reported; a broken job is failed.
+    const paths = await storeWith([mark("2026-08-02", "cx-a"), deposit("2026-08-03")]);
+    const run = await runGapReport({
+      argv: ["--since", "2026-08-02", "--until", YESTERDAY],
+      now: NOW,
+      paths,
+    });
+    expect(run.report.lost).toEqual([
+      { date: "2026-08-03", reason: "no-marks" },
+      { date: "2026-08-04", reason: "no-anchor" },
+    ]);
+    expect(run.exitCode).toBe(0);
+    expect(run.lines.some((line) => line.includes("2 lost day(s)"))).toBe(true);
+  });
+
+  it("exits 0 on a clean window too, and still prints the summary", async () => {
+    const paths = await storeWith([mark(YESTERDAY, "cx-a")]);
+    const run = await runGapReport({ argv: ["--since", YESTERDAY], now: NOW, paths });
+    expect(run.report.lost).toEqual([]);
+    expect(run.exitCode).toBe(0);
+    expect(run.lines).toEqual([
+      "[gap-report] Numisma: no lost days in 2026-08-04…2026-08-04 (1 day(s), 1 anchor(s) checked).",
+    ]);
+  });
+
+  it("throws — so the shell exits non-zero — when the derivation cannot run", async () => {
+    // A quarantined log line is a mark the derivation cannot see. Reporting
+    // anyway would manufacture a phantom lost day.
+    const dataDir = await mkdtemp(join(tmpdir(), "numisma-gap-cli-"));
+    created.push(dataDir);
+    const paths = resolveEventStorePaths(dataDir);
+    await writeFile(paths.log, `${JSON.stringify(mark(YESTERDAY, "cx-a"))}\n{ not an event }\n`, "utf8");
+    await expect(
+      runGapReport({ argv: ["--since", YESTERDAY], now: NOW, paths }),
+    ).rejects.toThrow(/quarantine/i);
+  });
+
+  it("throws — so the shell exits non-zero — when --write cannot persist", async () => {
+    const paths = await storeWith([mark(YESTERDAY, "cx-a")]);
+    await expect(
+      runGapReport({
+        argv: ["--since", YESTERDAY, "--write"],
+        now: NOW,
+        paths,
+        writeReport: () => Promise.reject(new Error("disk is full")),
+      }),
+    ).rejects.toThrow(/disk is full/);
+  });
+
+  it("reports where it wrote when --write succeeds", async () => {
+    const paths = await storeWith([mark(YESTERDAY, "cx-a")]);
+    const run = await runGapReport({
+      argv: ["--since", YESTERDAY, "--write"],
+      now: NOW,
+      paths,
+      writeReport: () => Promise.resolve("/tmp/gap-report.json"),
+    });
+    expect(run.exitCode).toBe(0);
+    expect(run.lines.at(-1)).toBe("[gap-report] written: /tmp/gap-report.json");
+  });
+
+  it("throws on --write until a writer is wired, rather than silently not writing", async () => {
+    // Persistence is #189. Until then `--write` FAILS LOUDLY: a flag that
+    // quietly does nothing is the same class of defect as a rolled-forward date.
+    const paths = await storeWith([mark(YESTERDAY, "cx-a")]);
+    await expect(
+      runGapReport({ argv: ["--since", YESTERDAY, "--write"], now: NOW, paths }),
+    ).rejects.toThrow(/--write/);
+  });
+});
+
+describe("no environment — the property that lets it run when the projection is what is broken", () => {
+  it("runs with no data-dir variable and no projection database URL set", async () => {
+    const paths = await storeWith([mark(YESTERDAY, "cx-a")]);
+    for (const key of Object.keys(process.env)) {
+      if (/^(NUMISMA_DATA_DIR|DATABASE_URL|POSTGRES_|PG|PROJECTION_)/.test(key)) {
+        delete process.env[key];
+      }
+    }
+    const run = await runGapReport({ argv: ["--since", YESTERDAY], now: NOW, paths });
+    expect(run.exitCode).toBe(0);
+  });
+
+  it("resolves its store with no NUMISMA_DATA_DIR set, to an absolute default", async () => {
+    delete process.env.NUMISMA_DATA_DIR;
+    const paths = resolveGapReportPaths();
+    expect(isAbsolute(paths.log)).toBe(true);
+    expect(paths.log.endsWith("events.jsonl")).toBe(true);
+  });
+
+  it("reaches no database driver at all", async () => {
+    // Structural, not incidental: the detector must not depend on the thing whose
+    // failure it detects. A future `import { Pool } from "pg"` here fails this.
+    const source = await import("node:fs/promises").then(({ readFile }) =>
+      readFile(new URL("./gap-report-core.ts", import.meta.url), "utf8"),
+    );
+    // Read the IMPORT SPECIFIERS, not the prose — the header legitimately names
+    // `push-core.ts` when explaining the shell/core split.
+    const specifiers = [...source.matchAll(/from\s*["']([^"']+)["']/g)].map((m) => m[1]);
+    expect(specifiers).toEqual(["@numisma/event-store"]);
+    expect(source).not.toMatch(/DATABASE_URL/);
+    expect(source).not.toMatch(/process\.env/);
+  });
+});

--- a/apps/web/src/push/gap-report-core.test.ts
+++ b/apps/web/src/push/gap-report-core.test.ts
@@ -11,11 +11,16 @@
  * The log fixtures are synthetic — invented instrument ids and round numbers,
  * written into a throwaway temp dir. No test here reads the real data store.
  */
-import { mkdtemp, rm, writeFile } from "node:fs/promises";
+import { mkdtemp, readFile, rm, writeFile } from "node:fs/promises";
 import { tmpdir } from "node:os";
 import { isAbsolute, join } from "node:path";
 import type { PortfolioEvent } from "@numisma/engine";
-import { resolveEventStorePaths, type EventStorePaths } from "@numisma/event-store";
+import {
+  GAP_REPORT_SCHEMA_VERSION,
+  gapReportPath,
+  resolveEventStorePaths,
+  type EventStorePaths,
+} from "@numisma/event-store";
 import { afterEach, describe, expect, it } from "vitest";
 import {
   MAX_WINDOW_DAYS,
@@ -234,13 +239,21 @@ describe("runGapReport — the exit contract", () => {
     expect(run.lines.at(-1)).toBe("[gap-report] written: /tmp/gap-report.json");
   });
 
-  it("throws on --write until a writer is wired, rather than silently not writing", async () => {
-    // Persistence is #189. Until then `--write` FAILS LOUDLY: a flag that
-    // quietly does nothing is the same class of defect as a rolled-forward date.
+  it("persists to the data dir by default, with no writer injected", async () => {
+    // #189 filled the seam: `--write` now writes `gap-report.json` beside the log
+    // and exits 0. No stub, no "not available yet".
     const paths = await storeWith([mark(YESTERDAY, "cx-a")]);
-    await expect(
-      runGapReport({ argv: ["--since", YESTERDAY, "--write"], now: NOW, paths }),
-    ).rejects.toThrow(/--write/);
+    const run = await runGapReport({
+      argv: ["--since", YESTERDAY, "--write"],
+      now: NOW,
+      paths,
+    });
+    expect(run.exitCode).toBe(0);
+    const written = gapReportPath(paths);
+    expect(run.lines.at(-1)).toBe(`[gap-report] written: ${written}`);
+    const body = JSON.parse(await readFile(written, "utf8")) as Record<string, unknown>;
+    expect(body.schemaVersion).toBe(GAP_REPORT_SCHEMA_VERSION);
+    expect(body.until).toBe(YESTERDAY);
   });
 });
 

--- a/apps/web/src/push/gap-report-core.test.ts
+++ b/apps/web/src/push/gap-report-core.test.ts
@@ -121,6 +121,17 @@ describe("parseGapReportArgs — refusing an input it cannot answer correctly", 
     expect(() => parseGapReportArgs(["--since", "--"])).toThrow(/--since expects a date/);
   });
 
+  it("rejects a repeated date flag rather than letting the last one win", () => {
+    // Same defect class as the cases above: last-wins produces a differently-scoped
+    // report that still looks right.
+    expect(() => parseGapReportArgs(["--since", "2026-07-03", "--since", "2026-07-10"])).toThrow(
+      /--since given twice \(2026-07-03 and 2026-07-10\)/,
+    );
+    expect(() => parseGapReportArgs(["--until", "2026-07-31", "--until", "2026-07-30"])).toThrow(
+      /--until given twice/,
+    );
+  });
+
   it("accepts the flags it documents, in any order", () => {
     expect(parseGapReportArgs([])).toEqual({ since: undefined, until: undefined, write: false });
     expect(parseGapReportArgs(["--write", "--since", "2026-07-03", "--until", "2026-07-31"])).toEqual({
@@ -146,6 +157,34 @@ describe("runGapReport — the window's bounds", () => {
       .toISOString()
       .slice(0, 10);
     const run = await runGapReport({ argv: ["--since", since], now: NOW, paths });
+    expect(run.exitCode).toBe(0);
+  });
+
+  it("refuses a --since that the ceiling clamp pulls the window behind", async () => {
+    // Found live: `pnpm gap-report -- --since 2026-08-05` printed
+    // "no lost days in 2026-08-05…2026-08-04 (0 day(s), 0 anchor(s) checked)" and
+    // exited 0. Each date is individually valid; the WINDOW is not. An all-clear
+    // that cannot be anything else is the failure mode that looks like success —
+    // and with --write it would overwrite the standup's gap-report.json with it.
+    const paths = await storeWith([mark(YESTERDAY, "cx-a")]);
+    await expect(
+      runGapReport({ argv: ["--since", TODAY_CDMX], now: NOW, paths }),
+    ).rejects.toThrow(/--since 2026-08-05 is after the effective ceiling 2026-08-04/);
+  });
+
+  it("refuses an explicitly inverted window too", async () => {
+    const paths = await storeWith([mark(YESTERDAY, "cx-a")]);
+    await expect(
+      runGapReport({ argv: ["--since", "2026-08-01", "--until", "2026-07-25"], now: NOW, paths }),
+    ).rejects.toThrow(/window is empty/);
+  });
+
+  it("does not refuse a single-day window, where since equals the ceiling", async () => {
+    // The guard is `>`, not `>=`: since === until is one real day, the narrowest
+    // report the command can produce, and it must stay reachable.
+    const paths = await storeWith([mark(YESTERDAY, "cx-a")]);
+    const run = await runGapReport({ argv: ["--since", YESTERDAY], now: NOW, paths });
+    expect(run.report.calendarDays).toBe(1);
     expect(run.exitCode).toBe(0);
   });
 

--- a/apps/web/src/push/gap-report-core.ts
+++ b/apps/web/src/push/gap-report-core.ts
@@ -138,6 +138,17 @@ export function parseGapReportArgs(argv: readonly string[]): GapReportArgs {
       throw new Error(`gap-report: ${dateFlag} expects a date (YYYY-MM-DD); ${got}.`);
     }
     const parsed = requireCalendarDate(dateFlag, value);
+    // A REPEATED flag is the same defect class as the three above: `--since A
+    // --since B` silently last-wins, and the report that comes back is scoped to a
+    // window the operator did not intend but cannot tell apart from the one they
+    // did. Refusing costs nothing; the alternative is a right-looking answer.
+    const existing = dateFlag === "--since" ? args.since : args.until;
+    if (existing !== undefined) {
+      throw new Error(
+        `gap-report: ${dateFlag} given twice (${existing} and ${parsed}). ` +
+          `Refusing rather than silently using the last one.`,
+      );
+    }
     if (dateFlag === "--since") {
       args.since = parsed;
     } else {
@@ -197,6 +208,24 @@ export async function runGapReport(options: GapReportRunOptions): Promise<GapRep
   // the derivation already clamped, so this reads the real window instead of
   // re-deriving — and re-deriving the clamp here is exactly how the two would
   // drift. The derivation is a linear walk; it is the PRINTING that must be bounded.
+  // DIRECTION BEFORE WIDTH. `--since 2026-08-05` is a real calendar date that the
+  // ceiling clamp then pulls `until` BEHIND, and the derivation's walk over an
+  // inverted window is empty by construction: zero days, zero lost, a confident
+  // all-clear — the failure mode that looks like success this whole command exists
+  // to refuse. With `--write` that all-clear overwrites the standup's file.
+  //
+  // It belongs to the COMMAND, not to `computeGapReport`: the derivation is a pure
+  // function whose empty-on-inverted result is deliberate and tested. Read here off
+  // the POST-CLAMP window, for the same reason the width check is.
+  if (report.since > report.until) {
+    throw new Error(
+      `gap-report: --since ${report.since} is after the effective ceiling ` +
+        `${report.until}, so the window is empty. An empty window reports no lost ` +
+        `days no matter what the log holds; refusing rather than printing an ` +
+        `all-clear nobody asked for.`,
+    );
+  }
+
   if (report.calendarDays > MAX_WINDOW_DAYS) {
     throw new Error(
       `gap-report: the window ${report.since}…${report.until} spans ` +

--- a/apps/web/src/push/gap-report-core.ts
+++ b/apps/web/src/push/gap-report-core.ts
@@ -8,7 +8,7 @@
  *   pnpm gap-report                          # print the report
  *   pnpm gap-report -- --since 2026-06-26    # override the calendar floor
  *   pnpm gap-report -- --until 2026-08-04    # override the ceiling
- *   pnpm gap-report -- --write               # …and persist it (#189)
+ *   pnpm gap-report -- --write               # …and write gap-report.json beside the log
  *
  * ── WHY THE ARGUMENT CHECKING IS NOT BOILERPLATE ──────────────────────────────
  * One input matters more than all the others: `--since 2026-02-30`. It satisfies
@@ -49,9 +49,11 @@
 import {
   formatGapReport,
   formatGapSummary,
+  gapReportPath,
   loadGapReport,
   resolveDataDirDefault,
   resolveEventStorePaths,
+  writeGapReportFile,
   type EventStorePaths,
   type GapReport,
 } from "@numisma/event-store";
@@ -158,9 +160,9 @@ export interface GapReportRunOptions {
   /** The resolved store. Defaults to {@link resolveGapReportPaths}. */
   paths?: EventStorePaths | undefined;
   /**
-   * Persistence, supplied by #189. Absent, `--write` FAILS LOUDLY rather than
-   * quietly doing nothing — a flag that silently no-ops is the same class of
-   * defect as a date that silently rolls forward.
+   * Persistence. Defaults to writing `gap-report.json` beside the log in `paths`
+   * — the standup's one well-known file. Injectable so the failure path (a write
+   * that throws must exit non-zero) is testable without breaking a disk.
    */
   writeReport?: ((report: GapReport) => Promise<string>) | undefined;
 }
@@ -207,13 +209,15 @@ export async function runGapReport(options: GapReportRunOptions): Promise<GapRep
   lines.push(`[gap-report] ${formatGapSummary(report)}`);
 
   if (args.write) {
-    if (options.writeReport === undefined) {
-      throw new Error(
-        "gap-report: --write is not available yet (persistence lands in #189). " +
-          "Re-run without --write to print the report.",
-      );
-    }
-    lines.push(`[gap-report] written: ${await options.writeReport(report)}`);
+    // The file lands beside the log in the store this run actually read, so a
+    // `NUMISMA_DATA_DIR` the caller honoured is honoured here too. A write that
+    // throws propagates: failing to PERSIST the report is failing to produce it,
+    // and #188's contract makes that a non-zero exit.
+    const write =
+      options.writeReport ??
+      ((written: GapReport) =>
+        writeGapReportFile(written, { path: gapReportPath(paths), now: options.now }));
+    lines.push(`[gap-report] written: ${await write(report)}`);
   }
 
   return { lines, report, exitCode: 0 };

--- a/apps/web/src/push/gap-report-core.ts
+++ b/apps/web/src/push/gap-report-core.ts
@@ -1,0 +1,220 @@
+/**
+ * The gap-report COMMAND — argument validation, orchestration and rendering, split
+ * from the self-executing `gap-report.ts` for the same reason `push-core.ts` is
+ * split from `push.ts`: importing the shell would run it, and a command with no
+ * importable core has no test surface. This file is that surface; the CLI had none
+ * before.
+ *
+ *   pnpm gap-report                          # print the report
+ *   pnpm gap-report -- --since 2026-06-26    # override the calendar floor
+ *   pnpm gap-report -- --until 2026-08-04    # override the ceiling
+ *   pnpm gap-report -- --write               # …and persist it (#189)
+ *
+ * ── WHY THE ARGUMENT CHECKING IS NOT BOILERPLATE ──────────────────────────────
+ * One input matters more than all the others: `--since 2026-02-30`. It satisfies
+ * `\d{4}-\d{2}-\d{2}` and it is not a date. Handed to `Date` it rolls silently to
+ * March 2, and the report then answers a question nobody asked IN THE SAME SHAPE
+ * AS A CORRECT ANSWER. **A detector whose entire value is trust cannot have a
+ * failure mode that looks like success**, so {@link requireCalendarDate} validates
+ * the CALENDAR, not merely the shape — it round-trips the parsed date and rejects
+ * anything that did not survive.
+ *
+ * The same principle governs the rest: a flag consumed as a value (`--since
+ * --write`), a trailing `--until` with nothing after it, and an unrecognized
+ * argument all STOP. Each of them, ignored, produces a differently-scoped report
+ * that still looks right.
+ *
+ * ── THE EXIT CONTRACT (what the deferred wrapper step will bind to) ────────────
+ * **Non-zero on any failure to PRODUCE or PERSIST the report** — a malformed flag,
+ * an out-of-bounds window, a derivation that threw, a `--write` that could not
+ * write. Everything in this module signals those by THROWING; `gap-report.ts` maps
+ * a rejection to exit 1. There is exactly one place the exit code is decided.
+ *
+ * **Exit 0 when days are lost.** Deliberate, and not to be tightened casually: a
+ * lost day is permanent — unmarkable after CDMX midnight — so gating the job's exit
+ * on it means a permanently red job, and a permanently red job is one nobody reads.
+ * *A lost day is reported; a broken job is failed.* {@link GapReportRun.exitCode}
+ * exists so that contract is asserted by a test rather than implied by the absence
+ * of code.
+ *
+ * ── IT NEEDS NO ENVIRONMENT ───────────────────────────────────────────────────
+ * No data-dir variable, no projection database URL, no credential. Unlike `push` /
+ * `backfill` this touches no database: it is a pure read of `events.jsonl` through
+ * the pure derivation in `@numisma/event-store`. That is the property that lets the
+ * report be run from anywhere, by anyone, at any time — INCLUDING WHEN THE
+ * PROJECTION IS EXACTLY WHAT IS BROKEN. The detector must not depend on the thing
+ * whose failure it detects, so it reaches no driver at all, and a test asserts that
+ * structurally rather than trusting it to stay true.
+ */
+import {
+  formatGapReport,
+  formatGapSummary,
+  loadGapReport,
+  resolveDataDirDefault,
+  resolveEventStorePaths,
+  type EventStorePaths,
+  type GapReport,
+} from "@numisma/event-store";
+
+/**
+ * The widest window the command will report on, in calendar days (a bit over a
+ * year). The CEILING is already pinned to yesterday by `computeGapReport` — which
+ * clamps rather than defaults, so no `--until` can push it forward — but nothing
+ * bounds how far back a `--since` may reach, and `--since 1970-01-01` would print
+ * one line per calendar day for twenty thousand of them. A report nobody can read
+ * is a report nobody reads.
+ */
+export const MAX_WINDOW_DAYS = 400;
+
+export interface GapReportArgs {
+  since: string | undefined;
+  until: string | undefined;
+  write: boolean;
+}
+
+const DATE_FLAGS = ["--since", "--until"] as const;
+
+/**
+ * Strict `YYYY-MM-DD`, AND a date the calendar actually has.
+ *
+ * The round-trip is the whole point: `2026-02-30` matches the pattern, and
+ * `Date.UTC(2026, 1, 30)` happily yields 2026-03-02. Comparing the normalized
+ * result back against the input is what turns a silent roll-forward into an error.
+ */
+function requireCalendarDate(flag: string, value: string): string {
+  const match = /^(\d{4})-(\d{2})-(\d{2})$/.exec(value);
+  if (!match) {
+    throw new Error(
+      `gap-report: ${flag} ${JSON.stringify(value)} is not a strict YYYY-MM-DD date.`,
+    );
+  }
+  const [, year, month, day] = match;
+  const normalized = new Date(Date.UTC(Number(year), Number(month) - 1, Number(day)))
+    .toISOString()
+    .slice(0, 10);
+  if (normalized !== value) {
+    throw new Error(
+      `gap-report: ${flag} ${value} is not a real calendar date ` +
+        `(it would roll forward to ${normalized}). Refusing rather than reporting on a ` +
+        `window you did not ask for.`,
+    );
+  }
+  return value;
+}
+
+/**
+ * Parse argv into the command's three inputs, rejecting everything else. Throws on
+ * any malformed input — the exit contract's "non-zero on a malformed flag".
+ */
+export function parseGapReportArgs(argv: readonly string[]): GapReportArgs {
+  const args: GapReportArgs = { since: undefined, until: undefined, write: false };
+  for (let index = 0; index < argv.length; index += 1) {
+    const token = argv[index] as string;
+    // `pnpm gap-report -- --since X` forwards the literal `--` into argv. It is a
+    // separator, not an argument, and dropping it is what makes the DOCUMENTED
+    // invocation work against a parser strict enough to reject typos.
+    if (token === "--") {
+      continue;
+    }
+    if (token === "--write") {
+      args.write = true;
+      continue;
+    }
+    const dateFlag = DATE_FLAGS.find((flag) => flag === token);
+    if (dateFlag === undefined) {
+      throw new Error(
+        `gap-report: unrecognized argument ${JSON.stringify(token)}. ` +
+          `Expected --since <YYYY-MM-DD>, --until <YYYY-MM-DD> or --write.`,
+      );
+    }
+    const value = argv[index + 1];
+    // A missing value and a FLAG-as-value are the same defect — the next token is
+    // not a date — and both are caught here rather than inside date arithmetic,
+    // where the message would be about a date the user never typed.
+    if (value === undefined || value.startsWith("--")) {
+      const got = value === undefined ? "nothing followed it" : `got the flag '${value}'`;
+      throw new Error(`gap-report: ${dateFlag} expects a date (YYYY-MM-DD); ${got}.`);
+    }
+    const parsed = requireCalendarDate(dateFlag, value);
+    if (dateFlag === "--since") {
+      args.since = parsed;
+    } else {
+      args.until = parsed;
+    }
+    index += 1;
+  }
+  return args;
+}
+
+/** The store this command reads, honoring `NUMISMA_DATA_DIR` when it is set. */
+export function resolveGapReportPaths(): EventStorePaths {
+  return resolveEventStorePaths(resolveDataDirDefault());
+}
+
+export interface GapReportRunOptions {
+  argv: readonly string[];
+  /** The instant "yesterday" is measured from. Injected so the run is testable. */
+  now: Date;
+  /** The resolved store. Defaults to {@link resolveGapReportPaths}. */
+  paths?: EventStorePaths | undefined;
+  /**
+   * Persistence, supplied by #189. Absent, `--write` FAILS LOUDLY rather than
+   * quietly doing nothing — a flag that silently no-ops is the same class of
+   * defect as a date that silently rolls forward.
+   */
+  writeReport?: ((report: GapReport) => Promise<string>) | undefined;
+}
+
+export interface GapReportRun {
+  /** Exactly what the command prints, in order. */
+  lines: string[];
+  report: GapReport;
+  /**
+   * ALWAYS 0 on a successful run — including a run that found lost days. Failures
+   * throw instead. The field exists so the "exit 0 when days are lost" contract is
+   * something a test asserts, not something the absence of code implies.
+   */
+  exitCode: 0;
+}
+
+/**
+ * Parse, derive, render. Throws on every failure to produce or persist the report;
+ * resolves with `exitCode: 0` otherwise, lost days or not.
+ */
+export async function runGapReport(options: GapReportRunOptions): Promise<GapReportRun> {
+  const args = parseGapReportArgs(options.argv);
+  const paths = options.paths ?? resolveGapReportPaths();
+
+  const report = await loadGapReport(paths, {
+    since: args.since,
+    until: args.until,
+    now: options.now,
+  });
+
+  // Bounded AFTER deriving, deliberately: `report.until` is the effective ceiling
+  // the derivation already clamped, so this reads the real window instead of
+  // re-deriving — and re-deriving the clamp here is exactly how the two would
+  // drift. The derivation is a linear walk; it is the PRINTING that must be bounded.
+  if (report.calendarDays > MAX_WINDOW_DAYS) {
+    throw new Error(
+      `gap-report: the window ${report.since}…${report.until} spans ` +
+        `${report.calendarDays} days, over the ${MAX_WINDOW_DAYS}-day maximum. ` +
+        `Narrow it with --since.`,
+    );
+  }
+
+  const lines = formatGapReport(report).map((line) => `[gap-report] ${line}`);
+  lines.push(`[gap-report] ${formatGapSummary(report)}`);
+
+  if (args.write) {
+    if (options.writeReport === undefined) {
+      throw new Error(
+        "gap-report: --write is not available yet (persistence lands in #189). " +
+          "Re-run without --write to print the report.",
+      );
+    }
+    lines.push(`[gap-report] written: ${await options.writeReport(report)}`);
+  }
+
+  return { lines, report, exitCode: 0 };
+}

--- a/apps/web/src/push/gap-report.ts
+++ b/apps/web/src/push/gap-report.ts
@@ -6,7 +6,7 @@
  *   pnpm gap-report                          # print the report
  *   pnpm gap-report -- --since 2026-06-26    # override the calendar floor
  *   pnpm gap-report -- --until 2026-08-04    # override the ceiling
- *   pnpm gap-report -- --write               # …and persist it (#189)
+ *   pnpm gap-report -- --write               # …and write gap-report.json beside the log
  *
  * THE EXIT CONTRACT LIVES HERE, IN ONE PLACE. Everything that can go wrong —
  * a malformed flag, an out-of-bounds window, a derivation that threw, a `--write`

--- a/apps/web/src/push/gap-report.ts
+++ b/apps/web/src/push/gap-report.ts
@@ -1,0 +1,39 @@
+/**
+ * The gap-report SHELL — a self-executing `main().then(..., process.exit)` script,
+ * split from the importable `gap-report-core.ts` for the same reason `push.ts` is
+ * split from `push-core.ts`: importing this file would run it.
+ *
+ *   pnpm gap-report                          # print the report
+ *   pnpm gap-report -- --since 2026-06-26    # override the calendar floor
+ *   pnpm gap-report -- --until 2026-08-04    # override the ceiling
+ *   pnpm gap-report -- --write               # …and persist it (#189)
+ *
+ * THE EXIT CONTRACT LIVES HERE, IN ONE PLACE. Everything that can go wrong —
+ * a malformed flag, an out-of-bounds window, a derivation that threw, a `--write`
+ * that could not write — reaches this file as a REJECTION and becomes exit 1.
+ * A successful run is exit 0 EVEN WHEN DAYS ARE LOST: a lost day is permanent, so
+ * failing on one would mean a permanently red job, and a permanently red job is one
+ * nobody reads. *A lost day is reported; a broken job is failed.* The reasoning,
+ * and the tests that hold it, are in `gap-report-core.ts`.
+ *
+ * NO ENVIRONMENT REQUIRED — no data-dir variable, no projection database URL, no
+ * credential. See the core's header for why that property is load-bearing.
+ *
+ * `argv.slice(2)` drops the node binary and this script's own path; everything
+ * after them is the user's, and an unrecognized token is an error rather than a
+ * shrug.
+ */
+import { runGapReport } from "./gap-report-core.ts";
+
+runGapReport({ argv: process.argv.slice(2), now: new Date() }).then(
+  (run) => {
+    for (const line of run.lines) {
+      console.log(line);
+    }
+    process.exit(run.exitCode);
+  },
+  (error: unknown) => {
+    console.error("[gap-report] failed:", error instanceof Error ? error.message : error);
+    process.exit(1);
+  },
+);

--- a/apps/web/src/push/glance.ts
+++ b/apps/web/src/push/glance.ts
@@ -37,7 +37,7 @@ import type {
   InstrumentRegistryEntry,
   PriceSource,
 } from "@numisma/engine";
-import { composeRowDependencies, instrumentsForSource } from "@numisma/engine";
+import { addDays, composeRowDependencies, instrumentsForSource } from "@numisma/engine";
 import type { GlanceBlock, GlanceMissingMark } from "../projection/contract.ts";
 
 /**
@@ -93,12 +93,6 @@ function allRegisteredInstruments(): InstrumentRegistryEntry[] {
 function isWeekend(asOf: string): boolean {
   const weekday = new Date(`${asOf}T00:00:00Z`).getUTCDay();
   return weekday === 0 || weekday === 6;
-}
-
-function addDays(asOf: string, delta: number): string {
-  const date = new Date(`${asOf}T00:00:00Z`);
-  date.setUTCDate(date.getUTCDate() + delta);
-  return date.toISOString().slice(0, 10);
 }
 
 /**

--- a/ops/price-feed/run-daily-fetch.sh
+++ b/ops/price-feed/run-daily-fetch.sh
@@ -35,6 +35,10 @@ LOG_DIR="${NUMISMA_PRICEFEED_LOG_DIR:-$HOME/Library/Logs/numisma}"
 # asdf entry if you do not use asdf). The manual dry run passes without this only
 # because it inherits your interactive PATH.
 PATH_PREPEND="${NUMISMA_PATH_PREPEND:-$HOME/.asdf/shims:$HOME/Library/pnpm:/opt/homebrew/bin:/usr/local/bin}"
+# The durable data root. RESOLVED HERE, not at step 3 where it is used for the
+# commit, because the heartbeat trap below must know where to write BEFORE the
+# exit-127 checks — which are the very failures the heartbeat exists to record.
+DATA_DIR="${NUMISMA_DATA_DIR:-$HOME/Dev/accumulus/data}"
 # ----------------------------------------------------------------------------
 
 # Give the scheduled (non-login) job a deterministic PATH that can find pnpm. This
@@ -42,8 +46,50 @@ PATH_PREPEND="${NUMISMA_PATH_PREPEND:-$HOME/.asdf/shims:$HOME/Library/pnpm:/opt/
 # additional belt-and-suspenders (see the plist / docs/price-feed-ops.md).
 export PATH="$PATH_PREPEND:$PATH"
 
-mkdir -p "$LOG_DIR"
 STAMP="$(date +%Y-%m-%dT%H-%M-%S%z)"
+# A real ISO-8601 instant for the heartbeat (STAMP's dashed time is filename-safe,
+# not machine-parseable). UTC so the reader never has to guess a zone.
+STARTED_AT="$(date -u +%Y-%m-%dT%H:%M:%SZ)"
+# How far the run got. MAINTAINED, not guessed: each step below advances it, so a
+# heartbeat can say WHERE a run died and not merely that it did.
+LAST_STEP="startup"
+HEARTBEAT_FILE="$DATA_DIR/job-heartbeat.json"
+
+# --- the heartbeat (#191) ---------------------------------------------------
+# THE ONE FACT THE DURABLE LOG CANNOT CONTAIN IS WHETHER THIS JOB RAN. The gap
+# report is a pure function of the log, deliberately — and the price of that purity
+# is exact: a run that fired and died leaves the same evidence as a machine that was
+# switched off, and a run that fetched cleanly then failed later leaves none at all.
+#
+# PURE BASH, ON PURPOSE. No node, no pnpm, no jq. The case that justifies the whole
+# design is exit 127 — `pnpm` or `node` unresolvable, in which NOTHING that needs
+# node can run — so the writer must have no dependency that could be the thing
+# that is missing. A `printf` into a file has none.
+#
+# It writes to a FILE, never to stdout: by the time this fires, stdout is a pipe to
+# a `tee` in a process substitution that may already be gone. And every command in
+# it is guarded, because a failure inside an EXIT trap under `set -e` would replace
+# the very exit code the heartbeat exists to record. `$?` is captured as the FIRST
+# act for the same reason — anything before it clobbers the status.
+#
+# It lands beside gap-report.json in the data dir, so the outcome travels with the
+# DATA rather than with the checkout. It is written after step 4's git checks have
+# already run, so it can never dirty the tree it just verified.
+write_heartbeat() {
+  HEARTBEAT_STATUS=$?
+  [[ -d "$DATA_DIR" ]] || return 0
+  HEARTBEAT_FINISHED_AT="$(date -u +%Y-%m-%dT%H:%M:%SZ 2>/dev/null)" || HEARTBEAT_FINISHED_AT="$STARTED_AT"
+  printf '{\n  "schemaVersion": 1,\n  "startedAt": "%s",\n  "finishedAt": "%s",\n  "exitCode": %d,\n  "lastStep": "%s"\n}\n' \
+    "$STARTED_AT" "$HEARTBEAT_FINISHED_AT" "$HEARTBEAT_STATUS" "$LAST_STEP" \
+    > "$HEARTBEAT_FILE" 2>/dev/null || true
+  return 0
+}
+# Installed BEFORE the log dir is even made, so every exit path below is covered —
+# including the two `exit 127`s, which happen before anything node-shaped exists.
+trap write_heartbeat EXIT
+# ----------------------------------------------------------------------------
+
+mkdir -p "$LOG_DIR"
 LOG_FILE="$LOG_DIR/price-feed-$STAMP.log"
 
 # Everything from here is tee'd to the per-run log AND the scheduler's stdout.
@@ -63,6 +109,7 @@ fi
 
 cd "$REPO_DIR"
 
+LAST_STEP="resolve-tools"
 # Fail LOUD if pnpm — or the node it drives — is still unresolvable. A clear, named
 # error beats dying as a bare exit 127 mid-run. This is exactly the scheduled-
 # environment PATH problem, so say so and point at the override.
@@ -86,6 +133,7 @@ fi
 # 1) Fetch + store + queue marks. Non-zero here = a provider failure OR a mark the
 #    spine would reject (the CLI's fetch-time pre-check). Either way, STOP: do not
 #    run spine on a run the operator has not looked at.
+LAST_STEP="prices-fetch"
 set +e
 pnpm prices:fetch
 FETCH_STATUS=$?
@@ -102,6 +150,7 @@ fi
 # 2) Clean fetch: land the day's marks through the unchanged spine ingest (the
 #    ±50% guard still owns the authoritative append). Its own non-zero exit is
 #    surfaced to the scheduler too.
+LAST_STEP="spine"
 echo "[$STAMP] prices:fetch clean — ingesting marks via pnpm spine"
 pnpm spine
 
@@ -117,7 +166,9 @@ pnpm spine
 #    (apps/tui/src/ingest-commit.ts derives ~/Dev/accumulus/data from os.homedir()
 #    when NUMISMA_DATA_DIR is unset), so this backstop AND the step-4 post-check
 #    always target the dir actually written to — never a no-op that leaves a failed
-#    capture uncommitted while the job stays green.
+#    capture uncommitted while the job stays green. It is now RESOLVED IN THE
+#    CONFIGURATION BLOCK at the top rather than here: the heartbeat trap needs it
+#    before the exit-127 checks, which run long before this step.
 #
 #    `git add -u` restages tracked modifications only, so a FIRST-TIME untracked
 #    source-of-truth file (e.g. an initial genesis.json) would slip past this
@@ -127,7 +178,7 @@ pnpm spine
 #    explicitly. head-digest.json is deliberately NOT added here — it may be intentionally ignored, and `git add` of an ignored
 #    path aborts under `set -e`. Each explicit add is guarded on file existence so a
 #    missing optional file doesn't trip `set -e`.
-DATA_DIR="${NUMISMA_DATA_DIR:-$HOME/Dev/accumulus/data}"
+LAST_STEP="commit"
 if ! git -C "$DATA_DIR" rev-parse --git-dir >/dev/null 2>&1; then
   echo "[$STAMP] WARNING: $DATA_DIR is not inside a git repo — skipping commit (durable log left uncommitted)."
 else
@@ -150,13 +201,21 @@ fi
 
 # 4) Post-check: assert the durable log actually landed. The 17-day silent miss
 #    (the in-process capture skipping every run, issue #132) was invisible because a
-#    launchd job's stderr goes to an UNREAD log — a "loud warning" reaches no one;
-#    only a FAILED job reaches the operator. So after the in-process capture AND the
+#    launchd job's stderr goes to an UNREAD log — a "loud warning" reaches no one.
+#    A FAILED JOB REACHES NO ONE EITHER. (An earlier version of this comment claimed
+#    it did. Measured against the live agent: launchd RECORDS the exit code and
+#    `launchctl print` will show it on request, but nothing is PUSHED — no
+#    notification, no badge, no mail. The `exit 1` below is only as loud as someone
+#    remembering to go and look, which is the same failure it was written to prevent.)
+#    That is why this run now also writes job-heartbeat.json (#191): the exit code
+#    becomes a breadcrumb the TUI reads on the next startup, which is what actually
+#    delivers it. So after the in-process capture AND the
 #    step-3 backstop have both run, verify the data-dir working tree is clean and
 #    turn the job RED if it is not. Split by ADR stance: the event log is the
 #    source-of-truth (STRICT — dirty ⇒ non-zero exit), head-digest.json is a forensic
 #    breadcrumb (LENIENT — warn only). Paths are relative to $DATA_DIR, which is the
 #    accumulus `data/` subdir holding the durable files directly.
+LAST_STEP="post-check"
 if git -C "$DATA_DIR" rev-parse --git-dir >/dev/null 2>&1; then
   # --ignored is REQUIRED: head-digest.json in the #132 shape is only-ignored (an
   # allowlist .gitignore keeps it out of history), and plain `git status --porcelain`
@@ -184,4 +243,5 @@ if git -C "$DATA_DIR" rev-parse --git-dir >/dev/null 2>&1; then
   echo "[$STAMP] post-check OK: durable log committed clean in $DATA_DIR."
 fi
 
+LAST_STEP="complete"
 echo "[$STAMP] price-feed daily run complete."

--- a/package.json
+++ b/package.json
@@ -20,6 +20,7 @@
     "smoke:tui": "bun apps/tui/src/smoke-openTui.ts",
     "smoke:startup": "bun apps/tui/src/smoke-startup-openTui.ts",
     "push": "tsx apps/web/src/push/push.ts",
+    "gap-report": "tsx apps/web/src/push/gap-report.ts",
     "backfill": "tsx apps/web/src/push/backfill.ts",
     "db:init": "tsx apps/web/src/push/push.ts --init-only",
     "db:provision": "tsx apps/web/src/projection/provision-projection.ts",

--- a/packages/engine/package.json
+++ b/packages/engine/package.json
@@ -5,7 +5,8 @@
   "type": "module",
   "exports": {
     ".": "./src/index.ts",
-    "./format": "./src/format.ts"
+    "./format": "./src/format.ts",
+    "./calendar": "./src/calendar.ts"
   },
   "types": "./src/index.ts",
   "scripts": {

--- a/packages/engine/src/calendar.test.ts
+++ b/packages/engine/src/calendar.test.ts
@@ -1,0 +1,69 @@
+/**
+ * The `asOf` calendar arithmetic, locked in its new single home. Every date here
+ * is synthetic — this exercises string/UTC arithmetic, not any fund data.
+ *
+ * The UTC assertions are the point: a local-time implementation passes the happy
+ * path in Greenwich and silently returns the PREVIOUS day west of it, which is how
+ * a liveness detector ends up calling a Monday a Sunday. Both helpers are pinned
+ * against an explicitly non-UTC process timezone below so that regression cannot
+ * hide behind the machine the suite happens to run on.
+ */
+import { afterAll, beforeAll, describe, expect, it } from "vitest";
+import { addDays, daysBetween } from "./calendar.js";
+
+const originalTz = process.env.TZ;
+
+// UTC-8: the failure mode the docstring names only reproduces west of Greenwich.
+beforeAll(() => {
+  process.env.TZ = "America/Los_Angeles";
+});
+afterAll(() => {
+  process.env.TZ = originalTz;
+});
+
+describe("addDays", () => {
+  it("walks forward and back in whole calendar days", () => {
+    expect(addDays("2026-07-26", 1)).toBe("2026-07-27");
+    expect(addDays("2026-07-26", -1)).toBe("2026-07-25");
+    expect(addDays("2026-07-26", 0)).toBe("2026-07-26");
+  });
+
+  it("stays on the UTC day west of Greenwich", () => {
+    // A local-time implementation renders UTC midnight as the previous evening
+    // and returns "2026-07-25" here.
+    expect(addDays("2026-07-26", 0)).toBe("2026-07-26");
+  });
+
+  it("crosses month, year and leap-day boundaries", () => {
+    expect(addDays("2026-07-31", 1)).toBe("2026-08-01");
+    expect(addDays("2026-12-31", 1)).toBe("2027-01-01");
+    expect(addDays("2026-01-01", -1)).toBe("2025-12-31");
+    expect(addDays("2028-02-28", 1)).toBe("2028-02-29");
+  });
+
+  it("throws rather than returning a silent garbage date", () => {
+    expect(() => addDays("not-a-date", 1)).toThrow(
+      'addDays: "not-a-date" is not a calendar date',
+    );
+  });
+});
+
+describe("daysBetween", () => {
+  it("counts whole calendar days, signed by direction", () => {
+    expect(daysBetween("2026-07-26", "2026-07-29")).toBe(3);
+    expect(daysBetween("2026-07-29", "2026-07-26")).toBe(-3);
+    expect(daysBetween("2026-07-26", "2026-07-26")).toBe(0);
+  });
+
+  it("counts across a DST transition as whole days, not 23- or 25-hour spans", () => {
+    // US DST springs forward 2026-03-08. In local time this window is 23 hours
+    // short of two days; in UTC — the only reading that makes a day-count honest —
+    // it is exactly 2.
+    expect(daysBetween("2026-03-07", "2026-03-09")).toBe(2);
+  });
+
+  it("throws on either endpoint being unparseable", () => {
+    expect(() => daysBetween("not-a-date", "2026-07-26")).toThrow(/daysBetween/);
+    expect(() => daysBetween("2026-07-26", "not-a-date")).toThrow(/daysBetween/);
+  });
+});

--- a/packages/engine/src/calendar.ts
+++ b/packages/engine/src/calendar.ts
@@ -1,0 +1,48 @@
+/**
+ * Calendar-date arithmetic over the `asOf`-as-`YYYY-MM-DD`-string convention —
+ * the ONE home, shared by every plane that speaks it.
+ *
+ * WHY IT IS ITS OWN MODULE IN THE ENGINE. These helpers were born in
+ * `apps/web/src/projection/as-of.ts`, validated and documented, and were then
+ * copied — private and undocumented, validation dropped — into
+ * `apps/web/src/push/glance.ts`. A package cannot import from an app, so the
+ * next consumer would have written a THIRD copy. They live here instead,
+ * alongside `tradingDayAsOf`'s `asOf` convention (`price-feed/mark.ts`), which
+ * these two speak. `apps/tui/src/format-contract.test.ts` guards the same class
+ * of de-duplication for the shared formatters (ADR-001's *Realized* note);
+ * `apps/web/src/calendar-contract.test.ts` guards this one.
+ *
+ * PURE, AND BROWSER-SAFE BY CONSTRUCTION — no imports at all, so it is reachable
+ * from a render surface through the `@numisma/engine/calendar` subpath without
+ * dragging the engine root's `node:os` / `node:path` reach into the client
+ * bundle. That is the same reason `@numisma/engine/format` exists.
+ */
+
+/**
+ * The `YYYY-MM-DD` date `delta` days from `asOf`, read and written in UTC.
+ *
+ * UTC THROUGHOUT, deliberately. `new Date("2026-07-26")` parses as UTC midnight and
+ * then renders in LOCAL time, which west of Greenwich lands on the previous day —
+ * enough to call a Monday a Sunday. Every caller — the projection's as-of module
+ * and the push glance builder alike — makes the same choice for the same reason.
+ */
+export function addDays(asOf: string, delta: number): string {
+  const date = new Date(`${asOf}T00:00:00Z`);
+  if (Number.isNaN(date.getTime())) {
+    throw new Error(`addDays: ${JSON.stringify(asOf)} is not a calendar date`);
+  }
+  date.setUTCDate(date.getUTCDate() + delta);
+  return date.toISOString().slice(0, 10);
+}
+
+/** Whole calendar days from `from` to `to`, in UTC. Negative when `to` precedes `from`. */
+export function daysBetween(from: string, to: string): number {
+  const start = Date.parse(`${from}T00:00:00Z`);
+  const end = Date.parse(`${to}T00:00:00Z`);
+  if (Number.isNaN(start) || Number.isNaN(end)) {
+    throw new Error(
+      `daysBetween: ${JSON.stringify(from)} → ${JSON.stringify(to)} is not a date range`,
+    );
+  }
+  return Math.round((end - start) / 86_400_000);
+}

--- a/packages/engine/src/index.ts
+++ b/packages/engine/src/index.ts
@@ -270,6 +270,13 @@ export {
   priceStoreFileName,
 } from "./price-feed/inbox-merge.js";
 
+// Calendar-date arithmetic over the `asOf`-as-`YYYY-MM-DD`-string convention that
+// `tradingDayAsOf` above already owns. The ONE home: the web projection's as-of
+// module and the push glance builder both import from here rather than keeping
+// private copies (guarded by apps/web/src/calendar-contract.test.ts). Also
+// reachable browser-side via the pure `@numisma/engine/calendar` subpath.
+export { addDays, daysBetween } from "./calendar.js";
+
 // The ONE pure resolver for the durable ledger's data root, honoring the
 // `NUMISMA_DATA_DIR` env override with an absolute, homedir-derived accumulus
 // default. Shared by the tui event-store, the price-feed config, and the

--- a/packages/event-store/src/gap-report-io.test.ts
+++ b/packages/event-store/src/gap-report-io.test.ts
@@ -1,0 +1,87 @@
+/**
+ * The gap report's ONE async surface, tested against a real log file on disk.
+ *
+ * The events written here are synthetic — invented instrument ids and round
+ * numbers, no real position, price or balance. What is being asserted is the
+ * shell's two jobs and nothing more: that it reads the log at the paths it was
+ * HANDED (so a caller's `NUMISMA_DATA_DIR` resolution is honoured rather than
+ * re-derived), and that it refuses to run on a partial log.
+ */
+import { mkdtemp, rm, writeFile } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import type { PortfolioEvent } from "@numisma/engine";
+import { afterEach, describe, expect, it } from "vitest";
+import { loadGapReport } from "./gap-report-io.js";
+import { resolveEventStorePaths } from "./event-store.js";
+
+const created: string[] = [];
+
+afterEach(async () => {
+  await Promise.all(created.map((dir) => rm(dir, { recursive: true, force: true })));
+  created.length = 0;
+});
+
+/** A throwaway data dir holding exactly the log lines given. */
+async function storeWithLog(lines: readonly string[]) {
+  const dataDir = await mkdtemp(join(tmpdir(), "numisma-gap-"));
+  created.push(dataDir);
+  const paths = resolveEventStorePaths(dataDir);
+  await writeFile(paths.log, lines.map((line) => `${line}\n`).join(""), "utf8");
+  return paths;
+}
+
+function mark(date: string, instrumentId: string): PortfolioEvent {
+  return { id: `pm-${instrumentId}-${date}`, asOf: date, type: "PriceMarked", instrumentId, price: 100 };
+}
+
+function deposit(date: string): PortfolioEvent {
+  return { id: `dep-${date}`, asOf: date, type: "Deposit", reserveId: "cash-core", amount: 500, tier: "c1" };
+}
+
+const LATER = new Date("2026-08-05T12:00:00Z");
+
+describe("loadGapReport", () => {
+  it("derives the report from the log at the paths it was handed", async () => {
+    const paths = await storeWithLog(
+      [mark("2026-07-10", "cx-a"), deposit("2026-07-11"), mark("2026-07-12", "cx-a")].map((event) =>
+        JSON.stringify(event),
+      ),
+    );
+    const report = await loadGapReport(paths, {
+      since: "2026-07-10",
+      until: "2026-07-12",
+      now: LATER,
+    });
+    expect(report.lost).toEqual([{ date: "2026-07-11", reason: "no-marks" }]);
+    expect(report.anchorsChecked).toBe(3);
+  });
+
+  it("treats a missing log as a window with no anchors at all", async () => {
+    const dataDir = await mkdtemp(join(tmpdir(), "numisma-gap-"));
+    created.push(dataDir);
+    const report = await loadGapReport(resolveEventStorePaths(dataDir), {
+      since: "2026-07-10",
+      until: "2026-07-11",
+      now: LATER,
+    });
+    expect(report.lost).toEqual([
+      { date: "2026-07-10", reason: "no-anchor" },
+      { date: "2026-07-11", reason: "no-anchor" },
+    ]);
+  });
+
+  it("refuses to run on a partial log rather than inventing a lost day", async () => {
+    // A quarantined line is a mark this derivation cannot see. Degrading
+    // gracefully here would turn a corrupt line into a PHANTOM lost day — a
+    // false positive manufactured by the reader, which is the one thing a
+    // liveness detector must not do.
+    const paths = await storeWithLog([
+      JSON.stringify(mark("2026-07-10", "cx-a")),
+      "{ this is not an event }",
+    ]);
+    await expect(
+      loadGapReport(paths, { since: "2026-07-10", until: "2026-07-10", now: LATER }),
+    ).rejects.toThrow(/quarantine/i);
+  });
+});

--- a/packages/event-store/src/gap-report-io.test.ts
+++ b/packages/event-store/src/gap-report-io.test.ts
@@ -7,12 +7,19 @@
  * HANDED (so a caller's `NUMISMA_DATA_DIR` resolution is honoured rather than
  * re-derived), and that it refuses to run on a partial log.
  */
-import { mkdtemp, rm, writeFile } from "node:fs/promises";
+import { mkdtemp, readFile, rm, writeFile } from "node:fs/promises";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import type { PortfolioEvent } from "@numisma/engine";
 import { afterEach, describe, expect, it } from "vitest";
-import { loadGapReport } from "./gap-report-io.js";
+import {
+  GAP_REPORT_FILENAME,
+  GAP_REPORT_SCHEMA_VERSION,
+  gapReportPath,
+  loadGapReport,
+  writeGapReportFile,
+} from "./gap-report-io.js";
+import { computeGapReport } from "./gap-report.js";
 import { resolveEventStorePaths } from "./event-store.js";
 
 const created: string[] = [];
@@ -83,5 +90,280 @@ describe("loadGapReport", () => {
     await expect(
       loadGapReport(paths, { since: "2026-07-10", until: "2026-07-10", now: LATER }),
     ).rejects.toThrow(/quarantine/i);
+  });
+});
+
+// ── The file the standup reads ───────────────────────────────────────────────
+
+/** A report with both lost-day reasons in it, derived from real events. */
+function reportWithBothReasons() {
+  return computeGapReport(
+    [mark("2026-07-10", "cx-a"), deposit("2026-07-11")],
+    { since: "2026-07-10", until: "2026-07-12", now: LATER },
+  );
+}
+
+async function writeInto(report: ReturnType<typeof computeGapReport>, now = LATER) {
+  const dataDir = await mkdtemp(join(tmpdir(), "numisma-gap-"));
+  created.push(dataDir);
+  const paths = resolveEventStorePaths(dataDir);
+  const written = await writeGapReportFile(report, { path: gapReportPath(paths), now });
+  const body = JSON.parse(await readFile(written, "utf8")) as Record<string, unknown>;
+  return { dataDir, paths, written, body };
+}
+
+describe("gapReportPath / GAP_REPORT_FILENAME", () => {
+  it("names one fixed file beside the log it derives from", async () => {
+    const dataDir = await mkdtemp(join(tmpdir(), "numisma-gap-"));
+    created.push(dataDir);
+    const paths = resolveEventStorePaths(dataDir);
+    expect(GAP_REPORT_FILENAME).toBe("gap-report.json");
+    expect(gapReportPath(paths)).toBe(join(dataDir, "gap-report.json"));
+    // Beside the log, not beside the checkout — the report travels with the data.
+    expect(gapReportPath(paths)).toBe(paths.log.replace("events.jsonl", "gap-report.json"));
+  });
+});
+
+describe("writeGapReportFile", () => {
+  it("round-trips the report into the data dir, lost and lines in agreement", async () => {
+    const report = reportWithBothReasons();
+    const { written, body, dataDir } = await writeInto(report);
+
+    expect(written).toBe(join(dataDir, "gap-report.json"));
+    expect(body.generatedAt).toBe(LATER.toISOString());
+    expect(body.since).toBe("2026-07-10");
+    expect(body.until).toBe("2026-07-12");
+    expect(body.calendarDays).toBe(3);
+    expect(body.anchorsChecked).toBe(2);
+    expect(body.lost).toEqual([
+      { date: "2026-07-11", reason: "no-marks" },
+      { date: "2026-07-12", reason: "no-anchor" },
+    ]);
+    // The structured array and the rendered lines describe the SAME days — the
+    // duplication is deliberate (the standup can `jq -r '.lines[]'`), so it has to
+    // be kept honest.
+    expect(body.lines).toHaveLength(report.lost.length);
+    for (const [index, day] of report.lost.entries()) {
+      expect((body.lines as string[])[index]).toContain(day.date);
+    }
+    expect(body.summary).toContain("2 lost day(s)");
+  });
+
+  it("carries a schemaVersion — asserted, not merely documented", async () => {
+    const { body } = await writeInto(reportWithBothReasons());
+    expect(body.schemaVersion).toBe(GAP_REPORT_SCHEMA_VERSION);
+    expect(GAP_REPORT_SCHEMA_VERSION).toBe(1);
+    // An integer, so a reader can compare it. Slice #191's sibling
+    // `job-heartbeat.json` follows the same convention with its own counter.
+    expect(Number.isInteger(body.schemaVersion)).toBe(true);
+    // First key in the serialized body, so `head -2` on the file tells you what
+    // you are reading before you parse it.
+    expect(Object.keys(body)[0]).toBe("schemaVersion");
+  });
+
+  it("writes a clean report too, with an empty lost array and no lines", async () => {
+    const report = computeGapReport([mark("2026-07-10", "cx-a")], {
+      since: "2026-07-10",
+      until: "2026-07-10",
+      now: LATER,
+    });
+    const { body } = await writeInto(report);
+    expect(body.lost).toEqual([]);
+    expect(body.lines).toEqual([]);
+    expect(body.summary).toContain("no lost days");
+  });
+
+  it("overwrites the one fixed file rather than rotating", async () => {
+    // Deliberately unchanged: no rotation, no history. "The standup reads THE
+    // file" needs exactly one well-known name.
+    const dataDir = await mkdtemp(join(tmpdir(), "numisma-gap-"));
+    created.push(dataDir);
+    const paths = resolveEventStorePaths(dataDir);
+    const first = await writeGapReportFile(reportWithBothReasons(), {
+      path: gapReportPath(paths),
+      now: LATER,
+    });
+    const second = await writeGapReportFile(
+      computeGapReport([mark("2026-07-10", "cx-a")], {
+        since: "2026-07-10",
+        until: "2026-07-10",
+        now: LATER,
+      }),
+      { path: gapReportPath(paths), now: LATER },
+    );
+    expect(second).toBe(first);
+    const body = JSON.parse(await readFile(first, "utf8")) as Record<string, unknown>;
+    expect(body.lost).toEqual([]); // the second run's content, not the first's
+  });
+});
+
+// ── The privacy walk ─────────────────────────────────────────────────────────
+//
+// THE CHECK THAT REPLACES INSPECTION.
+//
+// `gap-report.json` is written beside the private durable log and is meant to be
+// pasted into a standup, so it must carry NO NAV, no positions, no prices, no
+// balances, no magnitudes of any kind. Grepping for the literal string "NAV"
+// would not catch that — THE NEXT FIELD SOMEONE ADDS WILL NOT BE CALLED NAV. So
+// the check is inverted into an allowlist over the SERIALIZED BODY:
+//
+//   1. Every key must be one this file knows about. An unfamiliar key FAILS BY
+//      DEFAULT, which is the only rule that can catch a field nobody has thought
+//      of yet.
+//   2. Every number must be a non-negative INTEGER — a count. A magnitude is a
+//      decimal, and a count of days can never be one.
+//   3. Every string must be a calendar date, an ISO instant, a known reason enum,
+//      or one of the two rendered text fields.
+//   4. Inside those rendered strings, every numeric token must be a date or one of
+//      the report's own counts, and no currency symbol or decimal may appear. That
+//      is what stops a magnitude riding in on a sentence.
+//
+// IT LIVES AT MODULE SCOPE ON PURPOSE. Both tests below drive THIS function — one
+// asserting it returns nothing for the real written body, the other asserting the
+// exact violations it returns for a deliberately poisoned one. A walk that could
+// only ever say yes would pass the first test and fail the second, which is the
+// whole point: a guard that is never shown saying *no* is a guard guaranteed by
+// inspection again.
+const ALLOWED_KEYS = new Set([
+  "schemaVersion",
+  "generatedAt",
+  "since",
+  "until",
+  "calendarDays",
+  "anchorsChecked",
+  "lost",
+  "date",
+  "reason",
+  "summary",
+  "lines",
+]);
+const REASONS = new Set(["no-anchor", "no-marks"]);
+const RENDERED_KEYS = new Set(["summary", "lines"]);
+const ISO_DATE = /^\d{4}-\d{2}-\d{2}$/;
+const ISO_INSTANT = /^\d{4}-\d{2}-\d{2}T[\d:.]+Z$/;
+
+/** Every way `body` violates "dates and counts only", each as `path: reason`. */
+function privacyViolations(body: unknown, counts: ReadonlySet<string>): string[] {
+  const failures: string[] = [];
+  const walk = (value: unknown, path: string, renderedField: boolean): void => {
+    if (Array.isArray(value)) {
+      value.forEach((item, index) => walk(item, `${path}[${index}]`, renderedField));
+      return;
+    }
+    if (value !== null && typeof value === "object") {
+      for (const [key, child] of Object.entries(value as Record<string, unknown>)) {
+        if (!ALLOWED_KEYS.has(key)) {
+          failures.push(`${path}.${key}: unknown key — a new field must prove it is a date or a count`);
+          continue;
+        }
+        walk(child, `${path}.${key}`, renderedField || RENDERED_KEYS.has(key));
+      }
+      return;
+    }
+    if (typeof value === "number") {
+      if (!Number.isInteger(value) || value < 0) {
+        failures.push(`${path}: ${value} is not a count`);
+      }
+      return;
+    }
+    if (typeof value !== "string") {
+      failures.push(`${path}: ${typeof value} is neither a date nor a count`);
+      return;
+    }
+    if (ISO_DATE.test(value) || ISO_INSTANT.test(value) || REASONS.has(value)) {
+      return;
+    }
+    if (!renderedField) {
+      failures.push(`${path}: ${JSON.stringify(value)} is not a date, an instant or a known label`);
+      return;
+    }
+    // A rendered sentence. No currency, no decimals, and every number in it must
+    // already be a date or one of this report's counts.
+    if (/[$€£¥]|\d+\.\d/.test(value)) {
+      failures.push(`${path}: ${JSON.stringify(value)} carries a magnitude`);
+      return;
+    }
+    const residue = value.replace(/\d{4}-\d{2}-\d{2}/g, "");
+    for (const token of residue.match(/\d+/g) ?? []) {
+      if (!counts.has(token)) {
+        failures.push(`${path}: the number ${token} is not one of this report's counts`);
+      }
+    }
+  };
+  walk(body, "body", false);
+  return failures;
+}
+
+/** The only numbers a report's rendered sentences are allowed to contain. */
+function countsOf(report: ReturnType<typeof computeGapReport>): ReadonlySet<string> {
+  return new Set([
+    String(report.calendarDays),
+    String(report.anchorsChecked),
+    String(report.lost.length),
+    String(GAP_REPORT_SCHEMA_VERSION),
+  ]);
+}
+
+/** The `path` half of each violation, sorted — key order is not the assertion. */
+function violationPaths(violations: readonly string[]): string[] {
+  return violations.map((violation) => violation.slice(0, violation.indexOf(":"))).sort();
+}
+
+describe("the privacy property — dates and counts only", () => {
+  it("carries nothing but dates, counts, a version and known labels", async () => {
+    const report = reportWithBothReasons();
+    const { body } = await writeInto(report);
+    expect(privacyViolations(body, countsOf(report))).toEqual([]);
+  });
+
+  it("names every magnitude smuggled into the body — the same walk, saying no", async () => {
+    // The counterpart of the test above, driving THE SAME function. Without it,
+    // a walk that pushed nothing under any circumstance would pass — testing the
+    // rule and never the thing the rule is applied to, which is the exact defect
+    // this whole increment exists to remove.
+    //
+    // Four poisonings, three distinct rules:
+    //   `navUsd`             a new top-level field — the unknown-key rule
+    //   `lost[0].navUsd`     the same rule INSIDE an array of objects, so a walk
+    //                        that stopped descending into `lost` fails here
+    //   `anchorsChecked`     a decimal where a count belongs — the number rule
+    //   `lines[2]`           a magnitude inside a rendered sentence, where the key
+    //                        allowlist cannot help — the rendered-string rule
+    const report = reportWithBothReasons();
+    const { body } = await writeInto(report);
+    const lost = body.lost as Array<Record<string, unknown>>;
+    const smuggled = {
+      ...body,
+      navUsd: 12_345.67,
+      anchorsChecked: 2.5,
+      lost: [{ ...lost[0], navUsd: 68_000.12 }, ...lost.slice(1)],
+      lines: [...(body.lines as string[]), "Numisma: NAV is $12,345.67"],
+    };
+
+    const violations = privacyViolations(smuggled, countsOf(report));
+    expect(violationPaths(violations)).toEqual([
+      "body.anchorsChecked",
+      "body.lines[2]",
+      "body.lost[0].navUsd",
+      "body.navUsd",
+    ]);
+    expect(violations.find((v) => v.startsWith("body.anchorsChecked"))).toContain("is not a count");
+    expect(violations.find((v) => v.startsWith("body.lines[2]"))).toContain("carries a magnitude");
+    expect(violations.find((v) => v.startsWith("body.navUsd"))).toContain("unknown key");
+  });
+
+  it("catches a magnitude that hides behind no currency symbol at all", async () => {
+    // The subtlest case: a bare number in a sentence, no `$`, no decimal. It is
+    // caught because every number in a rendered line must already be one of the
+    // report's own counts.
+    const report = reportWithBothReasons();
+    const { body } = await writeInto(report);
+    const violations = privacyViolations(
+      { ...body, lines: ["Numisma: the fund holds 41230 units"] },
+      countsOf(report),
+    );
+    expect(violations).toEqual([
+      "body.lines[0]: the number 41230 is not one of this report's counts",
+    ]);
   });
 });

--- a/packages/event-store/src/gap-report-io.ts
+++ b/packages/event-store/src/gap-report-io.ts
@@ -1,10 +1,11 @@
 /**
  * The gap report's IO shell — and the ONLY async surface in the whole derivation.
  *
- * It does two things and deliberately nothing else: read the durable log, and hand
- * the events to the pure {@link computeGapReport}. Every decision about what
- * counts as a mark, where the window starts and where it stops lives in
- * `gap-report.ts`, which is synchronous and testable with no disk at all.
+ * It does three things and deliberately nothing else: read the durable log, hand
+ * the events to the pure {@link computeGapReport}, and write the result out as the
+ * standup's `gap-report.json`. Every decision about what counts as a mark, where
+ * the window starts and where it stops lives in `gap-report.ts`, which is
+ * synchronous and testable with no disk at all.
  *
  * IT ACCEPTS RESOLVED PATHS. The caller has already resolved its store — the TUI
  * from its startup path, the web push from its own — and re-deriving them here
@@ -15,9 +16,17 @@
  * `asOf >= genesis.review.asOf`; the window floor here is 2026-07-03, long after
  * genesis, so that filter is already subsumed by the window itself.
  */
+import { writeFile } from "node:fs/promises";
+import { dirname, join } from "node:path";
 import { assertLogFullyLoaded, loadEventLog } from "./event-store.js";
 import type { EventStorePaths } from "./event-store.js";
-import { computeGapReport, type GapReport, type GapWindow } from "./gap-report.js";
+import {
+  computeGapReport,
+  formatGapReport,
+  formatGapSummary,
+  type GapReport,
+  type GapWindow,
+} from "./gap-report.js";
 
 /**
  * Read the log and derive the report.
@@ -39,4 +48,74 @@ export async function loadGapReport(
   const load = await loadEventLog(paths.log);
   assertLogFullyLoaded(load, paths.log);
   return computeGapReport(load.events, window);
+}
+
+/**
+ * THE FILE THE MORNING STANDUP READS. One fixed, well-known name under the
+ * resolved data dir, beside the log it derives from, so the report travels with
+ * the DATA rather than with the checkout.
+ *
+ * DELIBERATELY UNCHANGED, and not an oversight: it is overwritten every run, with
+ * NO ROTATION AND NO HISTORY. "The standup reads THE file" needs exactly one
+ * well-known name; if you want to know what the report said last Tuesday, it is
+ * gone. Versioning is the blocking half of a history feature, rotation is not — so
+ * the version ships here and rotation is carried forward.
+ */
+export const GAP_REPORT_FILENAME = "gap-report.json";
+
+/**
+ * THE SCHEMA VERSION — enforced by a test, not by a docstring, because readers are
+ * arriving. An integer starting at 1, bumped on any change that would break a
+ * reader (a removed or retyped field; adding a field does not bump it), serialized
+ * as the FIRST key so `head -2` identifies the file before anything parses it.
+ *
+ * THE CONVENTION IS PER FILE, NOT GLOBAL. Each durable sidecar carries its own
+ * counter and moves on its own schedule — a sibling like `job-heartbeat.json` gets
+ * `schemaVersion: 1` of its own rather than sharing or forking this one. Two files
+ * with two lifetimes must not be coupled through a version number.
+ */
+export const GAP_REPORT_SCHEMA_VERSION = 1;
+
+/** The one path: `gap-report.json` beside the durable log in the caller's store. */
+export function gapReportPath(paths: EventStorePaths): string {
+  return join(dirname(paths.log), GAP_REPORT_FILENAME);
+}
+
+/**
+ * Serialize the report and write it. Returns the path written.
+ *
+ * CONTENT IS DATES AND COUNTS ONLY — no NAV, no positions, no prices, no balances,
+ * no magnitudes of any kind. That is what makes this file safe to write beside the
+ * private durable log and safe to paste into a standup, and it is enforced by the
+ * privacy walk in `gap-report-io.test.ts` rather than by inspection: every key is
+ * allowlisted there, so a field nobody has thought of yet fails by default.
+ *
+ * The structured `lost` array and the already-rendered `lines` are BOTH carried.
+ * The duplication is deliberate: the standup can `jq -r '.lines[]'` today without
+ * anything having to agree on a text format, and a later reader can consume the
+ * structure. A test keeps the two in agreement.
+ *
+ * NOT ATOMIC, AND IT DOES NOT CREATE THE DIRECTORY — both accepted. This is a
+ * small single-writer file in a directory that by construction already holds the
+ * event log it was derived from: if the directory is missing there is no log to
+ * report on, and a torn write is repaired by the next run, which is at most a day
+ * away. A temp-file-and-rename would buy nothing this file needs.
+ */
+export async function writeGapReportFile(
+  report: GapReport,
+  options: { path: string; now: Date },
+): Promise<string> {
+  const body = {
+    schemaVersion: GAP_REPORT_SCHEMA_VERSION,
+    generatedAt: options.now.toISOString(),
+    since: report.since,
+    until: report.until,
+    calendarDays: report.calendarDays,
+    anchorsChecked: report.anchorsChecked,
+    lost: report.lost,
+    summary: formatGapSummary(report),
+    lines: formatGapReport(report),
+  };
+  await writeFile(options.path, `${JSON.stringify(body, null, 2)}\n`, "utf8");
+  return options.path;
 }

--- a/packages/event-store/src/gap-report-io.ts
+++ b/packages/event-store/src/gap-report-io.ts
@@ -1,0 +1,42 @@
+/**
+ * The gap report's IO shell — and the ONLY async surface in the whole derivation.
+ *
+ * It does two things and deliberately nothing else: read the durable log, and hand
+ * the events to the pure {@link computeGapReport}. Every decision about what
+ * counts as a mark, where the window starts and where it stops lives in
+ * `gap-report.ts`, which is synchronous and testable with no disk at all.
+ *
+ * IT ACCEPTS RESOLVED PATHS. The caller has already resolved its store — the TUI
+ * from its startup path, the web push from its own — and re-deriving them here
+ * would silently ignore a `NUMISMA_DATA_DIR` the caller had honoured. Passing
+ * {@link EventStorePaths} in is what keeps one store resolution per process.
+ *
+ * IT LOADS NO GENESIS. The backfill's `enumerateAnchors` filters anchors to
+ * `asOf >= genesis.review.asOf`; the window floor here is 2026-07-03, long after
+ * genesis, so that filter is already subsumed by the window itself.
+ */
+import { assertLogFullyLoaded, loadEventLog } from "./event-store.js";
+import type { EventStorePaths } from "./event-store.js";
+import { computeGapReport, type GapReport, type GapWindow } from "./gap-report.js";
+
+/**
+ * Read the log and derive the report.
+ *
+ * REFUSES A PARTIAL LOG, matching `loadFoldedReview`. A quarantined line is a
+ * potential `PriceMarked` this derivation cannot see, and a mark it cannot see is
+ * a day it would call lost — a false positive MANUFACTURED BY THE READER on a day
+ * the feed actually ran. Stopping loud is the only honest option for a detector:
+ * the quarantine sidecar `loadEventLog` has already written names every offending
+ * line.
+ *
+ * A log file that does not exist is NOT an error — it is a window with no anchors,
+ * which is exactly what the report should say about it.
+ */
+export async function loadGapReport(
+  paths: EventStorePaths,
+  window: GapWindow,
+): Promise<GapReport> {
+  const load = await loadEventLog(paths.log);
+  assertLogFullyLoaded(load, paths.log);
+  return computeGapReport(load.events, window);
+}

--- a/packages/event-store/src/gap-report.test.ts
+++ b/packages/event-store/src/gap-report.test.ts
@@ -1,0 +1,310 @@
+/**
+ * The gap report's rule, tested the ONLY way that could have caught `M1`.
+ *
+ * EVERY CASE IS BUILT FROM REAL `PortfolioEvent` ARRAYS AND LETS
+ * `computeGapReport` DO THE COUNTING. Nothing here injects a count, stubs a
+ * per-date number, or hands the function a synthetic `arrived`. That is not a
+ * style preference — it is the property whose absence hid the bug this slice
+ * exists to fix. The prototype's nine tests each injected a synthetic
+ * arrived-count through a `{anchors, arrivedOn}` source pair, so all nine
+ * exercised the RULE and never the NUMBER THE RULE WAS APPLIED TO. Every one of
+ * them passed while the detector was structurally incapable of firing on a
+ * weekend.
+ *
+ * `arrivedUnderOldRule` below is the counterpart of that discipline: a faithful,
+ * test-only re-implementation of the rejected `feedGap.arrived > 0` rule over the
+ * SAME event array. It lets the Saturday case assert the disagreement as a fact
+ * rather than as a comment — the old rule reads 9-arrived and calls a
+ * zero-mark Saturday clean; the new rule calls it lost. If a future edit reverts
+ * the rule, that assertion is what fails.
+ *
+ * All events are synthetic. Instrument ids, amounts and prices are invented for
+ * the shape of the fixture and correspond to no real position.
+ */
+import type { PortfolioEvent } from "@numisma/engine";
+import { describe, expect, it } from "vitest";
+import {
+  LAUNCHD_ERA_START,
+  computeGapReport,
+  dueThrough,
+  formatGapReport,
+  formatGapSummary,
+} from "./gap-report.js";
+
+// ── The synthetic venue split ────────────────────────────────────────────────
+// Nine weekday-venue instruments and four daily ones, mirroring the real feed's
+// 9-equity / 4-crypto shape. The counts are what make the Saturday case bite:
+// under the old rule the nine self-skip onto Friday's marks, so a Saturday that
+// produced NOTHING still reads 9-arrived.
+const WEEKDAY_VENUE = ["eq-a", "eq-b", "eq-c", "eq-d", "eq-e", "eq-f", "eq-g", "eq-h", "eq-i"];
+const DAILY_VENUE = ["cx-a", "cx-b", "cx-c", "cx-d"];
+const ALL_INSTRUMENTS = [...WEEKDAY_VENUE, ...DAILY_VENUE];
+
+/** Real `PriceMarked` events — one per instrument, all carrying `asOf == date`. */
+function marks(date: string, instrumentIds: readonly string[]): PortfolioEvent[] {
+  return instrumentIds.map((instrumentId, index) => ({
+    id: `pm-${instrumentId}-${date}`,
+    asOf: date,
+    type: "PriceMarked",
+    instrumentId,
+    price: 100 + index,
+  }));
+}
+
+/** A full healthy day: every instrument marked. */
+function healthyDay(date: string): PortfolioEvent[] {
+  return marks(date, ALL_INSTRUMENTS);
+}
+
+/** A non-mark event, so a date can be ANCHORED while carrying zero marks. */
+function deposit(date: string, id = `dep-${date}`): PortfolioEvent {
+  return { id, asOf: date, type: "Deposit", reserveId: "cash-core", amount: 500, tier: "c1" };
+}
+
+function positionClosed(date: string, positionId: string): PortfolioEvent {
+  return {
+    id: `close-${positionId}-${date}`,
+    asOf: date,
+    type: "PositionClosed",
+    positionId,
+    settlement: { reserveId: "cash-core", proceeds: 250 },
+  };
+}
+
+// ── The rejected rule, kept executable ───────────────────────────────────────
+
+/** Is this `YYYY-MM-DD` a Saturday or Sunday, read in UTC? */
+function isWeekend(date: string): boolean {
+  const weekday = new Date(`${date}T00:00:00Z`).getUTCDay();
+  return weekday === 0 || weekday === 6;
+}
+
+/**
+ * The old rule's carry-back: a weekday venue's last EXPECTED mark date walks back
+ * over the weekend, so on a Saturday the nine equities are still measured against
+ * FRIDAY. This is `glance.ts`'s `lastExpectedMarkDate`, reduced to its essence.
+ */
+function lastExpectedMarkDate(instrumentId: string, asOf: string): string {
+  if (DAILY_VENUE.includes(instrumentId)) {
+    return asOf;
+  }
+  let cursor = asOf;
+  for (let guard = 0; guard < 10 && isWeekend(cursor); guard += 1) {
+    cursor = new Date(Date.parse(`${cursor}T00:00:00Z`) - 86_400_000).toISOString().slice(0, 10);
+  }
+  return cursor;
+}
+
+/**
+ * `feedGap.arrived` as the prototype computed it: how many instruments are FRESH
+ * against their last expected mark date. Not "how many marks landed on D" — which
+ * is precisely the confusion that made `M1` invisible.
+ */
+function arrivedUnderOldRule(events: readonly PortfolioEvent[], asOf: string): number {
+  const newestMark = new Map<string, string>();
+  for (const event of events) {
+    if (event.type === "PriceMarked" && event.asOf <= asOf) {
+      const seen = newestMark.get(event.instrumentId);
+      if (seen === undefined || event.asOf > seen) {
+        newestMark.set(event.instrumentId, event.asOf);
+      }
+    }
+  }
+  return ALL_INSTRUMENTS.filter((instrumentId) => {
+    const newest = newestMark.get(instrumentId);
+    return newest !== undefined && newest >= lastExpectedMarkDate(instrumentId, asOf);
+  }).length;
+}
+
+// ── Calendar landmarks (verified weekdays) ───────────────────────────────────
+const FRIDAY = "2026-07-10";
+const SATURDAY = "2026-07-11";
+const SUNDAY = "2026-07-12";
+/** Late enough that no window below is clamped by the yesterday ceiling. */
+const LATER = new Date("2026-08-05T12:00:00Z");
+
+describe("computeGapReport — the rule: did a mark land on day D", () => {
+  it("reports 2026-06-30 — a Tuesday anchored by a deposit and two closes, zero marks", () => {
+    // The regression HEAD, #185 and the grill all missed. The day is anchored, so
+    // every `max(as_of)` freshness test calls it present; not one instrument was
+    // marked, so the day is lost.
+    const events: PortfolioEvent[] = [
+      deposit("2026-06-30"),
+      positionClosed("2026-06-30", "pos-one"),
+      positionClosed("2026-06-30", "pos-two"),
+    ];
+    const report = computeGapReport(events, {
+      since: "2026-06-30",
+      until: "2026-06-30",
+      now: LATER,
+    });
+    expect(report.lost).toEqual([{ date: "2026-06-30", reason: "no-marks" }]);
+    expect(report.anchorsChecked).toBe(1);
+  });
+
+  it("reports a Saturday that is anchored and carries zero marks — the case the old rule calls clean", () => {
+    // M1. Friday is fully healthy; Saturday carries a deposit and NOT ONE
+    // `PriceMarked`. The fetch produced nothing that day.
+    const events: PortfolioEvent[] = [...healthyDay(FRIDAY), deposit(SATURDAY)];
+
+    // The old rule, run over these very events: the nine weekday-venue
+    // instruments carry back to Friday, find Friday's marks, and count as
+    // ARRIVED. 9 > 0, so `arrived > 0` returns CLEAN on a day that produced
+    // nothing. This is why a test written on `arrived` cannot fire on a weekend.
+    expect(arrivedUnderOldRule(events, SATURDAY)).toBe(9);
+
+    // The rule this slice ships counts marks LANDING ON the day, so it fires.
+    const report = computeGapReport(events, { since: FRIDAY, until: SATURDAY, now: LATER });
+    expect(report.lost).toEqual([{ date: SATURDAY, reason: "no-marks" }]);
+  });
+
+  it("leaves a Saturday with crypto marks only (4) clean — the weekend must not cry wolf", () => {
+    // 4 is COMPLETE for a Saturday, not degraded: the nine weekday-venue
+    // instruments legitimately do not mark. `marksOn(D) < 13` is not a finding.
+    const events: PortfolioEvent[] = [...healthyDay(FRIDAY), ...marks(SATURDAY, DAILY_VENUE)];
+    const report = computeGapReport(events, { since: FRIDAY, until: SATURDAY, now: LATER });
+    expect(report.lost).toEqual([]);
+    expect(report.anchorsChecked).toBe(2);
+  });
+
+  it("reports a day with no event of any kind as no-anchor", () => {
+    const events: PortfolioEvent[] = [...healthyDay(FRIDAY), ...healthyDay(SUNDAY)];
+    const report = computeGapReport(events, { since: FRIDAY, until: SUNDAY, now: LATER });
+    expect(report.lost).toEqual([{ date: SATURDAY, reason: "no-anchor" }]);
+    // The unanchored day was never an anchor, so it is not counted as one.
+    expect(report.anchorsChecked).toBe(2);
+  });
+
+  it("reports an INTERIOR gap sitting behind a healthy trailing day", () => {
+    // The shape a trailing `max(as_of)` check cannot see — and the one that let
+    // 07-18…07-26 hide for nine days.
+    const events: PortfolioEvent[] = [
+      ...healthyDay("2026-07-13"),
+      deposit("2026-07-14"), // anchored, zero marks
+      // 2026-07-15 carries no event at all
+      ...healthyDay("2026-07-16"),
+    ];
+    const report = computeGapReport(events, {
+      since: "2026-07-13",
+      until: "2026-07-16",
+      now: LATER,
+    });
+    expect(report.lost).toEqual([
+      { date: "2026-07-14", reason: "no-marks" },
+      { date: "2026-07-15", reason: "no-anchor" },
+    ]);
+    // Ascending, and the healthy trailing day is not itself reported.
+    expect(report.lost.map((day) => day.date)).toEqual([...report.lost.map((d) => d.date)].sort());
+  });
+
+  it("does not report a day whose marks are incomplete but non-zero, at any severity", () => {
+    // One Twelve Data symbol failed: twelve of thirteen marks landed. That is one
+    // blank cell, which the existing feed-gap trigger already speaks to — not a
+    // lost day.
+    const events: PortfolioEvent[] = marks(FRIDAY, ALL_INSTRUMENTS.slice(0, 12));
+    const report = computeGapReport(events, { since: FRIDAY, until: FRIDAY, now: LATER });
+    expect(report.lost).toEqual([]);
+  });
+
+  it("returns the window it actually used, and the calendar days in it", () => {
+    const report = computeGapReport(healthyDay(FRIDAY), {
+      since: FRIDAY,
+      until: SUNDAY,
+      now: LATER,
+    });
+    expect(report.since).toBe(FRIDAY);
+    expect(report.until).toBe(SUNDAY);
+    expect(report.calendarDays).toBe(3);
+  });
+
+  it("defaults the floor to LAUNCHD_ERA_START", () => {
+    expect(LAUNCHD_ERA_START).toBe("2026-07-03");
+    const report = computeGapReport(healthyDay(LAUNCHD_ERA_START), {
+      until: LAUNCHD_ERA_START,
+      now: LATER,
+    });
+    expect(report.since).toBe(LAUNCHD_ERA_START);
+  });
+
+  it("is pure: it does not mutate the events it is given, and repeats itself", () => {
+    const events: PortfolioEvent[] = [...healthyDay(FRIDAY), deposit(SATURDAY)];
+    const snapshot = JSON.stringify(events);
+    const window = { since: FRIDAY, until: SATURDAY, now: LATER } as const;
+    expect(computeGapReport(events, window)).toEqual(computeGapReport(events, window));
+    expect(JSON.stringify(events)).toBe(snapshot);
+  });
+
+  it("returns an empty report for an inverted window, and does not throw", () => {
+    const report = computeGapReport(healthyDay(FRIDAY), {
+      since: "2026-07-20",
+      until: "2026-07-05",
+      now: LATER,
+    });
+    expect(report.lost).toEqual([]);
+    expect(report.calendarDays).toBe(0);
+    expect(report.anchorsChecked).toBe(0);
+  });
+});
+
+describe("the ceiling — yesterday in CDMX, at every hour", () => {
+  // CDMX is UTC-6 year-round. 2026-07-12 in CDMX runs 06:00Z that day to 05:59Z
+  // the next; every instant inside it must yield the same ceiling.
+  const CDMX_DAY = "2026-07-12";
+  const YESTERDAY = "2026-07-11";
+  const HOURS: ReadonlyArray<readonly [string, string]> = [
+    ["00:01", "2026-07-12T06:01:00Z"],
+    ["17:59", "2026-07-12T23:59:00Z"],
+    ["18:00:00", "2026-07-13T00:00:00Z"],
+    ["23:59", "2026-07-13T05:59:00Z"],
+  ];
+
+  for (const [label, instant] of HOURS) {
+    it(`yields until = yesterday at ${label} CDMX`, () => {
+      const now = new Date(instant);
+      expect(dueThrough(now)).toBe(YESTERDAY);
+      const report = computeGapReport(healthyDay(YESTERDAY), { since: YESTERDAY, now });
+      expect(report.until).toBe(YESTERDAY);
+    });
+  }
+
+  it("never names today, even when the caller explicitly asks for it", () => {
+    // The prototype flipped the ceiling to TODAY once the clock passed 18:00 and
+    // printed "today — NO DATA … the day is lost" — false until CDMX midnight, and
+    // false during exactly the six-hour recovery window the design exists to use.
+    const now = new Date("2026-07-13T00:30:00Z"); // 18:30 CDMX on 2026-07-12
+    const report = computeGapReport(healthyDay(YESTERDAY), {
+      since: YESTERDAY,
+      until: CDMX_DAY,
+      now,
+    });
+    expect(report.until).toBe(YESTERDAY);
+    expect(report.lost.map((day) => day.date)).not.toContain(CDMX_DAY);
+  });
+});
+
+describe("formatGapReport / formatGapSummary", () => {
+  const window = { since: FRIDAY, until: SUNDAY, now: LATER } as const;
+
+  it("renders nothing and reports no lost days when the window is clean", () => {
+    const report = computeGapReport(
+      [...healthyDay(FRIDAY), ...marks(SATURDAY, DAILY_VENUE), ...marks(SUNDAY, DAILY_VENUE)],
+      window,
+    );
+    expect(formatGapReport(report)).toEqual([]);
+    expect(formatGapSummary(report)).toBe(
+      "Numisma: no lost days in 2026-07-10…2026-07-12 (3 day(s), 3 anchor(s) checked).",
+    );
+  });
+
+  it("renders one line per lost day, distinguishing the two reasons", () => {
+    // Saturday anchored with zero marks; Sunday carries no event at all.
+    const report = computeGapReport([...healthyDay(FRIDAY), deposit(SATURDAY)], window);
+    expect(formatGapReport(report)).toEqual([
+      "Numisma: 2026-07-11 — NO MARKS. The day is anchored but no price mark landed on it; the day is lost.",
+      "Numisma: 2026-07-12 — NO DATA. No event of any kind carries this date; the day is lost.",
+    ]);
+    expect(formatGapSummary(report)).toBe(
+      "Numisma: 2 lost day(s) in 2026-07-10…2026-07-12 (3 day(s), 2 anchor(s) checked).",
+    );
+  });
+});

--- a/packages/event-store/src/gap-report.ts
+++ b/packages/event-store/src/gap-report.ts
@@ -1,0 +1,224 @@
+/**
+ * THE GAP REPORT — a pure, synchronous derivation over the durable log that
+ * answers one question: **which calendar days in the launchd era did the price
+ * feed not run on?**
+ *
+ * IT REPORTS. IT NEVER FILLS. Folding an unanchored day writes a row on which all
+ * thirteen instruments were expected and none arrived: `feedGap` fires, every
+ * header key suppresses, and NAV is permanently blank on a historical row no later
+ * run can repair — a calendar-dense backfill manufactures its own graveyard
+ * (`apps/web/src/push/backfill-core.ts`). This module returns dates and counts,
+ * and writes nothing to the log or the projection.
+ *
+ * ── THE RULE, STATED RATHER THAN INHERITED ────────────────────────────────────
+ * **A `PriceMarked` event whose `asOf == D` is a mark landing on D.** That is the
+ * whole rule, and it is written here rather than borrowed because nobody has
+ * enumerated whether another event type should also count. It is a choice; the
+ * next reader deserves to see that it was made. (`InvalidationMarked` is the one
+ * verb whose NAME invites inclusion — it is latest-wins per position exactly as
+ * `PriceMarked` is per instrument — but it records an operator's decision, not a
+ * feed observation, so counting it would let a day look alive because someone
+ * moved a stop. It is deliberately not a mark.)
+ *
+ * **IT IS NOT `feedGap.arrived`.** That metric is *nearby* and answers a different
+ * question, and mistaking one for the other is the defect this module was rewritten
+ * to remove. `arrived` counts instruments FRESH AGAINST THEIR LAST EXPECTED MARK
+ * DATE, and for a weekday venue that expectation walks back over the weekend — so
+ * on a Saturday the nine equities count as arrived off FRIDAY's marks. A weekend on
+ * which the fetch produced nothing folds to 9, never 0. Measured against the real
+ * log, every weekend from mid-July on folds 13/13 while producing 4 marks. **A
+ * detector written on `arrived > 0` cannot fire on a weekend at all** — see
+ * `arrivedUnderOldRule` in the test suite, which keeps that disagreement executable.
+ *
+ * Two verdicts, and only two:
+ *
+ *   `no-anchor`  no event of any kind carries this `asOf`.
+ *   `no-marks`   an anchor exists, but zero `PriceMarked` events carry it. The day
+ *                has SOME event — a fill, a deposit — so it is "fresh" to any
+ *                `max(as_of)` test, while not one instrument was marked.
+ *
+ * **`marksOn(D) < 13` IS NOT REPORTED, AT ANY SEVERITY.** A Saturday's 4 is
+ * complete, not degraded, and one failed Twelve Data symbol is one blank cell that
+ * the existing `feedGap` trigger already speaks to. *Day lost* is permanent; *one
+ * instrument missing* is not.
+ *
+ * INTERIOR GAPS ARE THE POINT. A trailing `max(as_of)` check is exactly what let
+ * 07-18…07-26 hide until a human noticed nine days later. Walking the whole window
+ * catches a single lost Thursday sitting behind a healthy Friday.
+ *
+ * ── WHERE IT LIVES ────────────────────────────────────────────────────────────
+ * `@numisma/event-store`, and that is determined rather than chosen. Every input
+ * sits on an existing edge — the log loader and store-path resolver from this
+ * package, `PortfolioEvent` and `tradingDayAsOf` from `@numisma/engine`, which this
+ * package already depends on. No new package edge in either direction, and both
+ * consumers (`apps/web`, `apps/tui`) already declare it. `@numisma/engine` is not
+ * an alternative: ADR-001 keeps file IO out of it by name, and this is derived from
+ * the log. The prototype's `apps/tui → apps/web` reach through a computed specifier
+ * — untypechecked by construction — is what this placement retires.
+ *
+ * The prototype's injected `{anchors, arrivedOn}` source pair is RETIRED. Over two
+ * independent async folds it was a real seam with two adapters; over one
+ * synchronous pass it is indirection with a single adapter — and it is what let
+ * nine tests inject synthetic counts and never exercise the number the rule was
+ * applied to.
+ */
+import { addDays, tradingDayAsOf, type PortfolioEvent } from "@numisma/engine";
+
+/**
+ * THE FLOOR. 2026-07-03 is the day the daily launchd scheduler landed
+ * (`ops/price-feed`, #108/#109) and the first date from which the log is
+ * calendar-dense. Before it, a missing day is an artifact of there being no job;
+ * from it onward a missing day IS the failure this report exists to name. Dated
+ * and hardcoded on purpose: moving the floor must be a visible edit.
+ *
+ * REJECTED — a genesis / first-anchor floor (walk everything the log holds). The
+ * log's first week is hand-run: its anchors are `06-26, 06-28, 06-30, 07-03 …`, so
+ * 06-27 / 06-29 / 07-01 / 07-02 would be reported as lost on every run, forever,
+ * with no possible remedy — a missed day is permanently unmarkable after CDMX
+ * midnight. A detector that opens with four unfixable findings trains you to skim
+ * it, which is precisely the failure #185 was filed about.
+ *
+ * REJECTED — deriving the floor as "the day after the last gap". It is
+ * SELF-ERASING: every new gap advances the floor past itself and the report goes
+ * quiet exactly when it should shout. **A detector must not be a function of its
+ * own findings.**
+ */
+export const LAUNCHD_ERA_START = "2026-07-03";
+
+/**
+ * The timezone the trading day — and therefore "yesterday" — is anchored to. A
+ * BARE STRING, not a `MarkClock`: with the ceiling pinned to yesterday at every
+ * hour (below), the mark-TIME check drops out of this derivation entirely, so the
+ * only thing left to duplicate is the zone. It matches `apps/price-feed`'s
+ * `DEFAULT_CONFIG.timeZone`; this package does not depend on that app and will not
+ * grow an edge to read one constant.
+ */
+export const REPORT_TIME_ZONE = "America/Mexico_City";
+
+/** Why a day is lost. Both are "day lost"; they differ in what the log holds. */
+export type LostDayReason =
+  /** No event of any kind carries this `asOf`. */
+  | "no-anchor"
+  /** An anchor exists, but zero `PriceMarked` events carry this `asOf`. */
+  | "no-marks";
+
+export interface LostDay {
+  date: string;
+  reason: LostDayReason;
+}
+
+export interface GapReport {
+  /** Inclusive window floor actually used. */
+  since: string;
+  /** Inclusive window ceiling actually used — never today. */
+  until: string;
+  /** Calendar days in `[since, until]`. Zero when the window is inverted. */
+  calendarDays: number;
+  /** Anchored days that fell inside the window. */
+  anchorsChecked: number;
+  /** Ascending. Empty means every day in the window carried a mark. */
+  lost: LostDay[];
+}
+
+/**
+ * The window to inspect. `now` is REQUIRED and `since`/`until` are optional
+ * overrides — which is what keeps {@link computeGapReport} a pure function of its
+ * arguments: it reads no clock of its own, so the only surface that can produce a
+ * different answer on a different day is the caller.
+ */
+export interface GapWindow {
+  /** Inclusive floor. Defaults to {@link LAUNCHD_ERA_START}. */
+  since?: string | undefined;
+  /** Inclusive ceiling. Clamped to {@link dueThrough} — never today. */
+  until?: string | undefined;
+  /** The instant "yesterday" is measured from. */
+  now: Date;
+}
+
+/**
+ * THE CEILING: **yesterday in CDMX, at every hour of the day.** The report never
+ * names today.
+ *
+ * The prototype flipped the ceiling to TODAY once the clock passed the 18:00 CDMX
+ * mark time and then printed, verbatim, *"today — NO DATA … the day is lost."*
+ * That is false until CDMX midnight, and it is false during exactly the six-hour
+ * window the design exists to exploit — one run on record completed at 20:56. A
+ * liveness detector that cries about a day still in progress is the same
+ * skim-inducing false positive the genesis floor was rejected for.
+ */
+export function dueThrough(now: Date, timeZone: string = REPORT_TIME_ZONE): string {
+  return addDays(tradingDayAsOf(now, timeZone), -1);
+}
+
+/**
+ * Name the lost days in the window. Synchronous, pure, and ONE PASS over the
+ * events: the anchor set and the per-date mark counts are built together, because
+ * they are two readings of the same scan.
+ *
+ * An anchor is ANY event's `asOf` — matching how the backfill enumerates them.
+ * (The backfill additionally filters to `asOf >= genesis`; here the window floor
+ * is 2026-07-03, long after genesis, so that filter is already subsumed and no
+ * genesis load is needed. That is what lets the core be pure.)
+ */
+export function computeGapReport(
+  events: readonly PortfolioEvent[],
+  window: GapWindow,
+): GapReport {
+  const since = window.since ?? LAUNCHD_ERA_START;
+  const ceiling = dueThrough(window.now);
+  // Clamped, not merely defaulted: "the report never names today" is then a
+  // property of this function rather than of every caller's care.
+  const until =
+    window.until === undefined || window.until > ceiling ? ceiling : window.until;
+
+  const anchored = new Set<string>();
+  const marksOn = new Map<string, number>();
+  for (const event of events) {
+    const { asOf } = event;
+    if (asOf < since || asOf > until) {
+      continue;
+    }
+    anchored.add(asOf);
+    if (event.type === "PriceMarked") {
+      marksOn.set(asOf, (marksOn.get(asOf) ?? 0) + 1);
+    }
+  }
+
+  const lost: LostDay[] = [];
+  let calendarDays = 0;
+  let anchorsChecked = 0;
+  // Ascending by construction — the walk IS the sort.
+  for (let date = since; date <= until; date = addDays(date, 1)) {
+    calendarDays += 1;
+    if (!anchored.has(date)) {
+      lost.push({ date, reason: "no-anchor" });
+      continue;
+    }
+    anchorsChecked += 1;
+    // Zero marks, not "fewer than thirteen". See the header.
+    if ((marksOn.get(date) ?? 0) === 0) {
+      lost.push({ date, reason: "no-marks" });
+    }
+  }
+
+  return { since, until, calendarDays, anchorsChecked, lost };
+}
+
+/** One line per lost day. EMPTY when the window is clean — the caller stays quiet. */
+export function formatGapReport(report: GapReport): string[] {
+  return report.lost.map(({ date, reason }) =>
+    reason === "no-anchor"
+      ? `Numisma: ${date} — NO DATA. No event of any kind carries this date; the day is lost.`
+      : `Numisma: ${date} — NO MARKS. The day is anchored but no price mark landed on it; the day is lost.`,
+  );
+}
+
+/** The always-printed one-liner: what was checked, and the verdict. */
+export function formatGapSummary(report: GapReport): string {
+  const scope =
+    `${report.since}…${report.until} ` +
+    `(${report.calendarDays} day(s), ${report.anchorsChecked} anchor(s) checked)`;
+  return report.lost.length === 0
+    ? `Numisma: no lost days in ${scope}.`
+    : `Numisma: ${report.lost.length} lost day(s) in ${scope}.`;
+}

--- a/packages/event-store/src/heartbeat-io.ts
+++ b/packages/event-store/src/heartbeat-io.ts
@@ -1,0 +1,55 @@
+/**
+ * The heartbeat's IO shell — the read half only. **Nothing here writes it:** the
+ * writer is a `printf` from an `EXIT` trap in `ops/price-feed/run-daily-fetch.sh`,
+ * pure bash on purpose, because the case that justifies the whole design is
+ * exit 127 — `pnpm` or `node` unresolvable — in which nothing that needs node can
+ * run at all. A writer in this package could not record its own most important case.
+ *
+ * Mirrors `gap-report-io.ts`: the verdict is pure and lives in `heartbeat.ts`; this
+ * is the file read, and it accepts resolved {@link EventStorePaths} so the caller's
+ * store resolution is honoured rather than re-derived.
+ */
+import { readFile } from "node:fs/promises";
+import { dirname, join } from "node:path";
+import type { EventStorePaths } from "./event-store.js";
+import {
+  HEARTBEAT_FILENAME,
+  formatHeartbeatWarning,
+  parseHeartbeat,
+  type JobHeartbeat,
+} from "./heartbeat.js";
+
+/** `job-heartbeat.json`, beside `gap-report.json` and the log it accompanies. */
+export function heartbeatPath(paths: EventStorePaths): string {
+  return join(dirname(paths.log), HEARTBEAT_FILENAME);
+}
+
+/**
+ * Read and parse the breadcrumb, or `undefined` when there is none to read.
+ *
+ * AN ABSENT FILE IS NOT AN ERROR — it is the normal state of a machine that never
+ * hosted the job. Neither is an unreadable one: a file being written by a trap on a
+ * failing machine can legitimately be caught half-written, so every IO and parse
+ * failure alike resolves to `undefined`. This function cannot reject.
+ */
+export async function loadHeartbeat(
+  paths: EventStorePaths,
+): Promise<JobHeartbeat | undefined> {
+  try {
+    return parseHeartbeat(await readFile(heartbeatPath(paths), "utf8"));
+  } catch {
+    return undefined;
+  }
+}
+
+/**
+ * The lines the TUI prints, if any. Empty when the last run was healthy, when the
+ * file is absent, and when it cannot be read — see `heartbeat.ts` on why those
+ * three are deliberately the same answer.
+ */
+export async function loadHeartbeatLines(
+  paths: EventStorePaths,
+  now: Date,
+): Promise<string[]> {
+  return formatHeartbeatWarning(await loadHeartbeat(paths), now);
+}

--- a/packages/event-store/src/heartbeat.test.ts
+++ b/packages/event-store/src/heartbeat.test.ts
@@ -1,0 +1,299 @@
+/**
+ * The job heartbeat's reader — the half of #191 that CAN be tested.
+ *
+ * The writer is five lines of bash in `ops/price-feed/run-daily-fetch.sh` and the
+ * repo has no shell-test infrastructure; this slice deliberately does not invent
+ * one. The mitigation is to keep the bash to a trap and a `printf` and to test
+ * everything downstream of it exhaustively — so these fixtures are written in the
+ * EXACT byte shape that `printf` emits, not in a shape convenient for the parser.
+ * If the two ever disagree, that is the bug this file exists to catch.
+ *
+ * Dates, step names and exit codes only. No figures of any kind — the same privacy
+ * property `gap-report.json` carries, for the same reason.
+ */
+import { mkdtemp, rm, writeFile } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { addDays, tradingDayAsOf } from "@numisma/engine";
+import { afterEach, describe, expect, it } from "vitest";
+import { resolveEventStorePaths } from "./event-store.js";
+import {
+  HEARTBEAT_FILENAME,
+  HEARTBEAT_SCHEMA_VERSION,
+  formatHeartbeatWarning,
+  parseHeartbeat,
+} from "./heartbeat.js";
+import { heartbeatPath, loadHeartbeatLines } from "./heartbeat-io.js";
+import { REPORT_TIME_ZONE, dueThrough } from "./gap-report.js";
+
+const created: string[] = [];
+
+afterEach(async () => {
+  await Promise.all(created.map((dir) => rm(dir, { recursive: true, force: true })));
+  created.length = 0;
+});
+
+/**
+ * Byte-for-byte what the wrapper's `printf` writes — same key order, same
+ * two-space indent, same trailing newline.
+ */
+function heartbeatFileBody(fields: {
+  startedAt: string;
+  finishedAt: string;
+  exitCode: number;
+  lastStep: string;
+  schemaVersion?: number;
+}): string {
+  return (
+    `{\n` +
+    `  "schemaVersion": ${fields.schemaVersion ?? 1},\n` +
+    `  "startedAt": "${fields.startedAt}",\n` +
+    `  "finishedAt": "${fields.finishedAt}",\n` +
+    `  "exitCode": ${fields.exitCode},\n` +
+    `  "lastStep": "${fields.lastStep}"\n` +
+    `}\n`
+  );
+}
+
+async function storeWithHeartbeat(raw: string | undefined) {
+  const dataDir = await mkdtemp(join(tmpdir(), "numisma-heartbeat-"));
+  created.push(dataDir);
+  const paths = resolveEventStorePaths(dataDir);
+  if (raw !== undefined) {
+    await writeFile(heartbeatPath(paths), raw, "utf8");
+  }
+  return { dataDir, paths };
+}
+
+// 06:00 CDMX on 2026-08-05 → the gap report's ceiling is 2026-08-04.
+const NOW = new Date("2026-08-05T12:00:00Z");
+const CEILING = "2026-08-04";
+
+/**
+ * A run that fired at the 18:00 CDMX mark time on the given CDMX day.
+ *
+ * THE UTC OFFSET IS THE POINT, not incidental bookkeeping. CDMX is UTC-6, so an
+ * 18:05 finish on day D is `D+1T00:05:00Z` — the instant is stamped with
+ * TOMORROW's UTC date. A fixture that wrote `D T00:05:00Z` would be describing the
+ * PREVIOUS CDMX evening, which is precisely the off-by-one this whole increment
+ * exists to prevent. (This helper was wrong in exactly that way on first writing,
+ * and the reader caught it.)
+ */
+function ranOn(day: string, exitCode = 0, lastStep = "complete"): string {
+  const nextUtcDay = addDays(day, 1);
+  return heartbeatFileBody({
+    startedAt: `${nextUtcDay}T00:00:00Z`, // 18:00 CDMX on `day`
+    finishedAt: `${nextUtcDay}T00:05:00Z`, // 18:05 CDMX on `day`
+    exitCode,
+    lastStep,
+  });
+}
+
+describe("the heartbeat shares the gap report's ceiling", () => {
+  it("uses dueThrough, not a second staleness number of its own", () => {
+    // One window rule for the whole increment. A second, independently-derived
+    // threshold would drift against the first the moment either moved.
+    expect(dueThrough(NOW)).toBe(CEILING);
+    // A run ON the ceiling is current; the day before it is not. That boundary IS
+    // `dueThrough`, so moving the ceiling moves this with it.
+    expect(formatHeartbeatWarning(parseHeartbeat(ranOn(CEILING)), NOW)).toEqual([]);
+    expect(formatHeartbeatWarning(parseHeartbeat(ranOn("2026-08-03")), NOW)).not.toEqual([]);
+  });
+
+  it("credits a run to its CDMX day, not to the UTC date on the instant", () => {
+    // The 18:00 CDMX job finishes stamped with TOMORROW's UTC date. Reading that
+    // stamp literally would call every single healthy run a day stale — the same
+    // local-vs-UTC off-by-one the gap report's own docstring names.
+    const finishedAt = "2026-08-05T00:05:00Z"; // 18:05 CDMX on 2026-08-04
+    const parsed = parseHeartbeat(
+      heartbeatFileBody({ startedAt: finishedAt, finishedAt, exitCode: 0, lastStep: "complete" }),
+    );
+    expect(formatHeartbeatWarning(parsed, NOW)).toEqual([]);
+  });
+
+  it("A RUN RECORDED TODAY STAYS SILENT — the regression the future check could introduce", () => {
+    // THE everyday healthy case, and the one this whole increment has been guarding
+    // against getting wrong: the job runs at 18:00 CDMX and the TUI is opened at
+    // 20:00 the SAME day. That run is already past the ceiling (which is yesterday),
+    // so a "future" check measured against the ceiling instead of against today
+    // would fire on the most normal event there is — cry-wolf, rebuilt.
+    const tuiOpenedAt2000 = new Date("2026-08-06T02:00:00Z"); // 20:00 CDMX on 2026-08-05
+    expect(tradingDayAsOf(tuiOpenedAt2000, REPORT_TIME_ZONE)).toBe("2026-08-05");
+    expect(dueThrough(tuiOpenedAt2000)).toBe("2026-08-04"); // the ceiling is BEHIND the run
+    expect(
+      formatHeartbeatWarning(parseHeartbeat(ranOn("2026-08-05", 0, "complete")), tuiOpenedAt2000),
+    ).toEqual([]);
+  });
+
+  it("never calls a job stale for not having run today", () => {
+    // The ceiling is yesterday at every hour, so the day still in progress is never
+    // held against the job — the same reason the gap report never names today.
+    const lateToday = new Date("2026-08-06T05:59:00Z"); // 23:59 CDMX on 2026-08-05
+    expect(dueThrough(lateToday)).toBe("2026-08-04");
+    // A run earlier TODAY (2026-08-05) is ahead of the ceiling, so it is not stale
+    // even one minute before CDMX midnight.
+    expect(formatHeartbeatWarning(parseHeartbeat(ranOn("2026-08-05")), lateToday)).toEqual([]);
+  });
+});
+
+describe("formatHeartbeatWarning — the six cases", () => {
+  it("1. GREEN RUN: a clean run on the ceiling day says nothing", () => {
+    expect(formatHeartbeatWarning(parseHeartbeat(ranOn(CEILING, 0, "complete")), NOW)).toEqual([]);
+  });
+
+  it("2. RED RUN: a non-zero exit speaks, naming the step and the code", () => {
+    // The case the whole slice exists for: launchd recorded this exit code and
+    // pushed it to nobody.
+    expect(
+      formatHeartbeatWarning(parseHeartbeat(ranOn(CEILING, 127, "resolve-tools")), NOW),
+    ).toEqual([
+      "Numisma: the daily price job FAILED on 2026-08-04 — exit 127 at step 'resolve-tools'. " +
+        "Nothing pushed this to you; that is why it is here.",
+    ]);
+  });
+
+  it("3. STALE RUN: a clean run that predates the ceiling speaks", () => {
+    expect(formatHeartbeatWarning(parseHeartbeat(ranOn("2026-08-02")), NOW)).toEqual([
+      "Numisma: the daily price job has not completed since 2026-08-02 — nothing recorded for 2026-08-04.",
+    ]);
+  });
+
+  it("4. ABSENT FILE: says nothing at all", () => {
+    // A machine that never hosted the job, or a fresh checkout, must not speak on
+    // every startup. Safe because the gap report is the backstop: if the job has
+    // genuinely stopped, the marks stop landing and IT speaks.
+    expect(formatHeartbeatWarning(undefined, NOW)).toEqual([]);
+    expect(parseHeartbeat(undefined)).toBeUndefined();
+  });
+
+  it("5. MALFORMED FILE: treated as absent, never a throw", () => {
+    // The TUI startup path must not die on a bad breadcrumb.
+    for (const bad of [
+      "",
+      "   ",
+      "not json at all",
+      "{",
+      '{\n  "schemaVersion": 1,\n  "startedAt": "2026-08-04T00:0', // truncated mid-write
+      "[]",
+      "null",
+      '{"schemaVersion": 1}',
+      '{"schemaVersion": 1, "startedAt": "nope", "finishedAt": "nope", "exitCode": 0, "lastStep": "x"}',
+      '{"schemaVersion": 1, "startedAt": "2026-08-04T00:00:00Z", "finishedAt": "2026-08-04T00:00:00Z", "exitCode": "zero", "lastStep": "x"}',
+    ]) {
+      expect(() => parseHeartbeat(bad)).not.toThrow();
+      expect(parseHeartbeat(bad), `should be unreadable: ${JSON.stringify(bad)}`).toBeUndefined();
+      expect(formatHeartbeatWarning(parseHeartbeat(bad), NOW)).toEqual([]);
+    }
+  });
+
+  it("6. FUTURE-DATED FILE: speaks, because a breadcrumb it can see is impossible cannot be trusted", () => {
+    // A heartbeat stamped ahead of the present is not a healthy run — a clock is
+    // wrong, the file was hand-edited, or something wrote it that had no business
+    // doing so. In every one of those cases the heartbeat's OTHER verdicts become
+    // untrustworthy, including the staleness comparison. Staying quiet about it
+    // would be guaranteeing correctness by inspection.
+    expect(formatHeartbeatWarning(parseHeartbeat(ranOn("2027-01-01")), NOW)).toEqual([
+      "Numisma: the daily price job's last run is dated 2027-01-01, ahead of today " +
+        "(2026-08-05) — the machine clock or job-heartbeat.json is wrong, so nothing " +
+        "else this breadcrumb says can be trusted.",
+    ]);
+  });
+
+  it("6b. a FAILED future-dated run says BOTH things", () => {
+    const lines = formatHeartbeatWarning(parseHeartbeat(ranOn("2027-01-01", 1, "spine")), NOW);
+    expect(lines).toHaveLength(2);
+    expect(lines[0]).toContain("FAILED on 2027-01-01 — exit 1 at step 'spine'");
+    expect(lines[1]).toContain("ahead of today");
+    // Never also "stale": a run ahead of today cannot be behind the ceiling.
+    expect(lines.some((line) => line.includes("has not completed since"))).toBe(false);
+  });
+
+  it("says BOTH things when a run is stale and failed", () => {
+    const lines = formatHeartbeatWarning(parseHeartbeat(ranOn("2026-08-01", 1, "commit")), NOW);
+    expect(lines).toHaveLength(2);
+    expect(lines[0]).toContain("FAILED");
+    expect(lines[1]).toContain("has not completed since");
+  });
+
+  it("ignores a schemaVersion it does not understand rather than misreading it", () => {
+    // #189's convention: the version is bumped only when the shape changes in a way
+    // that breaks a reader. Refusing an unknown one is what makes that promise safe.
+    expect(HEARTBEAT_SCHEMA_VERSION).toBe(1);
+    const future = heartbeatFileBody({
+      startedAt: "2026-08-01T00:00:00Z",
+      finishedAt: "2026-08-01T00:05:00Z",
+      exitCode: 1,
+      lastStep: "spine",
+      schemaVersion: 2,
+    });
+    expect(parseHeartbeat(future)).toBeUndefined();
+    expect(formatHeartbeatWarning(parseHeartbeat(future), NOW)).toEqual([]);
+  });
+});
+
+describe("parseHeartbeat — over the writer's exact bytes", () => {
+  it("reads the shape the wrapper's printf emits", () => {
+    const parsed = parseHeartbeat(
+      heartbeatFileBody({
+        startedAt: "2026-08-04T23:00:00Z",
+        finishedAt: "2026-08-04T23:00:41Z",
+        exitCode: 0,
+        lastStep: "complete",
+      }),
+    );
+    expect(parsed).toEqual({
+      schemaVersion: 1,
+      startedAt: "2026-08-04T23:00:00Z",
+      finishedAt: "2026-08-04T23:00:41Z",
+      exitCode: 0,
+      lastStep: "complete",
+    });
+  });
+
+  it("carries dates, a step name and an exit code — and nothing else", () => {
+    // The privacy property, in the shape #189 established: an unknown key means a
+    // field nobody classified, so the parse drops it rather than passing it on.
+    const parsed = parseHeartbeat(
+      '{"schemaVersion":1,"startedAt":"2026-08-04T00:00:00Z","finishedAt":"2026-08-04T00:01:00Z",' +
+        '"exitCode":0,"lastStep":"complete","navUsd":12345.67}',
+    );
+    expect(Object.keys(parsed ?? {}).sort()).toEqual([
+      "exitCode",
+      "finishedAt",
+      "lastStep",
+      "schemaVersion",
+      "startedAt",
+    ]);
+    expect(JSON.stringify(parsed)).not.toContain("12345");
+  });
+});
+
+describe("loadHeartbeatLines — the IO shell", () => {
+  it("names the file beside the gap report in the data dir", async () => {
+    const { dataDir, paths } = await storeWithHeartbeat(undefined);
+    expect(HEARTBEAT_FILENAME).toBe("job-heartbeat.json");
+    expect(heartbeatPath(paths)).toBe(join(dataDir, "job-heartbeat.json"));
+  });
+
+  it("is silent when the file is absent", async () => {
+    const { paths } = await storeWithHeartbeat(undefined);
+    expect(await loadHeartbeatLines(paths, NOW)).toEqual([]);
+  });
+
+  it("speaks for a failed run recorded on disk", async () => {
+    const { paths } = await storeWithHeartbeat(ranOn(CEILING, 127, "resolve-tools"));
+    const lines = await loadHeartbeatLines(paths, NOW);
+    expect(lines).toHaveLength(1);
+    expect(lines[0]).toContain("exit 127");
+  });
+
+  it("is silent for a healthy run recorded on disk", async () => {
+    const { paths } = await storeWithHeartbeat(ranOn(CEILING));
+    expect(await loadHeartbeatLines(paths, NOW)).toEqual([]);
+  });
+
+  it("never throws on a truncated file — a half-written breadcrumb is not fatal", async () => {
+    const { paths } = await storeWithHeartbeat('{\n  "schemaVersion": 1,\n  "started');
+    await expect(loadHeartbeatLines(paths, NOW)).resolves.toEqual([]);
+  });
+});

--- a/packages/event-store/src/heartbeat.test.ts
+++ b/packages/event-store/src/heartbeat.test.ts
@@ -250,6 +250,51 @@ describe("parseHeartbeat — over the writer's exact bytes", () => {
     });
   });
 
+  it("rejects a date-only finishedAt, which Date.parse would accept as UTC midnight", () => {
+    // `"2026-08-05"` parses; read through tradingDayAsOf in CDMX it lands on
+    // 2026-08-04, so a job that completed normally would be reported as not having
+    // completed since the day before. Unreadable is the honest answer, and the
+    // reader treats it exactly like an absent file.
+    expect(
+      parseHeartbeat(
+        heartbeatFileBody({
+          startedAt: "2026-08-04",
+          finishedAt: "2026-08-05",
+          exitCode: 0,
+          lastStep: "complete",
+        }),
+      ),
+    ).toBeUndefined();
+    // Nor a bare time, nor an instant with no zone at all.
+    expect(
+      parseHeartbeat(
+        heartbeatFileBody({
+          startedAt: "2026-08-04T23:00:00Z",
+          finishedAt: "2026-08-04T23:00:41",
+          exitCode: 0,
+          lastStep: "complete",
+        }),
+      ),
+    ).toBeUndefined();
+  });
+
+  it("accepts the offset and fractional-second forms an ISO instant may take", () => {
+    // The tightening is to the WRITTEN CONTRACT — an ISO instant — not to the one
+    // wrapper's exact bytes. A conforming writer must not be refused.
+    for (const finishedAt of ["2026-08-04T23:00:41.250Z", "2026-08-04T17:00:41-06:00"]) {
+      expect(
+        parseHeartbeat(
+          heartbeatFileBody({
+            startedAt: "2026-08-04T23:00:00Z",
+            finishedAt,
+            exitCode: 0,
+            lastStep: "complete",
+          }),
+        )?.finishedAt,
+      ).toBe(finishedAt);
+    }
+  });
+
   it("carries dates, a step name and an exit code — and nothing else", () => {
     // The privacy property, in the shape #189 established: an unknown key means a
     // field nobody classified, so the parse drops it rather than passing it on.

--- a/packages/event-store/src/heartbeat.ts
+++ b/packages/event-store/src/heartbeat.ts
@@ -84,8 +84,21 @@ export interface JobHeartbeat {
   lastStep: string;
 }
 
+/**
+ * An ISO INSTANT — a date AND a time AND a zone — not merely something `Date` will
+ * parse. The distinction is load-bearing: `Date.parse("2026-08-05")` succeeds as UTC
+ * midnight, and {@link formatHeartbeatWarning} then reads that through
+ * `tradingDayAsOf(…, CDMX)`, which credits it to the PREVIOUS day and emits a false
+ * "has not completed since" for a job that finished normally. The wrapper's `printf`
+ * cannot emit that shape, so the reach is a hand-edited or foreign-written file —
+ * the same case this module already reasons about for its future-dated trigger.
+ */
 function isIsoInstant(value: unknown): value is string {
-  return typeof value === "string" && !Number.isNaN(Date.parse(value));
+  return (
+    typeof value === "string" &&
+    /^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}(\.\d+)?(Z|[+-]\d{2}:\d{2})$/.test(value) &&
+    !Number.isNaN(Date.parse(value))
+  );
 }
 
 /**

--- a/packages/event-store/src/heartbeat.ts
+++ b/packages/event-store/src/heartbeat.ts
@@ -1,0 +1,182 @@
+/**
+ * THE JOB HEARTBEAT — the one fact the durable log cannot contain.
+ *
+ * The gap report is a pure function of the log, deliberately: that is what lets it
+ * be computed wherever it is asked, and what stops it depending on the thing whose
+ * failure it detects. The price of that purity is exact — **a run that fired and
+ * died leaves the same evidence as a machine that was switched off**, and a run
+ * that fetched cleanly and then failed at a later step leaves no evidence at all.
+ * `ops/price-feed/run-daily-fetch.sh` writes this breadcrumb from an `EXIT` trap
+ * so those two cases stop looking identical.
+ *
+ * IT REPAIRS A GUARD THAT IS ALREADY INSTALLED AND ALREADY MUTE. The wrapper's
+ * post-check ends in an `exit 1` to protect the durable log against a repeat of the
+ * 17-day silent miss (#132). Measured: launchd RECORDS that exit code and
+ * `launchctl print` will show it on request, but nothing is PUSHED — no
+ * notification, no badge. So the guard is decorative today. This reader is what
+ * converts an exit code shown to nobody into a line on a surface opened daily.
+ *
+ * ── THE VERDICT: THREE TRIGGERS, ONE CLOCK ────────────────────────────────────
+ * It speaks when the last run exited NON-ZERO, when the last run PREDATES the gap
+ * report's ceiling, or when the last run is dated AFTER TODAY.
+ *
+ * The staleness ceiling is `dueThrough`, imported — **not a second staleness
+ * number.** One window rule for the whole increment: a second, independently-derived
+ * threshold would drift against the first the moment either one moved, and the
+ * reader would start disagreeing with the report beside it.
+ *
+ * THE THIRD TRIGGER IS MEASURED AGAINST TODAY, NOT AGAINST THE CEILING, and the
+ * difference is the whole care in it. The ceiling is YESTERDAY, so a job that ran at
+ * 18:00 today and a TUI opened at 20:00 today describe the everyday healthy case —
+ * a run already past the ceiling. Calling that "ahead of the window" would fire on
+ * the most normal event there is, which is precisely the cry-wolf failure the floor
+ * and the ceiling decisions were each chosen to avoid. Future means the run's CDMX
+ * trading day is later than TODAY'S: one more comparison off the same clock read
+ * and the same CDMX-day crediting, not a new rule.
+ *
+ * A breadcrumb dated ahead of the present is not a healthy run — a clock is wrong,
+ * the file was hand-edited, or something wrote it that had no business doing so. In
+ * every one of those cases the heartbeat's OTHER verdicts become untrustworthy,
+ * including the staleness comparison. A reader that silently trusts a file it can
+ * see is impossible is guaranteeing its correctness by inspection, which is the one
+ * thing this increment exists to stop doing.
+ *
+ * ── SILENCE WHEN ABSENT, AND WHY THAT LOSES NOTHING ───────────────────────────
+ * A TUI on a machine that never hosted the job — or a fresh checkout — must not
+ * speak on every startup. That is the cry-wolf failure the floor and the ceiling
+ * decisions each already rejected; this is the third place it would have appeared.
+ * It is safe because the gap report is the backstop: if the job has genuinely
+ * stopped, the marks stop landing and the gap report speaks.
+ *
+ * NOT FOLDED INTO `gap-report.json`. Two writers, two languages, two lifetimes —
+ * one written by bash on every run, the other by a TypeScript CLI on demand. The
+ * standup reads both files; that is cheaper than a shared format neither owner
+ * fully controls. Following #189's convention rather than sharing its counter, this
+ * file carries a `schemaVersion` OF ITS OWN.
+ */
+import { tradingDayAsOf } from "@numisma/engine";
+import { REPORT_TIME_ZONE, dueThrough } from "./gap-report.js";
+
+export const HEARTBEAT_FILENAME = "job-heartbeat.json";
+
+/**
+ * This file's OWN schema counter — #189's convention, not #189's number. An integer
+ * starting at 1, serialized as the first key, bumped only on a change that would
+ * break a reader (a removed or retyped field; adding one does not bump it). Two
+ * sidecars with two writers and two lifetimes must not be coupled through a shared
+ * version, so `gap-report.json` moves on its schedule and this moves on its own.
+ *
+ * A version this reader does not recognise is treated as UNREADABLE rather than
+ * guessed at — refusing an unknown shape is what makes the bump rule safe to rely on.
+ */
+export const HEARTBEAT_SCHEMA_VERSION = 1;
+
+/** What the wrapper's `printf` records. Dates, a step name and an exit code. */
+export interface JobHeartbeat {
+  schemaVersion: number;
+  /** ISO instant the run began. */
+  startedAt: string;
+  /** ISO instant the `EXIT` trap fired. */
+  finishedAt: string;
+  /** The run's exit status — 0, the step-1/post-check 1, or 127 for no node. */
+  exitCode: number;
+  /** How far the run got: `startup`, `resolve-tools`, `prices-fetch`, … */
+  lastStep: string;
+}
+
+function isIsoInstant(value: unknown): value is string {
+  return typeof value === "string" && !Number.isNaN(Date.parse(value));
+}
+
+/**
+ * Read the breadcrumb. **NEVER THROWS** — anything unreadable is `undefined`, which
+ * the verdict treats exactly like an absent file.
+ *
+ * That is not defensive habit, it is the contract: this is written by a `printf`
+ * from a trap that fires while the machine may be in the middle of failing, so a
+ * truncated or half-written file is an ordinary outcome rather than an exceptional
+ * one. The TUI startup path must not die on a bad breadcrumb. Every field is
+ * validated and only the known ones are carried forward, so an unrecognised field
+ * cannot ride along into a surface that promises dates and counts only.
+ */
+export function parseHeartbeat(raw: string | undefined): JobHeartbeat | undefined {
+  if (raw === undefined) {
+    return undefined;
+  }
+  let parsed: unknown;
+  try {
+    parsed = JSON.parse(raw);
+  } catch {
+    return undefined;
+  }
+  if (parsed === null || typeof parsed !== "object" || Array.isArray(parsed)) {
+    return undefined;
+  }
+  const body = parsed as Record<string, unknown>;
+  if (body.schemaVersion !== HEARTBEAT_SCHEMA_VERSION) {
+    return undefined;
+  }
+  const { startedAt, finishedAt, exitCode, lastStep } = body;
+  if (
+    !isIsoInstant(startedAt) ||
+    !isIsoInstant(finishedAt) ||
+    typeof exitCode !== "number" ||
+    !Number.isInteger(exitCode) ||
+    typeof lastStep !== "string" ||
+    lastStep.length === 0
+  ) {
+    return undefined;
+  }
+  // Rebuilt field by field, never spread: an unknown key is dropped here rather
+  // than carried into a line the operator reads.
+  return { schemaVersion: HEARTBEAT_SCHEMA_VERSION, startedAt, finishedAt, exitCode, lastStep };
+}
+
+/**
+ * The verdict — three triggers. EMPTY MEANS HEALTHY, or unknown, which is
+ * deliberately the same thing here (see the header on why silence is safe).
+ *
+ * Conditions are reported independently when more than one holds: a run that failed
+ * AND has not run since is two distinct facts, and collapsing them would hide the
+ * older one. The two DATE triggers are mutually exclusive by construction — the
+ * ceiling is always a day behind today, so a run cannot be both ahead of today and
+ * behind the ceiling.
+ */
+export function formatHeartbeatWarning(
+  heartbeat: JobHeartbeat | undefined,
+  now: Date,
+): string[] {
+  if (heartbeat === undefined) {
+    return [];
+  }
+  const lines: string[] = [];
+  // The run's CDMX trading day — the same calendar today and the ceiling are both
+  // expressed in, so all three are comparable without a second timezone decision.
+  const ranOn = tradingDayAsOf(new Date(heartbeat.finishedAt), REPORT_TIME_ZONE);
+  const today = tradingDayAsOf(now, REPORT_TIME_ZONE);
+  const ceiling = dueThrough(now);
+
+  if (heartbeat.exitCode !== 0) {
+    lines.push(
+      `Numisma: the daily price job FAILED on ${ranOn} — exit ${heartbeat.exitCode} ` +
+        `at step '${heartbeat.lastStep}'. Nothing pushed this to you; that is why it is here.`,
+    );
+  }
+  // AGAINST TODAY, NOT AGAINST THE CEILING. The ceiling is yesterday, so a job that
+  // ran at 18:00 today read by a TUI opened at 20:00 today is already past it —
+  // the everyday healthy case, which must stay silent.
+  if (ranOn > today) {
+    lines.push(
+      `Numisma: the daily price job's last run is dated ${ranOn}, ahead of today ` +
+        `(${today}) — the machine clock or job-heartbeat.json is wrong, so nothing ` +
+        `else this breadcrumb says can be trusted.`,
+    );
+  }
+  if (ranOn < ceiling) {
+    lines.push(
+      `Numisma: the daily price job has not completed since ${ranOn} — ` +
+        `nothing recorded for ${ceiling}.`,
+    );
+  }
+  return lines;
+}

--- a/packages/event-store/src/index.ts
+++ b/packages/event-store/src/index.ts
@@ -11,3 +11,20 @@ export {
   type EventStorePaths,
   type QuarantinedLine,
 } from "./event-store.js";
+
+// The gap report (#186): which calendar days in the launchd era did the price feed
+// not run on. The derivation is pure and synchronous (`gap-report.js`); the log
+// read is its one async shell (`gap-report-io.js`).
+export {
+  LAUNCHD_ERA_START,
+  REPORT_TIME_ZONE,
+  computeGapReport,
+  dueThrough,
+  formatGapReport,
+  formatGapSummary,
+  type GapReport,
+  type GapWindow,
+  type LostDay,
+  type LostDayReason,
+} from "./gap-report.js";
+export { loadGapReport } from "./gap-report-io.js";

--- a/packages/event-store/src/index.ts
+++ b/packages/event-store/src/index.ts
@@ -27,6 +27,17 @@ export {
   type LostDay,
   type LostDayReason,
 } from "./gap-report.js";
+// The daily job's heartbeat (#191): the one fact the durable log cannot contain —
+// whether the job ran. Written by bash from an EXIT trap; read here.
+export {
+  HEARTBEAT_FILENAME,
+  HEARTBEAT_SCHEMA_VERSION,
+  formatHeartbeatWarning,
+  parseHeartbeat,
+  type JobHeartbeat,
+} from "./heartbeat.js";
+export { heartbeatPath, loadHeartbeat, loadHeartbeatLines } from "./heartbeat-io.js";
+
 export {
   GAP_REPORT_FILENAME,
   GAP_REPORT_SCHEMA_VERSION,

--- a/packages/event-store/src/index.ts
+++ b/packages/event-store/src/index.ts
@@ -27,4 +27,10 @@ export {
   type LostDay,
   type LostDayReason,
 } from "./gap-report.js";
-export { loadGapReport } from "./gap-report-io.js";
+export {
+  GAP_REPORT_FILENAME,
+  GAP_REPORT_SCHEMA_VERSION,
+  gapReportPath,
+  loadGapReport,
+  writeGapReportFile,
+} from "./gap-report-io.js";

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -60,6 +60,11 @@ export default defineConfig({
         // credential + console + exit-code wiring over `backfill-core.ts`, which
         // IS measured (backfill-core.test.ts drives the whole loop with no DB).
         "apps/web/src/push/backfill.ts",
+        // Same category again: the gap-report shell is argv + console + exit-code
+        // wiring over `gap-report-core.ts`, which IS measured — its argument
+        // validation, window bound and exit contract are unit-tested with an
+        // injected clock and a throwaway store, no database and no environment.
+        "apps/web/src/push/gap-report.ts",
         // Self-executing provisioning/auth CLI scripts (same category as
         // push.ts): top-level main().then(..., process.exit) over the tested
         // provision.ts builders / vendored SQL. No unit to assert as written;


### PR DESCRIPTION
Spec #186, built in six slices on `feature/projection-push-liveness` off `main`. The daily obligation — fetch prices, write marks, publish the projection — could miss, and nothing said so. It had missed twice, and both times a human found it days later by going and looking. **This increment makes a missed day arrive at you instead.**

The prototype branch `prototype/projection-push-liveness` was the record, not the base. Nothing was branched from it or cherry-picked; the shipped shape differs deliberately.

Closes #192
Closes #187
Closes #188
Closes #189
Closes #190
Closes #191
Closes #186

## ⚠ #185 stays open, and this PR does not close it

The `08-02…08-04` outage #185 names was a **push** miss, not a fetch miss. The fetch ran all three days — the accumulus reflog shows `18:01:11` on 08-04, `18:01:12` on 08-03, `18:01:13` on 08-02, and the log is complete for all three. **This detector is correctly silent about those days**, and that silence is the design working, not a gap in it.

#185 closes when **S1** (a backfill step in the daily wrapper) and **S2** (`RunAtLoad` plus hourly retry intervals) land. Neither is in this increment. S2 is still gated on Twelve Data's daily credit cap.

## What changed since the spec was first drafted

Two decisions reshaped the increment, and both are why it looks the way it does.

**The rule is "did a mark land on day D", not `feedGap.arrived`.** The earlier rule was wrong two days in seven, proven against the real log. `arrived` does not count marks landing on a date — it counts instruments **fresh against their last expected mark date**, and that expectation walks back over the weekend. On a Saturday the nine equity instruments count as arrived off *Friday's* marks, so a weekend on which the fetch produced nothing folds to 9, never 0. **A detector written on `arrived > 0` cannot fire on a weekend at all.** The prototype's nine tests each injected a synthetic arrived-count, so they exercised the rule and never the number the rule was applied to — which is exactly why nine green tests hid it.

**The ceiling is yesterday, always.** The prototype flipped the ceiling to *today* the moment the clock passed 18:00 CDMX and then printed, verbatim, *"today — NO DATA … the day is lost."* That is false until CDMX midnight, and false during precisely the six-hour window the design exists to exploit — one run is on record completing at 20:56. The report never names today, and that is now a **clamp** on the derivation rather than a default, so no caller can push it forward.

## The six slices

| | Slice | Commit |
|---|---|---|
| #192 | `addDays` / `daysBetween` collapse into `@numisma/engine` | `fb03b9a` |
| #187 | The derivation — synchronous and pure over the log | `ab03f20` |
| #188 | The CLI — strict flag validation, corrected exit contract | `4da06c6` |
| #189 | The standup file — `schemaVersion` and the privacy test | `f50b51b` |
| #190 | The TUI surface | `b2549f6` |
| #191 | The job heartbeat — bash `EXIT` trap plus a tested reader | `cd59085` |

**#192** gives the date arithmetic one home. A package cannot import from an app, so the derivation would otherwise have written a *third* private copy of the same eight lines. A contract test walks every non-vendored source in the repo and asserts the declaring-file list is exactly one file.

**#187** is the core. `computeGapReport(events, window)` makes one pass to build both an anchor set and a per-date `PriceMarked` count. It lives in `packages/event-store` because every input already sits on an existing edge — no new package edge in either direction, and the `pg` driver stays out of the TUI process by construction rather than by care. The injected `{anchors, arrivedOn}` source pair is retired: over one synchronous pass it was indirection with a single adapter, and it was the reach that made the weekend bug possible.

**#188** refuses an input it cannot answer correctly. `--since 2026-02-30` matches `\d{4}-\d{2}-\d{2}` and is not a date; handed to `Date` it rolls silently to March 2 and the report answers a question nobody asked, **in the same shape as a correct answer**. A detector whose whole value is trust cannot have a failure mode that looks like success. Exit is non-zero on any failure to produce or persist the report, and **0 when days are lost** — a lost day is permanent, and a permanently red job is one nobody reads.

**#189** writes `gap-report.json` with a `schemaVersion` as its first key. The privacy property — dates, counts and known labels only — is enforced by a key-allowlist walk that is proved able to say *no*, not merely to say *yes* to a clean body.

**#190** puts lost days on the TUI's pre-alternate-screen startup channel. The dashboard's freshness verdict was derivation-correct and delivery-broken: it would have fired at four stale days and nobody saw it, because it speaks only when a human opens the dashboard. Its own comment predicted that. A module-graph test walks the TUI's transitive imports and asserts no `pg` at any depth and every import resolvable — the prototype hid its edge behind a computed specifier precisely so `tsc` could not follow it.

**#191** records whether the job ran at all — the one fact the durable log cannot contain. A run that fired and died leaves the same evidence as a machine that was switched off. The writer is pure bash `printf` from an `EXIT` trap, with no `node`, `pnpm` or `jq`, because the case that justifies the whole design is exit 127, in which nothing that needs node can run.

## The falsifiable checks, run

| # | Check | Result |
|---|---|---|
| 1 | 2026-06-30 replays as `no-marks` | ✅ Tuesday, anchored by a deposit and two closes, zero marks |
| 2 | A zero-mark Saturday replays as `no-marks` | ✅ verified as a mutation: the old rule returns `[]`, the shipped rule names the day |
| 3 | `pnpm gap-report` never names today | ✅ 00:01, 17:59, 18:00:00, 23:59 CDMX all yield yesterday; `--until <today>` on argv still ends yesterday |
| 4 | No false positives on the real log | ✅ `no lost days in 2026-07-03…2026-08-04 (33 day(s), 33 anchor(s) checked)` |
| 5 | A stubbed red run lands a heartbeat carrying its exit code | ✅ `exitCode: 1`, `lastStep: "prices-fetch"` |
| 6 | A `PATH` without `pnpm` still lands one carrying 127 | ✅ `exitCode: 127`, `lastStep: "resolve-tools"` |

Check 2 is the one the spec was rewritten for. Run against the same events, the same window and the same assertion, with only the verdict rule swapped:

```
× OLD RULE (arrived > 0) — reports the zero-mark Saturday
  → expected [] to deeply equal [ { date: '2026-07-11', reason: 'no-marks' } ]
✓ NEW RULE (a mark landed on D) — reports the zero-mark Saturday
```

The disagreement stays executable in the shipped suite: the rejected rule is re-implemented as `arrivedUnderOldRule` over the same event array, so the Saturday test asserts `arrived == 9` beside the new-rule verdict. Revert the rule and that line breaks.

## The by-hand checks, documented

The repo has **no shell-test infrastructure** and this increment did not invent one. The mitigation stated in the spec was to keep the bash to a trap and a `printf` and verify it once by hand. That was done, with `NUMISMA_DATA_DIR`, the log dir and the token-file path all pointed at a **temporary directory** — never the real durable log — and with the temp data dir deliberately not a git repo, so the wrapper's commit step takes its skip branch even if a stub were to fail.

```
CHECK 5 — stubbed red run (pnpm exits 1)
  wrapper exit = 1
  { "schemaVersion": 1, "startedAt": "…", "finishedAt": "…",
    "exitCode": 1, "lastStep": "prices-fetch" }

CHECK 6 — pnpm absent from PATH entirely
  [FATAL] 'pnpm' not found on PATH after prepending …
  wrapper exit = 127
  { "schemaVersion": 1, …, "exitCode": 127, "lastStep": "resolve-tools" }

CHECK 3 (additional) — fully stubbed green run
  wrapper exit = 0
  { "schemaVersion": 1, …, "exitCode": 0, "lastStep": "complete" }
```

The green run was added because the acceptance criteria require the trap to fire on *every* exit path and the two required checks only exercise failures. A genuine green run is impossible to do safely — it would hit the provider and append to the durable log — so a fully stubbed one is the only honest way to reach that arm.

The reader was then driven over each heartbeat state:

```
RED (exit 127)   → Numisma: the daily price job FAILED on 2026-08-05 — exit 127
                   at step 'resolve-tools'. Nothing pushed this to you; that is
                   why it is here.
GREEN (exit 0)   → silent
MALFORMED JSON   → silent (treated as absent, never a throw)
ABSENT           → silent
```

The real data dir was snapshotted before and after: no `job-heartbeat.json` appeared in it, `git status` stayed clean, and the pre-existing `gap-report.json` kept its original timestamp.

## One comment corrected here, two deliberately left alone

The post-check step's `exit 1` — the guard against a repeat of #132's 17-day silent miss — rested on a false premise: *"a 'loud warning' reaches no one; only a FAILED job reaches the operator."* **The second clause is false, measured against the live agent.** launchd records the exit code and `launchctl print` will show it on request, but nothing is pushed — no notification, no badge, no mail. A failed job reaches no one either, so that FATAL was decorative. It is corrected in #191's commit, because it is false *today* and sits in the file that slice edits.

Two other comments — the wrapper header's *"a missed run catches up on the next fire"* and the matching claim in the price-feed config — are **deliberately untouched**. They become true only when the hourly-retry change (S2) ships, so they belong in that commit.

## Carried forward, deliberately not built

- **An `at-risk` third status** reporting today as *"no marks yet, window closes 23:59."* A real want; its own slice.
- **S1 and S2** — the prevention half, and what #185 is still waiting on.
- **Rotation or history for `gap-report.json`.** Versioning was the blocking half and it shipped; rotation is not.
- **`calendarDaysBetween`** in the price-feed derive module is functionally the `daysBetween` #192 collapsed, under a different name, inside the FX freshness guard. It survived #192's contract test purely because of the name. Folding it in is a behaviour-risking edit rather than a rename, so it is flagged rather than fixed.
- **On a `--write` failure the CLI prints the error and exits non-zero but not the report lines it had already produced**, because the shell buffers and prints on success. The exit contract holds; the printout is lost. Restructuring is a design change, not a slice fix.
- **`pnpm smoke:startup` is broken and was broken before this work** (its fixture lacks a required funding cash leg, plausibly #140). Not repaired here — but it is the one harness that drives startup through the real renderer, so it is the natural home for an end-to-end assertion once it is fixed.

## Post-review fixes

Three follow-up commits after review:

- `fix(web)`: `runGapReport` bounded the window's width but never its direction — `--since 2026-08-05` is individually valid but the ceiling clamp pulls `until` behind it, so the derivation's walk over the inverted window was empty by construction and printed a false all-clear (0 days, 0 anchors) at exit 0. Now refused in the command, with the pure derivation left untouched. Also rejects a repeated `--since`/`--until` instead of silently using the last one.
- `fix(event-store)`: the heartbeat reader's `isIsoInstant` accepted anything `Date.parse` would, including a date-only string. `finishedAt: "2026-08-05"` parses as UTC midnight and reads back one trading day early in CDMX, which would have produced a false "job has not completed" warning. Tightened to the actual written contract (date + time + zone); a hand-edited or foreign-written file is the only realistic way to hit this, same as the module's existing future-dated-trigger case.
- `refactor(web)`: corrected the calendar-contract test's docstring, which overclaimed — the guarantee is name-scoped (it greps for `addDays`/`daysBetween` literally), not repo-wide; `calendarDaysBetween` in the price-feed derive module is a live duplicate that the test cannot see. Also hoisted the repo file walk to run once instead of once per helper name.

## Verification

`pnpm typecheck` clean across all six projects. `pnpm test` **1097 passed, 19 skipped** — up from 1001 on `main`, with the 3 skipped files being the pre-existing Postgres-substrate integration tests that need `NUMISMA_TEST_DATABASE_URL`. Every slice was verified green before the next began.

