### PR TITLE
fix(tui,engine): startup smoke gate, bounded gap channel, and pnpm verify

### DIFF
--- a/apps/tui/src/gap-lines.test.ts
+++ b/apps/tui/src/gap-lines.test.ts
@@ -14,7 +14,7 @@ import { resolve } from "node:path";
 import type { PortfolioEvent } from "@numisma/engine";
 import { resolveEventStorePaths, type EventStorePaths } from "@numisma/event-store";
 import { afterEach, describe, expect, it } from "vitest";
-import { loadGapLines } from "./gap-lines.js";
+import { loadGapLines, MAX_GAP_LINES } from "./gap-lines.js";
 
 const created: string[] = [];
 
@@ -37,6 +37,14 @@ function mark(date: string, instrumentId = "cx-a"): PortfolioEvent {
 
 function deposit(date: string): PortfolioEvent {
   return { id: `dep-${date}`, asOf: date, type: "Deposit", reserveId: "cash-core", amount: 500, tier: "c1" };
+}
+
+/** `count` consecutive `YYYY-MM-DD` days ending at (and including) `until`, ascending. */
+function daysEndingAt(until: string, count: number): string[] {
+  const end = Date.parse(`${until}T00:00:00Z`);
+  return Array.from({ length: count }, (_unused, index) =>
+    new Date(end - (count - 1 - index) * 86_400_000).toISOString().slice(0, 10),
+  );
 }
 
 const NOW = new Date("2026-08-05T12:00:00Z"); // 06:00 CDMX; yesterday = 2026-08-04
@@ -86,6 +94,52 @@ describe("loadGapLines", () => {
     expect(lines).toHaveLength(1);
     expect(lines[0]).toMatch(/^Numisma: lost days were NOT checked/);
     expect(lines[0]).toMatch(/quarantine/i);
+  });
+
+  it("prints only the MOST RECENT MAX_GAP_LINES lost days, and counts the rest", async () => {
+    // Every case above uses a window of three days or fewer, so none of them can
+    // tell a bounded channel from an unbounded one. This one is deliberately WIDER
+    // THAN THE CAP: after a long outage the derivation still finds every lost day —
+    // that is #194's third acceptance criterion and `computeGapReport` is untouched
+    // — but the startup channel must not push the TUI's own first frame off the
+    // scrollback. The bound is presentation-only, and it lives here at the leaf.
+    //
+    // Driven off the exported constant rather than a literal 7: a test that
+    // restates the number cannot catch the number changing.
+    const EXTRA = 4;
+    const until = "2026-08-04"; // yesterday, relative to NOW
+    const lostDays = daysEndingAt(until, MAX_GAP_LINES + EXTRA);
+
+    // An empty log: no event carries any date in the window, so every day is lost.
+    const paths = await storeWithLog([]);
+    const lines = await loadGapLines(paths, { since: lostDays[0] as string, now: NOW });
+
+    // MAX_GAP_LINES day-lines plus exactly one tail line.
+    expect(lines).toHaveLength(MAX_GAP_LINES + 1);
+    expect(lines).toEqual([
+      ...lostDays.slice(EXTRA).map(
+        (date) =>
+          `Numisma: ${date} — NO DATA. No event of any kind carries this date; the day is lost.`,
+      ),
+      `Numisma: …and ${EXTRA} earlier lost day(s) (pnpm gap-report).`,
+    ]);
+
+    // The withheld days are the OLDEST ones, and they are named nowhere.
+    for (const withheld of lostDays.slice(0, EXTRA)) {
+      expect(lines.join("\n")).not.toContain(withheld);
+    }
+  });
+
+  it("prints every lost day, and no tail line, at exactly the cap", async () => {
+    // The boundary the off-by-one lives on: a count EQUAL to the cap is not
+    // "bounded with zero withheld" — it withholds nothing, so it must say nothing
+    // about withholding. `…and 0 earlier lost day(s)` would be a line about nothing.
+    const lostDays = daysEndingAt("2026-08-04", MAX_GAP_LINES);
+    const paths = await storeWithLog([]);
+    const lines = await loadGapLines(paths, { since: lostDays[0] as string, now: NOW });
+
+    expect(lines).toHaveLength(MAX_GAP_LINES);
+    expect(lines.join("\n")).not.toContain("earlier lost day(s)");
   });
 
   it("reports an absent log as lost days rather than as a failure", async () => {

--- a/apps/tui/src/gap-lines.test.ts
+++ b/apps/tui/src/gap-lines.test.ts
@@ -11,7 +11,7 @@
 import { mkdtemp, rm, writeFile } from "node:fs/promises";
 import { tmpdir } from "node:os";
 import { resolve } from "node:path";
-import type { PortfolioEvent } from "@numisma/engine";
+import { addDays, type PortfolioEvent } from "@numisma/engine";
 import { resolveEventStorePaths, type EventStorePaths } from "@numisma/event-store";
 import { afterEach, describe, expect, it } from "vitest";
 import { loadGapLines, MAX_GAP_LINES } from "./gap-lines.js";
@@ -39,12 +39,15 @@ function deposit(date: string): PortfolioEvent {
   return { id: `dep-${date}`, asOf: date, type: "Deposit", reserveId: "cash-core", amount: 500, tier: "c1" };
 }
 
-/** `count` consecutive `YYYY-MM-DD` days ending at (and including) `until`, ascending. */
+/**
+ * `count` consecutive `YYYY-MM-DD` days ending at (and including) `until`, ascending.
+ *
+ * Built on the engine's `addDays` rather than hand-rolled millisecond arithmetic —
+ * the same helper the walk under test steps with (`gap-report.ts`), so the test and
+ * the derivation cannot drift on what "the next day" means.
+ */
 function daysEndingAt(until: string, count: number): string[] {
-  const end = Date.parse(`${until}T00:00:00Z`);
-  return Array.from({ length: count }, (_unused, index) =>
-    new Date(end - (count - 1 - index) * 86_400_000).toISOString().slice(0, 10),
-  );
+  return Array.from({ length: count }, (_unused, index) => addDays(until, index - (count - 1)));
 }
 
 const NOW = new Date("2026-08-05T12:00:00Z"); // 06:00 CDMX; yesterday = 2026-08-04

--- a/apps/tui/src/gap-lines.ts
+++ b/apps/tui/src/gap-lines.ts
@@ -32,6 +32,25 @@ import {
   type GapWindow,
 } from "@numisma/event-store";
 
+/**
+ * The most lost-day lines this channel will print before it summarizes the rest.
+ *
+ * A startup channel is not a report. After a long outage the derivation walks the
+ * WHOLE window and finds every lost day — that is `computeGapReport`'s job and it
+ * stays untouched — but printing sixty lines above the alternate screen scrolls the
+ * TUI's own first frame off the terminal, and a channel that buries its own product
+ * is a channel you learn to skip. So the BOUND IS PRESENTATION-ONLY, applied here
+ * at the leaf: the derivation still knows everything, and the operator is told
+ * exactly how much is being withheld and the one command that shows all of it.
+ *
+ * The MOST RECENT days, not the last 7 calendar days — a lost day is permanent, so
+ * the window's tail is where the still-actionable damage is.
+ *
+ * Exported because the test must DRIVE the bound rather than restate it; the same
+ * reason `MAX_WINDOW_DAYS` is exported from `gap-report-core.ts`.
+ */
+export const MAX_GAP_LINES = 7;
+
 /** The one wording for "the check itself did not run." Shared with `startup.ts`. */
 export function formatGapCheckFailure(error: unknown): string {
   const detail = error instanceof Error ? error.message : String(error);
@@ -45,14 +64,37 @@ export function formatGapCheckFailure(error: unknown): string {
  * this on a channel the operator sees every single day. The window's floor defaults
  * to the launchd era and its ceiling is pinned to yesterday by the derivation, so
  * this can never accuse the day still in progress.
+ *
+ * Bounded to {@link MAX_GAP_LINES} — see that constant. A CLEAN WINDOW STILL
+ * PRINTS NOTHING: the bound only ever removes lines, never adds one, so the
+ * silence contract above is untouched by it.
  */
 export async function loadGapLines(
   paths: EventStorePaths,
   window: GapWindow,
 ): Promise<string[]> {
+  let all: string[];
   try {
-    return formatGapReport(await loadGapReport(paths, window));
+    all = formatGapReport(await loadGapReport(paths, window));
   } catch (error) {
     return [formatGapCheckFailure(error)];
   }
+
+  const withheld = all.length - MAX_GAP_LINES;
+  if (withheld <= 0) {
+    return all;
+  }
+  // `formatGapReport` renders `report.lost`, which the derivation's walk builds
+  // ASCENDING — so the most recent lost days are the tail, and the withheld ones are
+  // the head. The count goes last, under the days it summarizes.
+  //
+  // Deliberately NOT `formatGapSummary`: that one reports the TOTAL over the FULL
+  // window and is contractually the always-printed one-liner — it speaks on a clean
+  // window, which this channel must never do. This says only how much was withheld,
+  // and names the command that shows the rest. `day(s)` is the house form
+  // (`formatGapSummary`'s `lost day(s)` / `anchor(s)`); there is no singular branch.
+  return [
+    ...all.slice(withheld),
+    `Numisma: …and ${withheld} earlier lost day(s) (pnpm gap-report).`,
+  ];
 }

--- a/apps/tui/src/smoke-startup-openTui.ts
+++ b/apps/tui/src/smoke-startup-openTui.ts
@@ -196,6 +196,11 @@ function openBtc() {
       lots: [{ quantity: 1, cost: 100, tier: "c1" }],
     },
     decision: DECISION,
+    // TOP-LEVEL on the event, not nested in `position` — `crossReferenceEvent`
+    // reads `event.funding.reserveId` / `.amount`. `cash-core` is the seed's only
+    // reserve, and it is USD like the position: a cross-currency funding leg is
+    // refused outright. 100 matches the lot (1 × 100), leaving `cash-core` at 900.
+    funding: { reserveId: "cash-core", amount: 100 },
   }
 }
 

--- a/package.json
+++ b/package.json
@@ -26,6 +26,7 @@
     "db:provision": "tsx apps/web/src/projection/provision-projection.ts",
     "typecheck": "pnpm --filter @numisma/engine run typecheck && pnpm --filter @numisma/event-store run typecheck && pnpm --filter @numisma/preferences run typecheck && pnpm --filter @numisma/price-feed run typecheck && pnpm --filter @numisma/tui run typecheck && pnpm --filter @numisma/web run typecheck",
     "test": "vitest run",
+    "verify": "pnpm typecheck && pnpm test && pnpm smoke:startup",
     "coverage": "vitest run --coverage"
   },
   "devDependencies": {

--- a/packages/engine/src/cash-settlement.test.ts
+++ b/packages/engine/src/cash-settlement.test.ts
@@ -95,9 +95,12 @@ describe("cash leg — Open debits the funding reserve, tiered by the lots' own 
     const data = foldEvents(genesis(), [open]);
     const reserve = reserveById(data, "tiered");
 
+    // Exact, not approximate: 330 × 200/300 is 66000/300 = 220 in IEEE-754, and c2
+    // takes the residual 330 - 220 = 110. Asserted with `toBe` like the equal-amount
+    // case above — a tolerance here would read as "the split is fuzzy", and it is not.
     expect(reserve.amount).toBe(1170); // 1500 - 330, NOT 1500 - 300
-    expect(tierQty(reserve, "c1")).toBeCloseTo(780, 6); // 1000 - 220 (330 × 200/300)
-    expect(tierQty(reserve, "c2")).toBeCloseTo(390, 6); // 500 - 110 (330 × 100/300)
+    expect(tierQty(reserve, "c1")).toBe(780); // 1000 - 220 (330 × 200/300)
+    expect(tierQty(reserve, "c2")).toBe(390); // 500 - 110 (330 × 100/300)
   });
 });
 

--- a/packages/engine/src/cash-settlement.test.ts
+++ b/packages/engine/src/cash-settlement.test.ts
@@ -56,6 +56,49 @@ describe("cash leg — Open debits the funding reserve, tiered by the lots' own 
     expect(tierQty(reserve, "c2")).toBe(400); // 500 - 100
     expect(data.positions.some((position) => position.id === "btc-pos")).toBe(true);
   });
+
+  it("takes `funding.amount` as authoritative when it diverges from Σ(quantity × cost)", () => {
+    // The case above has amount === Σ(quantity × cost) === 300, and so does every
+    // other `funding` fixture in the repo — which means nothing here would fail if
+    // `reserveDeltasForOpen` ignored its `amount` argument entirely and re-derived
+    // the total from the lots. `applyReserveDelta` documents `amount` as ALWAYS
+    // authoritative; this is the case that can tell the difference. Same two lots
+    // (c1 200 + c2 100 = 300 of cost basis), amount 330 — the extra 30 is real cash
+    // that left the reserve (fees, slippage, a partial fill priced up).
+    //
+    // AND IT MUST SPLIT, NOT LAND. The weighting is by native cost, 2:1 across
+    // c1:c2, so the 30 of excess is apportioned 20 / 10 — it does not fall on one
+    // Tier. That is the per-Tier assertion below, and it is the half of the
+    // contract a total-only check would miss.
+    const open: PortfolioEvent = {
+      id: "open-btc-divergent",
+      asOf: "2026-06-02",
+      type: "PositionOpened",
+      position: {
+        id: "btc-pos",
+        portfolioId: "core",
+        tempo: "Liquid",
+        executionMode: "live",
+        accountId: "venue",
+        instrumentId: "btc-usd",
+        direction: "long",
+        currency: "USD",
+        lots: [
+          { quantity: 1, cost: 200, tier: "c1" },
+          { quantity: 1, cost: 100, tier: "c2" },
+        ],
+      },
+      decision: DECISION,
+      funding: { reserveId: "tiered", amount: 330 },
+    };
+
+    const data = foldEvents(genesis(), [open]);
+    const reserve = reserveById(data, "tiered");
+
+    expect(reserve.amount).toBe(1170); // 1500 - 330, NOT 1500 - 300
+    expect(tierQty(reserve, "c1")).toBeCloseTo(780, 6); // 1000 - 220 (330 × 200/300)
+    expect(tierQty(reserve, "c2")).toBeCloseTo(390, 6); // 500 - 110 (330 × 100/300)
+  });
 });
 
 describe("cash leg — Close credits the settlement reserve, proceeds tiered proportionally", () => {


### PR DESCRIPTION
## Summary

- Closes #140. `openBtc()`'s smoke fixture seeded a `PositionOpened` with no `funding` cash leg, which `parseEvent` refused outright — `pnpm smoke:startup` exited 1 before it asserted anything. Added the missing `funding: { reserveId: "cash-core", amount: 100 }` leg, and paired it with an engine test that pins `funding.amount` as authoritative over Σ(quantity × cost) — a property `applyReserveDelta` documents but that all eight `funding` fixtures in the repo left unasserted — and checks the excess splits proportionally across tiers rather than landing on one.
- Closes #194. The startup gap channel could print dozens of lost-day lines above the alternate screen, scrolling the TUI's own first frame off the terminal. Bounded it at an exported `MAX_GAP_LINES = 7`: prints the most recent seven, then a `Numisma: …and K earlier lost day(s) (pnpm gap-report).` line only when more were withheld. Presentation-only — `computeGapReport` still walks the whole window, and a clean window still prints nothing.
- Adds `pnpm verify` (`typecheck && test && smoke:startup`). `smoke:startup` runs on bun while `test` runs on vitest, so it sat in neither existing gate — which is how #140 went unnoticed.

## Verification

- `pnpm typecheck` — exit 0
- `pnpm test` — 1100 passed / 19 skipped / 0 failed
- `pnpm smoke:startup` — exit 0 (previously exit 1, tracked as #140)
