### PR TITLE
refactor(price-feed): consume the event store's read path and collapse duplication

### DIFF
--- a/apps/price-feed/package.json
+++ b/apps/price-feed/package.json
@@ -8,7 +8,8 @@
   },
   "types": "./src/index.ts",
   "dependencies": {
-    "@numisma/engine": "workspace:*"
+    "@numisma/engine": "workspace:*",
+    "@numisma/event-store": "workspace:*"
   },
   "scripts": {
     "prices:fetch": "tsx src/cli.ts",

--- a/apps/price-feed/src/banxico-provider.test.ts
+++ b/apps/price-feed/src/banxico-provider.test.ts
@@ -125,4 +125,32 @@ describe("fetchBanxicoFix — loud failures", () => {
       fetchBanxicoFix({ ...OPTS, timeoutMs: 20, fetchImpl: stall }),
     ).rejects.toThrow(/timed out after 20ms/);
   });
+
+  it("attributes a timeout that strikes during the BODY read, not just the fetch", async () => {
+    // The JSON decode moved INSIDE `fetchJson`'s guarded region, so the R4
+    // AbortController now bounds the body read too — `clearTimeout` no longer fires
+    // before the decode begins. The stall above rejects at the FETCH stage and never
+    // reaches this path: here the headers arrive fine (200) and the body is what
+    // never completes. The abort must still surface as the timeout reason with the
+    // provider's own label, not as the transport's raw wording.
+    const stallBody: typeof fetch = ((_url: string | URL | Request, init?: RequestInit) => {
+      const body = new ReadableStream<Uint8Array>({
+        start(controller) {
+          controller.enqueue(new TextEncoder().encode('{"bmx":'));
+          init?.signal?.addEventListener("abort", () => {
+            // The shape undici surfaces for a mid-body abort: a DOMException whose
+            // `name` is `AbortError` and which satisfies `instanceof Error`.
+            controller.error(new DOMException("This operation was aborted", "AbortError"));
+          });
+        },
+      });
+      return Promise.resolve(
+        new Response(body, { status: 200, headers: { "content-type": "application/json" } }),
+      );
+    }) as typeof fetch;
+
+    await expect(
+      fetchBanxicoFix({ ...OPTS, timeoutMs: 20, fetchImpl: stallBody }),
+    ).rejects.toThrow(/^Banxico SF43718 -> request timed out after 20ms$/);
+  });
 });

--- a/apps/price-feed/src/banxico-provider.test.ts
+++ b/apps/price-feed/src/banxico-provider.test.ts
@@ -100,6 +100,18 @@ describe("fetchBanxicoFix — loud failures", () => {
     ).rejects.toThrow(/unexpected FIX date format/);
   });
 
+  it("attributes a non-JSON 200 to the series instead of throwing a bare SyntaxError", async () => {
+    // Regression guard for #110's finding 2 — see twelvedata-provider.test.ts. Banxico
+    // was always caught by the orchestrator, but unlabelled: the decode threw before
+    // any provider prefix was applied.
+    await expect(
+      fetchBanxicoFix({
+        ...OPTS,
+        fetchImpl: fetchWith(() => new Response("<html>maintenance</html>", { status: 200 })),
+      }),
+    ).rejects.toThrow(/^Banxico SF43718 -> /);
+  });
+
   it("attributes a request timeout", async () => {
     const stall: typeof fetch = ((_url: string | URL | Request, init?: RequestInit) =>
       new Promise<Response>((_resolve, reject) => {

--- a/apps/price-feed/src/banxico-provider.ts
+++ b/apps/price-feed/src/banxico-provider.ts
@@ -12,6 +12,7 @@
  * token is read from the environment (`BANXICO_TOKEN`), never committed.
  */
 import type { FixObservation } from "@numisma/engine";
+import { fetchJson, isRecord } from "./provider.js";
 
 const BANXICO_SF43718 =
   "https://www.banxico.org.mx/SieAPIRest/service/v1/series/SF43718/datos/oportuno";
@@ -36,31 +37,15 @@ export async function fetchBanxicoFix(options: FixFetchOptions): Promise<FixObse
         "before fetching the USD/MXN FIX.",
     );
   }
-  const fetchImpl = options.fetchImpl ?? fetch;
-  const controller = new AbortController();
-  const timer = setTimeout(() => controller.abort(), options.timeoutMs);
-  let res: Response;
-  try {
-    res = await fetchImpl(BANXICO_SF43718, {
-      signal: controller.signal,
-      headers: { "Bmx-Token": options.token, Accept: "application/json" },
-    });
-  } catch (error) {
-    if (error instanceof Error && error.name === "AbortError") {
-      throw new Error(`Banxico SF43718 -> request timed out after ${options.timeoutMs}ms`);
-    }
-    throw new Error(
-      `Banxico SF43718 -> ${error instanceof Error ? error.message : String(error)}`,
-    );
-  } finally {
-    clearTimeout(timer);
+  const r = await fetchJson(BANXICO_SF43718, {
+    timeoutMs: options.timeoutMs,
+    fetchImpl: options.fetchImpl,
+    init: { headers: { "Bmx-Token": options.token, Accept: "application/json" } },
+  });
+  if (!r.ok) {
+    throw new Error(`Banxico SF43718 -> ${r.reason}`);
   }
-
-  if (!res.ok) {
-    throw new Error(`Banxico SF43718 -> HTTP ${res.status} ${res.statusText}`);
-  }
-  const body = (await res.json()) as unknown;
-  const datum = extractLatestDatum(body);
+  const datum = extractLatestDatum(r.body);
   const rate = Number(datum.dato);
   if (!Number.isFinite(rate) || rate <= 0) {
     throw new Error(`Banxico SF43718 -> non-positive FIX rate '${datum.dato}'`);
@@ -100,8 +85,4 @@ function isoDateFromBanxico(fecha: string): string {
     throw new Error(`Banxico SF43718 -> unexpected FIX date format '${fecha}'`);
   }
   return `${match[3]}-${match[2]}-${match[1]}`;
-}
-
-function isRecord(value: unknown): value is Record<string, unknown> {
-  return typeof value === "object" && value !== null;
 }

--- a/apps/price-feed/src/binance-provider.test.ts
+++ b/apps/price-feed/src/binance-provider.test.ts
@@ -1,0 +1,32 @@
+// Binance public-REST provider suite. No live network (every fetch is mocked).
+// Currently one case: the non-JSON 200, which must stay symbol-attributable.
+import { describe, expect, it } from "vitest";
+import type { InstrumentRegistryEntry } from "@numisma/engine";
+import { fetchBinanceDailyClose } from "./binance-provider.js";
+
+const BTC: InstrumentRegistryEntry = {
+  instrumentId: "btc",
+  symbol: "BTCUSDT",
+  quoteCurrency: "USD",
+  source: "binance",
+};
+
+function fetchWith(res: () => Response | Promise<Response>): typeof fetch {
+  return (() => Promise.resolve(res())) as typeof fetch;
+}
+
+const OPTS = { timeoutMs: 5_000 };
+
+describe("fetchBinanceDailyClose — loud failures", () => {
+  it("attributes a non-JSON 200 to the symbol instead of throwing a bare SyntaxError", async () => {
+    // Regression guard for #110's finding 2 — see twelvedata-provider.test.ts. The
+    // decode used to run outside the guarded region, so a 200 carrying a maintenance
+    // page or a Cloudflare interstitial threw before Binance's prefix was applied.
+    await expect(
+      fetchBinanceDailyClose(BTC, {
+        ...OPTS,
+        fetchImpl: fetchWith(() => new Response("<html>maintenance</html>", { status: 200 })),
+      }),
+    ).rejects.toThrow(/^Binance BTCUSDT -> /);
+  });
+});

--- a/apps/price-feed/src/binance-provider.ts
+++ b/apps/price-feed/src/binance-provider.ts
@@ -9,33 +9,9 @@
  * it stays per-symbol attributable.
  */
 import type { InstrumentRegistryEntry } from "@numisma/engine";
+import { fetchJson, type FetchOptions, type ProviderObservation } from "./provider.js";
 
 const BINANCE_KLINES = "https://api.binance.com/api/v3/klines";
-
-/**
- * A raw provider observation: the close, the DATE of the bar it came from, and the
- * instant it was fetched. `observationDate` (`YYYY-MM-DD`) is the provider's own bar
- * date — a Binance 1d kline's `openTime` day (UTC), or a Twelve Data row's
- * `datetime` day. The orchestrator uses it to tell a fresh close from a stale one on
- * a market-closed day (see the per-provider bar-date rule in `fetch-prices.ts`); it
- * is NOT the trading-day `asOf` (which is timezone-anchored in the engine).
- */
-export interface ProviderObservation {
-  instrumentId: string;
-  symbol: string;
-  close: number;
-  fetchedAt: string;
-  /** The provider bar's own date (`YYYY-MM-DD`); see the interface doc above. */
-  observationDate: string;
-}
-
-export interface FetchOptions {
-  timeoutMs: number;
-  /** Injectable for tests; defaults to the global `fetch`. */
-  fetchImpl?: typeof fetch;
-  /** Injectable clock for the `fetchedAt` stamp; defaults to `Date.now`. */
-  now?: () => Date;
-}
 
 /**
  * Fetch the last COMPLETED daily close for one registry entry from Binance. It asks
@@ -50,31 +26,16 @@ export async function fetchBinanceDailyClose(
   entry: InstrumentRegistryEntry,
   options: FetchOptions,
 ): Promise<ProviderObservation> {
-  const fetchImpl = options.fetchImpl ?? fetch;
   const now = options.now ?? (() => new Date());
-  const controller = new AbortController();
-  const timer = setTimeout(() => controller.abort(), options.timeoutMs);
-  let res: Response;
-  try {
-    const url = `${BINANCE_KLINES}?symbol=${entry.symbol}&interval=1d&limit=2`;
-    res = await fetchImpl(url, { signal: controller.signal });
-  } catch (error) {
-    if (error instanceof Error && error.name === "AbortError") {
-      throw new Error(
-        `Binance ${entry.symbol} -> request timed out after ${options.timeoutMs}ms`,
-      );
-    }
-    throw new Error(
-      `Binance ${entry.symbol} -> ${error instanceof Error ? error.message : String(error)}`,
-    );
-  } finally {
-    clearTimeout(timer);
+  const url = `${BINANCE_KLINES}?symbol=${entry.symbol}&interval=1d&limit=2`;
+  const r = await fetchJson(url, {
+    timeoutMs: options.timeoutMs,
+    fetchImpl: options.fetchImpl,
+  });
+  if (!r.ok) {
+    throw new Error(`Binance ${entry.symbol} -> ${r.reason}`);
   }
-
-  if (!res.ok) {
-    throw new Error(`Binance ${entry.symbol} -> HTTP ${res.status} ${res.statusText}`);
-  }
-  const rows = (await res.json()) as unknown;
+  const rows = r.body;
   if (!Array.isArray(rows)) {
     throw new Error(`Binance ${entry.symbol} -> unexpected payload shape`);
   }

--- a/apps/price-feed/src/fetch-prices.ts
+++ b/apps/price-feed/src/fetch-prices.ts
@@ -59,7 +59,8 @@ import {
   type PriceFeedConfig,
   type ProviderCredentials,
 } from "./config.js";
-import { fetchBinanceDailyClose, type ProviderObservation } from "./binance-provider.js";
+import { fetchBinanceDailyClose } from "./binance-provider.js";
+import type { ProviderObservation } from "./provider.js";
 import { fetchTwelveDataDailyCloses, type ProviderFetchResult } from "./twelvedata-provider.js";
 import { fetchBanxicoFix } from "./banxico-provider.js";
 import { emitMarksToInbox } from "./inbox.js";

--- a/apps/price-feed/src/inbox.ts
+++ b/apps/price-feed/src/inbox.ts
@@ -8,8 +8,8 @@
  * The fetcher NEVER writes the event log (R6): it drops candidates in the inbox
  * and `pnpm spine` owns the guarded, validated append.
  */
-import { readFile } from "node:fs/promises";
 import { mergeInbox, type InboxRecord, type PriceMarkedEvent } from "@numisma/engine";
+import { readOptional } from "@numisma/event-store";
 import { atomicWrite } from "./atomic-write.js";
 
 /**
@@ -34,21 +34,29 @@ export async function emitMarksToInbox(
   return addedCount;
 }
 
-async function readInbox(inboxPath: string): Promise<InboxRecord[]> {
-  let raw: string;
-  try {
-    raw = await readFile(inboxPath, "utf8");
-  } catch (error) {
-    if (error instanceof Error && "code" in error && error.code === "ENOENT") {
-      return [];
-    }
-    throw error;
+/**
+ * Read the inbox as the JSON array of transactions `pnpm spine` expects, mirroring
+ * `ingestInbox`'s parse. A missing inbox is the normal case (ENOENT → `[]`, via the
+ * event-store package's `readOptional` — the one ENOENT-tolerant reader); invalid
+ * JSON or a non-array throws.
+ *
+ * The single reader for BOTH price-feed callers: this module's own merge and the
+ * fetch-time rejection pre-check (`rejection-check.ts`), which folds the pending
+ * inbox into the spine's reference. It yields `unknown[]` because the inbox holds
+ * records of any shape; every event-shape decision belongs to the engine's
+ * `parseEvent` afterwards.
+ *
+ * The parse sits OUTSIDE the ENOENT tolerance but WITH its own attribution: a
+ * corrupt or empty inbox file would otherwise throw a bare `SyntaxError: Unexpected
+ * token…` with no path — and, worse, only AFTER fresh marks were already written to
+ * the store, skipping the per-symbol report. Fail loudly naming the file, matching
+ * the tui's event-store phrasing (`Inbox … is not valid JSON.`).
+ */
+export async function readInboxArray(inboxPath: string): Promise<unknown[]> {
+  const raw = await readOptional(inboxPath);
+  if (raw === undefined) {
+    return [];
   }
-  // Parse OUTSIDE the ENOENT guard above but WITH its own attribution: a corrupt
-  // or empty inbox file would otherwise throw a bare `SyntaxError: Unexpected
-  // token…` with no path — and, worse, only AFTER fresh marks were already
-  // written to the store, skipping the per-symbol report. Fail loudly naming the
-  // file, matching the tui's event-store phrasing (`Inbox … is not valid JSON.`).
   let parsed: unknown;
   try {
     parsed = JSON.parse(raw);
@@ -58,5 +66,10 @@ async function readInbox(inboxPath: string): Promise<InboxRecord[]> {
   if (!Array.isArray(parsed)) {
     throw new Error(`Inbox ${inboxPath} must be a JSON array of transactions.`);
   }
-  return parsed as InboxRecord[];
+  return parsed;
+}
+
+/** The inbox as the `{ id }`-bearing records `mergeInbox` merges on. */
+async function readInbox(inboxPath: string): Promise<InboxRecord[]> {
+  return (await readInboxArray(inboxPath)) as InboxRecord[];
 }

--- a/apps/price-feed/src/index.ts
+++ b/apps/price-feed/src/index.ts
@@ -1,9 +1,10 @@
 /**
  * `@numisma/price-feed` — the headless runtime shell for the two-plane price
  * model (ADR-005). It hosts the provider fetch, the disposable price-store IO,
- * the atomic inbox emit, and the CLI, and depends ONLY on `@numisma/engine`,
- * never on `@numisma/tui`, so any future access surface (web, scheduler) can
- * reuse the pipeline. All domain decisions live in the engine's pure core.
+ * the atomic inbox emit, and the CLI. It depends on `@numisma/engine` and
+ * `@numisma/event-store` — never on `@numisma/tui` — so any future access surface
+ * (web, scheduler) can reuse the pipeline. All domain decisions live in the
+ * engine's pure core.
  */
 export type { PriceFeedConfig, ProviderCredentials } from "./config.js";
 export { DEFAULT_CONFIG, readCredentialsFromEnv } from "./config.js";

--- a/apps/price-feed/src/index.ts
+++ b/apps/price-feed/src/index.ts
@@ -8,7 +8,8 @@
 export type { PriceFeedConfig, ProviderCredentials } from "./config.js";
 export { DEFAULT_CONFIG, readCredentialsFromEnv } from "./config.js";
 export { atomicWrite, type AtomicWriteIo } from "./atomic-write.js";
-export { fetchBinanceDailyClose, type ProviderObservation, type FetchOptions } from "./binance-provider.js";
+export { fetchBinanceDailyClose } from "./binance-provider.js";
+export type { ProviderObservation, FetchOptions } from "./provider.js";
 export { fetchTwelveDataDailyClose, type EquitiesFetchOptions } from "./twelvedata-provider.js";
 export { fetchBanxicoFix, type FixFetchOptions } from "./banxico-provider.js";
 export { upsertQuote } from "./price-store.js";

--- a/apps/price-feed/src/paths.ts
+++ b/apps/price-feed/src/paths.ts
@@ -1,10 +1,12 @@
 /**
- * Resolve the two on-disk locations the shell writes to, from the shared engine
- * path convention (so price-feed and tui agree without depending on each other):
- * the disposable price-store directory and the shared inbox write channel.
+ * Resolve the two on-disk locations the shell writes to: the disposable
+ * price-store directory and the shared inbox write channel. The event-store
+ * locations come from `@numisma/event-store` itself, the same extracted read path
+ * the tui consumes — so price-feed and tui agree by construction rather than by
+ * two copies of one convention.
  */
 import { join, resolve } from "node:path";
-import { INBOX_PATH_SEGMENTS, PRICE_STORE_DIR_SEGMENT } from "@numisma/engine";
+import { PRICE_STORE_DIR_SEGMENT } from "@numisma/engine";
 import { resolveEventStorePaths } from "@numisma/event-store";
 
 export interface PriceFeedPaths {
@@ -28,12 +30,14 @@ export function resolvePriceFeedPaths(dataDir: string): PriceFeedPaths {
   // file, it only READS them to rebuild the known world the ±50% guard judges a
   // fetched mark against. That read does refresh the log's derived quarantine
   // lane (`events.jsonl.quarantine`), which is shared with `pnpm spine` and the
-  // tui and is not the log. Both filenames come from the event store itself, so
-  // there is nothing left here to drift from what the spine and tui read.
-  const { genesis, log } = resolveEventStorePaths(base);
+  // tui and is not the log. All three event-store locations come from the event
+  // store itself, so there is nothing left here to drift from what the spine and
+  // tui read; only `pricesDir` — which the event store has no equivalent for — is
+  // still assembled here, from the engine's own segment.
+  const { genesis, log, inbox } = resolveEventStorePaths(base);
   return {
     pricesDir: join(base, PRICE_STORE_DIR_SEGMENT),
-    inbox: join(base, ...INBOX_PATH_SEGMENTS),
+    inbox,
     genesis,
     log,
   };

--- a/apps/price-feed/src/paths.ts
+++ b/apps/price-feed/src/paths.ts
@@ -5,27 +5,36 @@
  */
 import { join, resolve } from "node:path";
 import { INBOX_PATH_SEGMENTS, PRICE_STORE_DIR_SEGMENT } from "@numisma/engine";
+import { resolveEventStorePaths } from "@numisma/event-store";
 
 export interface PriceFeedPaths {
   /** Directory holding `data/prices/<instrumentId>.jsonl`. */
   pricesDir: string;
   /** The shared inbox file `pnpm spine` consumes. */
   inbox: string;
-  /** The immutable t0 seed the fetch-time rejection pre-check reads (read-only). */
+  /** The immutable t0 seed the fetch-time rejection pre-check reads; never written. */
   genesis: string;
-  /** The append-only event log the rejection pre-check reads for last-close (read-only). */
+  /**
+   * The append-only event log the rejection pre-check reads for last-close. The log
+   * file itself is never written here; reading it refreshes its derived
+   * `events.jsonl.quarantine` side lane, exactly as every other reader does.
+   */
   log: string;
 }
 
 export function resolvePriceFeedPaths(dataDir: string): PriceFeedPaths {
   const base = resolve(dataDir);
+  // The spine owns genesis/log writes (R6): the pre-check never writes either
+  // file, it only READS them to rebuild the known world the ±50% guard judges a
+  // fetched mark against. That read does refresh the log's derived quarantine
+  // lane (`events.jsonl.quarantine`), which is shared with `pnpm spine` and the
+  // tui and is not the log. Both filenames come from the event store itself, so
+  // there is nothing left here to drift from what the spine and tui read.
+  const { genesis, log } = resolveEventStorePaths(base);
   return {
     pricesDir: join(base, PRICE_STORE_DIR_SEGMENT),
     inbox: join(base, ...INBOX_PATH_SEGMENTS),
-    // The spine owns genesis/log writes (R6); the pre-check only READS them to
-    // rebuild the known world the ±50% guard judges a fetched mark against. Same
-    // filenames the tui's event-store uses, without a price-feed→tui dependency.
-    genesis: join(base, "genesis.json"),
-    log: join(base, "events.jsonl"),
+    genesis,
+    log,
   };
 }

--- a/apps/price-feed/src/provider.ts
+++ b/apps/price-feed/src/provider.ts
@@ -1,0 +1,104 @@
+/**
+ * The provider kernel: the contracts every price provider speaks and the one
+ * network envelope they all ride. It exists so the three concrete providers
+ * (Binance, Twelve Data, Banxico) hold nothing but their own URL, payload shape
+ * and failure label — the shared `AbortController` timeout (R4), the HTTP-status
+ * check, the JSON decode and the error rewrap live here once.
+ *
+ * `fetchJson` deliberately returns a Result rather than throwing: the providers
+ * disagree on channel (Binance and Banxico throw a symbol-attributable error;
+ * Twelve Data maps a request-level failure onto every entry in the batch, and
+ * must never throw for a data problem). A helper that imposed a channel would
+ * force one of them to convert back. Each provider surfaces the bare reason in
+ * one line, with its own label — the helper never formats the label, because
+ * Twelve Data's is built per batch entry.
+ */
+/**
+ * A raw provider observation: the close, the DATE of the bar it came from, and the
+ * instant it was fetched. `observationDate` (`YYYY-MM-DD`) is the provider's own bar
+ * date — a Binance 1d kline's `openTime` day (UTC), or a Twelve Data row's
+ * `datetime` day. The orchestrator uses it to tell a fresh close from a stale one on
+ * a market-closed day (see the per-provider bar-date rule in `fetch-prices.ts`); it
+ * is NOT the trading-day `asOf` (which is timezone-anchored in the engine).
+ */
+export interface ProviderObservation {
+  instrumentId: string;
+  symbol: string;
+  close: number;
+  fetchedAt: string;
+  /** The provider bar's own date (`YYYY-MM-DD`); see the interface doc above. */
+  observationDate: string;
+}
+
+export interface FetchOptions {
+  timeoutMs: number;
+  /** Injectable for tests; defaults to the global `fetch`. */
+  fetchImpl?: typeof fetch;
+  /** Injectable clock for the `fetchedAt` stamp; defaults to `Date.now`. */
+  now?: () => Date;
+}
+
+/**
+ * The outcome of one guarded JSON fetch. `reason` is BARE — no provider label, no
+ * symbol: the caller owns the prefix (`Binance BTCUSDT -> …`), because Twelve Data
+ * builds one prefix per entry in a batch.
+ */
+export type FetchJsonResult = { ok: true; body: unknown } | { ok: false; reason: string };
+
+interface FetchJsonOptions {
+  timeoutMs: number;
+  /**
+   * Injectable for tests; defaults to the global `fetch`. Explicitly `| undefined`
+   * so a provider can forward its own optional `fetchImpl` straight through under
+   * `exactOptionalPropertyTypes`.
+   */
+  fetchImpl?: typeof fetch | undefined;
+  /** Extra request init (headers, method, …); the `signal` is always ours. */
+  init?: RequestInit | undefined;
+}
+
+/**
+ * Fetch `url` and decode its JSON body, bounded by an `AbortController` timeout
+ * (R4) so a stalled provider can never hang a scheduled run. Returns a bare-reason
+ * Result for a timeout, a transport error, a non-ok HTTP status, or a body that is
+ * not JSON — the caller labels it.
+ *
+ * The JSON decode is INSIDE the guarded region on purpose: a 200 with a non-JSON
+ * body (a maintenance page, a Cloudflare interstitial) used to escape each provider
+ * as an unlabelled `SyntaxError`, which in Twelve Data's case aborted the whole run
+ * against that function's own "never throws for a data problem" contract. Here it is
+ * an ordinary `{ ok: false, reason }`, attributed by whoever asked for it.
+ */
+export async function fetchJson(
+  url: string,
+  options: FetchJsonOptions,
+): Promise<FetchJsonResult> {
+  const fetchImpl = options.fetchImpl ?? fetch;
+  const controller = new AbortController();
+  const timer = setTimeout(() => controller.abort(), options.timeoutMs);
+  try {
+    const res = await fetchImpl(url, { ...options.init, signal: controller.signal });
+    if (!res.ok) {
+      return { ok: false, reason: `HTTP ${res.status} ${res.statusText}` };
+    }
+    return { ok: true, body: (await res.json()) as unknown };
+  } catch (error) {
+    if (error instanceof Error && error.name === "AbortError") {
+      return { ok: false, reason: `request timed out after ${options.timeoutMs}ms` };
+    }
+    return { ok: false, reason: error instanceof Error ? error.message : String(error) };
+  } finally {
+    clearTimeout(timer);
+  }
+}
+
+/**
+ * True for any non-null object — INCLUDING arrays, deliberately. Every caller
+ * follows the guard with a property read that an array answers `undefined`, which
+ * the shape checks then refuse attributably, so a narrower predicate would buy
+ * nothing. Package-internal: imported by sibling modules, intentionally NOT
+ * re-exported from `index.ts` (same stance as `packages/engine/src/internal.ts`).
+ */
+export function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === "object" && value !== null;
+}

--- a/apps/price-feed/src/rejection-check.test.ts
+++ b/apps/price-feed/src/rejection-check.test.ts
@@ -5,7 +5,7 @@
 // rule), so these tests exercise the exact gate `pnpm spine` enforces. No live
 // network and no live data files: an in-memory engine genesis fixture and a fresh
 // temp data dir.
-import { mkdtemp, mkdir, rm, writeFile } from "node:fs/promises";
+import { access, mkdtemp, mkdir, readFile, rm, writeFile } from "node:fs/promises";
 import { tmpdir } from "node:os";
 import { dirname, join } from "node:path";
 import {
@@ -16,6 +16,7 @@ import {
   type FundReviewData,
   type Quote,
 } from "@numisma/engine";
+import { quarantineLogPath } from "@numisma/event-store";
 import { afterEach, beforeEach, describe, expect, it } from "vitest";
 import {
   findMarkRejections,
@@ -247,6 +248,19 @@ describe("loadSpineReference + scanFetchedMarks — reads the real genesis/log o
     expect(scan.rejections).toEqual([]);
   });
 
+  it("names the missing genesis in an ENOENT Note rather than skipping silently", async () => {
+    // The payoff of routing the read through `loadGenesis`: an unseeded or damaged
+    // data dir is OPERATOR-VISIBLE. `skipped: true` alone is the old silence — the
+    // Note is what tells the operator WHICH file is missing and why. Matched on
+    // substance (the ENOENT condition + the file), not on the exact full message.
+    const scan = await scanFetchedMarks(runResult(BTC_LAST_CLOSE * 3), resolvePriceFeedPaths(dataDir));
+
+    expect(scan.skipped).toBe(true);
+    expect(scan.unavailableReason).toBeDefined();
+    expect(scan.unavailableReason).toMatch(/ENOENT|no such file/i);
+    expect(scan.unavailableReason).toMatch(/genesis\.json/);
+  });
+
   it("does not pre-check before the mark time (no marks emitted this run)", async () => {
     await writeGenesis();
     const preMarkResult: FetchRunResult = {
@@ -268,6 +282,65 @@ describe("loadSpineReference + scanFetchedMarks — reads the real genesis/log o
     expect(scan.skipped).toBe(true);
     expect(scan.rejections).toEqual([]);
     expect(scan.unavailableReason).toMatch(/not valid JSON/);
+  });
+
+  // The pre-check reads the operator's real data dir on every scheduled run, and
+  // that read has one deliberate write: the log's derived quarantine side lane. These
+  // three pin the whole side effect — the lane appears, the LOG never moves, and a
+  // stale lane is deleted when the log reads clean.
+  async function exists(filePath: string): Promise<boolean> {
+    try {
+      await access(filePath);
+      return true;
+    } catch {
+      return false;
+    }
+  }
+
+  it("surfaces the corrupt line to the quarantine lane beside the log", async () => {
+    await writeGenesis();
+    const paths = resolvePriceFeedPaths(dataDir);
+    await writeFile(paths.log, "{ not json\n", "utf8");
+
+    await scanFetchedMarks(runResult(BTC_LAST_CLOSE * 3), paths);
+
+    const lane = await readFile(quarantineLogPath(paths.log), "utf8");
+    expect(lane).toMatch(/\{ not json/);
+    expect(lane).toMatch(/not valid JSON/);
+  });
+
+  it("never mutates the log itself while reading it (bytes identical before and after)", async () => {
+    await writeGenesis();
+    const paths = resolvePriceFeedPaths(dataDir);
+    // A corrupt line is the case where a "repair on read" would be most tempting.
+    await writeFile(paths.log, "{ not json\n", "utf8");
+    const before = await readFile(paths.log);
+
+    await scanFetchedMarks(runResult(BTC_LAST_CLOSE * 3), paths);
+
+    const after = await readFile(paths.log);
+    expect(after.equals(before)).toBe(true);
+  });
+
+  it("removes a stale quarantine lane when the log reads clean", async () => {
+    await writeGenesis();
+    const paths = resolvePriceFeedPaths(dataDir);
+    // A log that loads fully, plus a leftover lane from an earlier corrupt read.
+    await writeFile(
+      paths.log,
+      JSON.stringify(markFromQuote(quote("btc", 66_000))) + "\n",
+      "utf8",
+    );
+    const lanePath = quarantineLogPath(paths.log);
+    await writeFile(lanePath, '{"lineNumber":1,"line":"stale","reason":"not valid JSON"}\n', "utf8");
+    expect(await exists(lanePath)).toBe(true);
+
+    // This is the branch the unattended 18:00 run actually takes: the pre-check
+    // DELETES the operator's sidecar as a side effect of reading a healthy log.
+    const scan = await scanFetchedMarks(runResult(BTC_LAST_CLOSE * 1.05), paths);
+
+    expect(scan.skipped).toBe(false);
+    expect(await exists(lanePath)).toBe(false);
   });
 });
 

--- a/apps/price-feed/src/rejection-check.test.ts
+++ b/apps/price-feed/src/rejection-check.test.ts
@@ -225,7 +225,7 @@ describe("loadSpineReference + scanFetchedMarks — reads the real genesis/log o
     const paths = resolvePriceFeedPaths(dataDir);
 
     const world = await loadSpineReference(paths);
-    expect(world?.reference).toBeDefined();
+    expect(world.reference).toBeDefined();
 
     const scan = await scanFetchedMarks(runResult(BTC_LAST_CLOSE * 3), paths);
     expect(scan.skipped).toBe(false);

--- a/apps/price-feed/src/rejection-check.ts
+++ b/apps/price-feed/src/rejection-check.ts
@@ -34,18 +34,18 @@
  * shell; building the reference and evaluating the guard are the engine's pure
  * functions, consumed unchanged.
  */
-import { readFile } from "node:fs/promises";
 import {
   applyEventToReference,
   buildEventReference,
   crossReferenceEvent,
   parseEvent,
-  parseFundReview,
   type EventReference,
   type PortfolioEvent,
   type PriceMarkedEvent,
 } from "@numisma/engine";
+import { assertLogFullyLoaded, loadEventLog, loadGenesis } from "@numisma/event-store";
 import type { FetchRunResult } from "./fetch-prices.js";
+import { readInboxArray } from "./inbox.js";
 
 /**
  * One fetched mark the spine guard would reject, carried with the engine guard's
@@ -116,53 +116,34 @@ export interface SpineWorld {
  * marks — and guarantees we never double-count this run's marks as both reference
  * context AND judged subjects.
  *
- * Returns `undefined` when there is no genesis to check against — a pre-check needs
- * a reference, so its absence is surfaced as "could not pre-check", never a false
- * all-clear. Throws (fail-loud, like the spine) if genesis, a log line, or the
- * inbox is unreadable; the caller treats a throw as a non-fatal "pre-check
- * unavailable" so a corrupt file never masks an otherwise-successful fetch.
+ * Genesis + the log are read through `@numisma/event-store` — the same
+ * `loadGenesis` / `loadEventLog` + `assertLogFullyLoaded` pair `ingestInbox` and the
+ * TUI's own fold use, so the pre-check cannot drift from the spine it advises on
+ * (#141). Throws (fail-loud, like the spine) if genesis is MISSING or invalid, if
+ * any log line will not load, or if the inbox is unreadable; the caller swallows
+ * every throw into a non-fatal "pre-check unavailable" so a corrupt or unseeded
+ * data dir never masks an otherwise-successful fetch. A missing genesis therefore
+ * surfaces as an ENOENT note rather than silence — a pre-check needs a reference,
+ * so its absence is reported as "could not pre-check", never a false all-clear.
+ *
+ * Reading the log refreshes `events.jsonl.quarantine` (the derived side lane), which
+ * is deliberate and shared with every other reader; the log and genesis themselves
+ * are never written here (R6).
  */
 export async function loadSpineReference(
   paths: SpineReferencePaths,
   options?: { freshlyQueuedCount?: number },
-): Promise<SpineWorld | undefined> {
-  const genesisRaw = await readOptional(paths.genesis);
-  if (genesisRaw === undefined) {
-    return undefined;
-  }
-  const genesis = parseFundReview(genesisRaw);
-  if (genesis.kind !== "ok") {
-    throw new Error(`Genesis seed failed validation (${genesis.kind}) at ${paths.genesis}.`);
-  }
+): Promise<SpineWorld> {
+  const genesis = await loadGenesis(paths.genesis);
 
-  const logRaw = await readOptional(paths.log);
-  const priorEvents: PortfolioEvent[] = [];
-  if (logRaw !== undefined) {
-    for (const [index, line] of logRaw.split("\n").entries()) {
-      const trimmed = line.trim();
-      if (!trimmed) {
-        continue;
-      }
-      let json: unknown;
-      try {
-        json = JSON.parse(trimmed);
-      } catch {
-        throw new Error(`Log ${paths.log} line ${index + 1} is not valid JSON.`);
-      }
-      const parsed = parseEvent(json);
-      if (parsed.kind !== "ok") {
-        throw new Error(
-          `Log ${paths.log} line ${index + 1} failed to parse (${parsed.path}: ${parsed.message}).`,
-        );
-      }
-      priorEvents.push(parsed.value);
-    }
-  }
+  const load = await loadEventLog(paths.log);
+  assertLogFullyLoaded(load, paths.log);
+  const priorEvents: PortfolioEvent[] = load.events;
 
   // The known world is genesis + the durable log; accepted pending inbox events
   // extend it in order, exactly as `ingestInbox`. `seen` starts as the log ids —
   // the ids the spine dedup-skips before the guard even runs (event-store.ts:245).
-  const reference = buildEventReference(genesis.value, priorEvents);
+  const reference = buildEventReference(genesis, priorEvents);
   const seenIds = new Set(priorEvents.map((event) => event.id));
 
   // Fold in the PRE-EXISTING inbox: everything on disk except the tail this run just
@@ -290,18 +271,17 @@ export async function scanFetchedMarks(
   if (!result.markEmitted) {
     return { rejections: [], skipped: false };
   }
-  let world: SpineWorld | undefined;
+  let world: SpineWorld;
   try {
     world = await loadSpineReference(paths, { freshlyQueuedCount: result.emittedCount });
   } catch (error) {
+    // Includes a MISSING genesis (ENOENT from `loadGenesis`): unseeded or damaged,
+    // it is surfaced as one Note rather than an unexplained silent skip.
     return {
       rejections: [],
       skipped: true,
       unavailableReason: error instanceof Error ? error.message : String(error),
     };
-  }
-  if (world === undefined) {
-    return { rejections: [], skipped: true };
   }
   // Judge only the marks spine will actually guard (new to the batch), in spine's
   // order: any already-doomed pending mark first, then this run's fresh marks
@@ -332,37 +312,4 @@ function toMarkRejection(event: PortfolioEvent, path: string, reason: string): M
     path,
     reason,
   };
-}
-
-/**
- * Read the inbox as the JSON array of transactions spine expects, mirroring
- * `ingestInbox`'s parse. A missing inbox is the normal case (returns `[]`); invalid
- * JSON or a non-array throws (the caller treats it as pre-check unavailable).
- */
-async function readInboxArray(inboxPath: string): Promise<unknown[]> {
-  const raw = await readOptional(inboxPath);
-  if (raw === undefined) {
-    return [];
-  }
-  let parsed: unknown;
-  try {
-    parsed = JSON.parse(raw);
-  } catch {
-    throw new Error(`Inbox ${inboxPath} is not valid JSON.`);
-  }
-  if (!Array.isArray(parsed)) {
-    throw new Error(`Inbox ${inboxPath} must be a JSON array of transactions.`);
-  }
-  return parsed;
-}
-
-async function readOptional(filePath: string): Promise<string | undefined> {
-  try {
-    return await readFile(filePath, "utf8");
-  } catch (error) {
-    if (error instanceof Error && "code" in error && error.code === "ENOENT") {
-      return undefined;
-    }
-    throw error;
-  }
 }

--- a/apps/price-feed/src/twelvedata-provider.test.ts
+++ b/apps/price-feed/src/twelvedata-provider.test.ts
@@ -202,6 +202,23 @@ describe("fetchTwelveDataDailyCloses — batched multi-symbol fetch (rate-limit 
     expect(result?.observation?.observationDate).toBe("2026-07-02");
   });
 
+  it("fails EVERY symbol attributably on a non-JSON 200 instead of aborting the run", async () => {
+    // Regression guard for #110's finding 2. `res.json()` used to sit OUTSIDE the
+    // guarded region, so a 200 carrying a maintenance page or a Cloudflare
+    // interstitial threw a bare SyntaxError that escaped this function entirely and
+    // aborted the whole fetch run — contradicting its own docstring promise that one
+    // bad symbol can never do that. It is an ordinary attributed result now.
+    const results = await fetchTwelveDataDailyCloses([AAPL, GOOGL], {
+      ...OPTS,
+      fetchImpl: fetchWith(
+        () => new Response("<html>scheduled maintenance</html>", { status: 200 }),
+      ),
+    });
+    expect(results.map((r) => r.observation)).toEqual([undefined, undefined]);
+    expect(results[0]?.error).toMatch(/^Twelve Data AAPL -> /);
+    expect(results[1]?.error).toMatch(/^Twelve Data GOOGL -> /);
+  });
+
   it("returns [] for an empty entry list without touching the network", async () => {
     let called = false;
     const spy: typeof fetch = (() => {

--- a/apps/price-feed/src/twelvedata-provider.test.ts
+++ b/apps/price-feed/src/twelvedata-provider.test.ts
@@ -219,6 +219,26 @@ describe("fetchTwelveDataDailyCloses — batched multi-symbol fetch (rate-limit 
     expect(results[1]?.error).toMatch(/^Twelve Data GOOGL -> /);
   });
 
+  it("attributes a malformed symbol (lone surrogate) instead of throwing a URIError", async () => {
+    // `encodeURIComponent` throws `URIError: URI malformed` on a lone surrogate, so
+    // building the request URL is a failure channel of its own. It must land as an
+    // attributed per-entry result like every other failure here — never a throw that
+    // escapes and aborts the whole run.
+    const BROKEN: InstrumentRegistryEntry = { ...AAPL, instrumentId: "broken", symbol: "\uD800" };
+    let called = false;
+    const spy: typeof fetch = (() => {
+      called = true;
+      return Promise.resolve(timeSeriesResponse("1"));
+    }) as typeof fetch;
+
+    const results = await fetchTwelveDataDailyCloses([BROKEN, GOOGL], { ...OPTS, fetchImpl: spy });
+
+    expect(called).toBe(false);
+    expect(results.map((r) => r.observation)).toEqual([undefined, undefined]);
+    expect(results[0]?.error).toMatch(/^Twelve Data \uD800 -> /);
+    expect(results[1]?.error).toMatch(/^Twelve Data GOOGL -> /);
+  });
+
   it("returns [] for an empty entry list without touching the network", async () => {
     let called = false;
     const spy: typeof fetch = (() => {

--- a/apps/price-feed/src/twelvedata-provider.ts
+++ b/apps/price-feed/src/twelvedata-provider.ts
@@ -79,10 +79,18 @@ export async function fetchTwelveDataDailyCloses(
     );
   }
 
-  const symbols = entries.map((entry) => encodeURIComponent(entry.symbol)).join(",");
-  const url =
-    `${TWELVEDATA_TIME_SERIES}?symbol=${symbols}` +
-    `&interval=1day&outputsize=1&apikey=${encodeURIComponent(options.apiKey)}`;
+  // `encodeURIComponent` THROWS (`URIError`) on a lone surrogate, so building the
+  // URL is itself a failure channel: a malformed key or registry symbol must become
+  // an attributed result here, not a throw that escapes and aborts the whole run.
+  let url: string;
+  try {
+    const symbols = entries.map((entry) => encodeURIComponent(entry.symbol)).join(",");
+    url =
+      `${TWELVEDATA_TIME_SERIES}?symbol=${symbols}` +
+      `&interval=1day&outputsize=1&apikey=${encodeURIComponent(options.apiKey)}`;
+  } catch (error) {
+    return failAll(error instanceof Error ? error.message : String(error));
+  }
   const r = await fetchJson(url, {
     timeoutMs: options.timeoutMs,
     fetchImpl: options.fetchImpl,

--- a/apps/price-feed/src/twelvedata-provider.ts
+++ b/apps/price-feed/src/twelvedata-provider.ts
@@ -25,7 +25,12 @@
  * passed in via {@link EquitiesFetchOptions.apiKey}.
  */
 import type { InstrumentRegistryEntry } from "@numisma/engine";
-import type { FetchOptions, ProviderObservation } from "./binance-provider.js";
+import {
+  fetchJson,
+  isRecord,
+  type FetchOptions,
+  type ProviderObservation,
+} from "./provider.js";
 
 const TWELVEDATA_TIME_SERIES = "https://api.twelvedata.com/time_series";
 
@@ -74,29 +79,18 @@ export async function fetchTwelveDataDailyCloses(
     );
   }
 
-  const fetchImpl = options.fetchImpl ?? fetch;
-  const controller = new AbortController();
-  const timer = setTimeout(() => controller.abort(), options.timeoutMs);
-  let res: Response;
-  try {
-    const symbols = entries.map((entry) => encodeURIComponent(entry.symbol)).join(",");
-    const url =
-      `${TWELVEDATA_TIME_SERIES}?symbol=${symbols}` +
-      `&interval=1day&outputsize=1&apikey=${encodeURIComponent(options.apiKey)}`;
-    res = await fetchImpl(url, { signal: controller.signal });
-  } catch (error) {
-    if (error instanceof Error && error.name === "AbortError") {
-      return failAll(`request timed out after ${options.timeoutMs}ms`);
-    }
-    return failAll(error instanceof Error ? error.message : String(error));
-  } finally {
-    clearTimeout(timer);
+  const symbols = entries.map((entry) => encodeURIComponent(entry.symbol)).join(",");
+  const url =
+    `${TWELVEDATA_TIME_SERIES}?symbol=${symbols}` +
+    `&interval=1day&outputsize=1&apikey=${encodeURIComponent(options.apiKey)}`;
+  const r = await fetchJson(url, {
+    timeoutMs: options.timeoutMs,
+    fetchImpl: options.fetchImpl,
+  });
+  if (!r.ok) {
+    return failAll(r.reason);
   }
-
-  if (!res.ok) {
-    return failAll(`HTTP ${res.status} ${res.statusText}`);
-  }
-  const body = (await res.json()) as unknown;
+  const body = r.body;
   if (!isRecord(body)) {
     return failAll(`unexpected payload shape`);
   }
@@ -188,8 +182,4 @@ function barDateFromRow(entry: InstrumentRegistryEntry, row: Record<string, unkn
     throw new Error(`Twelve Data ${entry.symbol} -> unexpected payload shape (no bar datetime)`);
   }
   return match[1]!;
-}
-
-function isRecord(value: unknown): value is Record<string, unknown> {
-  return typeof value === "object" && value !== null;
 }

--- a/packages/event-store/src/event-store.ts
+++ b/packages/event-store/src/event-store.ts
@@ -21,6 +21,7 @@
 import { mkdir, readFile, rm, writeFile } from "node:fs/promises";
 import { dirname, join, resolve } from "node:path";
 import {
+  INBOX_PATH_SEGMENTS,
   foldEvents,
   parseEvent,
   parseFundReview,
@@ -71,7 +72,7 @@ export function resolveEventStorePaths(dataDir = resolveDataDirDefault()): Event
   return {
     genesis: join(base, "genesis.json"),
     log: join(base, "events.jsonl"),
-    inbox: join(base, "inbox", "transactions.json"),
+    inbox: join(base, ...INBOX_PATH_SEGMENTS),
     ingestedDir: join(base, "ingested"),
   };
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -32,6 +32,9 @@ importers:
       '@numisma/engine':
         specifier: workspace:*
         version: link:../../packages/engine
+      '@numisma/event-store':
+        specifier: workspace:*
+        version: link:../../packages/event-store
 
   apps/tui:
     dependencies:


### PR DESCRIPTION
The price feed stops re-deriving the event store: three deduplications, two of which turned something up.

Three commits, separable for review. Commits 1–2 draw a new package edge and touch the durable-log pre-check; commit 3 touches the network providers only and collides with neither.

## What this closes

Closes #141 — `apps/price-feed` now declares `@numisma/event-store` as a `workspace:*` dependency and `rejection-check.ts` consumes the package's `readOptional`, `loadGenesis`, and `loadEventLog` + `assertLogFullyLoaded` instead of re-deriving them. `loadSpineReference` no longer re-implements genesis + log reconstruction. `@numisma/engine` remains I/O-free — the new edge is `apps/price-feed → @numisma/event-store`, which itself depends on `@numisma/engine` and node builtins and nothing else. The "exactly one `readOptional` repo-wide" criterion is met for the price feed's read path but **not literally repo-wide** — see finding 3.

Closes #110 — item 2 was already superseded by #141, and this PR takes the two that remained. Item 3: `paths.ts` resolves `genesis.json` and `events.jsonl` through `resolveEventStorePaths(dataDir)` rather than hardcoding them. Item 1: the fetch reliability envelope, `isRecord`, and the shared provider contracts collapse into one new `apps/price-feed/src/provider.ts`.

## Commit 1 — `apps/price-feed` consumes `@numisma/event-store` (#141)

The local `readOptional`, the genesis read, and the log's line walk are deleted and imported. `readInboxArray(path): Promise<unknown[]>` is exported from `inbox.ts` — which already owns the inbox — and both price-feed callers route through it, retiring the last of the "three ENOENT-tolerant readers" #110 item 2 complained about. `paths.ts`'s read-only comments are narrowed to what is actually true: genesis and `events.jsonl` are never written, and reading the log refreshes its quarantine lane.

**The pre-check now touches the quarantine sidecar, and that is accepted deliberately.** `loadEventLog` maintains `events.jsonl.quarantine`. It never writes the store — `event-store.ts:94` is explicit that "the log file itself is never mutated on read" — and the lane already appears on every corrupt-log run anyway: `pnpm spine`'s `ingestInbox` writes it seconds later in the same process tree, as does every TUI dashboard mount. Refusing it to the pre-check would protect a property the run does not have. The lane cannot be committed, cannot dirty the tree, and cannot trip the post-check: accumulus's `.gitignore` carries `/data/*.quarantine` explicitly.

**Naming the branch that actually runs, which the design note glossed.** The argument above prices the *write*. On a clean log — the overwhelmingly common path — `surfaceQuarantine` takes its other branch and **deletes** the lane (`event-store.ts:173-176`, `rm(lanePath, { force: true })`). So the effect of this PR on a normal day is that the unattended 18:00 `prices:fetch` job removes `events.jsonl.quarantine` if one is present, where previously only a manual `pnpm spine` or a TUI mount did. That is the package's documented intent — "remove a stale lane when the log reads clean, so a fixed log self-heals" — and the conclusion is unchanged: the lane is derived, gitignored, and reproducible by re-reading the log. But it is a deletion in the operator's data directory performed by a scheduled job, and it deserves to be stated rather than filed under "refreshes". The scenario to be aware of: an operator who hand-repairs bad lines out of `events.jsonl` and keeps the quarantine file as their only record of what was removed will find the next scheduled fetch has deleted it. The record was always derived and always disposable; the window to read it is now shorter.

All three of the sidecar's properties are now pinned by tests, since this is the widest-blast-radius side effect in the PR and none of them had coverage: the lane appears on a corrupt log, a stale lane is removed when the log reads clean, and — the load-bearing claim of the whole decision — `events.jsonl`'s own bytes are byte-identical before and after a read. That last one is what makes "the log file itself is never mutated on read" an enforced property rather than a comment.

**One signature change worth a reviewer's eye.** `loadSpineReference` narrowed from `Promise<SpineWorld | undefined>` to `Promise<SpineWorld>`, and `scanFetchedMarks`'s `if (world === undefined)` branch was deleted. Adopting `loadGenesis` makes that branch unreachable — it throws ENOENT where the old reader returned `undefined` — so keeping it would have been dead code asserting a contract that no longer exists. `index.ts` re-exports the name, not the return type, so the public surface is unaffected.

**The TUI's inbox parse (`apps/tui/src/event-store.ts:170-181`) stays a second copy on purpose.** #141's rationale — "two hand-maintained parsers that must stay byte-identical are a correctness risk the moment `schemaVersion` bumps" — does not reach it. That parse reads no schema: it is `JSON.parse` plus `Array.isArray`, yielding `unknown[]`, and every event-shape decision happens afterwards in `parseEvent`, already single-sourced in the engine. A `schemaVersion` bump cannot make the two diverge. It earns the lift to the package the moment that parse grows a schema-aware step; #181's proposed record kind is the live candidate.

## Commit 2 — `paths.ts` delegates to `resolveEventStorePaths` (#110 item 3)

`genesis` and `log` come from `resolveEventStorePaths(dataDir)`; `pricesDir` and `inbox` stay on the engine's path segments, which already own them.

**And a fourth copy neither issue knew about.** The prescribed seam itself hardcoded the one segment the engine already owns: `packages/event-store/src/event-store.ts:74` built `join(base, "inbox", "transactions.json")` while `INBOX_PATH_SEGMENTS` (`packages/engine/src/price-feed/inbox-merge.ts:51`) is that exact array and `paths.ts` already consumed it. Item 3 as written would have moved the price feed off the engine convention and onto the hardcode. It is re-pointed onto `INBOX_PATH_SEGMENTS` in the same commit — behaviour-identical by inspection, and event-store already imports from `@numisma/engine`. After this every segment has exactly one home.

## Commit 3 — one provider kernel (#110 item 1)

New `apps/price-feed/src/provider.ts` holds `ProviderObservation`, `FetchOptions`, `FetchJsonResult`, `fetchJson`, and `isRecord`. The two type declarations move off `binance-provider.ts`, where a concrete provider had become the de-facto home for the shared contracts. `index.ts` re-exports both type names from the new home, so the package's public surface is byte-identical. `isRecord` stays off `index.ts`, mirroring the engine's stated stance on `internal.ts`'s helpers.

`fetchJson` returns a Result — `{ ok: true; body: unknown } | { ok: false; reason: string }` — carrying a bare reason, because the error channel differs per provider by design: Binance and Banxico throw, Twelve Data returns `failAll(...)` since it is a batch call attributing one request failure to every symbol. Each provider surfaces in one line. The label stays per-provider: Twelve Data's `failAll` builds one prefix per entry, so a helper that formatted labels would have to know the batch shape.

## Two findings, surfaced rather than papered over

#141 asks that differences between the package's messages and the local copies be reported as findings rather than smoothed away. Both of these are real.

**Finding 1 — the pre-check's log message moves from per-line to the aggregate.** The local reader threw per line (`Log … line N is not valid JSON.`); `assertLogFullyLoaded` quarantines and aggregates (`Durable log … has N unloadable line(s); refusing to fold a partial log …`, with `  line N: not valid JSON` detail lines). So `unavailableReason`'s text changes. No `cli.ts` edit was needed — the detail lines self-indent to two spaces, which is already `cli.ts`'s indent — and no test expectation was edited: `rejection-check.test.ts:270`'s `/not valid JSON/` matches inside the aggregate unchanged, because `parseLogLine` returns that reason verbatim. Worth naming out loud: the aggregate embeds spine-voiced advice ("refusing to fold a partial log … Fix or migrate them, then retry") inside an advisory Note that is followed by "`pnpm spine` remains the authoritative guard". Consistent, but the advisory now speaks in the authority's voice.

Related and intentional: genesis-missing now yields `skipped: true` **with** an ENOENT `unavailableReason`, where before it was silent. `loadGenesis` throws ENOENT where the local reader returned `undefined`. Preserving the silence would have meant keeping `loadGenesis`'s body re-typed inline, which is precisely what #141 exists to delete. It also makes `loadSpineReference`'s own docstring true for the first time — it promises absence "is surfaced as 'could not pre-check', never a false all-clear", and it was surfaced to nobody. `genesis.json` is a tracked file; its absence means an unseeded install or real damage, neither of which deserves silence. `rejection-check.test.ts:243-248` passes unedited — it asserts only `skipped` and `rejections`.

**Finding 2 — a non-JSON 200 was unlabelled, and in one provider it aborted the whole run. This is a behaviour change, against #110's "none of this changes behavior" framing.** `await res.json()` sat **outside** the guarded region in all three providers (`binance-provider.ts:77`, `banxico-provider.ts:62`, `twelvedata-provider.ts:99`). A 200 response with a non-JSON body — a maintenance page, a Cloudflare interstitial — threw a bare `SyntaxError` with no provider label. Binance and Banxico were still caught by the orchestrator, unlabelled. **Twelve Data's escaped `fetchTwelveDataDailyCloses` as a throw and aborted the entire run**, directly contradicting that function's own docstring: "Never throws for a data problem … so one bad symbol can never abort the whole run." Moving `res.json()` inside `fetchJson` turns it into an ordinary `{ ok: false, reason }`, labelled by whichever provider received it. Calling this out explicitly: #110 framed item 1 as behaviour-preserving, and this part of it is not.

This carries a **second consequence the grill did not state**: with the decode inside the guarded region, the `AbortController` timeout now bounds the **body read** as well as the headers, where previously `clearTimeout` fired before the decode began. It follows unavoidably from putting `res.json()` inside the helper, and it is the safer direction — a provider that dribbles a body forever can no longer hang a run — but it is a behaviour change in its own right and reviewers should see it named.

Both halves of finding 2 are covered by regression tests that fail against the old code: all three providers now assert a non-JSON 200 yields an attributed error — per-entry for Twelve Data rather than a throw that escapes the batch, and carrying the `Banxico SF43718 -> ` / `Binance <symbol> -> ` prefix the other two used to lose. The timeout-bounds-the-body-read consequence is pinned too, by a test that stalls in the **body** rather than the fetch; the pre-existing timeout tests reject at the fetch stage and never reach that path, which was verified by perturbing the source and watching the old tests stay green while the new one failed.

The grill asked for none of this coverage. A behaviour fix shipped unguarded seemed the wrong trade.

**Finding 3 — `readOptional` is down to two definitions, not one, and the last one is out of this PR's reach.** #141's acceptance criterion asks for exactly one repo-wide. The price feed's copy is gone, but `packages/preferences/src/orders.ts:158` holds a fourth, private copy — byte-identical but for the parameter name — that neither #141 nor #110 mentions and that the grill's "met by construction" reading missed. It is deliberately **not** folded in here: `packages/preferences` depends on `@numisma/engine` alone, so consuming the package's `readOptional` would draw a brand-new `preferences → @numisma/event-store` edge, and whether the orders sidecar's append-lock module should depend on the durable log's IO shell is a real architectural question that was never priced. Note that `event-store.ts:201-202`'s docstring already claims "this package owns the single definition" — true of the read path it describes, not yet true of the repo.

Because this PR auto-closes #141 with that criterion unmet, the residue is tracked in **#198**, filed before merge so it cannot evaporate. The same issue carries a second miscount the review turned up: `isRecord` has **three** definitions repo-wide, not the "2, not 3" #110 arrived at — `packages/engine/src/orders/records.ts:225` holds `isRecordObject`, a byte-identical body under a different name, alongside `packages/engine/src/internal.ts:121`. The engine keeping two copies of its own predicate is the same shape as the `readOptional` case and needs no new package edge at all.

Two notes for review. `INBOX_PATH_SEGMENTS` is typed `readonly string[]` rather than a tuple, so the event-store's inbox path now derives from an array whose length TypeScript does not fix — behaviour is identical today, `paths.ts` already spread it the same way, and the point is precisely that the constant is now the single point of change for both. And the commit boundary between commits 1 and 2 is not clean in `apps/price-feed/src/paths.ts`: the comment narrowing #141 asks for and the `resolveEventStorePaths` delegation #110 item 3 asks for landed in the same lines — the delegation retires the very sentence ("Same filenames the tui's event-store uses") that the narrowing rewrote. Rather than split a file's history along an entangled hunk, `paths.ts` sits wholly in commit 2. All three commits ship together regardless.

## Verification

`pnpm typecheck` exits 0 and `pnpm test` is green. The full suite is the gate rather than a targeted run, because commit 2 touches `packages/event-store`, which `pnpm spine`, the TUI, and the web push all consume.

No ADR is owed. ADR-001's line is that the engine stays I/O-free; `packages/` = imported libraries and `apps/` = runnable surfaces is its 2026-07-07 amendment, and `apps/tui` and `apps/web` already consume `@numisma/event-store`.
