### PR TITLE
Skip the rung whose partial the venue restated, instead of refusing the whole batch

### DIFF
--- a/apps/price-feed/src/binance-provider.ts
+++ b/apps/price-feed/src/binance-provider.ts
@@ -27,7 +27,7 @@ export async function fetchBinanceDailyClose(
   options: FetchOptions,
 ): Promise<ProviderObservation> {
   const now = options.now ?? (() => new Date());
-  const url = `${BINANCE_KLINES}?symbol=${entry.symbol}&interval=1d&limit=2`;
+  const url = `${BINANCE_KLINES}?symbol=${encodeURIComponent(entry.symbol)}&interval=1d&limit=2`;
   const r = await fetchJson(url, {
     timeoutMs: options.timeoutMs,
     fetchImpl: options.fetchImpl,

--- a/apps/price-feed/src/config.ts
+++ b/apps/price-feed/src/config.ts
@@ -18,9 +18,21 @@ export interface PriceFeedConfig extends MarkClock {
   /** Daily mark time (`HH:MM` local). A fetch before it upserts the store only. */
   markTime: string;
   /**
-   * Per-request network timeout in milliseconds. A stalled provider cannot hang a
-   * scheduled run (R4); bounded retry/backoff is deferred (a missed run is
-   * harmless under the idempotent deterministic id).
+   * Per-request network budget in milliseconds, covering CONNECT + HEADERS + BODY
+   * DECODE — not just time-to-headers. `fetchJson` holds one `AbortController` over
+   * the whole exchange (the decode is inside the guarded region on purpose), so this
+   * single number funds every phase and must be sized for the slowest of them
+   * together. A stalled provider still cannot hang a scheduled run (R4); bounded
+   * retry/backoff is deferred (a missed run is harmless under the idempotent
+   * deterministic id).
+   *
+   * Sized well above the observed request so the budget is never the binding
+   * constraint on a congested link: an abort here is not one symbol's failure but a
+   * WHOLE DAY'S. Twelve Data maps a request-level failure onto every entry in the
+   * batch, so one slow body loses all 8 equities in that chunk, `prices:fetch` exits
+   * 1, and the wrapper halts before `pnpm spine` — no marks land at all that day. The
+   * stall case this bounds is a provider that never finishes, and 30s catches that
+   * just as surely as 10s did.
    */
   requestTimeoutMs: number;
   /**
@@ -59,7 +71,7 @@ export interface PriceFeedConfig extends MarkClock {
 export const DEFAULT_CONFIG: PriceFeedConfig = {
   timeZone: "America/Mexico_City",
   markTime: "18:00",
-  requestTimeoutMs: 10_000,
+  requestTimeoutMs: 30_000,
   fixMaxStaleDays: 4,
   // The SINGLE engine resolver: `NUMISMA_DATA_DIR` override with an absolute,
   // homedir-derived accumulus default (`~/Dev/accumulus/data`), never a CWD-relative

--- a/apps/price-feed/src/config.ts
+++ b/apps/price-feed/src/config.ts
@@ -25,14 +25,6 @@ export interface PriceFeedConfig extends MarkClock {
    * together. A stalled provider still cannot hang a scheduled run (R4); bounded
    * retry/backoff is deferred (a missed run is harmless under the idempotent
    * deterministic id).
-   *
-   * Sized well above the observed request so the budget is never the binding
-   * constraint on a congested link: an abort here is not one symbol's failure but a
-   * WHOLE DAY'S. Twelve Data maps a request-level failure onto every entry in the
-   * batch, so one slow body loses all 8 equities in that chunk, `prices:fetch` exits
-   * 1, and the wrapper halts before `pnpm spine` — no marks land at all that day. The
-   * stall case this bounds is a provider that never finishes, and 30s catches that
-   * just as surely as 10s did.
    */
   requestTimeoutMs: number;
   /**

--- a/apps/price-feed/src/inbox.test.ts
+++ b/apps/price-feed/src/inbox.test.ts
@@ -3,8 +3,8 @@
 //  1. Attribution (finding 8): a corrupt/empty inbox file must fail LOUDLY and
 //     NAMING the file — matching the tui's `Inbox … is not valid JSON.` — rather
 //     than throwing a bare, unattributed `SyntaxError` from `JSON.parse`. The
-//     parse now sits in its own try/catch inside `readInbox`, distinct from the
-//     ENOENT→[] guard around `readFile`.
+//     parse now sits in its own try/catch inside `readInboxArray`, distinct from
+//     the ENOENT→[] guard around `readOptional`.
 //
 //  2. Sibling-repo data dir (grill decision): `DEFAULT_CONFIG.dataDir` must be an
 //     ABSOLUTE path in the sibling private `accumulus` repo (`~/Dev/accumulus/data`),
@@ -32,7 +32,7 @@ afterEach(async () => {
   await rm(dir, { recursive: true, force: true });
 });
 
-describe("emitMarksToInbox / readInbox", () => {
+describe("emitMarksToInbox / readInboxArray", () => {
   it("throws an attributed error (not a bare SyntaxError) for a corrupt inbox", async () => {
     const inbox = join(dir, "inbox.json");
     await writeFile(inbox, "{ this is not json");

--- a/apps/price-feed/src/inbox.ts
+++ b/apps/price-feed/src/inbox.ts
@@ -21,9 +21,10 @@ export async function emitMarksToInbox(
   inboxPath: string,
   marks: readonly PriceMarkedEvent[],
 ): Promise<number> {
-  const existing = await readInbox(inboxPath);
   // Marks are engine-typed events; the inbox may also hold hand-authored records
-  // of any shape, so the merge operates on the shared `{ id }` surface.
+  // of any shape, so the merge operates on the shared `{ id }` surface — which is
+  // all this cast asserts over the shared reader's `unknown[]`.
+  const existing = (await readInboxArray(inboxPath)) as InboxRecord[];
   const { next, addedCount } = mergeInbox<InboxRecord>(existing, marks);
   // Nothing fresh (a pre-mark-time or idempotent re-run): leave the inbox exactly
   // as-is — never create an empty inbox, never reformat hand-authored entries.
@@ -67,9 +68,4 @@ export async function readInboxArray(inboxPath: string): Promise<unknown[]> {
     throw new Error(`Inbox ${inboxPath} must be a JSON array of transactions.`);
   }
   return parsed;
-}
-
-/** The inbox as the `{ id }`-bearing records `mergeInbox` merges on. */
-async function readInbox(inboxPath: string): Promise<InboxRecord[]> {
-  return (await readInboxArray(inboxPath)) as InboxRecord[];
 }

--- a/apps/price-feed/src/paths.ts
+++ b/apps/price-feed/src/paths.ts
@@ -26,14 +26,9 @@ export interface PriceFeedPaths {
 
 export function resolvePriceFeedPaths(dataDir: string): PriceFeedPaths {
   const base = resolve(dataDir);
-  // The spine owns genesis/log writes (R6): the pre-check never writes either
-  // file, it only READS them to rebuild the known world the ±50% guard judges a
-  // fetched mark against. That read does refresh the log's derived quarantine
-  // lane (`events.jsonl.quarantine`), which is shared with `pnpm spine` and the
-  // tui and is not the log. All three event-store locations come from the event
-  // store itself, so there is nothing left here to drift from what the spine and
-  // tui read; only `pricesDir` — which the event store has no equivalent for — is
-  // still assembled here, from the engine's own segment.
+  // Reading the log refreshes its derived `events.jsonl.quarantine` lane, which is
+  // shared with `pnpm spine` and the tui and is not the log itself (R6 holds).
+  // `pricesDir` is assembled here because the event store has no equivalent for it.
   const { genesis, log, inbox } = resolveEventStorePaths(base);
   return {
     pricesDir: join(base, PRICE_STORE_DIR_SEGMENT),

--- a/apps/price-feed/src/provider.ts
+++ b/apps/price-feed/src/provider.ts
@@ -1,9 +1,6 @@
 /**
  * The provider kernel: the contracts every price provider speaks and the one
- * network envelope they all ride. It exists so the three concrete providers
- * (Binance, Twelve Data, Banxico) hold nothing but their own URL, payload shape
- * and failure label — the shared `AbortController` timeout (R4), the HTTP-status
- * check, the JSON decode and the error rewrap live here once.
+ * network envelope they all ride.
  *
  * `fetchJson` deliberately returns a Result rather than throwing: the providers
  * disagree on channel (Binance and Banxico throw a symbol-attributable error;
@@ -13,6 +10,7 @@
  * one line, with its own label — the helper never formats the label, because
  * Twelve Data's is built per batch entry.
  */
+
 /**
  * A raw provider observation: the close, the DATE of the bar it came from, and the
  * instant it was fetched. `observationDate` (`YYYY-MM-DD`) is the provider's own bar

--- a/apps/tui/src/import-orders-cli.ts
+++ b/apps/tui/src/import-orders-cli.ts
@@ -44,10 +44,12 @@ if (!csvPath) {
     } else if (outcome.status === "imported-partial") {
       // HANDLED, AND DELIBERATELY 0 (`D3`, #177). Lines WERE written, so exiting 1 would
       // tell a caller the run failed when it partly succeeded — replacing one
-      // overstatement with another. The flow is interactive, and the operator's line
-      // (which opens on the unread rows and names the money direction) is the real
-      // channel. If this import is ever automated or piped, the exit code becomes the only
-      // surface left and this branch must be revisited — that is #183.
+      // overstatement with another. The flow is interactive, and the operator's lines
+      // (one per qualification, each opening on its own gap and naming its own money
+      // direction) are the real channel. #199 added a second qualification here —
+      // restated partials — and the reasoning is unchanged: it too wrote lines. If this
+      // import is ever automated or piped, the exit code becomes the only surface left
+      // and this branch must be revisited — that is #183.
       process.exitCode = 0;
     }
   } catch (error) {

--- a/apps/tui/src/import-orders-cli.ts
+++ b/apps/tui/src/import-orders-cli.ts
@@ -42,14 +42,15 @@ if (!csvPath) {
     if (outcome.status === "rejected") {
       process.exitCode = 1;
     } else if (outcome.status === "imported-partial") {
-      // HANDLED, AND DELIBERATELY 0 (`D3`, #177). Lines WERE written, so exiting 1 would
-      // tell a caller the run failed when it partly succeeded — replacing one
-      // overstatement with another. The flow is interactive, and the operator's lines
-      // (one per qualification, each opening on its own gap and naming its own money
-      // direction) are the real channel. #199 added a second qualification here —
-      // restated partials — and the reasoning is unchanged: it too wrote lines. If this
-      // import is ever automated or piped, the exit code becomes the only surface left
-      // and this branch must be revisited — that is #183.
+      // HANDLED, AND DELIBERATELY 0 (`D3`, #177). NOTHING WAS REFUSED, so exiting 1 would
+      // tell a caller the run failed when it did not — replacing one overstatement with
+      // another. Not "lines were written", which is what this said until the #200 review
+      // and is not true of every member: an export whose every readable rung was restated
+      // appends nothing and still ends here, and it is no more a failure than a re-import
+      // that appends nothing. The flow is interactive, and the operator's lines (one per
+      // qualification, each opening on its own gap and naming its own money direction)
+      // are the real channel. If this import is ever automated or piped, the exit code
+      // becomes the only surface left and this branch must be revisited — that is #183.
       process.exitCode = 0;
     }
   } catch (error) {

--- a/apps/tui/src/import-orders.test.ts
+++ b/apps/tui/src/import-orders.test.ts
@@ -390,6 +390,112 @@ describe("a restated partial is skipped per rung (#199)", () => {
     expect(await idsOnDisk(first.ordersPath)).toHaveLength(2);
   });
 
+  it("QUALIFIES the status rather than reporting an unqualified success", async () => {
+    const first = await harness({
+      csv: ladder(PARTLY_FILLED),
+      reserves: [{ id: "reserve-a", amount: 5000 }],
+    });
+    await importBitgetOpenOrders({ csvPath: first.csvPath, io: first.io });
+
+    await writeFile(
+      first.csvPath,
+      ladder(
+        partlyFilledRung("100", "10", "8", "2020-01-01 10:00:00"),
+        rung("90", "1", "2020-01-01 11:00:00"),
+      ),
+      "utf8",
+    );
+    const outcome = await importBitgetOpenOrders({ csvPath: first.csvPath, io: first.io });
+
+    // `imported` now means every row read AND nothing restated — a strengthened
+    // invariant, so the status keeps meaning what a reader who opens no second field
+    // assumes it means.
+    expect(outcome).not.toMatchObject({ status: "imported" });
+    expect(outcome).toMatchObject({ status: "imported-partial", appended: 1 });
+    if (outcome.status !== "imported-partial") throw new Error("expected a partial import");
+    expect(outcome.restated).toEqual([
+      { id: expect.stringContaining(":100:"), known: 6, observed: 8 },
+    ]);
+    // NOT absorbed into `skips`: `leavesRungUnweighed` is a predicate over PARSER
+    // problems, and this rung was read perfectly — it is weighed, and weighed HIGH.
+    expect(outcome.skips).toHaveLength(0);
+  });
+
+  it("LEADS its own line with the restatement and names the OPPOSITE money direction", async () => {
+    const first = await harness({
+      csv: ladder(PARTLY_FILLED),
+      reserves: [{ id: "reserve-a", amount: 5000 }],
+    });
+    await importBitgetOpenOrders({ csvPath: first.csvPath, io: first.io });
+
+    await writeFile(
+      first.csvPath,
+      ladder(
+        partlyFilledRung("100", "10", "8", "2020-01-01 10:00:00"),
+        rung("90", "1", "2020-01-01 11:00:00"),
+      ),
+      "utf8",
+    );
+    await importBitgetOpenOrders({ csvPath: first.csvPath, io: first.io });
+
+    const line = first.outputs.find((message) => message.includes("RESTATED"));
+    expect(line).toBeDefined();
+    // The qualification OPENS the line, and the counts follow it.
+    expect(line?.startsWith("RESTATED")).toBe(true);
+    expect(line).toContain("1 order(s) appended");
+    // Its own direction, which is the REVERSE of an unread row's.
+    expect(line).toContain("committed reads HIGH and available reads LOW");
+    expect(line).not.toContain("available reads HIGH");
+    // Both figures, and the honest consequence: this recurs until the venue resolves it.
+    expect(line).toContain("filled 6 → 8");
+    expect(line).toContain("REPRINTS");
+  });
+
+  it("reports BOTH lines when one export is qualified both ways at once", async () => {
+    // The case that killed the third-status option: a sum type can say only ONE of
+    // these, so one qualification would drop silently. Two fields say both.
+    const first = await harness({
+      csv: ladder(PARTLY_FILLED),
+      reserves: [{ id: "reserve-a", amount: 5000 }],
+    });
+    await importBitgetOpenOrders({ csvPath: first.csvPath, io: first.io });
+
+    await writeFile(
+      first.csvPath,
+      ladder(
+        partlyFilledRung("100", "10", "8", "2020-01-01 10:00:00"),
+        rung("90", "1", "2020-01-01 11:00:00"),
+        rung("not-a-price", "0.1", "2020-01-01 12:00:00"),
+      ),
+      "utf8",
+    );
+    const outcome = await importBitgetOpenOrders({ csvPath: first.csvPath, io: first.io });
+
+    expect(outcome).toMatchObject({ status: "imported-partial", appended: 1 });
+    if (outcome.status !== "imported-partial") throw new Error("expected a partial import");
+    expect(outcome.skips).toHaveLength(1);
+    expect(outcome.restated).toHaveLength(1);
+
+    const message = first.outputs.find((line) => line.includes("could not be read"));
+    expect(message).toBeDefined();
+    // BOTH qualifications, each on its own line, each naming its own direction — and the
+    // unread row leads, being the one we can say least about.
+    expect(message?.startsWith("INCOMPLETE")).toBe(true);
+    expect(message).toContain("\nRESTATED");
+    expect(message).toContain("available reads HIGH");
+    expect(message).toContain("committed reads HIGH and available reads LOW");
+    // The counts follow both, once.
+    expect(message).toContain("1 order(s) appended");
+  });
+
+  it("keeps `restated` EMPTY on the unqualified status", async () => {
+    const { csvPath, io } = await harness();
+    const outcome = await importBitgetOpenOrders({ csvPath, io });
+    expect(outcome).toMatchObject({ status: "imported", appended: 2 });
+    if (outcome.status !== "imported") throw new Error("expected a clean import");
+    expect(outcome.restated).toEqual([]);
+  });
+
   it("leaves the restated rung's line on file at the OLDER, more conservative partial", async () => {
     const first = await harness({
       csv: ladder(PARTLY_FILLED),

--- a/apps/tui/src/import-orders.test.ts
+++ b/apps/tui/src/import-orders.test.ts
@@ -533,6 +533,48 @@ describe("a restated partial is skipped per rung (#199)", () => {
     expect(load.records).toHaveLength(1);
   });
 
+  it("reports the qualification without prompting when EVERY rung is restated", async () => {
+    // The empty-batch path (#200 review). A one-rung export that filled further leaves
+    // NOTHING admitted, and the flow used to carry straight on: two prompts for the
+    // funding reserve of a batch of zero orders, a coverage guard over a book this
+    // import does not change, an append of nothing.
+    const first = await harness({
+      csv: ladder(PARTLY_FILLED),
+      reserves: [{ id: "reserve-a", amount: 5000 }],
+    });
+    await importBitgetOpenOrders({ csvPath: first.csvPath, io: first.io });
+    const before = await readFile(first.ordersPath, "utf8");
+    const askedByTheFirstImport = first.asked.length;
+
+    await writeFile(
+      first.csvPath,
+      ladder(partlyFilledRung("100", "10", "8", "2020-01-01 10:00:00")),
+      "utf8",
+    );
+    const outcome = await importBitgetOpenOrders({ csvPath: first.csvPath, io: first.io });
+
+    // Still a qualified success, and still NOT the unqualified one: `restated` is
+    // non-empty by construction on this path, since an export with no readable rows at
+    // all was already refused as `no-orders` further up.
+    expect(outcome).not.toMatchObject({ status: "imported" });
+    expect(outcome).toMatchObject({ status: "imported-partial", appended: 0, alreadyKnown: 0 });
+    if (outcome.status !== "imported-partial") throw new Error("expected a partial import");
+    expect(outcome.restated).toHaveLength(1);
+    expect(await readFile(first.ordersPath, "utf8")).toBe(before);
+    // The operator still gets the whole qualification — the short-circuit skips the
+    // prompt and the guard, never the reporting.
+    const line = first.outputs.find((message) => message.includes("RESTATED"));
+    expect(line).toBeDefined();
+    expect(line).toContain("0 order(s) appended");
+
+    // NOTHING WAS ASKED, and that is what makes the blank-answer refusal unreachable.
+    // "Funding reserve for this batch:" over a batch of zero orders has no honest
+    // answer, and the honest reply — a blank line — used to return
+    // `rejected`/`no-reserve-declared`: a refusal reported over an import that had
+    // nothing to refuse and nothing to fund.
+    expect(first.asked.length).toBe(askedByTheFirstImport);
+  });
+
   it("REFUSES the batch when the same claim also changed its quantity", async () => {
     const first = await harness({
       csv: ladder(PARTLY_FILLED),

--- a/apps/tui/src/import-orders.test.ts
+++ b/apps/tui/src/import-orders.test.ts
@@ -414,7 +414,15 @@ describe("a restated partial is skipped per rung (#199)", () => {
     expect(outcome).toMatchObject({ status: "imported-partial", appended: 1 });
     if (outcome.status !== "imported-partial") throw new Error("expected a partial import");
     expect(outcome.restated).toEqual([
-      { id: expect.stringContaining(":100:"), known: 6, observed: 8 },
+      // Both remainders ride along, and here they are the strictly-over case: the file
+      // still claims the 4 its placement line implies, the venue holds 2.
+      {
+        id: expect.stringContaining(":100:"),
+        known: 6,
+        observed: 8,
+        remainingOnFile: 4,
+        remainingAtVenue: 2,
+      },
     ]);
     // NOT absorbed into `skips`: `leavesRungUnweighed` is a predicate over PARSER
     // problems, and this rung was read perfectly — it is weighed, and weighed HIGH.
@@ -443,8 +451,11 @@ describe("a restated partial is skipped per rung (#199)", () => {
     // The qualification OPENS the line, and the counts follow it.
     expect(line?.startsWith("RESTATED")).toBe(true);
     expect(line).toContain("1 order(s) appended");
-    // Its own direction, which is the REVERSE of an unread row's.
-    expect(line).toContain("committed reads HIGH and available reads LOW");
+    // Its own direction, which is the REVERSE of an unread row's. Stated as a FLOOR
+    // rather than an inequality: the skip class now admits the EXACT case (the file's
+    // own fill lines having caught the venue up), where `committed` is neither high nor
+    // low, so the only claim true of every entry is that it is never understated.
+    expect(line).toContain("committed never reads LOW and available never reads HIGH");
     expect(line).not.toContain("available reads HIGH");
     // Both figures, and the honest consequence: this recurs until the venue resolves it.
     expect(line).toContain("filled 6 → 8");
@@ -483,7 +494,7 @@ describe("a restated partial is skipped per rung (#199)", () => {
     expect(message?.startsWith("INCOMPLETE")).toBe(true);
     expect(message).toContain("\nRESTATED");
     expect(message).toContain("available reads HIGH");
-    expect(message).toContain("committed reads HIGH and available reads LOW");
+    expect(message).toContain("committed never reads LOW and available never reads HIGH");
     // The counts follow both, once.
     expect(message).toContain("1 order(s) appended");
   });
@@ -559,6 +570,114 @@ describe("a restated partial is skipped per rung (#199)", () => {
 
     expect(outcome).toMatchObject({ status: "rejected", reason: "changed-claim" });
     expect(await readFile(first.ordersPath, "utf8")).toBe(before);
+
+    // THE MESSAGE, not just the reason. `quantity` is IDENTICAL here (10 both times),
+    // so a headline promising "a different SIZE" describes a disagreement this refusal
+    // does not have — and asserting only the status is exactly how that false wording
+    // survived a release. The operator is owed the disagreement that actually refused.
+    if (outcome.status !== "rejected") throw new Error("expected a refusal");
+    expect(outcome.message).not.toContain("different SIZE");
+    expect(outcome.message).toContain("observedFilledQuantity 6 → 4");
+  });
+
+  it("REFUSES a restatement the file's OWN fill lines have already overtaken", async () => {
+    // THE PROBE for the inverted guard. The partition used to read only the placement
+    // lines, so it concluded "the file over-states, therefore skipping is safe" without
+    // ever asking what the funding guard actually weighs — which is
+    // `pickRestingOrdersAsOf`, fill lines and all.
+    //
+    // The money argument, in figures: the file records placed 10 / filled 6, the
+    // operator then runs the fill flow and records the remaining 4, retiring the rung.
+    // The file now counts ZERO resting. The venue's next export shows filled 8 — 2 units
+    // STILL RESTING and funded by a reserve the book believes is free. Skipping this
+    // rung would make `available` read HIGH, the direction that costs money, which is
+    // precisely #174's hazard wearing #199's clothes.
+    const first = await harness({
+      csv: ladder(PARTLY_FILLED),
+      reserves: [{ id: "reserve-a", amount: 5000 }],
+    });
+    await importBitgetOpenOrders({ csvPath: first.csvPath, io: first.io });
+
+    // The id is DERIVED from what landed, never hand-written: it is synthesized from
+    // `(pair, side, price, submittedAt)` and spelling it out here would pin a test to a
+    // format the ingest owns.
+    const [restedId] = await idsOnDisk(first.ordersPath);
+    if (restedId === undefined) throw new Error("expected the rung on disk");
+    await appendOrders(first.ordersPath, [
+      {
+        id: restedId,
+        observedAt: "2020-01-01T12:00:00",
+        kind: "orderFilled",
+        currency: "USD",
+        filledQuantity: 4,
+      },
+    ]);
+    expect(await remainingOnDisk(first.ordersPath)).toEqual([]);
+    const before = await readFile(first.ordersPath, "utf8");
+
+    await writeFile(
+      first.csvPath,
+      ladder(partlyFilledRung("100", "10", "8", "2020-01-01 10:00:00")),
+      "utf8",
+    );
+    const outcome = await importBitgetOpenOrders({ csvPath: first.csvPath, io: first.io });
+
+    expect(outcome).toMatchObject({ status: "rejected", reason: "changed-claim" });
+    expect(await readFile(first.ordersPath, "utf8")).toBe(before);
+    // And the refusal NAMES the remainder gap, because that — not the partial figures —
+    // is what decided it.
+    if (outcome.status !== "rejected") throw new Error("expected a refusal");
+    expect(outcome.message).toContain("the file would claim 0 where the venue still holds 2");
+  });
+
+  it("SKIPS the restatement when the recorded fill left the file EXACTLY level", async () => {
+    // The other side of the same reading. Here the operator recorded the fill the venue
+    // actually took — 2 units — so the file claims 2 and the venue holds 2. Nothing is
+    // over-stated and nothing is under-stated, and the skip is still safe because the
+    // test the class is defined by is `fileRemaining >= venueRemaining`, not `>`.
+    const first = await harness({
+      csv: ladder(PARTLY_FILLED),
+      reserves: [{ id: "reserve-a", amount: 5000 }],
+    });
+    await importBitgetOpenOrders({ csvPath: first.csvPath, io: first.io });
+
+    const [restedId] = await idsOnDisk(first.ordersPath);
+    if (restedId === undefined) throw new Error("expected the rung on disk");
+    await appendOrders(first.ordersPath, [
+      {
+        id: restedId,
+        observedAt: "2020-01-01T12:00:00",
+        kind: "orderFilled",
+        currency: "USD",
+        filledQuantity: 2,
+      },
+    ]);
+    expect(await remainingOnDisk(first.ordersPath)).toEqual([2]);
+
+    await writeFile(
+      first.csvPath,
+      ladder(partlyFilledRung("100", "10", "8", "2020-01-01 10:00:00")),
+      "utf8",
+    );
+    const outcome = await importBitgetOpenOrders({ csvPath: first.csvPath, io: first.io });
+
+    expect(outcome).toMatchObject({ status: "imported-partial" });
+    if (outcome.status !== "imported-partial") throw new Error("expected a partial import");
+    expect(outcome.restated).toEqual([
+      { id: restedId, known: 6, observed: 8, remainingOnFile: 2, remainingAtVenue: 2 },
+    ]);
+
+    // The wording has to survive this case, which is the whole reason it changed: an
+    // EXACT rung is not over-stated, so a line claiming `committed` reads HIGH and
+    // `available` reads LOW would be flatly false about it — and that line reprints on
+    // every import by design, so a falsehood there is a falsehood the operator reads
+    // forever.
+    const line = first.outputs.find((message) => message.includes("RESTATED"));
+    expect(line).toBeDefined();
+    expect(line).not.toContain("committed reads HIGH");
+    expect(line).not.toContain("available reads LOW");
+    expect(line).toContain("committed never reads LOW and available never reads HIGH");
+    expect(line).toContain("the file still claims 2, the venue holds 2");
   });
 });
 

--- a/apps/tui/src/import-orders.test.ts
+++ b/apps/tui/src/import-orders.test.ts
@@ -343,14 +343,112 @@ describe("one id identifies exactly ONE claim (#174)", () => {
     expect(await readFile(first.ordersPath, "utf8")).toBe(before);
   });
 
-  it("REFUSES a rung whose observed partial moved, rather than silently keeping the old one", async () => {
-    const partial = ladder(partlyFilledRung("100", "10", "6", "2020-01-01 10:00:00"));
-    const first = await harness({ csv: partial });
+});
+
+/**
+ * #199 — a rung the venue filled FURTHER costs ITS OWN rung, not the whole batch.
+ *
+ * The id is synthesized from the submission stamp, so a rung that fills between two
+ * exports returns under the same id with a larger `filled_quantity`. Refusing the batch
+ * over it blocked every unrelated new rung in every later export from that venue,
+ * indefinitely, with no local remedy: nothing is written on a refusal, so recording the
+ * fill repaired `committed`/`available` and left the placement line — and therefore the
+ * refusal — exactly where it was. The only exits were at the venue.
+ *
+ * The split is safe for THIS FIELD AND NO OTHER, and the direction is the whole argument.
+ * A stale partial makes the file believe more is still resting than is, so the guard
+ * reads the encumbrance HIGH — it can refuse a fundable batch and can never admit an
+ * unfundable one. A stale `quantity` points the other way and stays a total refusal.
+ */
+describe("a restated partial is skipped per rung (#199)", () => {
+  /** The rung of the traced case: 10 units at 100, the venue showing 6 already filled. */
+  const PARTLY_FILLED = partlyFilledRung("100", "10", "6", "2020-01-01 10:00:00");
+
+  it("SKIPS the restated rung and imports every other rung in the export", async () => {
+    const first = await harness({
+      csv: ladder(PARTLY_FILLED),
+      reserves: [{ id: "reserve-a", amount: 5000 }],
+    });
+    await importBitgetOpenOrders({ csvPath: first.csvPath, io: first.io });
+
+    // The same rung filled further at the venue, PLUS an unrelated new rung — which is
+    // the whole point: that new rung used to be blocked with no local way to clear it.
+    await writeFile(
+      first.csvPath,
+      ladder(
+        partlyFilledRung("100", "10", "8", "2020-01-01 10:00:00"),
+        rung("90", "1", "2020-01-01 11:00:00"),
+      ),
+      "utf8",
+    );
+    const outcome = await importBitgetOpenOrders({ csvPath: first.csvPath, io: first.io });
+
+    expect(outcome).not.toMatchObject({ status: "rejected" });
+    // The new rung landed. The restated one is NOT `alreadyKnown` — it is not a
+    // re-sighting, and calling it one is the silence #174 named.
+    expect(outcome).toMatchObject({ appended: 1, alreadyKnown: 0 });
+    expect(await idsOnDisk(first.ordersPath)).toHaveLength(2);
+  });
+
+  it("leaves the restated rung's line on file at the OLDER, more conservative partial", async () => {
+    const first = await harness({
+      csv: ladder(PARTLY_FILLED),
+      reserves: [{ id: "reserve-a", amount: 5000 }],
+    });
+    await importBitgetOpenOrders({ csvPath: first.csvPath, io: first.io });
+
+    await writeFile(
+      first.csvPath,
+      ladder(partlyFilledRung("100", "10", "8", "2020-01-01 10:00:00")),
+      "utf8",
+    );
+    await importBitgetOpenOrders({ csvPath: first.csvPath, io: first.io });
+
+    // `orders.jsonl` is append-only and a second placement line is ignored by the
+    // selector, so the skip cannot repair the figure — and must not pretend to. The rung
+    // still claims 4 (10 less the partial of 6 on file), NOT the 2 the venue now shows.
+    const remaining = await remainingOnDisk(first.ordersPath);
+    expect(remaining).toEqual([4]);
+    expect(remaining).not.toContain(2);
+    // No second placement line was appended for it, and no fill was synthesized.
+    const load = await loadOrders(first.ordersPath, { warn: () => {} });
+    if (load.status !== "loaded") throw new Error("expected a loaded sidecar");
+    expect(load.records).toHaveLength(1);
+  });
+
+  it("REFUSES the batch when the same claim also changed its quantity", async () => {
+    const first = await harness({
+      csv: ladder(PARTLY_FILLED),
+      reserves: [{ id: "reserve-a", amount: 5000 }],
+    });
     await importBitgetOpenOrders({ csvPath: first.csvPath, io: first.io });
     const before = await readFile(first.ordersPath, "utf8");
 
-    const filledMore = ladder(partlyFilledRung("100", "10", "8", "2020-01-01 10:00:00"));
-    await writeFile(first.csvPath, filledMore, "utf8");
+    // Both fields at once. `quantity` is not in the synthesized id, so this is the SAME
+    // claim — and carrying the safe difference does not make the dangerous one safe.
+    await writeFile(
+      first.csvPath,
+      ladder(partlyFilledRung("100", "12", "8", "2020-01-01 10:00:00")),
+      "utf8",
+    );
+    const outcome = await importBitgetOpenOrders({ csvPath: first.csvPath, io: first.io });
+
+    expect(outcome).toMatchObject({ status: "rejected", reason: "changed-claim" });
+    expect(await readFile(first.ordersPath, "utf8")).toBe(before);
+  });
+
+  it("REFUSES a partial that moved DOWN — the direction is what makes the skip safe", async () => {
+    const first = await harness({ csv: ladder(PARTLY_FILLED) });
+    await importBitgetOpenOrders({ csvPath: first.csvPath, io: first.io });
+    const before = await readFile(first.ordersPath, "utf8");
+
+    // A fill does not un-fill. Whatever this is, the file would be left UNDER-stating
+    // the encumbrance — the permissive direction — so it gets #174's total refusal.
+    await writeFile(
+      first.csvPath,
+      ladder(partlyFilledRung("100", "10", "4", "2020-01-01 10:00:00")),
+      "utf8",
+    );
     const outcome = await importBitgetOpenOrders({ csvPath: first.csvPath, io: first.io });
 
     expect(outcome).toMatchObject({ status: "rejected", reason: "changed-claim" });

--- a/apps/tui/src/import-orders.ts
+++ b/apps/tui/src/import-orders.ts
@@ -140,13 +140,19 @@ interface OrdersImportWrite {
    */
   alreadyKnown: number;
   /**
-   * The export rows this build could not read. EMPTY on `imported`, by construction —
-   * one of the TWO invariants that status now carries, the sibling being `restated`.
+   * The export rows this build could not read — NOT empty on `imported`, and the
+   * asymmetry with `restated` is deliberate rather than an oversight. A `not-resting` row
+   * was read COMPLETELY and the parser's finding about it is that nothing is still
+   * claimed, so it rides here and qualifies nothing (#184). What `imported` promises
+   * about this field is that none of its entries left a rung UNWEIGHED — that is
+   * `leavesRungUnweighed`'s question, not this array's length.
    */
   skips: BitgetRowSkip[];
   /**
    * The rungs skipped because the venue has restated their partial (#199). EMPTY on
-   * `imported`, by construction, exactly as `skips` is.
+   * `imported`, by construction — the one field whose own length decides the status,
+   * because every entry in it is a qualification and `skips` needs a predicate to say
+   * which of its entries are.
    *
    * A SECOND FIELD RATHER THAN A THIRD STATUS, and that is the load-bearing choice: an
    * export can carry an unreadable row AND a restated rung at once, and a sum type can

--- a/apps/tui/src/import-orders.ts
+++ b/apps/tui/src/import-orders.ts
@@ -25,6 +25,7 @@ import {
   pickRestingOrdersAsOf,
   type BitgetOpenOrder,
   type BitgetRowSkip,
+  type ChangedClaim,
   type MergedOrderClaim,
   type OrderPlacedRecord,
   type OrderRecord,
@@ -65,7 +66,8 @@ export type OrdersImportRejection =
   | "unreadable-sidecar-lines"
   | "no-reserve-declared"
   /**
-   * A row names a claim already on file but says something DIFFERENT about it (#174).
+   * A row names a claim already on file but states a different `quantity` for it (#174)
+   * — the venue amended the size, or the file and the venue disagree about it.
    *
    * Refused rather than recorded, and this is the ONE place the "proceed with the
    * arithmetic" reasoning behind the within-batch merge does not extend. Recording a
@@ -73,6 +75,16 @@ export type OrdersImportRejection =
    * by `pickRestingOrdersAsOf` by construction (that guard is what makes re-import
    * idempotent), and an observation verb is a later design that must not be pre-empted
    * by one invented here, in an append-only file, to get past this import.
+   *
+   * NARROWED TO `quantity` BY #199, and the DIRECTION is the whole reason. Refusing the
+   * batch never repaired the stale line — nothing is written on a refusal — so what the
+   * refusal actually protects is the funding guard's reading of the OTHER rungs, which
+   * it weighs off the file. A `quantity` the file states LOW leaves the guard more
+   * PERMISSIVE than reality, so it could admit a batch the reserve cannot fund: #174's
+   * own hazard, and it stays a total refusal. A partial the venue has since restated
+   * leaves the file stating the encumbrance HIGH, which is the safe direction, and is
+   * handled per rung instead — see {@link RestatedPartial}. The argument for refusing
+   * here is about which way the leftover staleness points, not about the change itself.
    */
   | "changed-claim"
   | "unknown-reserve"
@@ -85,15 +97,46 @@ export type OrdersImportRejection =
    */
   | "write-failed";
 
+/**
+ * A rung the venue has filled FURTHER since its placement line was written (#199).
+ *
+ * The id is synthesized from the SUBMISSION stamp, so a rung that fills between two
+ * exports comes back under the same id carrying a larger `filled_quantity`. That is not
+ * an amendment and not a re-sighting — it is the ordinary life of a resting ladder — but
+ * the placement line cannot be rewritten (`orders.jsonl` is append-only and a second
+ * placement line is ignored by the selector), so the file keeps the OLDER partial until
+ * the observation verb #181 designs exists.
+ *
+ * Carrying the stale figure is safe in a way an amended `quantity` is not, and only
+ * because of the direction: the file believes MORE is still resting than actually is, so
+ * the encumbrance it computes is too large. That can refuse a batch the reserve could
+ * have funded; it can never admit one it cannot. So the rung is skipped and the rest of
+ * the export imports normally, rather than the whole batch being refused over it.
+ *
+ * A partial moving DOWN is excluded deliberately — it points the other way, and it is a
+ * venue contradiction besides (a fill does not un-fill). It stays a `changed-claim`.
+ */
+export interface RestatedPartial {
+  id: string;
+  /** The partial the placement line on file records. */
+  known: number;
+  /** The larger partial the venue's export now shows. */
+  observed: number;
+}
+
 /** What an import that WROTE reports, in the two shapes it can honestly take. */
 interface OrdersImportWrite {
   /** Lines actually appended. ZERO when the same export is imported twice. */
   appended: number;
   /**
    * Rungs already in the sidecar under the same synthesized id AND saying the same
-   * thing about it — the id components plus `quantity` and the observed partial. A
-   * row that differs never reaches this count; it refuses the batch as
-   * `changed-claim` (#174).
+   * thing about it — the id components plus `quantity` and the observed partial.
+   *
+   * A row that differs NEVER reaches this count, in either of the two ways it can
+   * differ: a changed `quantity` refuses the whole batch as `changed-claim` (#174), and
+   * a restated partial is skipped per rung and reported in `restated` (#199). Calling
+   * either one "already known" is the silence #174 named — it reports "nothing to do"
+   * about a rung the file now describes wrongly.
    */
   alreadyKnown: number;
   /** The export rows this build could not read. EMPTY on `imported`, by construction. */
@@ -157,6 +200,49 @@ function describe(order: BitgetOpenOrder): string {
 function isAffirmative(answer: string): boolean {
   const normalized = answer.trim().toLowerCase();
   return normalized === "y" || normalized === "yes";
+}
+
+/**
+ * Split the claims that disagree with the file into the ones that refuse the batch and
+ * the ones that cost their own rung — THE POLICY DECISION of #199, and the reason it
+ * lives here rather than in `import-orders-cli.ts`.
+ *
+ * Deciding which class a difference falls in is admission policy, and the wiring says so
+ * in its own words after #172 bit it for exactly this: "Admission is the engine's policy,
+ * not this wiring's." A CLI that filtered these out would be re-deciding, from the shell,
+ * something the flow is supposed to own.
+ *
+ * `quantity` decides whenever it is present. A claim differing in BOTH fields at once is
+ * refused, not skipped: the two point opposite ways, and a claim carrying the dangerous
+ * one is not made safe by also carrying the safe one.
+ */
+function partitionChangedClaims(changed: readonly ChangedClaim[]): {
+  amended: ChangedClaim[];
+  restated: RestatedPartial[];
+} {
+  const amended: ChangedClaim[] = [];
+  const restated: RestatedPartial[] = [];
+
+  for (const claim of changed) {
+    if (claim.differences.some((difference) => difference.field === "quantity")) {
+      amended.push(claim);
+      continue;
+    }
+    const fill = claim.differences.find(
+      (difference) => difference.field === "observedFilledQuantity",
+    );
+    // Unreachable today: `detectChangedClaims` never emits an empty `differences`, and
+    // those two are its only fields. Guarded rather than asserted so that a THIRD field
+    // added there — the descriptors its own KNOWN LIMIT contemplates persisting — lands
+    // in the REFUSAL class by default instead of silently becoming a per-rung skip.
+    if (fill === undefined || fill.observed < fill.known) {
+      amended.push(claim);
+      continue;
+    }
+    restated.push({ id: claim.id, known: fill.known, observed: fill.observed });
+  }
+
+  return { amended, restated };
 }
 
 /**
@@ -269,8 +355,9 @@ export async function importBitgetOpenOrders(
     ),
     orders,
   );
-  if (changed.length > 0) {
-    const detail = changed
+  const { amended, restated } = partitionChangedClaims(changed);
+  if (amended.length > 0) {
+    const detail = amended
       .map(
         (claim) =>
           `${claim.id} (` +
@@ -283,20 +370,29 @@ export async function importBitgetOpenOrders(
     return reject(
       io,
       "changed-claim",
-      `${csvPath} re-states a claim already on file with different terms — ${detail}. An id ` +
+      `${csvPath} re-states a claim already on file with a different SIZE — ${detail}. An id ` +
         `identifies exactly one claim, and this build has no verb for "the claim changed": a ` +
         `second placement line would be ignored by the selector, and calling this row ALREADY ` +
-        `KNOWN would leave the wrong size committed. Cancel the rung at the venue and record ` +
+        `KNOWN would leave the wrong size committed — under-stating it, so the guard would ` +
+        `admit a batch the reserve cannot fund. Cancel the rung at the venue and record ` +
         `the cancellation, or re-place it at a different price so it arrives as a new claim`,
     );
   }
 
-  const declaration = await declareFunding(io, orders);
+  // THE PER-RUNG SKIP (#199). The restated rung is dropped from THIS batch and its line
+  // on file is left exactly as it was — so the guard below still weighs it, at the older
+  // and LARGER remainder, which is the conservative reading. Everything after this point
+  // sees `admitted`: the rung is not prompted for, not built into a record, and not
+  // counted as `alreadyKnown`, because it is not a re-sighting.
+  const restatedIds = new Set(restated.map((claim) => claim.id));
+  const admitted = orders.filter((order) => !restatedIds.has(order.id));
+
+  const declaration = await declareFunding(io, admitted);
   if (declaration === undefined) {
     return reject(io, "no-reserve-declared", "no funding reserve was declared for this batch");
   }
 
-  const records = buildOrderPlacedRecords(orders, declaration);
+  const records = buildOrderPlacedRecords(admitted, declaration);
 
   // `O1`. Coverage is checked over the WHOLE resting book — what is already on file plus
   // this batch — because a reserve funds every claim against it, not one import's slice.

--- a/apps/tui/src/import-orders.ts
+++ b/apps/tui/src/import-orders.ts
@@ -30,6 +30,7 @@ import {
   type OrderPlacedRecord,
   type OrderRecord,
   type FundReviewData,
+  type RestingOrder,
 } from "@numisma/engine";
 import type { OrdersLoad } from "@numisma/preferences";
 
@@ -66,8 +67,18 @@ export type OrdersImportRejection =
   | "unreadable-sidecar-lines"
   | "no-reserve-declared"
   /**
-   * A row names a claim already on file but states a different `quantity` for it (#174)
-   * — the venue amended the size, or the file and the venue disagree about it.
+   * A row names a claim already on file and DISAGREES with it in a way that would leave
+   * the file claiming LESS than the venue still holds (#174).
+   *
+   * NOT "a different `quantity`", which is what this said until the #200 review: that is
+   * the commonest member, not the definition, and it left the branch's own proudest case
+   * — a partial that moved DOWN, `quantity` identical — described by a sentence that is
+   * false about it. Two disagreements land here:
+   *
+   *   - a different `quantity`, the venue having amended the size (or the two simply
+   *     disagreeing about it);
+   *   - a restated partial the file's OWN fill lines have already overtaken, so what the
+   *     file still counts as resting is smaller than the remainder the venue shows.
    *
    * Refused rather than recorded, and this is the ONE place the "proceed with the
    * arithmetic" reasoning behind the within-batch merge does not extend. Recording a
@@ -76,15 +87,18 @@ export type OrdersImportRejection =
    * idempotent), and an observation verb is a later design that must not be pre-empted
    * by one invented here, in an append-only file, to get past this import.
    *
-   * NARROWED TO `quantity` BY #199, and the DIRECTION is the whole reason. Refusing the
-   * batch never repaired the stale line — nothing is written on a refusal — so what the
-   * refusal actually protects is the funding guard's reading of the OTHER rungs, which
-   * it weighs off the file. A `quantity` the file states LOW leaves the guard more
-   * PERMISSIVE than reality, so it could admit a batch the reserve cannot fund: #174's
-   * own hazard, and it stays a total refusal. A partial the venue has since restated
-   * leaves the file stating the encumbrance HIGH, which is the safe direction, and is
-   * handled per rung instead — see {@link RestatedPartial}. The argument for refusing
-   * here is about which way the leftover staleness points, not about the change itself.
+   * NARROWED BY #199, and the DIRECTION is the whole reason. Refusing the batch never
+   * repaired the stale line — nothing is written on a refusal — so what the refusal
+   * actually protects is the funding guard's reading of the OTHER rungs, which it weighs
+   * off the file. A book that counts LESS resting than the venue holds leaves the guard
+   * more PERMISSIVE than reality, so it could admit a batch the reserve cannot fund:
+   * #174's own hazard, and it stays a total refusal. The direction is read off the
+   * REMAINDER the guard actually weighs — `pickRestingOrdersAsOf` over the whole stream,
+   * fill and cancellation lines included — not off the placement line alone, because a
+   * recorded fill can flip a restatement from the safe side to this one. A restatement
+   * that leaves the file claiming NO LESS than the venue holds is handled per rung
+   * instead — see {@link RestatedPartial}. The argument for refusing here is about which
+   * way the leftover staleness points, not about the change itself.
    */
   | "changed-claim"
   | "unknown-reserve"
@@ -108,13 +122,21 @@ export type OrdersImportRejection =
  * the observation verb #181 designs exists.
  *
  * Carrying the stale figure is safe in a way an amended `quantity` is not, and only
- * because of the direction: the file believes MORE is still resting than actually is, so
- * the encumbrance it computes is too large. That can refuse a batch the reserve could
- * have funded; it can never admit one it cannot. So the rung is skipped and the rest of
- * the export imports normally, rather than the whole batch being refused over it.
+ * because of the direction: what the file still counts as resting is NO LESS than what
+ * the venue actually holds, so the encumbrance it computes is never too small. That can
+ * refuse a batch the reserve could have funded; it can never admit one it cannot. So the
+ * rung is skipped and the rest of the export imports normally, rather than the whole
+ * batch being refused over it.
  *
- * A partial moving DOWN is excluded deliberately — it points the other way, and it is a
- * venue contradiction besides (a fill does not un-fill). It stays a `changed-claim`.
+ * THE DIRECTION IS READ OFF THE REMAINDER, not off the two partials (#200 review). The
+ * guard downstream weighs `pickRestingOrdersAsOf`, which replays fills and cancellations
+ * as well as placements, so a fill already recorded against this rung can shrink the
+ * file's remainder below the venue's and INVERT the safety claim while the partials still
+ * read as "moved up". Those rungs are refused as `changed-claim`; only a rung whose
+ * remainder on file is at least the venue's reaches this type. A partial moving DOWN is
+ * excluded by the same test rather than by a rule of its own — the algebra is on
+ * `partitionChangedClaims` — and it is a venue contradiction besides (a fill does not
+ * un-fill).
  */
 export interface RestatedPartial {
   id: string;
@@ -122,6 +144,18 @@ export interface RestatedPartial {
   known: number;
   /** The larger partial the venue's export now shows. */
   observed: number;
+  /**
+   * What this rung STILL CLAIMS on file — the selector's remainder, net of the placement
+   * line's own partial and every `orderFilled` line since, and `0` when the stream has
+   * already retired the id.
+   *
+   * Carried rather than left implicit because it, not `known`, is what makes the skip
+   * safe: this pair IS the safety argument, and printing both lets an operator check the
+   * claim instead of taking it on faith.
+   */
+  remainingOnFile: number;
+  /** What the venue's export says is still resting: `quantity` less its filled figure. */
+  remainingAtVenue: number;
 }
 
 /** What an import that WROTE reports, in the two shapes it can honestly take. */
@@ -132,11 +166,10 @@ interface OrdersImportWrite {
    * Rungs already in the sidecar under the same synthesized id AND saying the same
    * thing about it — the id components plus `quantity` and the observed partial.
    *
-   * A row that differs NEVER reaches this count, in either of the two ways it can
-   * differ: a changed `quantity` refuses the whole batch as `changed-claim` (#174), and
-   * a restated partial is skipped per rung and reported in `restated` (#199). Calling
-   * either one "already known" is the silence #174 named — it reports "nothing to do"
-   * about a rung the file now describes wrongly.
+   * A row that differs NEVER reaches this count, whichever way it goes: it either
+   * refuses the whole batch as `changed-claim` (#174) or is skipped per rung and
+   * reported in `restated` (#199). Calling either one "already known" is the silence
+   * #174 named — it reports "nothing to do" about a rung the file now describes wrongly.
    */
   alreadyKnown: number;
   /**
@@ -182,12 +215,15 @@ export type OrdersImportOutcome =
    *
    * - `skips` — a row was not read, so a rung resting at the venue is `committed` that
    *   nobody counted and `available` reads HIGH.
-   * - `restated` — a rung was read perfectly and its partial on file is stale, so the
-   *   encumbrance is over-stated: `committed` reads HIGH and `available` reads LOW.
+   * - `restated` — a rung was read perfectly and its partial on file is stale, so what
+   *   the file still claims is NO LESS than the venue holds: `committed` never reads LOW
+   *   and `available` never reads HIGH. (Never LOW, rather than always HIGH: a fill
+   *   already recorded against the rung can leave the two exactly level, and that case is
+   *   in the skip class too.)
    *
    * That opposition is why `restated` could not reuse `skips`: `leavesRungUnweighed` is
    * a predicate over PARSER problems, and a restated rung is not unweighed — it is
-   * weighed, and weighed high.
+   * weighed, and never weighed short.
    */
   | ({ status: "imported-partial" } & OrdersImportWrite)
   | { status: "rejected"; reason: OrdersImportRejection; message: string };
@@ -246,11 +282,43 @@ function isAffirmative(answer: string): boolean {
  * not this wiring's." A CLI that filtered these out would be re-deciding, from the shell,
  * something the flow is supposed to own.
  *
- * `quantity` decides whenever it is present. A claim differing in BOTH fields at once is
- * refused, not skipped: the two point opposite ways, and a claim carrying the dangerous
- * one is not made safe by also carrying the safe one.
+ * THE SKIP CLASS IS DECIDED BY THE REMAINDER THE GUARD ACTUALLY WEIGHS, which is why
+ * `resting` is a parameter rather than something this could work out from `changed`
+ * (#200 review). `detectChangedClaims` is fed only the `orderPlaced` lines, so reasoning
+ * from its two figures answers a question nobody downstream asks: `pickRestingOrdersAsOf`
+ * replays `orderFilled` and `orderCancelled` too, and a fill already recorded against the
+ * rung can shrink the file's remainder BELOW the venue's while the partials still read as
+ * "moved up". The traced case: file holds placed 10 / filled 6, the operator runs the
+ * fill flow and accepts the default remainder of 4, retiring the rung — the file now
+ * counts ZERO resting — and the venue's next export shows filled 8, i.e. 2 units still
+ * resting. Skipping that would make `available` read HIGH, which is #174's own hazard.
+ *
+ * Three things must hold, and anything else refuses the batch:
+ *
+ *  1. NO `quantity` DIFFERENCE — unchanged policy, and not merely because of today's
+ *     encumbrance. `placed.quantity` is the ORIGINAL size a cumulative venue reading is
+ *     compared against (#176), so a stale one corrupts every future comparison of this
+ *     rung, not just this guard's sum. It is the one figure nothing may go stale on.
+ *  2. EVERY REMAINING difference is `observedFilledQuantity` — today that means exactly
+ *     one, since `detectChangedClaims` emits only those two fields and never an empty
+ *     list, so nothing can fail this test until a third field exists. Guarded rather than
+ *     asserted precisely so that third field lands in the REFUSAL class by default
+ *     instead of silently riding in beside a safe fill as a per-rung skip.
+ *  3. `fileRemaining >= venueRemaining`. This SUBSUMES the down-check that used to sit
+ *     here, exactly rather than approximately, which is why that branch is gone: when the
+ *     partial moved down, `fileRemaining <= quantity − known < quantity − observed =
+ *     venueRemaining`, so a downward partial cannot pass this test by any route. The `<=`
+ *     on the left is where later fill lines live; they only make it stricter.
+ *
+ * An id ABSENT from `resting` reads as `0`, not as a missing case: absent means the
+ * stream already retired the claim — its fills exhausted it, or a cancellation took it —
+ * and zero is the honest statement of what the file now counts against that rung.
  */
-function partitionChangedClaims(changed: readonly ChangedClaim[]): {
+function partitionChangedClaims(
+  changed: readonly ChangedClaim[],
+  resting: readonly RestingOrder[],
+  observed: readonly BitgetOpenOrder[],
+): {
   amended: ChangedClaim[];
   restated: RestatedPartial[];
 } {
@@ -265,18 +333,58 @@ function partitionChangedClaims(changed: readonly ChangedClaim[]): {
     const fill = claim.differences.find(
       (difference) => difference.field === "observedFilledQuantity",
     );
-    // Unreachable today: `detectChangedClaims` never emits an empty `differences`, and
-    // those two are its only fields. Guarded rather than asserted so that a THIRD field
-    // added there — the descriptors its own KNOWN LIMIT contemplates persisting — lands
-    // in the REFUSAL class by default instead of silently becoming a per-rung skip.
-    if (fill === undefined || fill.observed < fill.known) {
+    const remainders = weighRemainders(claim.id, resting, observed);
+    // The restatement must be the ONLY difference left, not merely one of them. The
+    // `quantity` branch above already took the field that exists today, so this length
+    // test is about the THIRD field a later `ClaimDifference` may carry: without it, an
+    // unknown difference would ride into the skip class alongside a safe fill — silently,
+    // and in the permissive direction — which is the whole point of guarding here.
+    if (fill === undefined || claim.differences.length !== 1 || remainders === undefined) {
       amended.push(claim);
       continue;
     }
-    restated.push({ id: claim.id, known: fill.known, observed: fill.observed });
+    if (remainders.onFile < remainders.atVenue) {
+      amended.push(claim);
+      continue;
+    }
+    restated.push({
+      id: claim.id,
+      known: fill.known,
+      observed: fill.observed,
+      remainingOnFile: remainders.onFile,
+      remainingAtVenue: remainders.atVenue,
+    });
   }
 
   return { amended, restated };
+}
+
+/**
+ * What one id still claims on each side — the file's remainder and the venue's.
+ *
+ * ONE function for both the partition and the refusal message, so the figures the
+ * operator is shown are the same ones the decision was made on rather than a second
+ * derivation that can drift from it.
+ *
+ * `undefined` only when the observed row is missing, which cannot happen for a
+ * `ChangedClaim` (every one of them is raised FROM an observed row) — reported rather
+ * than defaulted, so a future caller that does not hold that invariant cannot get a
+ * silently invented `0` out of it.
+ */
+function weighRemainders(
+  id: string,
+  resting: readonly RestingOrder[],
+  observed: readonly BitgetOpenOrder[],
+): { onFile: number; atVenue: number } | undefined {
+  const row = observed.find((order) => order.id === id);
+  if (row === undefined) {
+    return undefined;
+  }
+  const open = resting.find((order) => order.placed.id === id);
+  return {
+    onFile: open?.remainingQuantity ?? 0,
+    atVenue: row.quantity - (row.filledQuantity ?? 0),
+  };
 }
 
 /**
@@ -389,34 +497,49 @@ export async function importBitgetOpenOrders(
     ),
     orders,
   );
-  const { amended, restated } = partitionChangedClaims(changed);
+  // The SAME reading the `O1` guard takes below, over `[...existingRecords, ...records]`
+  // — and for these already-known ids the two agree by construction, because a repeat
+  // placement line is ignored by the selector, so this batch's own records cannot move
+  // the remainder of a rung already on file. Taken here because the partition needs it
+  // before anything is prompted for or built.
+  const restingOnFile = pickRestingOrdersAsOf(existingRecords);
+  const { amended, restated } = partitionChangedClaims(changed, restingOnFile, orders);
   if (amended.length > 0) {
     const detail = amended
-      .map(
-        (claim) =>
-          `${claim.id} (` +
-          claim.differences
-            .map((difference) => `${difference.field} ${difference.known} → ${difference.observed}`)
-            .join(", ") +
-          `)`,
-      )
+      .map((claim) => {
+        const differences = claim.differences
+          .map((difference) => `${difference.field} ${difference.known} → ${difference.observed}`)
+          .join(", ");
+        // The remainder clause is appended ONLY when the remainder test is what refused
+        // this claim, because otherwise it is not the reason and printing it would send
+        // the operator after the wrong disagreement. A changed `quantity` refuses on its
+        // own terms, whatever the remainders happen to say.
+        const remainders = weighRemainders(claim.id, restingOnFile, orders);
+        const gap =
+          remainders !== undefined && remainders.onFile < remainders.atVenue
+            ? `; the file would claim ${remainders.onFile} where the venue still holds ` +
+              `${remainders.atVenue}`
+            : "";
+        return `${claim.id} (${differences}${gap})`;
+      })
       .join("; ");
     return reject(
       io,
       "changed-claim",
-      `${csvPath} re-states a claim already on file with a different SIZE — ${detail}. An id ` +
-        `identifies exactly one claim, and this build has no verb for "the claim changed": a ` +
-        `second placement line would be ignored by the selector, and calling this row ALREADY ` +
-        `KNOWN would leave the wrong size committed — under-stating it, so the guard would ` +
-        `admit a batch the reserve cannot fund. Cancel the rung at the venue and record ` +
-        `the cancellation, or re-place it at a different price so it arrives as a new claim`,
+      `${csvPath} re-states a claim already on file in a way this build cannot carry — ` +
+        `${detail}. An id identifies exactly one claim, and this build has no verb for ` +
+        `"the claim changed": a second placement line would be ignored by the selector, and ` +
+        `calling this row ALREADY KNOWN would leave the file claiming LESS than the venue ` +
+        `still holds, so the guard would admit a batch the reserve cannot fund. Cancel the ` +
+        `rung at the venue and record the cancellation, or re-place it at a different price ` +
+        `so it arrives as a new claim`,
     );
   }
 
   // THE PER-RUNG SKIP (#199). The restated rung is dropped from THIS batch and its line
-  // on file is left exactly as it was — so the guard below still weighs it, at the older
-  // and LARGER remainder, which is the conservative reading. Everything after this point
-  // sees `admitted`: the rung is not prompted for, not built into a record, and not
+  // on file is left exactly as it was — so the guard below still weighs it, at a remainder
+  // no smaller than the venue's, which is the conservative reading. Everything after this
+  // point sees `admitted`: the rung is not prompted for, not built into a record, and not
   // counted as `alreadyKnown`, because it is not a re-sighting.
   const restatedIds = new Set(restated.map((claim) => claim.id));
   const admitted = orders.filter((order) => !restatedIds.has(order.id));
@@ -527,18 +650,25 @@ export async function importBitgetOpenOrders(
   }
 
   if (restated.length > 0) {
+    // BOTH REMAINDERS, not just the two partials: the remainders are what the skip was
+    // decided on, so printing them lets the operator check the safety claim the rest of
+    // this line makes rather than take it on faith.
     const detail = restated
-      .map((claim) => `${claim.id} (filled ${claim.known} → ${claim.observed})`)
+      .map(
+        (claim) =>
+          `${claim.id} (filled ${claim.known} → ${claim.observed}; the file still claims ` +
+          `${claim.remainingOnFile}, the venue holds ${claim.remainingAtVenue})`,
+      )
       .join("; ");
     qualifications.push(
       `RESTATED — ${restated.length} rung(s) of ${csvPath} have filled FURTHER at the ` +
         `venue since this file recorded them — ${detail} — and were SKIPPED; every other ` +
         `rung imported normally. Their lines on file still read the OLDER partial, so they ` +
-        `encumber MORE than the venue actually holds: committed reads HIGH and available ` +
-        `reads LOW. That is the safe direction — it can refuse a batch you could fund, ` +
-        `never fund one you cannot — but it is not free, and recording the restatement ` +
-        `needs an observation verb this build does not have. This line REPRINTS on every ` +
-        `import until the rung fills out or is cancelled at the venue.`,
+        `encumber NO LESS than the venue still holds: committed never reads LOW and ` +
+        `available never reads HIGH. That is the safe direction — it can refuse a batch ` +
+        `you could fund, never fund one you cannot — but it is not free, and recording the ` +
+        `restatement needs an observation verb this build does not have. This line ` +
+        `REPRINTS on every import until the rung fills out or is cancelled at the venue.`,
     );
   }
 

--- a/apps/tui/src/import-orders.ts
+++ b/apps/tui/src/import-orders.ts
@@ -139,21 +139,49 @@ interface OrdersImportWrite {
    * about a rung the file now describes wrongly.
    */
   alreadyKnown: number;
-  /** The export rows this build could not read. EMPTY on `imported`, by construction. */
+  /**
+   * The export rows this build could not read. EMPTY on `imported`, by construction —
+   * one of the TWO invariants that status now carries, the sibling being `restated`.
+   */
   skips: BitgetRowSkip[];
+  /**
+   * The rungs skipped because the venue has restated their partial (#199). EMPTY on
+   * `imported`, by construction, exactly as `skips` is.
+   *
+   * A SECOND FIELD RATHER THAN A THIRD STATUS, and that is the load-bearing choice: an
+   * export can carry an unreadable row AND a restated rung at once, and a sum type can
+   * say only one of those, so a third member would drop one qualification silently. Two
+   * fields under one qualified status say both.
+   */
+  restated: RestatedPartial[];
 }
 
 export type OrdersImportOutcome =
-  /** Every row of the export was read. The unqualified success, and the only one. */
+  /**
+   * Every row of the export was read AND nothing was restated. The unqualified success,
+   * and the only one — its invariant STRENGTHENED by #199 rather than widened, so the
+   * status keeps meaning what a reader who never opens a second field assumes it means.
+   */
   | ({ status: "imported" } & OrdersImportWrite)
   /**
-   * The readable rungs were written and at least one row was NOT read (`D3`, #177).
+   * Lines were written, and SOMETHING ABOUT THE EXPORT WAS QUALIFIED (`D3`, #177; #199).
    *
-   * A DISTINCT MEMBER, not `imported` carrying a non-empty `skips`. The risk is real —
-   * an unread rung is `committed` that nobody counted, so `available` reads HIGH, the
-   * direction that costs money — and a shape that forces every reader to open a second
-   * field to discover the first was qualified is a type that lies to the reader who does
-   * not. It is still a SUCCESS: lines were written, and the CLI exits 0 (`D3`).
+   * A DISTINCT MEMBER, not `imported` carrying a non-empty field. A shape that forces
+   * every reader to open a second field to discover the first was qualified is a type
+   * that lies to the reader who does not. It is still a SUCCESS: lines were written, and
+   * the CLI exits 0 (`D3`).
+   *
+   * TWO qualifications reach it, with OPPOSITE money directions, each carrying its own
+   * field and printing its own operator line:
+   *
+   * - `skips` — a row was not read, so a rung resting at the venue is `committed` that
+   *   nobody counted and `available` reads HIGH.
+   * - `restated` — a rung was read perfectly and its partial on file is stale, so the
+   *   encumbrance is over-stated: `committed` reads HIGH and `available` reads LOW.
+   *
+   * That opposition is why `restated` could not reuse `skips`: `leavesRungUnweighed` is
+   * a predicate over PARSER problems, and a restated rung is not unweighed — it is
+   * weighed, and weighed high.
    */
   | ({ status: "imported-partial" } & OrdersImportWrite)
   | { status: "rejected"; reason: OrdersImportRejection; message: string };
@@ -460,32 +488,55 @@ export async function importBitgetOpenOrders(
   // and the count below run through the engine's predicate rather than the raw total.
   // `outcome.skips` still carries every skip and stderr still reports every one of them.
   const unweighed = parsed.skips.filter((entry) => leavesRungUnweighed(entry.problem));
-  if (unweighed.length === 0) {
-    io.out(`Imported ${csvPath}: ${counts}.\n`);
-    return {
-      status: "imported",
-      appended: fresh.length,
-      alreadyKnown: records.length - fresh.length,
-      skips: parsed.skips,
-    };
-  }
 
-  // THE GAP OPENS THE LINE, AND IN MONEY TERMS (`D3`, #177). It used to be a suffix after
-  // two success numbers — `..., 1 row(s) skipped.` — in exactly the position an operator
-  // skims past. An unread row is a rung resting at the venue that no committed sum
-  // includes, so the figure this import feeds reads HIGH; naming that direction is what
-  // makes it a risk rather than a statistic.
-  io.out(
-    `INCOMPLETE — ${unweighed.length} row(s) of ${csvPath} could not be read, so that ` +
-      `many rung(s) resting at the venue are NOT counted as committed and available reads ` +
-      `HIGH by whatever they encumber. Imported ${csvPath}: ${counts}. Re-export and ` +
-      `re-import to pick the missing rung(s) up; the reasons are on the error channel above.\n`,
-  );
-
-  return {
-    status: "imported-partial",
+  const write = {
     appended: fresh.length,
     alreadyKnown: records.length - fresh.length,
     skips: parsed.skips,
+    restated,
   };
+
+  if (unweighed.length === 0 && restated.length === 0) {
+    io.out(`Imported ${csvPath}: ${counts}.\n`);
+    return { status: "imported", ...write };
+  }
+
+  // EVERY QUALIFICATION GETS ITS OWN LINE, EACH OPENING ON THE GAP AND NAMING ITS OWN
+  // MONEY DIRECTION (`D3`, #177; #199). The counts follow all of them, once — they used
+  // to be the whole line, with the qualification a suffix (`..., 1 row(s) skipped.`) in
+  // exactly the position an operator skims past. An export qualified BOTH ways prints
+  // BOTH lines; that case is why this is two fields and not a third status.
+  //
+  // Unread rows lead, because they are the qualification we know least about: a restated
+  // rung was read perfectly and we can state its figures, an unread one we cannot.
+  const qualifications: string[] = [];
+
+  if (unweighed.length > 0) {
+    qualifications.push(
+      `INCOMPLETE — ${unweighed.length} row(s) of ${csvPath} could not be read, so that ` +
+        `many rung(s) resting at the venue are NOT counted as committed and available reads ` +
+        `HIGH by whatever they encumber. Re-export and re-import to pick the missing ` +
+        `rung(s) up; the reasons are on the error channel above.`,
+    );
+  }
+
+  if (restated.length > 0) {
+    const detail = restated
+      .map((claim) => `${claim.id} (filled ${claim.known} → ${claim.observed})`)
+      .join("; ");
+    qualifications.push(
+      `RESTATED — ${restated.length} rung(s) of ${csvPath} have filled FURTHER at the ` +
+        `venue since this file recorded them — ${detail} — and were SKIPPED; every other ` +
+        `rung imported normally. Their lines on file still read the OLDER partial, so they ` +
+        `encumber MORE than the venue actually holds: committed reads HIGH and available ` +
+        `reads LOW. That is the safe direction — it can refuse a batch you could fund, ` +
+        `never fund one you cannot — but it is not free, and recording the restatement ` +
+        `needs an observation verb this build does not have. This line REPRINTS on every ` +
+        `import until the rung fills out or is cancelled at the venue.`,
+    );
+  }
+
+  io.out(`${qualifications.join("\n")}\nImported ${csvPath}: ${counts}.\n`);
+
+  return { status: "imported-partial", ...write };
 }

--- a/apps/tui/src/import-orders.ts
+++ b/apps/tui/src/import-orders.ts
@@ -9,8 +9,9 @@
  * `O1` reject — is testable without a terminal, a real export or the real data dir.
  *
  * THE ORDERING IS THE CONTRACT: parse → merge id collisions → load the sidecar → refuse
- * changed claims → prompt → check coverage → append. The coverage check is the LAST thing before the only write, and every refusal
- * before it returns having written nothing at all. `orders.jsonl` is append-only, so a
+ * changed claims → skip the restated rungs → prompt → check coverage → append. The
+ * coverage check is the LAST thing before the only write, and every refusal before it
+ * returns having written nothing at all. `orders.jsonl` is append-only, so a
  * wrong claim written here is not edited away later — it costs a compensating line
  * forever, and that asymmetry is why the refusals are loud and total rather than
  * warnings the operator can walk past.
@@ -158,9 +159,22 @@ export interface RestatedPartial {
   remainingAtVenue: number;
 }
 
-/** What an import that WROTE reports, in the two shapes it can honestly take. */
+/**
+ * What an import that REFUSED NOTHING reports, in the two shapes it can honestly take.
+ *
+ * Not "an import that WROTE" (#200 review): an export whose every readable rung was
+ * restated writes no line at all and still reports here, because the flow reached its end
+ * with nothing refused. Writing is what these outcomes usually DO; not refusing is what
+ * they all MEAN.
+ */
 interface OrdersImportWrite {
-  /** Lines actually appended. ZERO when the same export is imported twice. */
+  /**
+   * Lines actually appended. ZERO in two different ways, and the distinction is visible
+   * only in the other fields: every rung was already known — the same export imported
+   * twice, so `alreadyKnown` carries them — or nothing was admitted at all, every
+   * readable rung having been restated, so `alreadyKnown` is 0 too and `restated` holds
+   * them.
+   */
   appended: number;
   /**
    * Rungs already in the sidecar under the same synthesized id AND saying the same
@@ -203,12 +217,15 @@ export type OrdersImportOutcome =
    */
   | ({ status: "imported" } & OrdersImportWrite)
   /**
-   * Lines were written, and SOMETHING ABOUT THE EXPORT WAS QUALIFIED (`D3`, #177; #199).
+   * The import ran to its end, and SOMETHING ABOUT THE EXPORT WAS QUALIFIED (`D3`, #177;
+   * #199).
    *
    * A DISTINCT MEMBER, not `imported` carrying a non-empty field. A shape that forces
    * every reader to open a second field to discover the first was qualified is a type
-   * that lies to the reader who does not. It is still a SUCCESS: lines were written, and
-   * the CLI exits 0 (`D3`).
+   * that lies to the reader who does not. It is still a SUCCESS, and the test is that
+   * NOTHING WAS REFUSED — not that lines were written, which is the weaker claim this
+   * used to make and which an export of nothing but restated rungs falsifies while still
+   * being a perfectly honest run. The CLI exits 0 either way (`D3`).
    *
    * TWO qualifications reach it, with OPPOSITE money directions, each carrying its own
    * field and printing its own operator line:
@@ -544,6 +561,94 @@ export async function importBitgetOpenOrders(
   const restatedIds = new Set(restated.map((claim) => claim.id));
   const admitted = orders.filter((order) => !restatedIds.has(order.id));
 
+  /**
+   * THE ONE TAIL, reached by both exits (#200 review). Extracted rather than duplicated
+   * at the short-circuit below, because a qualification added to one exit and forgotten
+   * on the other is exactly the silent half-report this whole flow is built to refuse.
+   */
+  const report = (appended: number, alreadyKnown: number): OrdersImportOutcome => {
+    const counts = `${appended} order(s) appended, ${alreadyKnown} already known`;
+    const write = { appended, alreadyKnown, skips: parsed.skips, restated };
+
+    // NOT `parsed.skips.length` (#184). `skips` is heterogeneous, and a `not-resting` row
+    // was read COMPLETELY — the parser's finding about it is that nothing is still
+    // claimed. The gap this line warns about is rungs we could not weigh, so both the
+    // discrimination and the count below run through the engine's predicate rather than
+    // the raw total. `outcome.skips` still carries every skip and stderr still reports
+    // every one of them.
+    const unweighed = parsed.skips.filter((entry) => leavesRungUnweighed(entry.problem));
+
+    if (unweighed.length === 0 && restated.length === 0) {
+      io.out(`Imported ${csvPath}: ${counts}.\n`);
+      return { status: "imported", ...write };
+    }
+
+    // EVERY QUALIFICATION GETS ITS OWN LINE, EACH OPENING ON THE GAP AND NAMING ITS OWN
+    // MONEY DIRECTION (`D3`, #177; #199). The counts follow all of them, once — they used
+    // to be the whole line, with the qualification a suffix (`..., 1 row(s) skipped.`) in
+    // exactly the position an operator skims past. An export qualified BOTH ways prints
+    // BOTH lines; that case is why this is two fields and not a third status.
+    //
+    // Unread rows lead, because they are the qualification we know least about: a restated
+    // rung was read perfectly and we can state its figures, an unread one we cannot.
+    const qualifications: string[] = [];
+
+    if (unweighed.length > 0) {
+      qualifications.push(
+        `INCOMPLETE — ${unweighed.length} row(s) of ${csvPath} could not be read, so that ` +
+          `many rung(s) resting at the venue are NOT counted as committed and available reads ` +
+          `HIGH by whatever they encumber. Re-export and re-import to pick the missing ` +
+          `rung(s) up; the reasons are on the error channel above.`,
+      );
+    }
+
+    if (restated.length > 0) {
+      // BOTH REMAINDERS, not just the two partials: the remainders are what the skip was
+      // decided on, so printing them lets the operator check the safety claim the rest of
+      // this line makes rather than take it on faith.
+      const detail = restated
+        .map(
+          (claim) =>
+            `${claim.id} (filled ${claim.known} → ${claim.observed}; the file still claims ` +
+            `${claim.remainingOnFile}, the venue holds ${claim.remainingAtVenue})`,
+        )
+        .join("; ");
+      qualifications.push(
+        `RESTATED — ${restated.length} rung(s) of ${csvPath} have filled FURTHER at the ` +
+          `venue since this file recorded them — ${detail} — and were SKIPPED; every other ` +
+          `rung imported normally. Their lines on file still read the OLDER partial, so they ` +
+          `encumber NO LESS than the venue still holds: committed never reads LOW and ` +
+          `available never reads HIGH. That is the safe direction — it can refuse a batch ` +
+          `you could fund, never fund one you cannot — but it is not free, and recording the ` +
+          `restatement needs an observation verb this build does not have. This line ` +
+          `REPRINTS on every import until the rung fills out or is cancelled at the venue.`,
+      );
+    }
+
+    io.out(`${qualifications.join("\n")}\nImported ${csvPath}: ${counts}.\n`);
+
+    return { status: "imported-partial", ...write };
+  };
+
+  // NOTHING LEFT TO IMPORT — every readable rung of this export was restated (#200
+  // review). Reported here rather than walked through the rest of the flow, which used to
+  // prompt TWICE for the funding reserve of a batch of ZERO orders and then, on the only
+  // honest answer to that question — a blank line — return `no-reserve-declared`: a
+  // refusal raised over an import that had nothing to fund and nothing to refuse.
+  //
+  // The status is honest BY CONSTRUCTION rather than by choice. An export with no readable
+  // rows at all was already refused as `no-orders` above, and `admitted` is `orders` less
+  // the restated ids, so an empty `admitted` means `restated` is non-empty — this path
+  // cannot reach the unqualified `imported`, and `report` does not have to be told so.
+  //
+  // NO COVERAGE GUARD HERE, deliberately. It would weigh only the book already on file,
+  // which this import does not change by a single line, so a refusal from it would be a
+  // NEW refusal raised over a PRE-EXISTING condition — and unfixable at that, since we
+  // did not prompt for the declaration that is the only thing the operator could correct.
+  if (admitted.length === 0) {
+    return report(0, 0);
+  }
+
   const declaration = await declareFunding(io, admitted);
   if (declaration === undefined) {
     return reject(io, "no-reserve-declared", "no funding reserve was declared for this batch");
@@ -609,70 +714,5 @@ export async function importBitgetOpenOrders(
     return reject(io, "write-failed", `could not append to ${io.ordersPath}: ${detail}`);
   }
 
-  const counts =
-    `${fresh.length} order(s) appended, ${records.length - fresh.length} already known`;
-  // NOT `parsed.skips.length` (#184). `skips` is heterogeneous, and a `not-resting` row
-  // was read COMPLETELY — the parser's finding about it is that nothing is still claimed.
-  // The gap this line warns about is rungs we could not weigh, so both the discrimination
-  // and the count below run through the engine's predicate rather than the raw total.
-  // `outcome.skips` still carries every skip and stderr still reports every one of them.
-  const unweighed = parsed.skips.filter((entry) => leavesRungUnweighed(entry.problem));
-
-  const write = {
-    appended: fresh.length,
-    alreadyKnown: records.length - fresh.length,
-    skips: parsed.skips,
-    restated,
-  };
-
-  if (unweighed.length === 0 && restated.length === 0) {
-    io.out(`Imported ${csvPath}: ${counts}.\n`);
-    return { status: "imported", ...write };
-  }
-
-  // EVERY QUALIFICATION GETS ITS OWN LINE, EACH OPENING ON THE GAP AND NAMING ITS OWN
-  // MONEY DIRECTION (`D3`, #177; #199). The counts follow all of them, once — they used
-  // to be the whole line, with the qualification a suffix (`..., 1 row(s) skipped.`) in
-  // exactly the position an operator skims past. An export qualified BOTH ways prints
-  // BOTH lines; that case is why this is two fields and not a third status.
-  //
-  // Unread rows lead, because they are the qualification we know least about: a restated
-  // rung was read perfectly and we can state its figures, an unread one we cannot.
-  const qualifications: string[] = [];
-
-  if (unweighed.length > 0) {
-    qualifications.push(
-      `INCOMPLETE — ${unweighed.length} row(s) of ${csvPath} could not be read, so that ` +
-        `many rung(s) resting at the venue are NOT counted as committed and available reads ` +
-        `HIGH by whatever they encumber. Re-export and re-import to pick the missing ` +
-        `rung(s) up; the reasons are on the error channel above.`,
-    );
-  }
-
-  if (restated.length > 0) {
-    // BOTH REMAINDERS, not just the two partials: the remainders are what the skip was
-    // decided on, so printing them lets the operator check the safety claim the rest of
-    // this line makes rather than take it on faith.
-    const detail = restated
-      .map(
-        (claim) =>
-          `${claim.id} (filled ${claim.known} → ${claim.observed}; the file still claims ` +
-          `${claim.remainingOnFile}, the venue holds ${claim.remainingAtVenue})`,
-      )
-      .join("; ");
-    qualifications.push(
-      `RESTATED — ${restated.length} rung(s) of ${csvPath} have filled FURTHER at the ` +
-        `venue since this file recorded them — ${detail} — and were SKIPPED; every other ` +
-        `rung imported normally. Their lines on file still read the OLDER partial, so they ` +
-        `encumber NO LESS than the venue still holds: committed never reads LOW and ` +
-        `available never reads HIGH. That is the safe direction — it can refuse a batch ` +
-        `you could fund, never fund one you cannot — but it is not free, and recording the ` +
-        `restatement needs an observation verb this build does not have. This line ` +
-        `REPRINTS on every import until the rung fills out or is cancelled at the venue.`,
-    );
-  }
-
-  io.out(`${qualifications.join("\n")}\nImported ${csvPath}: ${counts}.\n`);
-
-  return { status: "imported-partial", ...write };
+  return report(fresh.length, records.length - fresh.length);
 }

--- a/packages/engine/src/orders/records.ts
+++ b/packages/engine/src/orders/records.ts
@@ -97,11 +97,25 @@ export interface OrderPlacedRecord extends OrderRecordBase {
    *
    * KNOWN LIMIT, named rather than papered over: the id is synthesized from the venue's
    * SUBMISSION stamp, so a later export showing the same rung further filled arrives under
-   * the same id. It USED TO BE SKIPPED AS ALREADY KNOWN, silently keeping the partial
-   * observed at first import; since #174 it is REFUSED as a `changed-claim` instead —
-   * loudly, with nothing written — because recording it needs an observation verb this
-   * build does not have and a second placement line would be ignored by the selector.
-   * Until that verb exists the operator records the fill, or cancels and re-places.
+   * the same id, and THIS FIELD CANNOT BE UPDATED — the file is append-only and a second
+   * placement line is ignored by the selector. So the value here is the partial as of the
+   * FIRST import that saw the rung, not the venue's current one, until the observation
+   * verb #181 designs exists.
+   *
+   * The handling of that has moved twice. It was originally SKIPPED AS ALREADY KNOWN,
+   * silently. #174 made it a `changed-claim` refusal — loud, with nothing written — which
+   * fixed the silence and created a worse problem: the refusal is batch-wide, so one
+   * further-filled rung blocked every unrelated new rung in every later export from that
+   * venue, indefinitely. THE EXIT THIS PARAGRAPH USED TO NAME — "the operator records the
+   * fill" — DOES NOT WORK, and never did: `recordFill` appends an `orderFilled` line and
+   * never rewrites this one, so it repairs `committed`/`available` and leaves the refusal
+   * exactly where it was.
+   *
+   * Since #199 the rung is SKIPPED PER RUNG and reported as `restated`: the rest of the
+   * export imports, and this field keeps the older partial. That is safe only because of
+   * the direction — a stale partial over-states what is still resting, so the funding
+   * guard reads the encumbrance HIGH and can only ever be too strict. A stale `quantity`
+   * points the other way and is still a total refusal.
    */
   observedFilledQuantity?: number;
   /**


### PR DESCRIPTION
**PR E of five.** Seven commits: the engine-side partition, the outcome shape and
its two operator lines, the six #197 review items riding alongside — and four
more from this PR's own `/pr-review`, which found the partition deciding its
safety on a figure the funding guard does not read.

This closes #199 — a standalone user story with no parent and no children, so it
is the only issue this PR closes.

## The failure it ends

A rung the venue had filled *further* since the last import blocked **every
unrelated new rung in every later export from that venue**, indefinitely — and
nothing the operator could do locally cleared it. Nothing is written on a
refusal, so recording the fill repaired `committed`/`available` and left the
placement line, and therefore the refusal, exactly where it was. The only exits
were at the venue: fill the rung out, or cancel it there.

`records.ts`'s KNOWN LIMIT named an exit — *"the operator records the fill"* —
that does not work and never did. That paragraph is rewritten here.

## What changed

`changed-claim` narrows to **a disagreement that would leave the file claiming
LESS than the venue still holds**, and keeps the whole-batch refusal. A
restatement that leaves the file claiming **no less** becomes `restated` and is
skipped **per rung**, with the rest of the export importing normally.

The **direction** is the whole argument, and it is read off the **remainder the
funding guard actually weighs** — `pickRestingOrdersAsOf` over the whole stream,
`orderFilled` and `orderCancelled` lines included — not off the placement line
alone. The batch refusal never repaired the stale line either way; what it
protects is the guard's reading of the *other* rungs, which it weighs off the
file.

One rung, placed 10 with 6 filled, the venue now showing 8 — the class it falls
in depends on what the file's own stream has since recorded:

| state of the file | file claims | venue holds | guard is | per-rung skip? |
|---|---|---|---|---|
| no fill recorded | 4 | 2 | *stricter* — committed over-stated | **yes** |
| the fill of 2 recorded | 2 | 2 | *exact* — neither high nor low | **yes** — the test is `>=`, not `>` |
| the whole remainder of 4 recorded, retiring the rung | **0** | 2 | *permissive* — **committed short** | **no** — #174's own hazard |
| `quantity` amended 10 → 12 | — | — | *permissive* | **no**, whatever the remainders say (#176) |

Three boundaries the partition draws explicitly, beyond what the issue specified:

- **A changed `quantity` is refused on its own terms.** Not merely today's
  encumbrance: `placed.quantity` is the original size a cumulative venue reading
  is compared against (#176), the one figure nothing may go stale on.
- **A partial that moved DOWN is refused** — now by the *same* remainder test
  rather than a rule of its own, which subsumes it exactly:
  `fileRemaining <= quantity − known < quantity − observed = venueRemaining`.
  A fill does not un-fill, and it leaves the file under-stating the encumbrance.
- **An unknown difference defaults to refusal.** The restatement must be the
  *only* difference left, so a third field added to `ClaimDifference` lands in
  the refusal class rather than riding into the skip class beside a safe fill.

## The outcome shape

`imported-partial` widens from "a row was not read" to "the import ran to its
end, and something was qualified", carrying **two fields** — `skips` and
`restated` — with an opposite money direction and its own operator line each.
`imported` keeps its meaning by *strengthening* its invariant: every row read
**and** nothing restated. Exit code stays 0, justified by **nothing was
refused** rather than by lines having been written.

```
INCOMPLETE — a rung resting at the venue is committed nobody counted, so
             available reads HIGH.
RESTATED   — a rung was read perfectly and its partial on file is stale, so the
             file claims NO LESS than the venue holds: committed never reads
             LOW and available never reads HIGH.
```

A second field rather than a third status because an export can be qualified
**both ways at once**, and a sum type can say only one — dropping the other
silently. That case has the test that decides the design. It could not reuse
`skips` either: `leavesRungUnweighed` is a predicate over *parser* problems, and
a restated rung is weighed, just never weighed short.

**Accepted consequence, named rather than hidden:** the stale figure stays in the
book, so the RESTATED line reprints on every import until the venue resolves the
rung — including in the exact case, where a recorded fill has left the file level
with the venue and nothing is over-stated at all. That is why the line states a
floor (*never short*) rather than an inequality: it has to be true of every rung
in the class, on every reprint. Both remainders are printed with it, so the
operator can check the claim instead of taking it on faith.

## What the #200 review found

Five findings, all fixed here — commits 4 through 7.

1. **The safety argument read only the placement line, and it inverts**
   *(correctness).* `partitionChangedClaims` decided the safe direction from
   `detectChangedClaims`, which is fed only `orderPlaced` records — while the
   guard it reasons about replays fills and cancellations too. Traced: the file
   holds placed 10 / filled 6, the operator runs the fill flow and accepts the
   default remainder of 4, retiring the rung, so the book counts **zero**
   resting; the venue's next export shows filled 8, i.e. **2 units still
   resting**. That rung was *skipped*, and the flow printed "committed reads HIGH
   and available reads LOW" over a book counting 0 against 2 — available read
   HIGH, the direction that costs money. Before #199 it was a loud refusal. The
   partition now takes the resting set and the observed rows and admits a rung to
   the skip class only when its remainder on file is at least the venue's, an id
   absent from the resting set reading 0 because absent means the stream already
   retired it.
2. **The weaker half of the same finding.** Even a *correct* fill leaves the
   file exactly level with the venue, where "committed reads HIGH" is flatly
   false — on a line that reprints every import by design. Hence the floor
   wording above, and `remainingOnFile` / `remainingAtVenue` on the payload.
3. **`imported-partial` returned with nothing written** *(correctness).* When
   every readable rung is restated, `admitted` is empty and the flow carried
   straight on: two prompts for the funding reserve of a batch of **zero**
   orders, and on the only honest answer to that question — a blank line —
   `rejected`/`no-reserve-declared`, a refusal raised over an import that had
   nothing to fund. It now returns immediately after the per-rung skip, before
   the prompt and without the coverage guard (which would weigh only the
   unchanged on-file book, making any refusal a new refusal over a pre-existing
   condition). The status stays honest by construction: `no-orders` is refused
   further up, so an empty `admitted` means a non-empty `restated`.
4. **The refusal announced "a different SIZE" when the size was identical.** The
   message and the `changed-claim` docstring both defined the member as a changed
   `quantity` — false for the branch this PR is proudest of, a partial that moved
   DOWN with `quantity` untouched, and false for the remainder class besides.
   Both re-grounded on what the class actually is; the refusal now names the
   remainder gap when the remainder is what refused it. The DOWN test asserted
   only status and reason, which is how the wording survived — it asserts the
   message now.
5. **`skips: EMPTY on 'imported', by construction` was never true,** and this PR
   had promoted it to an invariant with `restated` leaning on it. `imported` is
   returned whenever no skip leaves a rung *unweighed*, and `skips` still carries
   every `not-resting` row — the whole point of #184; the repo's own test asserts
   `imported` alongside a skip. The comment states the asymmetry now.
6. **A reviewer-facing paragraph in `requestTimeoutMs`** — the 10s → 30s argument,
   addressed to a reviewer and already living verbatim in its commit message —
   cut from the code. The paragraph the code does not show (that the one budget
   funds connect + headers + decode) stays. The value is unchanged.

Each of 1, 3 and 4 has a test that fails before its fix; the probe for 1 appends
a real `orderFilled` line and re-imports, and the probe for 3 witnesses the
defect by prompt count, since the status was already right *by accident*.

## The six #197 items (commit 1)

#197 merged without a `/pr-review`; the after-the-fact review came back **clean —
no correctness bug**. Five were actionable:

1. **`requestTimeoutMs` 10s → 30s.** The only one with teeth. `10daa53` moved
   `res.json()` inside the guarded region — right call — but the same 10s budget
   then funded strictly more work. Headers at 9.6s with the body 0.5s behind used
   to succeed and would now abort, and Twelve Data maps a request-level failure
   onto every entry in the batch, so `prices:fetch` exits 1 and the wrapper halts
   before `pnpm spine` — **no marks land at all that day**. 30s bounds a
   never-finishing provider just as surely.
2. `encodeURIComponent` on Binance's symbol — an asymmetry, not a bug; neither
   provider is reachable from untrusted input. No `URIError` catch added.
3. `readInbox` deleted (a one-line cast wrapper); `readInboxArray` stays exported.
4. `provider.ts` — 21 lines of stacked preamble split and trimmed, Result-vs-throw
   rationale kept.
5. `paths.ts` — 8 lines of diff-justification cut to the two facts the code does
   not show.
6. Record-only. Left alone; a merged PR is not re-opened for a word count.

Not in the audit note: item 3 left `readInbox` named in `inbox.test.ts`'s header
comment and a `describe` title, both now corrected.

## Verification

`pnpm typecheck` exit 0. **Full** `pnpm test` — not a targeted run, since item 1
touches the shared `fetchJson` all three providers ride and the feed runs
unattended at 18:00 — **91 files passed / 3 skipped; 1119 tests passed / 19
skipped**. Synthetic figures only (`O7`): invented pair, round sizes, property
assertions.

## Deliberately out of scope

- `packages/preferences/src/orders.ts:158`'s `readOptional` — that is #198, left
  alone on purpose; folding it in would draw an unpriced
  `preferences → @numisma/event-store` edge.
- The observation verb (#181), #180/#179's PR C, and #196. **Merge this before PR
  C is built** — they collide on `OrdersImportRejection`'s declaration.
