### PR TITLE
Close the daily run's derived surfaces after the log is verified

### DIFF
--- a/apps/web/src/push/gap-report-core.test.ts
+++ b/apps/web/src/push/gap-report-core.test.ts
@@ -14,9 +14,11 @@
 import { mkdtemp, readFile, rm, writeFile } from "node:fs/promises";
 import { tmpdir } from "node:os";
 import { isAbsolute, join } from "node:path";
-import type { PortfolioEvent } from "@numisma/engine";
+import { daysBetween, type PortfolioEvent } from "@numisma/engine";
 import {
   GAP_REPORT_SCHEMA_VERSION,
+  LAUNCHD_ERA_START,
+  dueThrough,
   gapReportPath,
   resolveEventStorePaths,
   type EventStorePaths,
@@ -24,6 +26,7 @@ import {
 import { afterEach, describe, expect, it } from "vitest";
 import {
   MAX_WINDOW_DAYS,
+  defaultGapReportSince,
   parseGapReportArgs,
   resolveGapReportPaths,
   runGapReport,
@@ -210,6 +213,47 @@ describe("runGapReport — the window's bounds", () => {
     });
     expect(run.report.until).toBe(YESTERDAY);
     expect(run.lines.join("\n")).not.toContain(TODAY_CDMX);
+  });
+
+  it("floors a zero-argument run at the era start while the era is younger than the cap", async () => {
+    // The unchanged behavior, pinned so the clamp below cannot quietly narrow
+    // today's report: the era start is LATER than 400 days back, so it wins.
+    const paths = await storeWith([mark(YESTERDAY, "cx-a")]);
+    expect(defaultGapReportSince(NOW)).toBe(LAUNCHD_ERA_START);
+    const run = await runGapReport({ argv: [], now: NOW, paths });
+    expect(run.report.since).toBe(LAUNCHD_ERA_START);
+  });
+
+  it("rolls the zero-argument floor forward once the era outgrows the cap, instead of throwing", async () => {
+    // THE REGRESSION THIS EXISTS FOR. The era start is fixed and the ceiling is
+    // yesterday, so the default window grows a day per day and crosses
+    // MAX_WINDOW_DAYS on 2027-08-08 — at which point the 18:00 job's zero-argument
+    // `pnpm gap-report -- --write` would have thrown every night, forever, AFTER
+    // every other step had succeeded. Driven by a real future `now`, not by a
+    // restated bound.
+    const paths = await storeWith([mark("2027-08-06", "cx-a")]);
+    const firstOverLimit = new Date("2027-08-08T12:00:00Z");
+    // Unclamped this window would be 401 days — one past the cap.
+    expect(daysBetween(LAUNCHD_ERA_START, dueThrough(firstOverLimit)) + 1).toBe(
+      MAX_WINDOW_DAYS + 1,
+    );
+
+    const run = await runGapReport({ argv: [], now: firstOverLimit, paths });
+    expect(run.exitCode).toBe(0);
+    expect(run.report.calendarDays).toBe(MAX_WINDOW_DAYS);
+    expect(run.report.since).toBe("2026-07-04");
+    expect(run.report.until).toBe("2027-08-07");
+  });
+
+  it("still refuses an explicit --since past the cap — the clamp fills a floor, it does not lift the bound", async () => {
+    const paths = await storeWith([mark("2027-08-06", "cx-a")]);
+    await expect(
+      runGapReport({
+        argv: ["--since", LAUNCHD_ERA_START],
+        now: new Date("2027-08-08T12:00:00Z"),
+        paths,
+      }),
+    ).rejects.toThrow(new RegExp(`window .*${MAX_WINDOW_DAYS}`));
   });
 });
 

--- a/apps/web/src/push/gap-report-core.ts
+++ b/apps/web/src/push/gap-report-core.ts
@@ -47,6 +47,7 @@
  * structurally rather than trusting it to stay true.
  */
 import {
+  boundedEraFloor,
   formatGapReport,
   formatGapSummary,
   gapReportPath,
@@ -67,6 +68,38 @@ import {
  * is a report nobody reads.
  */
 export const MAX_WINDOW_DAYS = 400;
+
+/**
+ * The floor a run that did not ask for one gets: `LAUNCHD_ERA_START`, or
+ * `MAX_WINDOW_DAYS` back from the ceiling — WHICHEVER IS LATER.
+ *
+ * WITHOUT THIS CLAMP THE TWO CONSTANTS COLLIDE ON A DATE. `computeGapReport`
+ * defaults the floor to the era start, which is a FIXED day and not a rolling one,
+ * so the default window grows by one day every day; the cap above refuses anything
+ * over 400. The zero-argument run — the only one the 18:00 job makes — therefore
+ * starts THROWING on 2027-08-08 and throws every night after, with no remedy short
+ * of a code change. A job that goes permanently red on a date nobody wrote down is
+ * the same skim-inducing failure the era floor itself was chosen to avoid, arriving
+ * through the scheduler instead of through the report.
+ *
+ * THE CAP STILL BITES, and only where it was aimed: an explicit `--since
+ * 1970-01-01` is an operator asking for twenty thousand lines and still gets the
+ * refusal. This clamp only fills in the floor nobody supplied.
+ *
+ * THE COST, SAID PLAINLY: once the era is older than the window, a lost day
+ * eventually ages out of the default report. That is the right trade for a finding
+ * that is PERMANENT and unfixable — a day lost in 2026 is not actionable in 2028,
+ * and `--since` still reaches it — but it does mean the default report is a
+ * trailing window, not a complete history, from 2027-08-08 on.
+ *
+ * The calendar arithmetic and the era start stay in `@numisma/event-store`; only
+ * the WIDTH is this command's, because readability is this command's reason. That
+ * split is also what keeps this module's one-import property intact — see the
+ * structural test in `gap-report-core.test.ts`.
+ */
+export function defaultGapReportSince(now: Date): string {
+  return boundedEraFloor(now, MAX_WINDOW_DAYS);
+}
 
 export interface GapReportArgs {
   since: string | undefined;
@@ -199,7 +232,12 @@ export async function runGapReport(options: GapReportRunOptions): Promise<GapRep
   const paths = options.paths ?? resolveGapReportPaths();
 
   const report = await loadGapReport(paths, {
-    since: args.since,
+    // The command supplies the floor rather than letting the derivation default it,
+    // so the zero-argument run can never grow into the cap below. See
+    // `defaultGapReportSince`. The pure derivation keeps its own era-start default
+    // for callers that bound their output some other way (the TUI channel bounds by
+    // LINES, not by window).
+    since: args.since ?? defaultGapReportSince(options.now),
     until: args.until,
     now: options.now,
   });
@@ -226,6 +264,9 @@ export async function runGapReport(options: GapReportRunOptions): Promise<GapRep
     );
   }
 
+  // Reachable ONLY through an explicit `--since` now that the default floor is
+  // clamped to the same bound. Kept as a real check rather than an assertion: the
+  // operator-supplied case is the one it was written for.
   if (report.calendarDays > MAX_WINDOW_DAYS) {
     throw new Error(
       `gap-report: the window ${report.since}…${report.until} spans ` +

--- a/docs/price-feed-ops.md
+++ b/docs/price-feed-ops.md
@@ -14,7 +14,7 @@ Everything here is machine-local. Nothing secret or trade-derived enters the rep
 
 | File | Role |
 | --- | --- |
-| `ops/price-feed/run-daily-fetch.sh` | Wrapper the scheduler calls. Sets a PATH that can find `pnpm`, sources tokens, runs `pnpm prices:fetch`; on a clean fetch: (2) `pnpm spine` then (3) an auto-commit of any new data-repo changes scoped to `$NUMISMA_DATA_DIR` — idempotent if no new marks, never pushes — then (4) a post-check that **fails the job** if the durable event log is still uncommitted (lenient warn for the `head-digest.json` breadcrumb). Only once the log is verified does it touch anything derived: (5) `pnpm backfill` to refresh the hosted projection and (6) `pnpm gap-report -- --write` to rewrite `gap-report.json` beside the log. Preserves the non-zero exit code so the scheduler notices a failure or rejection. |
+| `ops/price-feed/run-daily-fetch.sh` | Wrapper the scheduler calls. Sets a PATH that can find `pnpm`, sources tokens, runs `pnpm prices:fetch`; on a clean fetch: (2) `pnpm spine` then (3) an auto-commit of any new data-repo changes scoped to `$NUMISMA_DATA_DIR` — idempotent if no new marks, never pushes — then (4) a post-check that **fails the job** if the durable event log is still uncommitted (lenient warn for the `head-digest.json` breadcrumb). Only once the log is verified does it touch anything derived, local before networked: (5) `pnpm gap-report -- --write` to rewrite `gap-report.json` beside the log and (6) `pnpm backfill` to refresh the hosted projection. Preserves the non-zero exit code so the scheduler notices a failure or rejection. |
 | `ops/price-feed/com.numisma.pricefeed.daily.plist` | launchd definition firing the wrapper at 18:00 local (the default mark time), **every day** (see "Why the schedule fires 7 days/week" below). |
 
 Both files are templates: replace `__REPO_DIR__` / `__HOME__` before installing.
@@ -61,6 +61,16 @@ Both files are templates: replace `__REPO_DIR__` / `__HOME__` before installing.
   repo (`~/Dev/accumulus/data` by default, or wherever `NUMISMA_DATA_DIR` points),
   never inside the numisma checkout; secrets likewise are a machine-local artifact
   beside the repo, not in it.
+
+  **Credentials only — do not put `NUMISMA_DATA_DIR` in this file.** The wrapper
+  resolves `DATA_DIR` in its configuration block at the top, *before* it sources
+  this file, because the heartbeat trap must know where to write before the
+  exit-127 checks run. A `NUMISMA_DATA_DIR` set here would therefore reach every
+  node command but not the wrapper's own git steps: the commit and post-check would
+  guard `~/Dev/accumulus/data` while `spine` wrote somewhere else, and the job would
+  stay green over an unverified log. Set it in the launchd plist's
+  `EnvironmentVariables` (or the shell environment) instead, where both halves see
+  it.
 
 ### Twelve Data free tier: why the run pauses ~1 minute
 
@@ -262,25 +272,45 @@ Confirm, in order:
    `head-digest.json` warns but does not fail the run (it is a forensic breadcrumb,
    not the source of truth); the warning uses `git status --ignored` so it fires even
    when the breadcrumb is only-ignored-and-present, the actual #132 shape.
-7. **Backfill (step 5):** the log reads `[backfill] N anchor(s) upserted: <first>
+7. **Gap report (step 5):** the report's own lines appear and `gap-report.json` in
+   the data dir carries a `generatedAt` from **this** run. Before this step existed
+   the file was written only by hand, so it was a day stale every morning — and
+   stale precisely on the morning after a miss, the one morning anybody reads it.
+8. **Backfill (step 6):** the log reads `[backfill] N anchor(s) upserted: <first>
    … <last>`, one line per anchored date. `[backfill] failed:
    PROJECTION_WRITE_DATABASE_URL is not set` means the key is missing from the env
    file — the run goes red here, deliberately, rather than leaving the dashboard to
    rot quietly. Note the exit is non-zero but the durable log is already committed
    and verified: this failure costs a stale projection, never fund data.
-8. **Gap report (step 6):** the run ends with the report's own lines and
-   `gap-report.json` in the data dir carries a `generatedAt` from **this** run.
-   Before this step existed the file was written only by hand, so it was a day
-   stale every morning — and stale precisely on the morning after a miss, the one
-   morning anybody reads it.
+
+**Why the local step runs before the networked one.** Under `set -e` a failing step
+aborts everything after it, so the order decides what a partial run still delivers.
+`gap-report` needs no credential and no network — it is a pure read of the log the
+post-check just verified — so putting it first means it succeeds on every run that
+got past step 4, **including the runs where the database is unreachable**. The
+other order would let a 30-second projection outage leave the standup reading
+yesterday's `generatedAt`, which is the exact staleness these steps end.
 
 **The failure mode these two steps create, and who catches it.** Fetch succeeds,
-`backfill` fails: the durable log is clean and committed, the projection is stale,
-and the gap report is **structurally silent** — it derives purely over the log,
-and the log is fine. Nothing in the data says anything is wrong. Only
-`job-heartbeat.json` sees it, carrying `exitCode` non-zero and
-`lastStep: "backfill"`, which the TUI surfaces on its next startup (#191). That
-dependency is why these steps could not be added before the heartbeat shipped.
+`backfill` fails: the durable log is clean and committed, the gap report is fresh,
+and the projection is stale. The gap report cannot say so — it is **structurally
+silent** here, deriving purely over the log, and the log is fine. Nothing in the
+data says anything is wrong. Only `job-heartbeat.json` sees it, carrying `exitCode`
+non-zero and `lastStep: "backfill"`, which the TUI surfaces on its next startup
+(#191). That dependency is why these steps could not be added before the heartbeat
+shipped.
+
+**The gap report's window is bounded and self-flooring, so this step cannot age
+into a failure.** `pnpm gap-report` refuses a window over 400 calendar days (it
+would print one line per day), and its floor defaults to the launchd era start —
+a *fixed* day against a ceiling that moves. Left alone those two would have
+collided on **2027-08-08**, turning the last step of every night's run red forever,
+after everything else had succeeded. The command now floors a zero-argument run at
+the later of the era start and 400 days back (`boundedEraFloor`), so the scheduled
+invocation stays zero-argument — no date for a cron job to get wrong — and can
+never grow into its own cap. The trade, stated: from 2027-08-08 the default report
+is a trailing 400-day window rather than the whole era. A lost day is permanent and
+unfixable, so aging one out is right; `--since` still reaches it.
 
 ### Dry-run record
 

--- a/docs/price-feed-ops.md
+++ b/docs/price-feed-ops.md
@@ -14,7 +14,7 @@ Everything here is machine-local. Nothing secret or trade-derived enters the rep
 
 | File | Role |
 | --- | --- |
-| `ops/price-feed/run-daily-fetch.sh` | Wrapper the scheduler calls. Sets a PATH that can find `pnpm`, sources tokens, runs `pnpm prices:fetch`; on a clean fetch: (2) `pnpm spine` then (3) an auto-commit of any new data-repo changes scoped to `$NUMISMA_DATA_DIR` — idempotent if no new marks, never pushes — then (4) a post-check that **fails the job** if the durable event log is still uncommitted (lenient warn for the `head-digest.json` breadcrumb). Preserves the non-zero exit code so the scheduler notices a failure or rejection. |
+| `ops/price-feed/run-daily-fetch.sh` | Wrapper the scheduler calls. Sets a PATH that can find `pnpm`, sources tokens, runs `pnpm prices:fetch`; on a clean fetch: (2) `pnpm spine` then (3) an auto-commit of any new data-repo changes scoped to `$NUMISMA_DATA_DIR` — idempotent if no new marks, never pushes — then (4) a post-check that **fails the job** if the durable event log is still uncommitted (lenient warn for the `head-digest.json` breadcrumb). Only once the log is verified does it touch anything derived: (5) `pnpm backfill` to refresh the hosted projection and (6) `pnpm gap-report -- --write` to rewrite `gap-report.json` beside the log. Preserves the non-zero exit code so the scheduler notices a failure or rejection. |
 | `ops/price-feed/com.numisma.pricefeed.daily.plist` | launchd definition firing the wrapper at 18:00 local (the default mark time), **every day** (see "Why the schedule fires 7 days/week" below). |
 
 Both files are templates: replace `__REPO_DIR__` / `__HOME__` before installing.
@@ -34,6 +34,25 @@ Both files are templates: replace `__REPO_DIR__` / `__HOME__` before installing.
   #   TWELVEDATA_API_KEY=...   # Twelve Data free key, US equities
   #   BANXICO_TOKEN=...        # Banxico SIE free token, USD/MXN FIX series SF43718
   ```
+
+- **The projection write credential lives here too, and it is not like the other
+  two.** Step 5's `pnpm backfill` throws immediately without
+  `PROJECTION_WRITE_DATABASE_URL`, so the scheduled run needs it in this same file:
+
+  ```sh
+  #   PROJECTION_WRITE_DATABASE_URL=postgres://numisma_push:…  # ADR-007 writer cred
+  ```
+
+  It is the **same value** as `apps/web/.env.push.local` (the hand-run push's
+  source, `docs/hosted-cutover-runbook.md` step 8), duplicated rather than sourced
+  as a second file so the wrapper keeps exactly one `source` line. **Say the
+  consequence plainly: this file now holds a database WRITE credential alongside
+  two read-only market-data keys, so "the blast radius is someone reading public
+  prices on your quota" below no longer covers all of it.** The `numisma_push`
+  role holds SELECT/INSERT/UPDATE and **no DELETE** (`docs/projection-provisioning.md`),
+  so the worst case is a corrupted derived read surface that a `pnpm backfill` from
+  the durable log rebuilds — the event log itself is out of its reach. Rotate it
+  through the projection provisioning path, not the provider dashboards.
 
   The wrapper `source`s it if present. If a key is absent, only that provider's
   instruments fail (loud, per-symbol) — crypto still runs keyless. The file is never
@@ -59,12 +78,23 @@ skip the pause.)
 
 ### Why plaintext-at-rest is the right posture here (and when to upgrade)
 
-These are **free, read-only, revocable market-data keys** — not exchange/trading
-keys. They carry no write access, move no money, and expose no PII. The blast
-radius of a leak is "someone reads public prices on your quota until you
-regenerate the key." Against that thin threat, a `chmod 600` file outside the repo
-is proportionate, and it keeps the hands-off 18:00 launchd run dead-simple: no
-interactive keychain/vault unlock that could block a scheduled, non-login job.
+Two of the three are **free, read-only, revocable market-data keys** — not
+exchange/trading keys. They carry no write access, move no money, and expose no
+PII. The blast radius of a leak is "someone reads public prices on your quota
+until you regenerate the key."
+
+The third, `PROJECTION_WRITE_DATABASE_URL`, **does** carry write access, and the
+posture holds anyway rather than by omission: the `numisma_push` role can
+SELECT/INSERT/UPDATE the projection and **cannot DELETE**, the projection is a
+**derived** read surface, and the durable event log it derives from lives in a
+different place under a different credential the role does not have. So a leak
+buys an attacker the ability to corrupt a dashboard that `pnpm backfill` rebuilds
+from the log — not to touch the source of truth, and not to move money. That is a
+real step up from "reads public prices," and still short of the trigger below.
+
+Against that threat, a `chmod 600` file outside the repo is proportionate, and it
+keeps the hands-off 18:00 launchd run dead-simple: no interactive keychain/vault
+unlock that could block a scheduled, non-login job.
 
 **Your real defense is fast revocation, not encryption-at-rest.** If a key ever
 leaks (committed by mistake, copied into a shared backup, pasted somewhere):
@@ -75,13 +105,19 @@ leaks (committed by mistake, copied into a shared backup, pasted somewhere):
   (email signup flow) and replace `BANXICO_TOKEN`. The old token stops working
   once reissued.
 - **Binance:** nothing to revoke — the daily fetch uses keyless public REST.
+- **Projection writer:** not a dashboard rotation — change the `numisma_push`
+  role's password at the database and update **both** copies
+  (`~/.config/numisma/price-feed.env` and `apps/web/.env.push.local`). Two copies
+  is the price of the single `source` line; a rotation that updates only one
+  leaves either the hand-run push or the 18:00 job failing.
 
 After rotating, re-run the manual dry run to confirm the new credential works.
 
 **Upgrade the posture (to macOS Keychain or 1Password/Bitwarden CLI) only when a
 real trigger appears** — do not pre-build it:
 
-- a **write-capable or trading** key enters the picture (real money at risk), or
+- a key that **moves money or writes the durable log** enters the picture (the
+  projection writer is write-capable but does neither — see above), or
 - a **second machine or operator** needs the same secret, or
 - a **hosted surface** ships (then use the platform's secret store / Vercel env,
   not a machine-local file at all).
@@ -226,6 +262,25 @@ Confirm, in order:
    `head-digest.json` warns but does not fail the run (it is a forensic breadcrumb,
    not the source of truth); the warning uses `git status --ignored` so it fires even
    when the breadcrumb is only-ignored-and-present, the actual #132 shape.
+7. **Backfill (step 5):** the log reads `[backfill] N anchor(s) upserted: <first>
+   … <last>`, one line per anchored date. `[backfill] failed:
+   PROJECTION_WRITE_DATABASE_URL is not set` means the key is missing from the env
+   file — the run goes red here, deliberately, rather than leaving the dashboard to
+   rot quietly. Note the exit is non-zero but the durable log is already committed
+   and verified: this failure costs a stale projection, never fund data.
+8. **Gap report (step 6):** the run ends with the report's own lines and
+   `gap-report.json` in the data dir carries a `generatedAt` from **this** run.
+   Before this step existed the file was written only by hand, so it was a day
+   stale every morning — and stale precisely on the morning after a miss, the one
+   morning anybody reads it.
+
+**The failure mode these two steps create, and who catches it.** Fetch succeeds,
+`backfill` fails: the durable log is clean and committed, the projection is stale,
+and the gap report is **structurally silent** — it derives purely over the log,
+and the log is fine. Nothing in the data says anything is wrong. Only
+`job-heartbeat.json` sees it, carrying `exitCode` non-zero and
+`lastStep: "backfill"`, which the TUI surfaces on its next startup (#191). That
+dependency is why these steps could not be added before the heartbeat shipped.
 
 ### Dry-run record
 

--- a/ops/price-feed/run-daily-fetch.sh
+++ b/ops/price-feed/run-daily-fetch.sh
@@ -243,5 +243,44 @@ if git -C "$DATA_DIR" rev-parse --git-dir >/dev/null 2>&1; then
   echo "[$STAMP] post-check OK: durable log committed clean in $DATA_DIR."
 fi
 
+# 5) Refresh the hosted projection. `backfill`, NOT `push`, and the difference is
+#    the whole reason this step can be unattended: `push` writes ONE row — the
+#    current fold's `asOf` — so a run that died yesterday leaves yesterday
+#    permanently missing from the dashboard. `backfill` enumerates the log's own
+#    anchored dates and upserts every one under `ON CONFLICT (fund_id, as_of) DO
+#    UPDATE`, so a missed day heals on the next fire. It is zero-argument by
+#    construction (it reads the dates off the log), which is what keeps a cron job
+#    from eventually writing the wrong date.
+#
+#    IT NEEDS `PROJECTION_WRITE_DATABASE_URL` AND WILL THROW IMMEDIATELY WITHOUT IT.
+#    That key comes from $ENV_FILE, sourced at the top — the same private,
+#    chmod-600, outside-the-repo file as the provider tokens. If it is absent the
+#    run goes red here (exit 1) rather than silently skipping, which is correct:
+#    the projection going stale is exactly the thing this step exists to prevent.
+#
+#    WHY THIS RUNS AFTER THE POST-CHECK, not before. This is a network call that
+#    can fail on its own terms. Placed earlier it would abort the run after step 3
+#    committed the log but BEFORE step 4 verified it landed — muddying the one
+#    check that guards real fund data with an unrelated database failure. The
+#    durable log is the source of truth; the projection is a derived read surface,
+#    so it is verified last and cannot pre-empt the log's own check.
+LAST_STEP="backfill"
+pnpm backfill
+
+# 6) Rewrite gap-report.json beside the durable log. Without this the file exists
+#    only from manual runs, so the standup's data source is a day stale every
+#    morning BY CONSTRUCTION — and stale precisely on the morning after a miss,
+#    the only morning it exists for. (The TUI channel derives the same report
+#    live and was never affected; this is the file half only.)
+#
+#    Needs no credential and no data-dir variable — it is a pure function of the
+#    log. It writes into $DATA_DIR, the accumulus tree step 3 just committed, but
+#    cannot dirty it: accumulus uses an allowlist .gitignore under which
+#    gap-report.json falls through to /data/* (ignored, untracked), and step 4's
+#    strict arm runs `git status --porcelain` WITHOUT `--ignored` over five named
+#    durable files, so the sidecar is invisible to it either way.
+LAST_STEP="gap-report"
+pnpm gap-report -- --write
+
 LAST_STEP="complete"
 echo "[$STAMP] price-feed daily run complete."

--- a/ops/price-feed/run-daily-fetch.sh
+++ b/ops/price-feed/run-daily-fetch.sh
@@ -243,7 +243,42 @@ if git -C "$DATA_DIR" rev-parse --git-dir >/dev/null 2>&1; then
   echo "[$STAMP] post-check OK: durable log committed clean in $DATA_DIR."
 fi
 
-# 5) Refresh the hosted projection. `backfill`, NOT `push`, and the difference is
+# Steps 5 and 6 are the DERIVED surfaces, and they run in this order for a reason
+# stated once here: THE LOCAL ONE FIRST, THE NETWORKED ONE SECOND. Under `set -e` a
+# failing step aborts every step after it, so ordering decides what a partial run
+# still delivers. `gap-report` needs no credential and no network — it is a pure
+# read of the log this run just verified, so if it runs first it succeeds on every
+# run that got past step 4, INCLUDING the runs where the database is unreachable.
+# The other order would have let a 30-second Neon outage leave the standup reading
+# a `generatedAt` from yesterday — which is the exact staleness these two steps were
+# added to end.
+
+# 5) Rewrite gap-report.json beside the durable log. Without this the file exists
+#    only from manual runs, so the standup's data source is a day stale every
+#    morning BY CONSTRUCTION — and stale precisely on the morning after a miss,
+#    the only morning it exists for. (The TUI channel derives the same report
+#    live and was never affected; this is the file half only.)
+#
+#    Needs no credential and no data-dir variable — it is a pure function of the
+#    log. It writes into $DATA_DIR, the accumulus tree step 3 just committed, but
+#    cannot dirty it: accumulus uses an allowlist .gitignore under which
+#    gap-report.json falls through to /data/* (ignored, untracked), and step 4's
+#    strict arm runs `git status --porcelain` WITHOUT `--ignored` over the FOUR
+#    durable files it names, so the sidecar is invisible to it either way. (Four,
+#    not five: the allowlist versions five files, but head-digest.json is handled
+#    by the lenient `--ignored` arm above, and that arm reports rather than fails.)
+#
+#    ZERO-ARGUMENT, and it stays that way even as the log ages: the command floors
+#    its own window at `boundedEraFloor` — the launchd era start, or 400 days back,
+#    whichever is later — so the default window can never grow into the command's
+#    own width cap. Before that clamp this line was a date-bomb: the era start is
+#    fixed while the ceiling is yesterday, so on 2027-08-08 the window would have
+#    hit 401 days and this step would have thrown every night from then on, after
+#    every other step had already succeeded.
+LAST_STEP="gap-report"
+pnpm gap-report -- --write
+
+# 6) Refresh the hosted projection. `backfill`, NOT `push`, and the difference is
 #    the whole reason this step can be unattended: `push` writes ONE row — the
 #    current fold's `asOf` — so a run that died yesterday leaves yesterday
 #    permanently missing from the dashboard. `backfill` enumerates the log's own
@@ -258,29 +293,14 @@ fi
 #    run goes red here (exit 1) rather than silently skipping, which is correct:
 #    the projection going stale is exactly the thing this step exists to prevent.
 #
-#    WHY THIS RUNS AFTER THE POST-CHECK, not before. This is a network call that
-#    can fail on its own terms. Placed earlier it would abort the run after step 3
-#    committed the log but BEFORE step 4 verified it landed — muddying the one
-#    check that guards real fund data with an unrelated database failure. The
+#    WHY BOTH OF THESE RUN AFTER THE POST-CHECK, not before. This is a network call
+#    that can fail on its own terms. Placed earlier it would abort the run after
+#    step 3 committed the log but BEFORE step 4 verified it landed — muddying the
+#    one check that guards real fund data with an unrelated database failure. The
 #    durable log is the source of truth; the projection is a derived read surface,
 #    so it is verified last and cannot pre-empt the log's own check.
 LAST_STEP="backfill"
 pnpm backfill
-
-# 6) Rewrite gap-report.json beside the durable log. Without this the file exists
-#    only from manual runs, so the standup's data source is a day stale every
-#    morning BY CONSTRUCTION — and stale precisely on the morning after a miss,
-#    the only morning it exists for. (The TUI channel derives the same report
-#    live and was never affected; this is the file half only.)
-#
-#    Needs no credential and no data-dir variable — it is a pure function of the
-#    log. It writes into $DATA_DIR, the accumulus tree step 3 just committed, but
-#    cannot dirty it: accumulus uses an allowlist .gitignore under which
-#    gap-report.json falls through to /data/* (ignored, untracked), and step 4's
-#    strict arm runs `git status --porcelain` WITHOUT `--ignored` over five named
-#    durable files, so the sidecar is invisible to it either way.
-LAST_STEP="gap-report"
-pnpm gap-report -- --write
 
 LAST_STEP="complete"
 echo "[$STAMP] price-feed daily run complete."

--- a/packages/event-store/src/gap-report.ts
+++ b/packages/event-store/src/gap-report.ts
@@ -151,6 +151,27 @@ export function dueThrough(now: Date, timeZone: string = REPORT_TIME_ZONE): stri
 }
 
 /**
+ * THE FLOOR, BOUNDED: `LAUNCHD_ERA_START`, or `maxDays` back from the ceiling —
+ * whichever is LATER. Inclusive of the ceiling itself, so the window it opens is
+ * exactly `maxDays` calendar days wide at its widest.
+ *
+ * IT EXISTS BECAUSE THE ERA START IS A FIXED DAY AND THE CEILING IS NOT. A caller
+ * that both defaults its floor to the era start AND refuses windows over some width
+ * has written a date-bomb without noticing: the default window grows by one day
+ * every day and eventually crosses the refusal. For the gap-report command that day
+ * is 2027-08-08, and the cost is the 18:00 job going permanently red at its last
+ * step, long after anyone remembers why.
+ *
+ * The WIDTH lives with the caller that has the reason for it (readability, a line
+ * budget, a screen); the ERA START and the calendar arithmetic live here, with the
+ * derivation they belong to. Neither has to know the other's constant.
+ */
+export function boundedEraFloor(now: Date, maxDays: number): string {
+  const widest = addDays(dueThrough(now), -(maxDays - 1));
+  return widest > LAUNCHD_ERA_START ? widest : LAUNCHD_ERA_START;
+}
+
+/**
  * Name the lost days in the window. Synchronous, pure, and ONE PASS over the
  * events: the anchor set and the per-date mark counts are built together, because
  * they are two readings of the same scan.

--- a/packages/event-store/src/index.ts
+++ b/packages/event-store/src/index.ts
@@ -18,6 +18,7 @@ export {
 export {
   LAUNCHD_ERA_START,
   REPORT_TIME_ZONE,
+  boundedEraFloor,
   computeGapReport,
   dueThrough,
   formatGapReport,


### PR DESCRIPTION
**A1 of the two items #185 needs.** Two commits: the first is `ops/` + `docs/`
only, the second adds the application-code half of a fix the review turned up
(see "Second commit" below). Disjoint from the PR A–E chain.

**No closing keyword, deliberately.** #186 is already closed. #185 stays OPEN
until A2 lands as well (`RunAtLoad true` + hourly 18:00–23:00, still gated on the
Twelve Data daily credit cap), so this PR must not auto-close it — A1 alone
leaves the laptop-asleep-at-18:00 miss uncovered.

## The bleeding

The wrapper ended at step (4)'s post-check, so two derived surfaces went stale
unattended:

- **`gap-report.json`** — the standup's data source — existed only from manual
  runs. It was **a day stale every morning by construction**, and stale precisely
  on the morning after a miss, which is the one morning it exists for. (The TUI
  channel derives live and was never affected; this is the file half only.)
- **The hosted projection** was refreshed only by hand.

## What changed

Two steps appended after the post-check, each setting `LAST_STEP` first so #191's
heartbeat can name where a run died — **local before networked**:

```
LAST_STEP="gap-report"   ; pnpm gap-report -- --write
LAST_STEP="backfill"     ; pnpm backfill
```

**`backfill`, not `push`.** `push` writes one row — the current fold's `asOf` — so
a run that died yesterday leaves yesterday permanently missing. `backfill`
enumerates the log's own anchored dates and upserts every one under
`ON CONFLICT DO UPDATE`, so a missed day heals on the next fire. It is
zero-argument by construction: no date for a cron job to get wrong. That
self-healing property is what makes it right for an unattended job.

**Appending after the post-check is load-bearing.** `backfill` is a network call
that can fail on its own terms; placed earlier it would abort the run after step
(3) committed the log but before step (4) verified it landed — muddying the one
check guarding real fund data with an unrelated database failure. The log is the
source of truth and the projection is derived, so the derived surface can never
pre-empt the log's check.

**And the local step runs before the networked one.** Under `set -e` a failing
step aborts everything after it, so the order decides what a partial run still
delivers. `gap-report` needs no credential and no network — it is a pure read of
the log step (4) just verified — so first place means it succeeds on every run
that got past the post-check, *including the runs where the database is
unreachable*. The other order let a 30-second projection outage abort before the
report was ever written, leaving the standup on yesterday's `generatedAt` —
verbatim the staleness this PR exists to end, reintroduced on the failure path.
That was one of three review findings; see below.

## This is NOT the one-line change #186 described

`backfill` throws immediately without `PROJECTION_WRITE_DATABASE_URL`, and under
launchd that key was simply absent: it lives in `apps/web/.env.push.local`, while
the wrapper sources `~/.config/numisma/price-feed.env`, which held only
`TWELVEDATA_API_KEY` and `BANXICO_TOKEN`.

The credential goes into `price-feed.env` — one file, one existing source line,
already `chmod 600` and outside the repo — rather than sourcing a second file.

**The consequence, stated rather than omitted:** that file goes from holding two
read-only market-data keys to holding a database **WRITE** credential. The
posture still holds, but by argument: the `numisma_push` role is
SELECT/INSERT/UPDATE with **no DELETE**, the projection is a derived read surface,
and the durable event log sits behind a different credential that role does not
have. A leak buys a corrupted dashboard `pnpm backfill` rebuilds from the log —
not the source of truth, and not money. `docs/price-feed-ops.md` now says this
instead of claiming all three keys are read-only, and the rotation note covers
the two copies of the write URL a rotation must update together.

## New failure mode this creates, and what already covers it

Fetch succeeds, backfill fails → log clean, gap report fresh, projection stale.
The gap report cannot say so — it is **structurally silent** here, deriving purely
over the log, and the log is fine. Only #191's heartbeat sees it, carrying
`exitCode` non-zero and `lastStep: "backfill"`. That shipped and is proven live,
which is what made this item's precondition met.

## Second commit: three review findings

A review of the first commit found three defects in it. All three are fixed in
`fix(price-feed): derive locally before networked, and bound the report's own
window`.

1. **Ordering** — the swap described above. Behavioral.
2. **The scheduled `gap-report` was a date-bomb.** Its floor defaulted to
   `LAUNCHD_ERA_START`, a **fixed** day, against a ceiling pinned to yesterday, so
   the default window grew a day per day — while the command refuses any window
   over `MAX_WINDOW_DAYS` (400). The zero-argument run, the only one the 18:00 job
   makes, would have started throwing on **2027-08-08** and thrown every night
   after, with no remedy short of a code change, going red at the *last* step
   after every other step had already succeeded. A job that turns permanently red
   on a date nobody wrote down is the same skim-inducing failure the era floor was
   itself chosen to avoid, arriving through the scheduler instead of the report.

   Fixed by flooring a zero-argument run at the later of the era start and 400
   days back (`boundedEraFloor`), so the invocation stays zero-argument and can
   never grow into its own cap. An explicit over-wide `--since` is still refused —
   that is an operator asking for twenty thousand lines. **The trade, stated:**
   from 2027-08-08 the default report is a trailing 400-day window rather than the
   whole era. A lost day is permanent and unfixable, so aging one out of the
   default view is right, and `--since` still reaches it.
3. **A miscount in a comment whose job is precision** — step (6) said the strict
   arm names "five named durable files". It names four; five is the accumulus
   *allowlist* count, which includes the one file (`head-digest.json`) deliberately
   handled by the lenient `--ignored` arm.

Plus one note the review raised: `price-feed.env` is for **credentials only**. The
wrapper resolves `DATA_DIR` before it sources that file (the heartbeat trap needs
it before the exit-127 checks), so a `NUMISMA_DATA_DIR` set there would reach every
node command but not the wrapper's own git steps — the post-check would guard one
tree while `spine` wrote to another, and the job would stay green over an
unverified log. Now documented as belonging in the plist's `EnvironmentVariables`.

**Why this commit touches application code** and the first deliberately did not:
the window fix is not expressible in `ops/` alone. A bash-computed `--since` would
duplicate the era constant in shell *and* hand a cron job a date to get wrong —
the exact property `backfill`'s own header argues against.

**Where the clamp lives, and why it is not arbitrary.** The width stays with the
command (readability is the command's reason); the era start and the calendar
arithmetic moved to `@numisma/event-store` as `boundedEraFloor(now, maxDays)`.
`gap-report-core.ts` carries a structural test asserting it imports from
`@numisma/event-store` and **nothing else** — the detector must not be able to
reach the thing whose failure it detects — and doing the math in place by pulling
`addDays` from `@numisma/engine` broke it. The guard caught that, and the guard is
right.

## Verification

The wrapper itself has no test surface. Verified safe on the two claims that could
dirty a tree: accumulus uses an allowlist `.gitignore` and both `gap-report.json`
and `job-heartbeat.json` fall through to `/data/*` (ignored, untracked), and the
strict post-check runs `git status --porcelain` *without* `--ignored` over the four
named durable files, so the sidecars are invisible to it.

Second commit: `pnpm typecheck` exit 0; `pnpm test` 91 files / **1122 passed** / 19
skipped (+3 new tests, driving the clamp from a real future `now` rather than
restating the bound); `bash -n` clean; `pnpm gap-report -- --write` run live —
exit 0, file written, floor **unmoved** at `2026-07-03…2026-08-05` (34 days, so
nothing about today's report changes), accumulus tree still clean under the strict
arm.

**Live verification is tonight's 18:00 run.** Afterward `job-heartbeat.json`
should read `exitCode 0` / `lastStep "complete"`, and `gap-report.json`'s `until`
should be `2026-08-06`. `PROJECTION_WRITE_DATABASE_URL` is confirmed present in
`~/.config/numisma/price-feed.env`, so step (6) will not throw for a missing key.
