### PR TITLE
The orders refusal says what it means, then says all of it

### DIFF
--- a/apps/tui/src/import-orders.test.ts
+++ b/apps/tui/src/import-orders.test.ts
@@ -878,14 +878,20 @@ describe("`O1` — the over-commitment reject (testing decision 6)", () => {
     // (one declaration fix clears all of them), the mismatched one per rung.
     expect(refusal).toContain("      reserve-odd\n        rung-odd");
     expect(refusal).toContain("\n      reserve-paper\n");
-    expect(refusal).toContain("rung-mxn (USD) against reserve-mxn");
+    // Marker-agnostic here — the id sits on its own line and the mismatch is indented
+    // beneath it; the marked form is pinned exactly below.
+    expect(refusal).toMatch(
+      /\n {6}rung-mxn.*\n {8}quoted in USD, declared against reserve-mxn\n/,
+    );
     // PROVENANCE (#202 review). The count is the whole book's, so the two rungs that were
     // already in the sidecar are MARKED and the legend says what the mark means — without
     // it, the operator reconciles "4 rungs" against an export holding two of them and
     // cannot make it come out even.
     expect(refusal).toContain('rungs marked "on file"');
     expect(refusal).toContain("        rung-odd — on file");
-    expect(refusal).toContain("      rung-mxn (USD) against reserve-mxn — on file");
+    expect(refusal).toContain(
+      "      rung-mxn — on file\n        quoted in USD, declared against reserve-mxn",
+    );
     // This batch's own rungs carry NO marker: they are in the export just read.
     const exported = parseBitgetOpenOrdersCsv(await readFile(csvPath, "utf8"));
     expect(exported.status).toBe("ok");

--- a/apps/tui/src/import-orders.test.ts
+++ b/apps/tui/src/import-orders.test.ts
@@ -18,6 +18,7 @@ import {
   parseFundReview,
   pickRestingOrdersAsOf,
   type FundReviewData,
+  type OrderRecord,
 } from "@numisma/engine";
 import { afterEach, describe, expect, it } from "vitest";
 import { importBitgetOpenOrders, type OrdersImportIo } from "./import-orders.js";
@@ -97,6 +98,25 @@ function ladder(...rows: string[]): string {
   return [HEADER, ...rows, ""].join("\n");
 }
 
+/**
+ * One resting rung written STRAIGHT to the sidecar, under a chosen id and funding
+ * reserve — the only way to build a book whose rungs name DIFFERENT reserves, since the
+ * import prompts for one declaration per batch. Synthetic throughout (`O7`).
+ */
+function seededRung(id: string, at: string, fundingReserveId: string): OrderRecord {
+  return {
+    id,
+    observedAt: at.replace(" ", "T"),
+    kind: "orderPlaced",
+    currency: "USD",
+    symbol: "XYZ/USDT",
+    side: "buy",
+    price: 100,
+    quantity: 0.1,
+    fundingReserveId,
+  };
+}
+
 /** A two-rung synthetic ladder: 0.1 @ 1000 and 0.1 @ 900, committing 190 in total. */
 const TWO_RUNG_LADDER = ladder(
   rung("1000", "0.1", "2020-01-01 10:00:00"),
@@ -127,24 +147,40 @@ interface HarnessOptions {
    * and derives its own reserve set from it (#172). A harness can no longer hand the
    * guard a reserve list the rendered report would reject.
    */
-  reserves?: { id: string; amount: number }[];
+  reserves?: SyntheticReserve[];
 }
 
-/** A minimal folded fund carrying the given LIVE, USD reserves. Round fakes only (`O7`). */
-function syntheticFund(reserves: { id: string; amount: number }[]): FundReviewData {
+/**
+ * One reserve of the synthetic fund. LIVE and USD unless the case is specifically about a
+ * reserve the fold will REFUSE to admit — `executionMode: "paper"`, an unsupported
+ * `currency`, or a `currency` the rungs are not quoted in.
+ */
+interface SyntheticReserve {
+  id: string;
+  amount: number;
+  executionMode?: string;
+  currency?: string;
+  accountId?: string;
+}
+
+/** A minimal folded fund carrying the given reserves. Round fakes only (`O7`). */
+function syntheticFund(reserves: SyntheticReserve[]): FundReviewData {
   const parsed = parseFundReview({
     fund: { id: "synthetic-fund", name: "Synthetic Fund", baseCurrency: "USD" },
     review: { asOf: "2026-01-31", usdMxn: 20 },
     portfolios: [{ id: "core", name: "Core" }],
-    accounts: [{ id: "venue-usd", name: "Synthetic Venue", platform: "BITGET", currency: "USD" }],
+    accounts: [
+      { id: "venue-usd", name: "Synthetic Venue", platform: "BITGET", currency: "USD" },
+      { id: "venue-mxn", name: "Other Venue", platform: "XTB", currency: "MXN" },
+    ],
     instruments: [{ id: "test-usd", name: "Test Asset", symbol: "XYZ", currency: "USD" }],
     reserves: reserves.map((reserve) => ({
       id: reserve.id,
       portfolioId: "core",
       tempo: "Capital",
-      executionMode: "live",
-      accountId: "venue-usd",
-      currency: "USD",
+      executionMode: reserve.executionMode ?? "live",
+      accountId: reserve.accountId ?? "venue-usd",
+      currency: reserve.currency ?? "USD",
       amount: reserve.amount,
     })),
     positions: [],
@@ -796,8 +832,80 @@ describe("`O1` — the over-commitment reject (testing decision 6)", () => {
   it("refuses a reserve the fold has never heard of, rather than reading it as zero", async () => {
     const { csvPath, io, ordersPath } = await harness({ answers: ["reserve-typo", "n"] });
     const outcome = await importBitgetOpenOrders({ csvPath, io });
-    expect(outcome).toMatchObject({ status: "rejected", reason: "unfundable-reserve" });
+    expect(outcome).toMatchObject({ status: "rejected", reason: "unattributed" });
     expect(await readOrDefault(ordersPath, "<<absent>>")).toBe("<<absent>>");
+  });
+
+  it("names EVERY reason the book cannot be placed, in ONE refusal", async () => {
+    // THE MESSAGE IS THE DELIVERABLE (#179). A book wrong in BOTH attribution ways used
+    // to report whichever class the guard filtered for first, so the operator fixed it,
+    // re-ran the whole import — declaration prompt included — and was refused again for a
+    // fault already computed on the first pass.
+    //
+    // The batch itself declares ONE reserve, so the mixed book is built the way the guard
+    // actually sees one: rungs ALREADY ON FILE against two other unplaceable reserves,
+    // plus this batch's two against a paper one. `reserve-odd` is unfundable for a second
+    // reason (unsupported currency) so the section has two reserves to dedup to, and
+    // `reserve-mxn` is live and admitted but holds a currency these USD rungs are not
+    // quoted in — the other class entirely.
+    const { csvPath, io, ordersPath, errors } = await harness({
+      answers: ["reserve-paper", "n"],
+      reserves: [
+        { id: "reserve-paper", amount: 1000, executionMode: "paper" },
+        { id: "reserve-odd", amount: 1000, currency: "EUR" },
+        { id: "reserve-mxn", amount: 1000, currency: "MXN", accountId: "venue-mxn" },
+      ],
+    });
+    await appendOrders(ordersPath, [
+      seededRung("rung-odd", "2020-01-01 09:00:00", "reserve-odd"),
+      seededRung("rung-mxn", "2020-01-01 09:00:01", "reserve-mxn"),
+    ]);
+
+    const outcome = await importBitgetOpenOrders({ csvPath, io });
+    expect(outcome).toMatchObject({ status: "rejected", reason: "unattributed" });
+
+    const refusal = errors.join("\n");
+    // BOTH sections, both labels, and the counts with the RIGHT plurals — `2 reserves`
+    // and `3 rungs` against a bare `1 rung`, pinned here rather than left to the
+    // renderer's luck.
+    expect(refusal).toContain("REFUSED — 4 rungs cannot be placed against a fundable reserve.");
+    expect(refusal).toContain("unfundable reserve — 2 reserves, 3 rungs");
+    expect(refusal).toContain("currency mismatch — 1 rung");
+    // Each class's advice, distinct and never concatenated.
+    expect(refusal).toContain("The fold excluded these reserves");
+    expect(refusal).toContain("Cross-currency funding is not supported");
+    // Every unplaceable rung is NAMED — the unfundable ones grouped under their reserve
+    // (one declaration fix clears all of them), the mismatched one per rung.
+    expect(refusal).toContain("      reserve-odd\n        rung-odd");
+    expect(refusal).toContain("\n      reserve-paper\n");
+    expect(refusal).toContain("rung-mxn (USD) against reserve-mxn");
+    // NOTHING written: the file still carries exactly the two rungs seeded above.
+    expect(await idsOnDisk(ordersPath)).toEqual(["rung-odd", "rung-mxn"]);
+    // The honest cost of batching, and not droppable: `over-committed` never ran, so the
+    // operator has NOT been told everything, and one sentence says so.
+    expect(refusal).toContain(
+      "Reserve balances were NOT weighed: an unplaceable rung has no balance to compare",
+    );
+    // A blank line before `reject()`'s tail, so it does not read as a continuation of the
+    // balances sentence.
+    expect(refusal).toContain(`placeable.\n\nNothing was written to ${ordersPath}.`);
+  });
+
+  it("renders ONE section when only one class is present", async () => {
+    // Each section is absent when its class is: the homogeneous case does not pay for the
+    // batching, and the singular counts are exercised here rather than the plural ones.
+    const { csvPath, io, errors } = await harness({
+      csv: ladder(rung("1000", "0.1", "2020-01-01 10:00:00")),
+      answers: ["reserve-paper", "n"],
+      reserves: [{ id: "reserve-paper", amount: 1000, executionMode: "paper" }],
+    });
+    await importBitgetOpenOrders({ csvPath, io });
+
+    const refusal = errors.join("\n");
+    expect(refusal).toContain("REFUSED — 1 rung cannot be placed against a fundable reserve.");
+    expect(refusal).toContain("unfundable reserve — 1 reserve, 1 rung");
+    expect(refusal).toContain("The fold excluded this reserve");
+    expect(refusal).not.toContain("currency mismatch");
   });
 });
 

--- a/apps/tui/src/import-orders.test.ts
+++ b/apps/tui/src/import-orders.test.ts
@@ -796,7 +796,7 @@ describe("`O1` — the over-commitment reject (testing decision 6)", () => {
   it("refuses a reserve the fold has never heard of, rather than reading it as zero", async () => {
     const { csvPath, io, ordersPath } = await harness({ answers: ["reserve-typo", "n"] });
     const outcome = await importBitgetOpenOrders({ csvPath, io });
-    expect(outcome).toMatchObject({ status: "rejected", reason: "unknown-reserve" });
+    expect(outcome).toMatchObject({ status: "rejected", reason: "unfundable-reserve" });
     expect(await readOrDefault(ordersPath, "<<absent>>")).toBe("<<absent>>");
   });
 });

--- a/apps/tui/src/import-orders.test.ts
+++ b/apps/tui/src/import-orders.test.ts
@@ -879,6 +879,23 @@ describe("`O1` — the over-commitment reject (testing decision 6)", () => {
     expect(refusal).toContain("      reserve-odd\n        rung-odd");
     expect(refusal).toContain("\n      reserve-paper\n");
     expect(refusal).toContain("rung-mxn (USD) against reserve-mxn");
+    // PROVENANCE (#202 review). The count is the whole book's, so the two rungs that were
+    // already in the sidecar are MARKED and the legend says what the mark means — without
+    // it, the operator reconciles "4 rungs" against an export holding two of them and
+    // cannot make it come out even.
+    expect(refusal).toContain('rungs marked "on file"');
+    expect(refusal).toContain("        rung-odd — on file");
+    expect(refusal).toContain("      rung-mxn (USD) against reserve-mxn — on file");
+    // This batch's own rungs carry NO marker: they are in the export just read.
+    const exported = parseBitgetOpenOrdersCsv(await readFile(csvPath, "utf8"));
+    expect(exported.status).toBe("ok");
+    if (exported.status !== "ok") return;
+    const batchRungIds = exported.orders.map((order) => order.id);
+    expect(batchRungIds).toHaveLength(2);
+    for (const id of batchRungIds) {
+      expect(refusal).toContain(`        ${id}\n`);
+      expect(refusal).not.toContain(`${id} — on file`);
+    }
     // NOTHING written: the file still carries exactly the two rungs seeded above.
     expect(await idsOnDisk(ordersPath)).toEqual(["rung-odd", "rung-mxn"]);
     // The honest cost of batching, and not droppable: `over-committed` never ran, so the

--- a/apps/tui/src/import-orders.test.ts
+++ b/apps/tui/src/import-orders.test.ts
@@ -907,7 +907,9 @@ describe("`O1` — the over-commitment reject (testing decision 6)", () => {
     // The honest cost of batching, and not droppable: `over-committed` never ran, so the
     // operator has NOT been told everything, and one sentence says so.
     expect(refusal).toContain(
-      "Reserve balances were NOT weighed: an unplaceable rung has no balance to compare",
+      "Reserve balances were NOT weighed: an unplaceable rung has no balance to\n" +
+        "compare against, so a coverage refusal may still follow once every rung\n" +
+        "above is placeable.",
     );
     // A blank line before `reject()`'s tail, so it does not read as a continuation of the
     // balances sentence.

--- a/apps/tui/src/import-orders.ts
+++ b/apps/tui/src/import-orders.ts
@@ -307,14 +307,52 @@ function plural(count: number, noun: string): string {
  * classes and narrows nothing (see `FundingCoverage`).
  *
  * EACH SECTION IS ABSENT WHEN ITS CLASS IS, so a homogeneous batch renders one section.
- * There will never be a third: `over-committed` cannot join the pair, because an
- * unplaceable rung has no balance to weigh — which is exactly what the closing line says,
- * and why that line is not droppable. Batching creates the expectation *"I have now been
- * told everything"*, and without that sentence the expectation is false.
+ * `over-committed` cannot join them, because an unplaceable rung has no balance to weigh —
+ * which is exactly what the closing line says, and why that line is not droppable.
+ * Batching creates the expectation *"I have now been told everything"*, and without that
+ * sentence the expectation is false.
+ *
+ * WHICH IS ALSO WHY THE PARTITION IS A SWITCH AND NOT TWO FILTERS. The header counts off
+ * `unmatched.length` while the body lists only what the partition matched, so under two
+ * `.filter` calls a third {@link UnmatchedReason} was COUNTED AND NEVER NAMED — and with a
+ * homogeneous batch of it, `sections` was empty and the refusal named ZERO rungs while
+ * claiming one could not be placed. That is #179's masking defect rebuilt at the render
+ * boundary, and splitting `unfundable-reserve` into its three causes — paper mode,
+ * unsupported currency, dangling account — is a change `UnmatchedReason` needs no new
+ * shape for, so the premise is a live one.
+ *
+ * TWO LAYERS NOW STOP IT, AND ONLY ONE OF THEM IS THE FIX. The `never` assignment makes a
+ * new member a `pnpm typecheck` failure AT THIS SITE — that is the fix, and it is the only
+ * thing that catches the omission before an operator does. The fallback section is what
+ * the output degrades to if one ever arrives here unhandled anyway: named under its raw
+ * token rather than swallowed, so the count and the listing still agree.
  */
 function renderUnattributedRefusal(unmatched: readonly UnmatchedRung[]): string {
-  const unfundable = unmatched.filter((entry) => entry.reason === "unfundable-reserve");
-  const mismatched = unmatched.filter((entry) => entry.reason === "currency-mismatch");
+  const unfundable: UnmatchedRung[] = [];
+  const mismatched: UnmatchedRung[] = [];
+  // Raw reason token → the rungs carrying it. Empty in every reachable state.
+  const unclassified = new Map<string, string[]>();
+  for (const entry of unmatched) {
+    switch (entry.reason) {
+      case "unfundable-reserve":
+        unfundable.push(entry);
+        break;
+      case "currency-mismatch":
+        mismatched.push(entry);
+        break;
+      default: {
+        const _never: never = entry.reason;
+        // It does NOT throw, unlike `foldEvents`'s latch. The message IS the deliverable
+        // here, and `import-orders-cli.ts` would collapse a throw into one bare error
+        // line — losing every rung the operator was owed, to protect them from a
+        // rendering gap. Degrade the section, never the refusal.
+        const token: string = _never;
+        const existing = unclassified.get(token);
+        if (existing) existing.push(entry.rung.orderId);
+        else unclassified.set(token, [entry.rung.orderId]);
+      }
+    }
+  }
 
   const sections: string[] = [];
 
@@ -355,6 +393,17 @@ function renderUnattributedRefusal(unmatched: readonly UnmatchedRung[]): string 
       `  currency mismatch — ${plural(mismatched.length, "rung")}\n` +
         `    Cross-currency funding is not supported; fix the declaration.\n` +
         `${listing.join("\n")}`,
+    );
+  }
+
+  for (const [token, orderIds] of unclassified) {
+    // No advice line: nothing here knows the remedy for a reason it does not know. The
+    // token and the rungs are what can be said honestly, and they are enough to report.
+    sections.push(
+      `  ${token} — ${plural(orderIds.length, "rung")}\n` +
+        `    This refusal has no section for that reason; it is named as the engine\n` +
+        `    gave it, so no rung counted above goes unlisted.\n` +
+        `${orderIds.map((orderId) => `      ${orderId}`).join("\n")}`,
     );
   }
 

--- a/apps/tui/src/import-orders.ts
+++ b/apps/tui/src/import-orders.ts
@@ -32,6 +32,7 @@ import {
   type OrderRecord,
   type FundReviewData,
   type RestingOrder,
+  type UnmatchedRung,
 } from "@numisma/engine";
 import type { OrdersLoad } from "@numisma/preferences";
 
@@ -103,16 +104,30 @@ export type OrdersImportRejection =
    */
   | "changed-claim"
   /**
-   * A rung declares a reserve `fundableReserves` did not ADMIT — paper execution mode, an
-   * unsupported currency, a dangling account reference (#180). The reserve is usually
-   * right there in the operator's own fund file; what it lacks is the capacity to fund a
-   * live claim, so the token names FUNDABILITY and never existence (#180). Spelled
-   * identically to the engine's `UnmatchedReason` member on purpose: the two unions naming
+   * ATTRIBUTION FAILED: at least one rung of the whole resting book cannot be placed
+   * against a fundable reserve. ONE rejection may name rungs of BOTH classes the engine
+   * distinguishes, and the message ENUMERATES them, section by labelled section (#179).
+   *
+   *   - `unfundable-reserve` — the rung declares a reserve `fundableReserves` did not
+   *     ADMIT: paper execution mode, an unsupported currency, a dangling account
+   *     reference (#180). The reserve is usually right there in the operator's own fund
+   *     file; what it lacks is the capacity to fund a live claim, so the engine's token
+   *     names FUNDABILITY and never existence.
+   *   - `currency-mismatch` — the rung is quoted in a currency its declared reserve does
+   *     not hold.
+   *
+   * WHY THE TOKEN NAMES NEITHER OF THEM. This was two members until #179, and a
+   * two-member union cannot express the outcome batching created: a token naming one
+   * class would have to pick a winner on a batch wrong in both ways, which is the masking
+   * bug re-introduced at the boundary that reports it. So the token names the PHASE, and
+   * the per-rung reasons stay where they are already modelled — the engine's
+   * `UnmatchedReason`, rendered into the message below.
+   *
+   * Spelled identically to `FundingCoverage`'s own arm on purpose: the two unions naming
    * the same refusal must not diverge. `record-fill.ts`'s same-shaped rejection asks the
    * OTHER question — see the docstring on its own member — and the two stay distinct.
    */
-  | "unfundable-reserve"
-  | "currency-mismatch"
+  | "unattributed"
   | "over-committed"
   /**
    * The sidecar append itself failed (#177 item 5). `appendOrders` builds a full next
@@ -268,6 +283,90 @@ function reject(
   // be able to mistake a refusal for a quiet no-op.
   io.err(`REFUSED — ${message}\nNothing was written to ${io.ordersPath}.`);
   return { status: "rejected", reason, message };
+}
+
+function plural(count: number, noun: string): string {
+  return `${count} ${noun}${count === 1 ? "" : "s"}`;
+}
+
+/**
+ * THE WHOLE ATTRIBUTION REFUSAL, IN ONE PASS — every rung the engine could not place,
+ * grouped by the class whose remedy it shares (#179).
+ *
+ * Reading order inside a section is LABEL → ADVICE → RUNGS, and the ordering is load
+ * bearing rather than cosmetic. Advice last orphans it: with two unfundable reserves it
+ * sits directly under the second reserve's rungs and reads as advice about that reserve
+ * alone, which is what the prototype exposed and the grill's one-reserve example could
+ * not. Advice under the label plainly governs everything beneath it.
+ *
+ * GRANULARITY IS THE ENGINE'S, NOT A RENDERING TASTE, and the two classes differ because
+ * their remedies do. `unfundable-reserve` dedups to RESERVE IDS with its rungs listed
+ * beneath — one declaration fix clears every rung against that reserve. `currency-mismatch`
+ * stays PER RUNG — the fix is per rung. That is the same split the guard used to make in
+ * the engine, moved to where it belongs: the engine now forwards every rung of both
+ * classes and narrows nothing (see `FundingCoverage`).
+ *
+ * EACH SECTION IS ABSENT WHEN ITS CLASS IS, so a homogeneous batch renders one section.
+ * There will never be a third: `over-committed` cannot join the pair, because an
+ * unplaceable rung has no balance to weigh — which is exactly what the closing line says,
+ * and why that line is not droppable. Batching creates the expectation *"I have now been
+ * told everything"*, and without that sentence the expectation is false.
+ */
+function renderUnattributedRefusal(unmatched: readonly UnmatchedRung[]): string {
+  const unfundable = unmatched.filter((entry) => entry.reason === "unfundable-reserve");
+  const mismatched = unmatched.filter((entry) => entry.reason === "currency-mismatch");
+
+  const sections: string[] = [];
+
+  if (unfundable.length > 0) {
+    // First-appearance order, so the rungs' own order survives inside each reserve and
+    // across the reserves — the grouping is stable, and nothing is sorted.
+    const byReserve = new Map<string, string[]>();
+    for (const entry of unfundable) {
+      const existing = byReserve.get(entry.rung.fundingReserveId);
+      if (existing) existing.push(entry.rung.orderId);
+      else byReserve.set(entry.rung.fundingReserveId, [entry.rung.orderId]);
+    }
+    const many = byReserve.size !== 1;
+    const advice = many
+      ? `    The fold excluded these reserves: paper execution mode, an unsupported\n` +
+        `    currency, or a dangling account reference. They cannot fund a live order,\n` +
+        `    and the available-capital report would not be able to place them either.`
+      : `    The fold excluded this reserve: paper execution mode, an unsupported\n` +
+        `    currency, or a dangling account reference. It cannot fund a live order,\n` +
+        `    and the available-capital report would not be able to place it either.`;
+    const listing = [...byReserve].map(
+      ([reserveId, orderIds]) =>
+        `      ${reserveId}\n${orderIds.map((orderId) => `        ${orderId}`).join("\n")}`,
+    );
+    sections.push(
+      `  unfundable reserve — ${plural(byReserve.size, "reserve")}, ` +
+        `${plural(unfundable.length, "rung")}\n${advice}\n${listing.join("\n")}`,
+    );
+  }
+
+  if (mismatched.length > 0) {
+    const listing = mismatched.map(
+      (entry) =>
+        `      ${entry.rung.orderId} (${entry.rung.currency}) against ` +
+        `${entry.rung.fundingReserveId}`,
+    );
+    sections.push(
+      `  currency mismatch — ${plural(mismatched.length, "rung")}\n` +
+        `    Cross-currency funding is not supported; fix the declaration.\n` +
+        `${listing.join("\n")}`,
+    );
+  }
+
+  return (
+    `${plural(unmatched.length, "rung")} cannot be placed against a fundable reserve.\n\n` +
+    `${sections.join("\n\n")}\n\n` +
+    `Reserve balances were NOT weighed: an unplaceable rung has no balance to compare\n` +
+    `against, so a coverage refusal may still follow once every rung above is placeable.\n`
+    // That trailing newline is the blank line before `reject()`'s "Nothing was written to
+    // …" tail. Without it the tail reads as a continuation of the balances sentence —
+    // invisible when the body was one paragraph, plainly wrong now that it is several.
+  );
 }
 
 /**
@@ -670,29 +769,13 @@ export async function importBitgetOpenOrders(
   // The selector dedupes by id, so a re-import does not double-count the same rung.
   const resting = pickRestingOrdersAsOf([...existingRecords, ...records]);
   const coverage = checkFundingCoverage(resting, await io.fundReview());
-  if (coverage.status === "unfundable-reserve") {
-    return reject(
-      io,
-      "unfundable-reserve",
-      `no such fundable reserve: ${coverage.fundingReserveIds.join(", ")}. A reserve the ` +
-        `fold excluded — paper execution mode, an unsupported currency, a dangling ` +
-        `account reference — cannot fund a live order either, and the available-capital ` +
-        `report would not be able to place it`,
-    );
-  }
-  if (coverage.status === "currency-mismatch") {
-    // Cross-currency funding is not designed; it is refused, here and in the report.
-    // Accepting it would sum a quote-denominated committed into a native balance and
-    // report free capital that does not exist.
-    const detail = coverage.rungs
-      .map((rung) => `${rung.orderId} (${rung.currency}) against ${rung.fundingReserveId}`)
-      .join("; ");
-    return reject(
-      io,
-      "currency-mismatch",
-      `these rungs are quoted in a currency their declared reserve does not hold — ` +
-        `${detail}. Cross-currency funding is not supported; fix the declaration`,
-    );
+  if (coverage.status === "unattributed") {
+    // ONE refusal for BOTH classes. Cross-currency funding is not designed and an
+    // unadmitted reserve cannot fund a live claim; either way the rung is refused here
+    // and in the report, and the operator is told about every one of them at once rather
+    // than paying a second full pass — declaration prompt included — to learn the second
+    // class (#179).
+    return reject(io, "unattributed", renderUnattributedRefusal(coverage.unmatched));
   }
   if (coverage.status === "over-committed") {
     const detail = coverage.shortfalls

--- a/apps/tui/src/import-orders.ts
+++ b/apps/tui/src/import-orders.ts
@@ -435,8 +435,14 @@ function renderUnattributedRefusal(
       : ``) +
     `\n` +
     `${sections.join("\n\n")}\n\n` +
-    `Reserve balances were NOT weighed: an unplaceable rung has no balance to compare\n` +
-    `against, so a coverage refusal may still follow once every rung above is placeable.\n`
+    // Wrapped at 72/71/19 rather than 80/83 (#202 review). Every other line this renderer
+    // emits sits inside 76, and these two were the only ones that did not — so on an
+    // 80-column terminal the one paragraph that admits what the operator has NOT been told
+    // was also the one paragraph that wrapped, which is the worst place to spend the
+    // reader's attention.
+    `Reserve balances were NOT weighed: an unplaceable rung has no balance to\n` +
+    `compare against, so a coverage refusal may still follow once every rung\n` +
+    `above is placeable.\n`
     // That trailing newline is the blank line before `reject()`'s "Nothing was written to
     // …" tail. Without it the tail reads as a continuation of the balances sentence —
     // invisible when the body was one paragraph, plainly wrong now that it is several.

--- a/apps/tui/src/import-orders.ts
+++ b/apps/tui/src/import-orders.ts
@@ -35,6 +35,7 @@ import {
   type UnmatchedRung,
 } from "@numisma/engine";
 import type { OrdersLoad } from "@numisma/preferences";
+import { plural } from "./plural.js";
 
 /** Everything this flow touches that is not a pure function, in one injectable bag. */
 export interface OrdersImportIo {
@@ -283,10 +284,6 @@ function reject(
   // be able to mistake a refusal for a quiet no-op.
   io.err(`REFUSED — ${message}\nNothing was written to ${io.ordersPath}.`);
   return { status: "rejected", reason, message };
-}
-
-function plural(count: number, noun: string): string {
-  return `${count} ${noun}${count === 1 ? "" : "s"}`;
 }
 
 /**

--- a/apps/tui/src/import-orders.ts
+++ b/apps/tui/src/import-orders.ts
@@ -102,7 +102,16 @@ export type OrdersImportRejection =
    * way the leftover staleness points, not about the change itself.
    */
   | "changed-claim"
-  | "unknown-reserve"
+  /**
+   * A rung declares a reserve `fundableReserves` did not ADMIT — paper execution mode, an
+   * unsupported currency, a dangling account reference (#180). The reserve is usually
+   * right there in the operator's own fund file; what it lacks is the capacity to fund a
+   * live claim, so the token names FUNDABILITY and never existence (#180). Spelled
+   * identically to the engine's `UnmatchedReason` member on purpose: the two unions naming
+   * the same refusal must not diverge. `record-fill.ts`'s same-shaped rejection asks the
+   * OTHER question — see the docstring on its own member — and the two stay distinct.
+   */
+  | "unfundable-reserve"
   | "currency-mismatch"
   | "over-committed"
   /**
@@ -661,10 +670,10 @@ export async function importBitgetOpenOrders(
   // The selector dedupes by id, so a re-import does not double-count the same rung.
   const resting = pickRestingOrdersAsOf([...existingRecords, ...records]);
   const coverage = checkFundingCoverage(resting, await io.fundReview());
-  if (coverage.status === "unknown-reserve") {
+  if (coverage.status === "unfundable-reserve") {
     return reject(
       io,
-      "unknown-reserve",
+      "unfundable-reserve",
       `no such fundable reserve: ${coverage.fundingReserveIds.join(", ")}. A reserve the ` +
         `fold excluded — paper execution mode, an unsupported currency, a dangling ` +
         `account reference — cannot fund a live order either, and the available-capital ` +

--- a/apps/tui/src/import-orders.ts
+++ b/apps/tui/src/import-orders.ts
@@ -327,7 +327,10 @@ function plural(count: number, noun: string): string {
  * the output degrades to if one ever arrives here unhandled anyway: named under its raw
  * token rather than swallowed, so the count and the listing still agree.
  */
-function renderUnattributedRefusal(unmatched: readonly UnmatchedRung[]): string {
+function renderUnattributedRefusal(
+  unmatched: readonly UnmatchedRung[],
+  batchIds: ReadonlySet<string>,
+): string {
   const unfundable: UnmatchedRung[] = [];
   const mismatched: UnmatchedRung[] = [];
   // Raw reason token → the rungs carrying it. Empty in every reachable state.
@@ -354,6 +357,18 @@ function renderUnattributedRefusal(unmatched: readonly UnmatchedRung[]): string 
     }
   }
 
+  // PROVENANCE, PER RUNG (#202 review). `O1` weighs the WHOLE resting book — the sidecar's
+  // existing records plus this batch — so a listed rung need not appear anywhere in the
+  // export the operator just read. Unmarked, the count invited a reconciliation against
+  // that export which could not come out even. The marker is short because these lines
+  // already carry a synthesized id and would wrap; the header spells out what it means.
+  // It marks the LINE, not the id: on the currency-mismatch line the id is followed by the
+  // rung's own currency and reserve, and a marker wedged between them reads as part of
+  // that clause rather than as a note about the rung.
+  const mark = (line: string, orderId: string): string =>
+    batchIds.has(orderId) ? line : `${line} — on file`;
+  const anyOnFile = unmatched.some((entry) => !batchIds.has(entry.rung.orderId));
+
   const sections: string[] = [];
 
   if (unfundable.length > 0) {
@@ -375,7 +390,8 @@ function renderUnattributedRefusal(unmatched: readonly UnmatchedRung[]): string 
         `    and the available-capital report would not be able to place it either.`;
     const listing = [...byReserve].map(
       ([reserveId, orderIds]) =>
-        `      ${reserveId}\n${orderIds.map((orderId) => `        ${orderId}`).join("\n")}`,
+        `      ${reserveId}\n` +
+        `${orderIds.map((orderId) => mark(`        ${orderId}`, orderId)).join("\n")}`,
     );
     sections.push(
       `  unfundable reserve — ${plural(byReserve.size, "reserve")}, ` +
@@ -384,10 +400,12 @@ function renderUnattributedRefusal(unmatched: readonly UnmatchedRung[]): string 
   }
 
   if (mismatched.length > 0) {
-    const listing = mismatched.map(
-      (entry) =>
+    const listing = mismatched.map((entry) =>
+      mark(
         `      ${entry.rung.orderId} (${entry.rung.currency}) against ` +
-        `${entry.rung.fundingReserveId}`,
+          `${entry.rung.fundingReserveId}`,
+        entry.rung.orderId,
+      ),
     );
     sections.push(
       `  currency mismatch — ${plural(mismatched.length, "rung")}\n` +
@@ -403,12 +421,19 @@ function renderUnattributedRefusal(unmatched: readonly UnmatchedRung[]): string 
       `  ${token} — ${plural(orderIds.length, "rung")}\n` +
         `    This refusal has no section for that reason; it is named as the engine\n` +
         `    gave it, so no rung counted above goes unlisted.\n` +
-        `${orderIds.map((orderId) => `      ${orderId}`).join("\n")}`,
+        `${orderIds.map((orderId) => mark(`      ${orderId}`, orderId)).join("\n")}`,
     );
   }
 
   return (
-    `${plural(unmatched.length, "rung")} cannot be placed against a fundable reserve.\n\n` +
+    `${plural(unmatched.length, "rung")} cannot be placed against a fundable reserve.\n` +
+    // Only when there is something to explain: a batch whose every unplaceable rung came
+    // out of the export just read owes the operator no marker and no legend for one.
+    (anyOnFile
+      ? `Coverage weighs the WHOLE resting book, so rungs marked "on file" below were\n` +
+        `already in the sidecar before this import, not in the export just read.\n`
+      : ``) +
+    `\n` +
     `${sections.join("\n\n")}\n\n` +
     `Reserve balances were NOT weighed: an unplaceable rung has no balance to compare\n` +
     `against, so a coverage refusal may still follow once every rung above is placeable.\n`
@@ -824,7 +849,18 @@ export async function importBitgetOpenOrders(
     // and in the report, and the operator is told about every one of them at once rather
     // than paying a second full pass — declaration prompt included — to learn the second
     // class (#179).
-    return reject(io, "unattributed", renderUnattributedRefusal(coverage.unmatched));
+    //
+    // `records` is passed so the message can mark which listed rungs are NOT this batch's:
+    // `resting` above is the whole book, and only the caller knows which half the operator
+    // just exported.
+    return reject(
+      io,
+      "unattributed",
+      renderUnattributedRefusal(
+        coverage.unmatched,
+        new Set(records.map((record) => record.id)),
+      ),
+    );
   }
   if (coverage.status === "over-committed") {
     const detail = coverage.shortfalls

--- a/apps/tui/src/import-orders.ts
+++ b/apps/tui/src/import-orders.ts
@@ -359,9 +359,11 @@ function renderUnattributedRefusal(
   // export the operator just read. Unmarked, the count invited a reconciliation against
   // that export which could not come out even. The marker is short because these lines
   // already carry a synthesized id and would wrap; the header spells out what it means.
-  // It marks the LINE, not the id: on the currency-mismatch line the id is followed by the
-  // rung's own currency and reserve, and a marker wedged between them reads as part of
-  // that clause rather than as a note about the rung.
+  // It marks the LINE, not the id: a marker wedged between an id and the clause that
+  // follows it reads as part of that clause rather than as a note about the rung. Keeping
+  // the marker at end-of-line is why the currency-mismatch section puts the id alone on
+  // its line and indents the mismatch beneath it — end-of-line and inside 80 columns are
+  // both wanted, and the id plus the clause plus the marker do not fit one line.
   const mark = (line: string, orderId: string): string =>
     batchIds.has(orderId) ? line : `${line} — on file`;
   const anyOnFile = unmatched.some((entry) => !batchIds.has(entry.rung.orderId));
@@ -397,12 +399,13 @@ function renderUnattributedRefusal(
   }
 
   if (mismatched.length > 0) {
-    const listing = mismatched.map((entry) =>
-      mark(
-        `      ${entry.rung.orderId} (${entry.rung.currency}) against ` +
-          `${entry.rung.fundingReserveId}`,
-        entry.rung.orderId,
-      ),
+    // Id on its own line, its mismatch indented beneath — the shape the unfundable section
+    // already uses for a grouping and its rungs, rather than a third layout for this one.
+    const listing = mismatched.map(
+      (entry) =>
+        `${mark(`      ${entry.rung.orderId}`, entry.rung.orderId)}\n` +
+        `        quoted in ${entry.rung.currency}, declared against ` +
+        `${entry.rung.fundingReserveId}`,
     );
     sections.push(
       `  currency mismatch — ${plural(mismatched.length, "rung")}\n` +

--- a/apps/tui/src/plural.ts
+++ b/apps/tui/src/plural.ts
@@ -1,0 +1,16 @@
+/**
+ * COUNT AND NOUN, AGREEING — the one place this app spells the `-s`.
+ *
+ * It is here rather than inline because the shape had already been written three times
+ * (`spine.ts`'s ingest line twice, the orders refusal once) and every copy is a chance for
+ * one operator-facing line to read "1 rungs". The output is byte-identical to the inline
+ * form it replaces: `count`, a space, the noun, and an `s` unless the count is exactly one.
+ *
+ * IRREGULAR PLURALS ARE OUT OF SCOPE, deliberately. This app's countable nouns are
+ * `rung`, `reserve`, `transaction`, `duplicate` — all regular — and a lookup table for
+ * plurals nobody counts would be machinery guarding nothing. A caller that needs one
+ * should write the literal rather than teach this function a rule with one user.
+ */
+export function plural(count: number, noun: string): string {
+  return `${count} ${noun}${count === 1 ? "" : "s"}`;
+}

--- a/apps/tui/src/record-fill.ts
+++ b/apps/tui/src/record-fill.ts
@@ -110,6 +110,13 @@ export type RecordFillRejection =
   | "bad-quantity"
   | "impossible-verdict"
   | "verdict-contradicts-operator"
+  /**
+   * LITERAL, and deliberately not the engine's `unfundable-reserve` (#180). The lookup
+   * below goes straight at `folded.reserves`, so this fires only when the fold really does
+   * not have the id. The engine's token is a claim about ADMISSION — a reserve that exists
+   * and is plainly visible can still be unfundable. Two questions, two names; do not unify
+   * them.
+   */
   | "unknown-reserve"
   | "unknown-instrument"
   | "ambiguous-ladder-position"
@@ -575,8 +582,8 @@ export async function recordFill(io: RecordFillIo): Promise<RecordFillOutcome> {
   // and the DEFAULT answer — `proposedFunding`, the two multiplied — is exactly
   // available-neutral BY CONSTRUCTION. The fill itself therefore cannot break the
   // `available ≥ 0` invariant no matter what shape the book is in, which is why this flow
-  // does NOT call `checkFundingCoverage`: that guard weighs the WHOLE book and returns on
-  // the first `unknown-reserve` anywhere in it (#179), so one stale `fundingReserveId` on
+  // does NOT call `checkFundingCoverage`: that guard weighs the WHOLE book and refuses it
+  // if ANY rung anywhere in it is unplaceable (#179), so one stale `fundingReserveId` on
   // an unrelated rung would refuse a fill that really happened at the venue. A fill is an
   // observed fact; the flow does not get to disbelieve it.
   //

--- a/apps/tui/src/spine.ts
+++ b/apps/tui/src/spine.ts
@@ -20,6 +20,7 @@
 import { buildCompositionReport, formatCompositionReport } from "@numisma/engine";
 import { loadFoldedReview, resolveEventStorePaths } from "@numisma/event-store";
 import { ingestInbox, parseAsOfArg, parseMagnitudeThresholdArg } from "./event-store.js";
+import { plural } from "./plural.js";
 
 try {
   const paths = resolveEventStorePaths();
@@ -38,8 +39,8 @@ try {
       ? await ingestInbox(paths)
       : await ingestInbox(paths, { magnitudeThreshold });
   process.stdout.write(
-    `Success, ${ingest.newCount} new transaction${ingest.newCount === 1 ? "" : "s"} found, ` +
-      `${ingest.duplicateCount} duplicate${ingest.duplicateCount === 1 ? "" : "s"} skipped` +
+    `Success, ${plural(ingest.newCount, "new transaction")} found, ` +
+      `${plural(ingest.duplicateCount, "duplicate")} skipped` +
       (ingest.archivedTo ? ` (inbox archived to ${ingest.archivedTo})` : "") +
       "\n\n",
   );

--- a/packages/engine/src/orders/attribution.ts
+++ b/packages/engine/src/orders/attribution.ts
@@ -53,7 +53,7 @@ export interface FundableReserve {
 }
 
 /** Why a resting rung could not be placed against any fundable reserve. */
-export type UnmatchedReason = "unknown-reserve" | "currency-mismatch";
+export type UnmatchedReason = "unfundable-reserve" | "currency-mismatch";
 
 /**
  * A rung that cannot be placed. Surfaced rather than dropped: a silently ignored rung is
@@ -81,6 +81,12 @@ export interface RungAttribution {
  * A paper reserve, an unsupported currency or a dangling account reference is excluded
  * here for exactly the reasons it is excluded from the composition, with no second
  * admission policy to keep in step.
+ *
+ * WHAT EXCLUSION MEANS, and it is why {@link UnmatchedReason}'s first member is spelled
+ * `unfundable-reserve`. Every one of those three exclusions describes a reserve the
+ * operator can plainly SEE in the fund file: it exists, it is spelled correctly, and it
+ * still may not fund a live claim. This function answers "can this fund anything?", never
+ * "does this exist?" — so a rung refused against its output is unfundable, not unknown.
  */
 export function fundableReserves(data: FundReviewData): FundableReserve[] {
   return buildCanonicalState(data).reserveReconciliation.map((line) => ({
@@ -118,10 +124,13 @@ export function attributeRungs(
   for (const rung of committedRungs(resting)) {
     const currency = currencyOf.get(rung.fundingReserveId);
     if (currency === undefined) {
-      // An unadmitted or unknown id is refused rather than read as a zero balance: a
-      // typo'd id would otherwise render the whole ladder as "over-committed", or worse,
-      // silently attribute it to a reserve nobody can see.
-      unmatched.push({ rung, reason: "unknown-reserve" });
+      // A reserve {@link fundableReserves} did not admit is refused rather than read as a
+      // zero balance: an unadmitted reserve would otherwise render the whole ladder as
+      // "over-committed", or worse, be silently attributed capacity nobody granted it.
+      // The id usually EXISTS in the operator's own fund file — it is the admission that
+      // is missing, which is why the reason is `unfundable-reserve` and not a claim that
+      // the reserve is unknown (#180).
+      unmatched.push({ rung, reason: "unfundable-reserve" });
       continue;
     }
     if (currency !== rung.currency) {

--- a/packages/engine/src/orders/attribution.ts
+++ b/packages/engine/src/orders/attribution.ts
@@ -108,8 +108,23 @@ export function fundableReserves(data: FundReviewData): FundableReserve[] {
  * balance would produce a confidently wrong number rather than an obviously missing one.
  * Cross-currency funding is not designed; it is refused, identically, on both sides.
  *
- * Rung order is preserved within a reserve, and the refusal order is the rungs' own, so
- * the guard's error message and the report's list name the same rungs in the same order.
+ * Rung order is preserved within a reserve, and the refusal order is the rungs' own — so
+ * the guard and the report name THE SAME RUNGS WITH THE SAME REASONS, because they name
+ * them off THIS list. The `unmatched` array returned here is the one `checkFundingCoverage`
+ * hands back verbatim on its `unattributed` arm (`./ingest.js`) and the one
+ * `composeAvailableCapital` renders (`./available.js`); neither filters it, dedups it or
+ * re-derives it.
+ *
+ * IT NO LONGER SAYS "IN THE SAME ORDER", AND THAT WORDING WAS FALSE BEFORE #179 AS WELL
+ * AS AFTER IT. Before: the guard's message named a deduped SET of reserve ids for one
+ * class while the report named every rung of both, so a mixed batch had no common order
+ * to preserve. After: both receive this list in the rungs' own order, but the import
+ * boundary's message GROUPS it — unfundable rungs under their reserve id, mismatched
+ * rungs per rung — because one class's remedy is per reserve and the other's is per rung.
+ * The grouping is stable, so the rungs' own order survives inside each group; across
+ * groups an interleaved batch is deliberately reordered. Order was never the property
+ * worth promising. Sameness of the rungs and their reasons is, and that one is now an
+ * identity rather than an assertion.
  */
 export function attributeRungs(
   data: FundReviewData,

--- a/packages/engine/src/orders/available.test.ts
+++ b/packages/engine/src/orders/available.test.ts
@@ -342,7 +342,7 @@ describe("a rung the fold cannot place is surfaced, never silently dropped or mi
   it("reports a rung naming an unknown reserve as unmatched", () => {
     const { report } = capitalOf(ladder("reserve-that-does-not-exist", 1));
     expect(report.unmatched).toHaveLength(1);
-    expect(report.unmatched[0]?.reason).toBe("unknown-reserve");
+    expect(report.unmatched[0]?.reason).toBe("unfundable-reserve");
   });
 
   it("refuses to add a rung priced in another currency into a reserve's balance", () => {

--- a/packages/engine/src/orders/available.ts
+++ b/packages/engine/src/orders/available.ts
@@ -77,9 +77,10 @@ export interface ReserveCapital {
 }
 
 // `UnmatchedReason` and `UnmatchedRung` are RE-EXPORTED from `./attribution.js` (see the
-// import above) rather than declared here. They are the vocabulary of the placement
-// rule, and that rule is now shared with the import guard — two declarations of the same
-// two reasons is exactly the drift #172 was about.
+// import above) rather than declared here. They are the vocabulary of the ADMISSION rule
+// — `unfundable-reserve` says `fundableReserves` did not admit the declared reserve, not
+// that the id is unknown — and that rule is now shared with the import guard, so two
+// declarations of the same two reasons is exactly the drift #172 was about.
 
 export interface AvailableCapitalReport {
   /** One entry per LIVE reserve the canonical state admitted, in its order. */

--- a/packages/engine/src/orders/available.ts
+++ b/packages/engine/src/orders/available.ts
@@ -77,9 +77,12 @@ export interface ReserveCapital {
 }
 
 // `UnmatchedReason` and `UnmatchedRung` are RE-EXPORTED from `./attribution.js` (see the
-// import above) rather than declared here. They are the vocabulary of the ADMISSION rule
-// — `unfundable-reserve` says `fundableReserves` did not admit the declared reserve, not
-// that the id is unknown — and that rule is now shared with the import guard, so two
+// import above) rather than declared here. They are the vocabulary of the PLACEMENT rule,
+// which is the pair's common ground: admission is only one of the two ways placement
+// fails. `unfundable-reserve` says `fundableReserves` did not admit the declared reserve,
+// not that the id is unknown; `currency-mismatch` is the other way, and that reserve WAS
+// admitted — live mode, supported currency, resolvable account — with only the rung's
+// quote currency disagreeing. That rule is now shared with the import guard, so two
 // declarations of the same two reasons is exactly the drift #172 was about.
 
 export interface AvailableCapitalReport {

--- a/packages/engine/src/orders/bitget-ingest.test.ts
+++ b/packages/engine/src/orders/bitget-ingest.test.ts
@@ -387,8 +387,11 @@ describe("checkFundingCoverage — `O1`, and slack >= 0", () => {
   it("rejects a declared reserve that does not exist, rather than reading it as zero", () => {
     const resting = restingFrom(csv(row()), "reserve-ghost");
     const coverage = checkFundingCoverage(resting, fundWith(1000));
-    expect(coverage.status).toBe("unfundable-reserve");
-    if (coverage.status !== "unfundable-reserve") return;
-    expect(coverage.fundingReserveIds).toEqual(["reserve-ghost"]);
+    expect(coverage.status).toBe("unattributed");
+    if (coverage.status !== "unattributed") return;
+    expect(coverage.unmatched.map((entry) => entry.reason)).toEqual(["unfundable-reserve"]);
+    expect(coverage.unmatched.map((entry) => entry.rung.fundingReserveId)).toEqual([
+      "reserve-ghost",
+    ]);
   });
 });

--- a/packages/engine/src/orders/bitget-ingest.test.ts
+++ b/packages/engine/src/orders/bitget-ingest.test.ts
@@ -387,8 +387,8 @@ describe("checkFundingCoverage — `O1`, and slack >= 0", () => {
   it("rejects a declared reserve that does not exist, rather than reading it as zero", () => {
     const resting = restingFrom(csv(row()), "reserve-ghost");
     const coverage = checkFundingCoverage(resting, fundWith(1000));
-    expect(coverage.status).toBe("unknown-reserve");
-    if (coverage.status !== "unknown-reserve") return;
+    expect(coverage.status).toBe("unfundable-reserve");
+    if (coverage.status !== "unfundable-reserve") return;
     expect(coverage.fundingReserveIds).toEqual(["reserve-ghost"]);
   });
 });

--- a/packages/engine/src/orders/funding-parity.test.ts
+++ b/packages/engine/src/orders/funding-parity.test.ts
@@ -125,9 +125,11 @@ describe("the guard and the report admit the SAME reserves (one admission policy
     // nothing. The import said yes and the rendered figure showed the capital as free.
     const { coverage, report } = bothSurfaces(ladder(PAPER_USD));
 
-    expect(coverage.status).toBe("unfundable-reserve");
-    if (coverage.status !== "unfundable-reserve") throw new Error("unreachable");
-    expect(coverage.fundingReserveIds).toEqual([PAPER_USD]);
+    expect(coverage.status).toBe("unattributed");
+    if (coverage.status !== "unattributed") throw new Error("unreachable");
+    expect(coverage.unmatched.map((entry) => entry.rung.fundingReserveId)).toEqual(
+      Array.from({ length: RUNG_COUNT }, () => PAPER_USD),
+    );
     expect(report.unmatched.map((entry) => entry.reason)).toEqual(
       Array.from({ length: RUNG_COUNT }, () => "unfundable-reserve"),
     );
@@ -137,12 +139,35 @@ describe("the guard and the report admit the SAME reserves (one admission policy
   it("both REFUSE a rung funded by an UNSUPPORTED-CURRENCY reserve", () => {
     const { coverage, report } = bothSurfaces(ladder(ODD_CURRENCY));
 
-    expect(coverage.status).toBe("unfundable-reserve");
-    if (coverage.status !== "unfundable-reserve") throw new Error("unreachable");
-    expect(coverage.fundingReserveIds).toEqual([ODD_CURRENCY]);
+    expect(coverage.status).toBe("unattributed");
+    if (coverage.status !== "unattributed") throw new Error("unreachable");
+    expect(coverage.unmatched.map((entry) => entry.rung.fundingReserveId)).toEqual(
+      Array.from({ length: RUNG_COUNT }, () => ODD_CURRENCY),
+    );
     expect(report.unmatched.map((entry) => entry.reason)).toEqual(
       Array.from({ length: RUNG_COUNT }, () => "unfundable-reserve"),
     );
+  });
+
+  it("names BOTH failure classes when the book is wrong in both ways", () => {
+    // #179's explicit AC, and the case the four hand-picked ones above could not reach:
+    // a book carrying a PAPER-mode ladder AND a cross-currency ladder. The guard used to
+    // filter for one class, return on it, and throw the other away — so the operator
+    // fixed the reserve declaration, re-ran the whole import including its prompts, and
+    // was refused a second time for a fault that was already computed on the first pass.
+    const { coverage, report } = bothSurfaces([...ladder(PAPER_USD), ...ladder(LIVE_MXN, "USD")]);
+
+    expect(coverage.status).toBe("unattributed");
+    if (coverage.status !== "unattributed") throw new Error("unreachable");
+    // `RUNG_COUNT` of EACH reason, and the list is INTERLEAVED rather than blocked by
+    // class — the two ladders share a stamp series, so `pickRestingOrdersAsOf` alternates
+    // them. That is the shape worth locking: the old guard filtered by reason, so it
+    // could not have seen past the first block even if one existed.
+    const reasons = coverage.unmatched.map((entry) => entry.reason);
+    expect(reasons.filter((reason) => reason === "unfundable-reserve")).toHaveLength(RUNG_COUNT);
+    expect(reasons.filter((reason) => reason === "currency-mismatch")).toHaveLength(RUNG_COUNT);
+    // And the report says exactly the same thing about exactly the same rungs.
+    expect(coverage.unmatched).toEqual(report.unmatched);
   });
 });
 
@@ -154,9 +179,12 @@ describe("the guard and the report treat CURRENCY the same way", () => {
     // accepted — while the report refused the identical rung as `currency-mismatch`.
     const { coverage, report } = bothSurfaces(ladder(LIVE_MXN, "USD"));
 
-    expect(coverage.status).toBe("currency-mismatch");
-    if (coverage.status !== "currency-mismatch") throw new Error("unreachable");
-    expect(coverage.rungs.map((rung) => rung.fundingReserveId)).toEqual(
+    expect(coverage.status).toBe("unattributed");
+    if (coverage.status !== "unattributed") throw new Error("unreachable");
+    expect(coverage.unmatched.map((entry) => entry.reason)).toEqual(
+      Array.from({ length: RUNG_COUNT }, () => "currency-mismatch"),
+    );
+    expect(coverage.unmatched.map((entry) => entry.rung.fundingReserveId)).toEqual(
       Array.from({ length: RUNG_COUNT }, () => LIVE_MXN),
     );
     expect(report.unmatched.map((entry) => entry.reason)).toEqual(
@@ -190,11 +218,29 @@ describe("no verdict the guard accepts leaves the report with an unplaceable run
     // and a refused import must be refused for the reason the report gives.
     for (const reserveId of [LIVE_USD, PAPER_USD, ODD_CURRENCY, LIVE_MXN]) {
       const { coverage, report } = bothSurfaces(ladder(reserveId));
-      if (coverage.status === "ok") {
-        expect(report.unmatched).toEqual([]);
+      if (coverage.status === "unattributed") {
+        // WHAT THIS PINS IS FORWARDING WITHOUT NARROWING — not agreement between two
+        // implementations, and it must not be read as though it were. Both sides now
+        // return the SAME array from the SAME `attributeRungs` call, so `toEqual` here is
+        // close to tautological as a comparison of two independent derivations: there is
+        // only one derivation left. That is the point of #172's shape, not a weakness of
+        // it — but it does mean this assertion earns its keep somewhere else.
+        //
+        // Where it earns it: NARROWING is the defect, and narrowing is what this catches.
+        // The guard used to filter `unmatched` by reason, return on the first non-empty
+        // filter, and dedup one class down to a set of reserve ids — so the two surfaces
+        // named different rungs while both were "derived from attribution". The likeliest
+        // future regression is someone re-adding a dedup HERE, in the engine, "for
+        // rendering convenience". The rendering does dedup, per reserve, and that is
+        // correct — at the import boundary, where the remedy is. Do it in
+        // `checkFundingCoverage` and this line fails, which is the whole intent.
+        expect(coverage.unmatched).toEqual(report.unmatched);
       } else {
-        expect(report.unmatched.length).toBeGreaterThan(0);
-        expect(coverage.status).toBe(report.unmatched[0]?.reason);
+        // `ok` AND `over-committed` both mean attribution succeeded — the report places
+        // everything. The old form asserted against `report.unmatched[0]?.reason`, the
+        // FIRST entry only, and said nothing at all about `over-committed`; this is total
+        // over all three arms.
+        expect(report.unmatched).toEqual([]);
       }
     }
   });

--- a/packages/engine/src/orders/funding-parity.test.ts
+++ b/packages/engine/src/orders/funding-parity.test.ts
@@ -121,15 +121,15 @@ describe("the guard and the report admit the SAME reserves (one admission policy
 
   it("both REFUSE a rung funded by a PAPER-mode reserve", () => {
     // Before the fix the guard said `ok` here — `data.reserves` carries the paper
-    // reserve — while the report listed the rung as `unknown-reserve` and encumbered
+    // reserve — while the report listed the rung as `unfundable-reserve` and encumbered
     // nothing. The import said yes and the rendered figure showed the capital as free.
     const { coverage, report } = bothSurfaces(ladder(PAPER_USD));
 
-    expect(coverage.status).toBe("unknown-reserve");
-    if (coverage.status !== "unknown-reserve") throw new Error("unreachable");
+    expect(coverage.status).toBe("unfundable-reserve");
+    if (coverage.status !== "unfundable-reserve") throw new Error("unreachable");
     expect(coverage.fundingReserveIds).toEqual([PAPER_USD]);
     expect(report.unmatched.map((entry) => entry.reason)).toEqual(
-      Array.from({ length: RUNG_COUNT }, () => "unknown-reserve"),
+      Array.from({ length: RUNG_COUNT }, () => "unfundable-reserve"),
     );
     expect(report.reserves.some((entry) => entry.reserveId === PAPER_USD)).toBe(false);
   });
@@ -137,11 +137,11 @@ describe("the guard and the report admit the SAME reserves (one admission policy
   it("both REFUSE a rung funded by an UNSUPPORTED-CURRENCY reserve", () => {
     const { coverage, report } = bothSurfaces(ladder(ODD_CURRENCY));
 
-    expect(coverage.status).toBe("unknown-reserve");
-    if (coverage.status !== "unknown-reserve") throw new Error("unreachable");
+    expect(coverage.status).toBe("unfundable-reserve");
+    if (coverage.status !== "unfundable-reserve") throw new Error("unreachable");
     expect(coverage.fundingReserveIds).toEqual([ODD_CURRENCY]);
     expect(report.unmatched.map((entry) => entry.reason)).toEqual(
-      Array.from({ length: RUNG_COUNT }, () => "unknown-reserve"),
+      Array.from({ length: RUNG_COUNT }, () => "unfundable-reserve"),
     );
   });
 });

--- a/packages/engine/src/orders/ingest.ts
+++ b/packages/engine/src/orders/ingest.ts
@@ -370,7 +370,11 @@ export interface FundingShortfall {
  */
 export type FundingCoverage =
   | { status: "ok" }
-  | { status: "unattributed"; unmatched: UnmatchedRung[] }
+  // `readonly`, because "the identical array, narrowed by nobody" is a claim about the
+  // list the caller receives too: a consumer that spliced its own class out of it would
+  // re-create #179's masking one layer down, and the surfaces that render it already take
+  // `readonly UnmatchedRung[]`.
+  | { status: "unattributed"; unmatched: readonly UnmatchedRung[] }
   | { status: "over-committed"; shortfalls: FundingShortfall[] };
 
 /**

--- a/packages/engine/src/orders/ingest.ts
+++ b/packages/engine/src/orders/ingest.ts
@@ -11,8 +11,8 @@
  * second parser and nothing here.
  */
 import type { Currency, FundReviewData } from "../contracts.js";
-import { attributeRungs } from "./attribution.js";
-import { isNegativeSlack, type CommittedRung } from "./committed.js";
+import { attributeRungs, type UnmatchedRung } from "./attribution.js";
+import { isNegativeSlack } from "./committed.js";
 import type { OrderPlacedRecord, OrderSide } from "./records.js";
 import type { RestingOrder } from "./select.js";
 
@@ -343,16 +343,35 @@ export interface FundingShortfall {
 }
 
 /**
- * The two REFUSAL arms are, deliberately, the two `UnmatchedReason`s the report already
- * uses — same names, same meanings. A rung the report would list as `unfundable-reserve`
- * refuses the import as `unfundable-reserve`; likewise `currency-mismatch`. The parity is
- * legible in the type rather than asserted in prose.
+ * THREE ARMS, AND THEY ARE THE REAL STRUCTURE: attribution succeeds or it does not, and
+ * coverage is only weighable when it does.
+ *
+ * `unattributed` carries the report's OWN `UnmatchedRung[]` — the identical array from
+ * the identical {@link attributeRungs} call the rendered available-capital report makes.
+ * That is what finishes #172's thesis: parity is no longer legible in a pair of
+ * hand-mirrored arm names, it is an IDENTITY, because there is only one list and both
+ * surfaces return it.
+ *
+ * IT USED TO BE FOUR, AND THE FOURTH MASKED THE THIRD (#179). The arm pair
+ * `unfundable-reserve` / `currency-mismatch` mirrored `UnmatchedReason` one level up, so
+ * a batch wrong in BOTH ways could only report the class that happened to be tested
+ * first: the operator fixed it, re-ran, and was refused again for the other. The reasons
+ * were all computed on the first pass and then thrown away. `UnmatchedReason` itself
+ * SURVIVES untouched — it is the per-RUNG reason, and it is what both the report
+ * (`./available.js`) and the import boundary's refusal message render from.
+ *
+ * `over-committed` is NOT folded in with them and stays a separate later pass: an
+ * unplaceable rung has no honest balance to be compared against, so there is nothing to
+ * weigh it with until every rung is placeable.
+ *
+ * The arm is named after the PHASE that failed rather than after a reason, because it is
+ * a class of reasons — and it is that phase's failure which is precisely why
+ * `over-committed` could not be computed.
  */
 export type FundingCoverage =
   | { status: "ok" }
-  | { status: "over-committed"; shortfalls: FundingShortfall[] }
-  | { status: "unfundable-reserve"; fundingReserveIds: string[] }
-  | { status: "currency-mismatch"; rungs: CommittedRung[] };
+  | { status: "unattributed"; unmatched: UnmatchedRung[] }
+  | { status: "over-committed"; shortfalls: FundingShortfall[] };
 
 /**
  * `O1` — no order may encumber a reserve that cannot fund it.
@@ -399,11 +418,19 @@ export type FundingCoverage =
  * inputs moves the caller's problem into the callee's type. It would harden `ok` against
  * a caller that does not exist — one non-test call site, and `record-fill.ts` names this
  * function only in a comment saying why it deliberately does not call it. It would also
- * break #172's parity property in TWO places: `funding-parity.test.ts:197`'s token
- * equality against `UnmatchedReason`, and `:193`'s `if (coverage.status === "ok")
- * expect(report.unmatched).toEqual([])`, where a fifth arm falls to the `else` and
- * asserts a non-empty unmatched list against an empty one — on the ACCEPT path, which is
- * the path a qualified verdict lives on.
+ * break #172's parity property, which lives in `funding-parity.test.ts` under *"no
+ * verdict the guard accepts leaves the report with an unplaceable rung"* — cited BY NAME,
+ * because line numbers drift and these two citations already had. A qualifying arm falls
+ * to that property's `else`, which asserts `report.unmatched` is EMPTY for every verdict
+ * other than `unattributed` — so a fifth arm would assert a non-empty unmatched list
+ * against an empty one, on the ACCEPT path, which is the path a qualified verdict lives
+ * on.
+ *
+ * The property was RESTATED by #179 and the change was deliberate: it used to compare
+ * this function's status token against `report.unmatched[0]?.reason` — the FIRST entry
+ * only, which is the very blindness #179 removed — and it now relates the whole
+ * `unattributed` list to the whole report list, over all three arms. #183's conclusion
+ * above is untouched by that; only these citations are.
  *
  * KNOWINGLY OPEN, tracked on #183 — A SKIPPED EXPORT ROW IS NEVER PERSISTED. `OrderRecord`
  * is exactly three kinds — `orderPlaced`, `orderCancelled`, `orderFilled`
@@ -429,16 +456,16 @@ export function checkFundingCoverage(
   // compared against — reading it as a zero balance would render the ladder as
   // "over-committed" on a typo, and summing it into a foreign-denominated balance would
   // produce the confidently wrong slack that #172 was about.
-  const unfundable = unmatched.filter((entry) => entry.reason === "unfundable-reserve");
-  if (unfundable.length > 0) {
-    return {
-      status: "unfundable-reserve",
-      fundingReserveIds: [...new Set(unfundable.map((entry) => entry.rung.fundingReserveId))],
-    };
-  }
-  const mismatched = unmatched.filter((entry) => entry.reason === "currency-mismatch");
-  if (mismatched.length > 0) {
-    return { status: "currency-mismatch", rungs: mismatched.map((entry) => entry.rung) };
+  //
+  // EVERY unplaceable rung goes back, of both classes, in the rungs' own order (#179).
+  // This used to filter twice and return on the first non-empty filter, so a batch wrong
+  // in both ways reported only one class and the operator paid a second full pass to
+  // learn the other. Nothing here is recomputed and nothing is deduped: the list is
+  // `attributeRungs`' own, and dedup — where it is right at all, which is per RESERVE for
+  // `unfundable-reserve` and never for `currency-mismatch` — belongs at render time,
+  // where the remedy is.
+  if (unmatched.length > 0) {
+    return { status: "unattributed", unmatched };
   }
 
   const balanceById = new Map(reserves.map((reserve) => [reserve.reserveId, reserve.balance]));

--- a/packages/engine/src/orders/ingest.ts
+++ b/packages/engine/src/orders/ingest.ts
@@ -344,14 +344,14 @@ export interface FundingShortfall {
 
 /**
  * The two REFUSAL arms are, deliberately, the two `UnmatchedReason`s the report already
- * uses — same names, same meanings. A rung the report would list as `unknown-reserve`
- * refuses the import as `unknown-reserve`; likewise `currency-mismatch`. The parity is
+ * uses — same names, same meanings. A rung the report would list as `unfundable-reserve`
+ * refuses the import as `unfundable-reserve`; likewise `currency-mismatch`. The parity is
  * legible in the type rather than asserted in prose.
  */
 export type FundingCoverage =
   | { status: "ok" }
   | { status: "over-committed"; shortfalls: FundingShortfall[] }
-  | { status: "unknown-reserve"; fundingReserveIds: string[] }
+  | { status: "unfundable-reserve"; fundingReserveIds: string[] }
   | { status: "currency-mismatch"; rungs: CommittedRung[] };
 
 /**
@@ -429,11 +429,11 @@ export function checkFundingCoverage(
   // compared against — reading it as a zero balance would render the ladder as
   // "over-committed" on a typo, and summing it into a foreign-denominated balance would
   // produce the confidently wrong slack that #172 was about.
-  const unknown = unmatched.filter((entry) => entry.reason === "unknown-reserve");
-  if (unknown.length > 0) {
+  const unfundable = unmatched.filter((entry) => entry.reason === "unfundable-reserve");
+  if (unfundable.length > 0) {
     return {
-      status: "unknown-reserve",
-      fundingReserveIds: [...new Set(unknown.map((entry) => entry.rung.fundingReserveId))],
+      status: "unfundable-reserve",
+      fundingReserveIds: [...new Set(unfundable.map((entry) => entry.rung.fundingReserveId))],
     };
   }
   const mismatched = unmatched.filter((entry) => entry.reason === "currency-mismatch");


### PR DESCRIPTION
Two commits. The rename goes first, and that ordering is forced: authoring the batched arm while the reason token still lied would have made `ingest.ts`'s arm-for-reason parity docstring false mid-history.

Closes #180
Closes #179

## 1 — `refactor(orders)`: the token names fundability, not existence

After #172 the guard's reserve set became the canonical state's *admitted* reserves, so `unknown-reserve` began firing for reserves that exist and are plainly visible in the operator's own fund file. Three of its four situations were a real reserve being told it was unknown. `unfundable-reserve` is a claim about **capacity**, which is what the admission policy actually decides, and it negates the `FundableReserve` / `fundableReserves` vocabulary the module already used.

`record-fill.ts` keeps its own `unknown-reserve` deliberately — a different predicate, since that lookup goes straight at `folded.reserves` and fires only when the fold really does not have the id. Both of its comments were rewritten in this commit to say so, worded to stay true across commit 2.

**No migration is owed, and the commit says so.** `OrderRecord` carries no funding-status field, a refused import writes zero bytes, and the status is computed at read time. A repo-wide grep found the token in source only — no ADR, no docs, no durable log.

## 2 — `feat(orders)`: every reason, in one pass

`checkFundingCoverage` classified every rung in one pass and then threw most of it away: it filtered `unmatched` by reason and returned on the first non-empty filter, so in a mixed batch a single unfundable rung swallowed every cross-currency rung in the same book. The operator fixed one fault, paid the batch-declaration prompt and the per-order override pass again, and only then learned there was a second.

`FundingCoverage` goes from four arms to three:

```ts
| { status: "ok" }
| { status: "unattributed"; unmatched: UnmatchedRung[] }
| { status: "over-committed"; shortfalls: FundingShortfall[] };
```

The batched arm carries the report's own `UnmatchedRung[]` — the identical array from the identical `attributeRungs` call — so parity between the guard and the report stops being an assertion and becomes an identity. `over-committed` stays a separate later pass, because an unplaceable rung has no honest balance to be compared against. The TUI's two rejection members collapse to one `unattributed`, spelled identically to the engine arm; a two-member union could not express an outcome that now carries both classes without picking a winner, which is the masking bug re-introduced at the boundary that reports it.

The refusal renders as two labelled sections, each absent when its class is absent, each keeping its own advice. Real rendered output, driven through the real `reject()` frame with real `synthesizeOrderId` ids — not a hand-written sample:

```
REFUSED — 4 rungs cannot be placed against a fundable reserve.
Coverage weighs the WHOLE resting book, so rungs marked "on file" below were
already in the sidecar before this import, not in the export just read.

  unfundable reserve — 2 reserves, 2 rungs
    The fold excluded these reserves: paper execution mode, an unsupported
    currency, or a dangling account reference. They cannot fund a live order,
    and the available-capital report would not be able to place them either.
      reserve-odd
        BITGET:BTCUSDT:buy:56000:2026-01-01T09:00:00Z — on file
      reserve-paper
        BITGET:BTCUSDT:buy:58000:2026-01-01T10:00:00Z

  currency mismatch — 2 rungs
    Cross-currency funding is not supported; fix the declaration.
      BITGET:BTCUSDT:buy:55000:2026-01-01T09:00:01Z — on file
        quoted in USD, declared against reserve-mxn
      BITGET:BTCUSDT:buy:57000:2026-01-01T10:00:01Z
        quoted in USD, declared against reserve-mxn

Reserve balances were NOT weighed: an unplaceable rung has no balance to
compare against, so a coverage refusal may still follow once every rung
above is placeable.
```

The `on file` markers and the legend explaining them came out of the review of this PR, and they are load bearing: the guard weighs the whole resting book, so the header count is the book's and not the export's. Two of the four rungs above are not in the CSV just read. Unmarked, an operator reconciling "4 rungs" against a two-rung export could not make it come out even.

Granularity is unchanged from before: unfundable dedups to reserve ids because one declaration fix clears every rung against it; mismatch stays per rung because the remedy is per rung. The closing line is new and not droppable — batching creates the expectation *"I have now been told everything"*, which is false, because `over-committed` did not run.

## Two things a reviewer will not find in either issue

**The message is more scannable, not shorter.** A prototype rendered it through the real `reject()` frame before the build, and the height claim in the design note did not survive contact with a terminal. What improved is that rung ids sit on their own lines instead of buried mid-prose, and the remedy is a labelled block rather than a trailing clause.

Re-measured on real rendered output after this PR's review, counting the whole `io.err` payload including `reject()`'s `Nothing was written to …` tail:

| case | emitted lines | longest line | lines over 80 columns |
|---|---|---|---|
| unfundable only, nothing on file | 14 | 75 | 0 |
| currency mismatch only, nothing on file | 12 | 72 | 0 |
| mixed, legend and markers in both sections | 25 | 77 | 0 |

**The no-wrap property is now measured rather than asserted, and it did not hold when it was first claimed.** The earlier wording — *"nothing wraps at any realistic terminal width — advice lines are capped at 76 characters"* — was true of the advice lines and false of the message: the closing balances paragraph was itself 80 and 83 characters, so the one paragraph that admits what the operator has **not** been told was also the one that wrapped. It is re-wrapped at 72/71/19. The `on file` marker forced the second half of the fix: appended to a currency-mismatch line already at 76-77 with a real synthesized id, it pushed that line to 86-87, so the rung id now sits alone on its line with the mismatch indented beneath it — the shape the unfundable section already used for a reserve and its rungs, rather than a third layout. The tail line is excluded from the cap on purpose: its length is `Nothing was written to ` plus the sidecar path, which is the operator's own filesystem and not this renderer's to wrap.

**`attributeRungs`' prose contract is now true about rungs, and the order clause is retracted rather than repaired.** It promised that *"the guard's error message and the report's list name the same rungs in the same order"*. The first half is now an identity — both surfaces hold the same array from the same call. The order half was **already false before this change** (the guard named a deduped set of reserve ids while the report named rungs, so no common order existed), and it stays false afterwards for a new and deliberate reason: the import boundary groups the flat list into two class sections. The selector interleaves rungs by timestamp, so an interleaved book really is reordered across groups — grouping is a genuine reordering, not a cosmetic one. The docstring now promises sameness of rungs and reasons and states plainly why order is not promised. Order was standing in for sameness; sameness is the property that catches the defect.

## The parity property, restated

`funding-parity.test.ts`'s old assertion compared the guard's status token against `report.unmatched[0]?.reason` — the **first** entry, which is exactly the blindness this PR fixes. It becomes a total property over all three arms: on `unattributed`, array equality of the whole list; otherwise the report places everything, which covers `over-committed` — a case the old assertion never reached.

The restatement's own weakness is documented **at the assertion**, in the test's own comment, because it would otherwise mislead: both surfaces now derive from one `attributeRungs` call, so `toEqual` is close to tautological as a comparison of two independent derivations — there is only one derivation left. What it actually pins is **forwarding without narrowing**, and narrowing is the defect. The likeliest future regression is someone re-adding a dedup in the engine "for rendering convenience"; the rendering does dedup, per reserve, at the import boundary where the remedy is, and doing it in `checkFundingCoverage` fails this line by design.

## Tests

Three new cases, covering what was previously unrepresented:

- **Engine, the mixed batch** — one book carrying both an unfundable rung and a cross-currency rung, asserting the guard names both. This case existed nowhere in `funding-parity.test.ts`.
- **TUI, the rendered pair** — one import wrong in both ways, asserting both section labels, both rungs, the counts with correct plurals, and the closing balances line. The rendered refusal was otherwise untested, and it is the only operator-visible change here.
- **TUI, the homogeneous case** — pinning that the absent section is genuinely absent and the singular advice variant renders.

Reaching a mixed batch from the TUI required seeding the sidecar directly: `declareFunding` prompts once per batch, so a single import can only name one funding reserve. That is not a test artifact — it is how the operator will actually meet this refusal, since the guard weighs the whole resting book rather than the batch.

`pnpm typecheck` clean; `pnpm test` green at 1125 passed / 19 skipped (the skips are the pre-existing Postgres suites that need `NUMISMA_TEST_DATABASE_URL`).

## Out of scope, deliberately

Splitting `unfundable-reserve` into paper-mode / unsupported-currency / dangling-account remains its own question — though the new arm already carries per-rung reasons, so a finer `UnmatchedReason` would need no shape change. The report's own per-rung rendering in `format.ts` is untouched, as is `attributeRungs`' classification rule, the committed formula, and the admission policy.

