### PR TITLE
Point the two live-gap citations at an open issue, not a closed one

### DIFF
--- a/apps/tui/src/import-orders-cli.ts
+++ b/apps/tui/src/import-orders-cli.ts
@@ -50,7 +50,8 @@ if (!csvPath) {
       // that appends nothing. The flow is interactive, and the operator's lines (one per
       // qualification, each opening on its own gap and naming its own money direction)
       // are the real channel. If this import is ever automated or piped, the exit code
-      // becomes the only surface left and this branch must be revisited — that is #183.
+      // becomes the only surface left and this branch must be revisited — that is #203.
+      // (#183 DECIDED this and is closed; #203 is where the conditional work now lives.)
       process.exitCode = 0;
     }
   } catch (error) {

--- a/packages/engine/src/orders/ingest.ts
+++ b/packages/engine/src/orders/ingest.ts
@@ -436,7 +436,10 @@ export type FundingCoverage =
  * `unattributed` list to the whole report list, over all three arms. #183's conclusion
  * above is untouched by that; only these citations are.
  *
- * KNOWINGLY OPEN, tracked on #183 — A SKIPPED EXPORT ROW IS NEVER PERSISTED. `OrderRecord`
+ * KNOWINGLY OPEN, tracked on #203 — A SKIPPED EXPORT ROW IS NEVER PERSISTED. The gap was
+ * argued and accepted on #183, which is CLOSED because what it owed was a decision; the
+ * citations above are to that decision and stay pointed at it. This one is different: it
+ * names a cost still being paid, so it points at an OPEN issue. `OrderRecord`
  * is exactly three kinds — `orderPlaced`, `orderCancelled`, `orderFilled`
  * (`./records.ts:132`) — and `appendOrders` (`packages/preferences/src/orders.ts:244`)
  * writes only fresh `orderPlaced` rows. There is no record for "line N of the export


### PR DESCRIPTION
One commit, comments only. No behaviour change, no type change; `pnpm typecheck` clean and `pnpm test` green at 1125 passed / 19 skipped.

Found while auditing what was left after #202 merged.

## The problem

#183 closed as COMPLETED on 2026-07-31. That was right — what it owed was a decision, the decision was made, and the one part that was broken rather than undecided was split out as #184 and landed. But #183 also recorded two costs it deliberately did **not** pay off, and the code still names it as their tracker. A closed issue tracks nothing, so those two gaps were being carried by comments pointing at a dead end.

## What changed, and what deliberately did not

Both kinds of citation are correct and they mean opposite things, so the fix is not a find-and-replace:

| citation | means | target |
|---|---|---|
| `ingest.ts:407`, `:419`, `:436` | a DECISION #183 reached | **unchanged** — a closed issue is the right thing to cite for a settled argument |
| `ingest.ts:439` | a cost still being paid | now **#203** |
| `import-orders-cli.ts:53` | work conditional on a future that has not happened | now **#203** |

The `ingest.ts:439` comment gains a sentence saying which of the two it is and why the neighbouring citations point elsewhere, so the next reader does not "fix" the ones that are already right.

## What #203 holds

- **A skipped export row leaves no durable trace.** `OrderRecord` is three kinds and `appendOrders` writes only fresh `orderPlaced` rows, so there is no record for "line N could not be read". The skip reaches stderr and dies with the process; `orders.jsonl` carries no trace, and every later reader sees a book that looks complete. The live import says so via `imported-partial`; a reader arriving the next day gets silence, and the error direction is `available` reading HIGH.
- **`imported-partial` exits 0.** Deliberate, and defensible only while a human is watching. If the import is ever automated or piped, the exit code is the only surface left.

#203 carries the reasoning that rejected the obvious fix for each, so neither gets re-litigated from scratch: a skipped row has no id to be retired by a later import, and the exit-code question should not be answered speculatively.

**Deliberately NOT linked as a fix.** Issue #203 must stay OPEN — it is the tracker the two comments now name, and this PR only re-points the citations at it.
