### PR TITLE
feat(orders): update a rung's observed partial on later export (#181)

### DIFF
--- a/apps/tui/src/available-capital.ts
+++ b/apps/tui/src/available-capital.ts
@@ -25,6 +25,7 @@ import {
   type FundReviewData,
 } from "@numisma/engine";
 import type { OrdersLoad } from "@numisma/preferences";
+import { renderSkipMessage } from "./skip-message.js";
 
 /** Everything not pure, in one injectable bag — so the whole flow is testable. */
 export interface AvailableCapitalIo {
@@ -74,12 +75,10 @@ export async function loadAvailableCapital(
   const records = load.status === "absent" ? [] : load.records;
   const skips = load.status === "loaded" ? load.skips : [];
   if (skips.length > 0) {
-    return {
-      status: "refused",
-      message:
-        `${io.ordersPath} has ${skips.length} unreadable line(s); a committed figure ` +
-        `over a partially-read book would understate what is encumbered.`,
-    };
+    // Still refuses on ANY skip; only the sentence changed (#181). The wording is the
+    // shared renderer's, so a `malformed` line and a line from a newer build no longer
+    // read as the same problem here or at the other three shells.
+    return { status: "refused", message: renderSkipMessage(io.ordersPath, skips) };
   }
 
   return {

--- a/apps/tui/src/cancel-order.ts
+++ b/apps/tui/src/cancel-order.ts
@@ -144,6 +144,30 @@ export async function cancelOrder(options: OrderCancelOptions): Promise<OrderCan
     );
   }
 
+  // THE RESTING LIST IS THIS FLOW'S WHOLE GATE, AND IT CAN PRESENT A RESURRECTED RUNG.
+  // Stated, known, and deliberately NOT closed here (#181).
+  //
+  // `pickRestingOrdersAsOf` folds ONE `consumed` baseline per rung and an
+  // `orderFillObserved` line SETS it, so `consumed` is NOT MONOTONIC (`select.ts`,
+  // invariant 2): an observation asserting a figure BELOW the baseline takes `remaining`
+  // from zero back to positive, and a rung the fund already exhausted reappears below. So
+  // `not-resting` can be answered "it is resting" about a claim that is not really on the
+  // book, and this flow will retire it.
+  //
+  // WHY NO CEILING HERE, WHERE `record-fill.ts` HAS ONE. The two gates guard different
+  // exposures, and the asymmetry is the reason rather than an oversight. A fill writes a
+  // LOT and a CASH LEG into `events.jsonl` — an append-only log with NO REVERSAL VERB — so
+  // admitting one against a resurrected rung spends capital twice and nothing can discharge
+  // it; that gate carries the booked-fills ceiling. A cancellation writes ONE LINE into
+  // this sidecar and touches no lot and no cash leg. Its worst case is a false assertion in
+  // a file whose OWN verbs can correct it: a later observation restates the baseline and
+  // the book is right again. A torn money state and a recoverable sidecar line do not earn
+  // the same guard.
+  //
+  // Latching retirement in the fold instead was considered and REJECTED on its merits: in
+  // an append-only file with no reversal verb, a rung latched in error is permanently
+  // un-fillable AND un-cancellable, with hand-editing history the only recourse.
+  // Resurrection is recoverable, which is exactly what this flow relies on.
   const resting = pickRestingOrdersAsOf(records);
   const target = resting.find((order) => order.placed.id === orderId);
   if (!target) {

--- a/apps/tui/src/cancel-order.ts
+++ b/apps/tui/src/cancel-order.ts
@@ -38,6 +38,7 @@ import {
   type OrderRecord,
 } from "@numisma/engine";
 import type { OrdersLoad } from "@numisma/preferences";
+import { renderSkipMessage } from "./skip-message.js";
 
 /** Everything this act touches that is not a pure function, in one injectable bag. */
 export interface OrderCancelIo {
@@ -124,12 +125,9 @@ export async function cancelOrder(options: OrderCancelOptions): Promise<OrderCan
     // The same refusal the import makes, for the same reason: a partially-read book
     // cannot tell us whether this rung is resting, and a cancellation decided over one
     // would free capital on a guess.
-    return reject(
-      io,
-      "unreadable-sidecar-lines",
-      `${io.ordersPath} has ${existing.skips.length} line(s) this build cannot read, so the ` +
-        `resting book would be resolved over a partially-read file`,
-    );
+    // Same refusal, same reason code, same exit — one shared sentence (#181), so a line
+    // from a newer build is not reported to the operator as a broken file.
+    return reject(io, "unreadable-sidecar-lines", renderSkipMessage(io.ordersPath, existing.skips));
   }
   const records: OrderRecord[] = existing.status === "loaded" ? existing.records : [];
 

--- a/apps/tui/src/import-orders-cli.ts
+++ b/apps/tui/src/import-orders-cli.ts
@@ -50,9 +50,12 @@ if (!csvPath) {
       // HANDLED, AND DELIBERATELY 0 (`D3`, #177). NOTHING WAS REFUSED, so exiting 1 would
       // tell a caller the run failed when it did not — replacing one overstatement with
       // another. Not "lines were written", which is what this said until the #200 review
-      // and is not true of every member: an export whose every readable rung was restated
-      // appends nothing and still ends here, and it is no more a failure than a re-import
-      // that appends nothing. The flow is interactive, and the operator's lines (one per
+      // and is not true of every member: an export with an unreadable row whose every
+      // READABLE rung was already on file appends nothing and still ends here, and it is no
+      // more a failure than a re-import that appends nothing. An export of nothing but
+      // RESTATED rungs no longer arrives here at all — #210 records the restatement, so it
+      // qualifies nothing and the run ends at `imported`; only an unread row reaches this
+      // branch now. The flow is interactive, and the operator's lines (one per
       // qualification, each opening on its own gap and naming its own money direction)
       // are the real channel. If this import is ever automated or piped, the exit code
       // becomes the only surface left and this branch must be revisited — that is #203.

--- a/apps/tui/src/import-orders-cli.ts
+++ b/apps/tui/src/import-orders-cli.ts
@@ -25,6 +25,11 @@ if (!csvPath) {
       csvPath,
       io: {
         readExport: (path) => readFile(path, "utf8"),
+        // THE REAL CLOCK, and the only place it is read (#181). An observation line is
+        // stamped with the import moment, so the one adapter that runs against a real
+        // venue export is the one that supplies a real instant; the test harness supplies
+        // a frozen one, which is what makes the same-second case assertable at all.
+        now: () => new Date(),
         ordersPath: resolveOrdersPath(),
         loadOrders,
         appendOrders,

--- a/apps/tui/src/import-orders-report.test.ts
+++ b/apps/tui/src/import-orders-report.test.ts
@@ -1,0 +1,223 @@
+/**
+ * THE COUNTING RULE, ASSERTED DIRECTLY — the reason `report` left `import-orders.ts`.
+ *
+ * Every fact below was reachable before only through a whole import: an export file, a
+ * sidecar, an injected clock, a prompt answered, a funding guard satisfied. The rule is a
+ * pure function of what landed, so it is tested as one — no stub, no IO bag, no temp dir.
+ *
+ * The observation lines are built through `buildOrderFillObserved` rather than by object
+ * literal, because that is the only way to obtain one: the record type carries a
+ * compile-time brand precisely so an unvalidated figure cannot be passed off as observed.
+ */
+import {
+  buildOrderFillObserved,
+  type BitgetRowSkip,
+  type OrderFillObservedRecord,
+  type OrderPlacedRecord,
+} from "@numisma/engine";
+import { describe, expect, it } from "vitest";
+import { reportOrdersImport, type OrdersImportReportInput } from "./import-orders-report.js";
+
+const CSV = "/tmp/bitget-open-orders.csv";
+
+function placed(id: string): OrderPlacedRecord {
+  return {
+    id,
+    observedAt: "2026-08-07T10:00:00",
+    kind: "orderPlaced",
+    currency: "USD",
+    symbol: "BTCUSDT",
+    side: "buy",
+    price: 100,
+    quantity: 2,
+    fundingReserveId: "cash-core",
+  };
+}
+
+function observedLine(id: string, observedFilledQuantity: number): OrderFillObservedRecord {
+  const built = buildOrderFillObserved({
+    id,
+    observedAt: "2026-08-07T12:00:00",
+    currency: "USD",
+    observedFilledQuantity,
+  });
+  if (built.status !== "ok") {
+    throw new Error(`fixture is not buildable: ${built.message}`);
+  }
+  return built.record;
+}
+
+function skip(problem: BitgetRowSkip["problem"], line: number): BitgetRowSkip {
+  return { line, problem, message: `row ${line} is ${problem}` };
+}
+
+/** The empty import, for a test to override exactly the field it is about. */
+function input(overrides: Partial<OrdersImportReportInput> = {}): OrdersImportReportInput {
+  return {
+    written: [],
+    placements: [],
+    knownFigures: new Map(),
+    skips: [],
+    csvPath: CSV,
+    ...overrides,
+  };
+}
+
+describe("reportOrdersImport", () => {
+  it("counts `appended` over ORDERS ONLY — never the length of what was written", () => {
+    // The #181 defect in one line: the two numbers were the same until an import could
+    // write a second kind, and a build that counts lines reports observations as orders.
+    const { outcome } = reportOrdersImport(
+      input({
+        written: [placed("a"), observedLine("b", 3), placed("c"), observedLine("d", 4)],
+        placements: [placed("a"), placed("c")],
+        knownFigures: new Map([
+          ["b", 1],
+          ["d", 2],
+        ]),
+      }),
+    );
+    expect(outcome.appended).toBe(2);
+  });
+
+  it("reports `alreadyKnown` as what the batch PROPOSED less what landed", () => {
+    // Three placements went in, one was already on file under the same id saying the same
+    // thing, so the append filter dropped it. Both halves of that subtraction are counted
+    // here, from the array, which is why `placements` is not passed as a number.
+    const { outcome } = reportOrdersImport(
+      input({
+        written: [placed("a"), placed("b")],
+        placements: [placed("a"), placed("b"), placed("c")],
+      }),
+    );
+    expect(outcome.appended).toBe(2);
+    expect(outcome.alreadyKnown).toBe(1);
+  });
+
+  it("derives observations from the WRITTEN lines, joined to the decision's old figure", () => {
+    const { outcome } = reportOrdersImport(
+      input({
+        written: [observedLine("rung-1", 5)],
+        knownFigures: new Map([["rung-1", 2]]),
+      }),
+    );
+    expect(outcome.observations).toEqual([{ id: "rung-1", known: 2, observed: 5 }]);
+  });
+
+  it("NEVER REPORTS A DECIDED OBSERVATION THAT DID NOT LAND (#181)", () => {
+    // The defect this rebuild exists to fix. The decision proposed two restatements and
+    // the append filter let one through — a repeat of a figure already on file dedupes —
+    // and the operator must be told about the one on disk, not the one that was decided.
+    const { outcome, message } = reportOrdersImport(
+      input({
+        written: [observedLine("landed", 5)],
+        knownFigures: new Map([
+          ["landed", 2],
+          ["dropped", 3],
+        ]),
+      }),
+    );
+    expect(outcome.observations).toEqual([{ id: "landed", known: 2, observed: 5 }]);
+    expect(message).toContain("1 observation(s) recorded");
+    expect(message).not.toContain("dropped");
+  });
+
+  it("DROPS a written observation with no decision behind it rather than defaulting it", () => {
+    // Unreachable by construction, and the behaviour on reaching it is still decided:
+    // inventing a `known` would print an arithmetic nobody performed — `filled 0 → 5` for
+    // a rung whose old figure this build never read.
+    const { outcome, message } = reportOrdersImport(
+      input({ written: [observedLine("orphan", 5)], knownFigures: new Map() }),
+    );
+    expect(outcome.observations).toEqual([]);
+    expect(message).toContain("0 observation(s) recorded");
+    expect(message).not.toContain("OBSERVED —");
+  });
+
+  it("RENDERS THE OBSERVATION CLAUSE AT ZERO — a placements-only import still says so", () => {
+    // A clause that appears conditionally is two shapes for a reader to learn and two for
+    // a test to assert. This is the invariant, locked at the number that tempts an author
+    // to hide it.
+    const { message } = reportOrdersImport(
+      input({ written: [placed("a")], placements: [placed("a")] }),
+    );
+    expect(message).toBe(
+      `Imported ${CSV}: 1 order(s) appended, 0 already known, 0 observation(s) recorded.\n`,
+    );
+  });
+
+  it("reads `0 order(s) appended` beside a non-zero observation count — the honest pair", () => {
+    // The pure-observation import: nothing new claims capital, two rungs claim less. Both
+    // numbers are true at once, and the shape that looks like a contradiction is the one
+    // that would have to lie to avoid looking like one.
+    const { outcome, message } = reportOrdersImport(
+      input({
+        written: [observedLine("rung-1", 5), observedLine("rung-2", 7)],
+        placements: [],
+        knownFigures: new Map([
+          ["rung-1", 2],
+          ["rung-2", 6],
+        ]),
+      }),
+    );
+    expect(outcome.appended).toBe(0);
+    expect(outcome.observations).toHaveLength(2);
+    expect(message).toContain("0 order(s) appended, 0 already known, 2 observation(s) recorded");
+  });
+
+  it("weighs skips through `leavesRungUnweighed`, NOT through their count (#184)", () => {
+    // A `not-resting` row was read COMPLETELY — the parser's positive finding is that
+    // nothing is still claimed — so it must not fire a money-direction alarm about a rung
+    // nobody weighed. One genuinely unreadable row rides beside it, and the notice counts
+    // one, not two.
+    const skips = [skip("not-resting", 4), skip("malformed", 9)];
+    const { outcome, message } = reportOrdersImport(
+      input({ written: [placed("a")], placements: [placed("a")], skips }),
+    );
+    expect(message).toContain(`INCOMPLETE — 1 row(s) of ${CSV} could not be read`);
+    // Every skip still rides on the outcome; only the ALARM discriminates.
+    expect(outcome.skips).toEqual(skips);
+  });
+
+  it("stays `imported` when every skip was read completely", () => {
+    const { outcome, message } = reportOrdersImport(
+      input({
+        written: [placed("a")],
+        placements: [placed("a")],
+        skips: [skip("not-resting", 4)],
+      }),
+    );
+    expect(outcome.status).toBe("imported");
+    expect(message).not.toContain("INCOMPLETE");
+  });
+
+  it("qualifies to `imported-partial` on a row that left a rung UNWEIGHED", () => {
+    for (const problem of ["malformed", "unknown-status", "unknown-quote-currency"] as const) {
+      const { outcome } = reportOrdersImport(input({ skips: [skip(problem, 2)] }));
+      expect(outcome.status).toBe("imported-partial");
+    }
+  });
+
+  it("orders the notices unread-rows-first and speaks exactly once", () => {
+    // Unread rows lead because they are the one thing we know least about. The counts
+    // follow all of them, once — they used to be the whole line, with the notice a suffix
+    // in exactly the position an operator skims past.
+    const { message } = reportOrdersImport(
+      input({
+        written: [placed("a"), observedLine("rung-1", 5)],
+        placements: [placed("a"), placed("b")],
+        knownFigures: new Map([["rung-1", 2]]),
+        skips: [skip("malformed", 9)],
+      }),
+    );
+    const lines = message.split("\n");
+    expect(lines).toHaveLength(4); // three notice/count lines plus the trailing newline
+    expect(lines[0]).toMatch(/^INCOMPLETE — 1 row\(s\)/);
+    expect(lines[1]).toMatch(/^OBSERVED — 1 rung\(s\)/);
+    expect(lines[1]).toContain("rung-1 (filled 2 → 5)");
+    expect(lines[2]).toBe(
+      `Imported ${CSV}: 1 order(s) appended, 1 already known, 1 observation(s) recorded.`,
+    );
+    expect(lines[3]).toBe("");
+  });
+});

--- a/apps/tui/src/import-orders-report.ts
+++ b/apps/tui/src/import-orders-report.ts
@@ -1,0 +1,298 @@
+/**
+ * THE REPORT, FED THE LINES THAT WERE ACTUALLY WRITTEN (#181).
+ *
+ * It used to be handed two bare numbers from ABOVE the write and then reach past its own
+ * parameter list into the DECISION array for the rest — so it described what the flow
+ * DECIDED while the file held what the append filter LET THROUGH. One defect with three
+ * faces, and the visible one was a dropped line surfacing as a confident `RECORDED`.
+ *
+ * Every count and every operator line is derived HERE, from `written`. `placements` is
+ * passed as an ARRAY rather than as a count for the same reason: `alreadyKnown` is "what
+ * this batch proposed, less what landed", and both halves of that subtraction must be
+ * counted by one rule in one place. The only thing read out of the decision is the `known`
+ * figure joined per line, because the line itself cannot remember it.
+ *
+ * ONE MESSAGE, CONSTRUCTED AT ONE EXIT, so the `OBSERVED —` detail is built once BY
+ * CONSTRUCTION rather than by discipline. It was written out verbatim at two exits before,
+ * eight lines under a comment stating the very invariant that duplication breaks.
+ *
+ * THE WRITE ITSELF IS THE CALLER'S (ADR-001), and that is the one thing this module changed
+ * on the way out of `import-orders.ts`. The rule used to end at "one `io.out`, reached by
+ * every exit"; the function now returns the message beside the outcome and
+ * `importBitgetOpenOrders` performs the single `io.out`. The invariant is unweakened —
+ * there is still exactly one message and exactly one write — and it buys the thing the
+ * closure could not have: the counting rule is a pure function of its arguments, so every
+ * fact below is assertable without an export file, a sidecar or a stubbed IO bag.
+ */
+import {
+  leavesRungUnweighed,
+  type BitgetRowSkip,
+  type OrderPlacedRecord,
+  type OrderRecord,
+} from "@numisma/engine";
+
+/**
+ * A rung the venue has filled FURTHER since the file last observed it, RECORDED (#181).
+ *
+ * The id is synthesized from the SUBMISSION stamp, so a rung that fills between two
+ * exports comes back under the same id carrying a larger `filled_quantity`. That is not
+ * an amendment and not a re-sighting — it is the ordinary life of a resting ladder — and
+ * it now gets its own durable line: an `orderFillObserved`, stamped with the IMPORT
+ * moment, which `pickRestingOrdersAsOf` folds as a new `consumed` baseline.
+ *
+ * IT REPLACES `RestatedPartial` RATHER THAN REPURPOSING IT (#199 → #181). That type
+ * carried BOTH remainders because the pair WAS the safety argument for a per-rung SKIP:
+ * printing them let an operator check that the stale line still encumbered no less than
+ * the venue held. There is no skip left to justify, and after the observation lands the
+ * pair is redundant by construction — the file's remainder becomes `quantity − observed`,
+ * which is exactly the venue's. What an operator still wants is the one thing this
+ * carries: what the file knew, and what it now records.
+ *
+ * IT IS NOT A QUALIFICATION. A restatement qualified the status while it was a DEFERRAL —
+ * a rung read perfectly and then not written down — and this build writes it down. See
+ * {@link OrdersImportRecorded}'s `imported` member for what that does to the union.
+ *
+ * THE DIRECTION IS STILL READ OFF THE REMAINDER, not off the two figures (#200 review).
+ * A restatement the file's OWN fill lines have already overtaken is not a restatement at
+ * all — the fund has BOOKED units the venue does not corroborate — and those rungs stay a
+ * batch-wide `changed-claim` refusal. The algebra is on `partitionChangedClaims`.
+ */
+export interface RecordedObservation {
+  id: string;
+  /**
+   * The file's LATEST OBSERVATION of this rung's partial — a later `orderFillObserved`
+   * line when one exists, else the placement line's own figure, else `0` (#181). Was "the
+   * partial the placement line records", which stopped being the same number the moment a
+   * restatement could be written down.
+   */
+  known: number;
+  /** The larger cumulative partial the venue's export now shows, and what was written. */
+  observed: number;
+}
+
+/**
+ * What an import that REFUSED NOTHING reports, in the two shapes it can honestly take.
+ *
+ * Not "an import that WROTE" (#200 review): an export whose every readable rung was
+ * already on file saying the same thing writes no line at all and still reports here,
+ * because the flow reached its end with nothing refused. Writing is what these outcomes
+ * usually DO; not refusing is what they all MEAN.
+ */
+interface OrdersImportWrite {
+  /**
+   * ORDERS appended — placement lines, and never a line count (#181). The two were the
+   * same number until an import could write a second kind, and the moment it could, a
+   * pure-observation import reported `1 order(s) appended` about ZERO orders.
+   *
+   * `appended` KEEPS MEANING ORDERS because that is the question the number is read for:
+   * *how many claims on my capital did this import create?* An observation creates none —
+   * it only ever REDUCES what a rung still claims — so counting it here would answer that
+   * question wrongly in the direction that matters. Observations are counted by
+   * {@link observations}, whose length IS the count.
+   *
+   * ZERO in three different ways now, and the other fields tell them apart: every rung was
+   * already known (`alreadyKnown` carries them), every readable rung was restated
+   * (`observations` carries them), or the export named nothing this build admitted.
+   */
+  appended: number;
+  /**
+   * Rungs already in the sidecar under the same synthesized id AND saying the same
+   * thing about it — the id components plus `quantity` and the observed partial.
+   *
+   * A row that differs NEVER reaches this count, whichever way it goes: it either
+   * refuses the whole batch as `changed-claim` / `backwards-claim` (#174, #181) or is
+   * recorded as an observation and reported in {@link observations} (#181). Calling
+   * either one "already known" is the silence #174 named — it reports "nothing to do"
+   * about a rung the file now describes wrongly.
+   */
+  alreadyKnown: number;
+  /**
+   * The export rows this build could not read — NOT empty on `imported`, and the
+   * asymmetry with {@link observations} is deliberate rather than an oversight. A
+   * `not-resting` row was read COMPLETELY and the parser's finding about it is that
+   * nothing is still claimed, so it rides here and qualifies nothing (#184). What
+   * `imported` promises about this field is that none of its entries left a rung
+   * UNWEIGHED — that is `leavesRungUnweighed`'s question, not this array's length.
+   */
+  skips: BitgetRowSkip[];
+  /**
+   * The restatements this import RECORDED — exactly one `orderFillObserved` line each
+   * (#181), and never a superset of what was written.
+   *
+   * DERIVED FROM THE LINES THAT WERE WRITTEN, not from the decision that proposed them,
+   * and that is the whole shape of {@link reportOrdersImport}. A decision the append
+   * filter did not let through is ABSENT here, so the operator is never told a line was
+   * RECORDED that is not on disk. The `known`/`observed` pair is the one thing joined back
+   * from the decision — the written line carries the new figure, and only the decision
+   * remembers the old one.
+   *
+   * NOT A QUALIFICATION, unlike the `restated` field it replaces. That field's own length
+   * decided the status, because a skipped rung was work DEFERRED; this one records work
+   * DONE, so `imported` widens back over it. A reader who never opens this field is not
+   * misled by one, which is the test that decides what may qualify a status.
+   */
+  observations: RecordedObservation[];
+}
+
+/**
+ * The two outcomes of an import that refused nothing — every member of
+ * `OrdersImportOutcome` except the refusal, which is the whole of what this module can
+ * return. Spelled here rather than in `import-orders.ts` so the reporter's return type
+ * does not have to reach back into the shell it reports for.
+ */
+export type OrdersImportRecorded =
+  /**
+   * Every row of the export was read. The unqualified success, and the only one.
+   *
+   * ITS INVARIANT WIDENS BACK HERE (#199 → #181), and this union has never shrunk before,
+   * so it is worth saying plainly: this is a GAP CLOSING, not precision lost. #199
+   * strengthened the member to "every row read AND nothing restated" because a
+   * restatement was then a DEFERRAL — a rung read perfectly and then not written down —
+   * and a status that called that unqualified would be lying to the reader who opens no
+   * second field. The restatement is now RECORDED, so it defers nothing and qualifies
+   * nothing, and the only thing left qualifying an import is a row nobody could read.
+   */
+  | ({ status: "imported" } & OrdersImportWrite)
+  /**
+   * The import ran to its end, and SOMETHING ABOUT THE EXPORT WAS QUALIFIED (`D3`, #177;
+   * #199).
+   *
+   * A DISTINCT MEMBER, not `imported` carrying a non-empty field. A shape that forces
+   * every reader to open a second field to discover the first was qualified is a type
+   * that lies to the reader who does not. It is still a SUCCESS, and the test is that
+   * NOTHING WAS REFUSED — not that lines were written, which is the weaker claim this
+   * used to make and which an export of nothing but restated rungs falsifies while still
+   * being a perfectly honest run. The CLI exits 0 either way (`D3`).
+   *
+   * ONE qualification reaches it now (#181): `skips` — a row was not read, so a rung
+   * resting at the venue is `committed` that nobody counted and `available` reads HIGH.
+   * A restated rung used to be the second, and it is a RECORDED line rather than a
+   * deferral since #181, so it no longer qualifies anything.
+   *
+   * STILL A DISTINCT MEMBER RATHER THAN A PREDICATE OVER `skips`, because `skips` is
+   * heterogeneous: a `not-resting` row was read completely and qualifies nothing, so the
+   * status is decided by `leavesRungUnweighed` over the entries rather than by the
+   * array's length. It is still a SUCCESS, and the test is that NOTHING WAS REFUSED.
+   */
+  | ({ status: "imported-partial" } & OrdersImportWrite);
+
+/** Everything the counting rule reads. No IO, no clock, no enclosing scope. */
+export interface OrdersImportReportInput {
+  /**
+   * The lines the append filter LET THROUGH — what is on disk, and the basis of every
+   * count below. Both kinds ride in one array because one `appendOrders` call wrote them.
+   */
+  written: readonly OrderRecord[];
+  /**
+   * What this batch PROPOSED to place — an ARRAY rather than a count, deliberately. See
+   * the module header: `alreadyKnown` is this length less what landed, and one rule in one
+   * place must count both halves of that subtraction.
+   */
+  placements: readonly OrderPlacedRecord[];
+  /**
+   * The old figure, per rung, joined onto the observations that were written.
+   *
+   * PASSED AS THE ALREADY-BUILT MAP rather than as the `restated` decision array, and the
+   * choice is the #181 defect's own lesson: a decision array here could be ITERATED, which
+   * is exactly how the old reporter came to describe lines the file did not hold. A Map is
+   * only joinable — there is no entry point into it except an id read off a written line —
+   * so the failure mode is unreachable by construction rather than by comment.
+   */
+  knownFigures: ReadonlyMap<string, number>;
+  /** The parser's skips, whole and unfiltered — the reporter discriminates, not the caller. */
+  skips: BitgetRowSkip[];
+  /** The export's path, as the operator named it. Interpolated into both notices. */
+  csvPath: string;
+}
+
+/**
+ * The outcome and the words for it — returned as a pair so the caller owns the write.
+ */
+export interface OrdersImportReport {
+  outcome: OrdersImportRecorded;
+  /** Ready to hand to `io.out` verbatim, trailing newline included. */
+  message: string;
+}
+
+/** Count what landed, say what it means, and let the caller print it. */
+export function reportOrdersImport(input: OrdersImportReportInput): OrdersImportReport {
+  const { written, placements, knownFigures, skips, csvPath } = input;
+  const appended = written.filter((record) => record.kind === "orderPlaced").length;
+  const alreadyKnown = placements.length - appended;
+  const observed: RecordedObservation[] = [];
+  for (const record of written) {
+    if (record.kind !== "orderFillObserved") {
+      continue;
+    }
+    const known = knownFigures.get(record.id);
+    // A written observation with no decision behind it cannot exist — every one of them
+    // was built from a `restated` entry by the caller. Dropped rather than defaulted if it
+    // ever did: inventing a `known` would print an arithmetic nobody performed.
+    if (known !== undefined) {
+      observed.push({ id: record.id, known, observed: record.observedFilledQuantity });
+    }
+  }
+
+  // THE OBSERVATION CLAUSE RENDERS ALWAYS, INCLUDING AT ZERO. A clause that appears
+  // conditionally is two shapes for a reader to learn and two for a test to assert, and
+  // it is one more place for the two exits to diverge again. `appended` counts ORDERS,
+  // so a pure-observation import reads `0 order(s) appended` beside a non-zero
+  // observation count — which is the honest pair, not a contradiction.
+  const counts =
+    `${appended} order(s) appended, ${alreadyKnown} already known, ` +
+    `${observed.length} observation(s) recorded`;
+  const write = { appended, alreadyKnown, skips, observations: observed };
+
+  // NOT `skips.length` (#184). `skips` is heterogeneous, and a `not-resting` row was read
+  // COMPLETELY — the parser's finding about it is that nothing is still claimed. The gap
+  // this line warns about is rungs we could not weigh, so both the discrimination and the
+  // count below run through the engine's predicate rather than the raw total.
+  // `outcome.skips` still carries every skip and stderr still reports every one of them.
+  const unweighed = skips.filter((entry) => leavesRungUnweighed(entry.problem));
+
+  // EACH NOTICE GETS ITS OWN LINE, OPENING ON WHAT IT IS ABOUT (`D3`, #177; #199). The
+  // counts follow all of them, once — they used to be the whole line, with the notice a
+  // suffix (`..., 1 row(s) skipped.`) in exactly the position an operator skims past.
+  //
+  // Unread rows lead, because they are the one thing here we know least about: a
+  // restatement was read perfectly and we can state its figures, an unread row we cannot.
+  const notices: string[] = [];
+
+  if (unweighed.length > 0) {
+    notices.push(
+      `INCOMPLETE — ${unweighed.length} row(s) of ${csvPath} could not be read, so that ` +
+        `many rung(s) resting at the venue are NOT counted as committed and available reads ` +
+        `HIGH by whatever they encumber. Re-export and re-import to pick the missing ` +
+        `rung(s) up; the reasons are on the error channel above.`,
+    );
+  }
+
+  if (observed.length > 0) {
+    // BOTH FIGURES AND NO REMAINDERS. The remainders were printed while the rung was
+    // SKIPPED, because they were the safety argument an operator was owed a way to
+    // check; the line is written now, so the file's remainder IS the venue's and the
+    // pair would print the same number twice.
+    const detail = observed
+      .map((claim) => `${claim.id} (filled ${claim.known} → ${claim.observed})`)
+      .join("; ");
+    notices.push(
+      `OBSERVED — ${observed.length} rung(s) of ${csvPath} have filled FURTHER at the ` +
+        `venue since this file last observed them — ${detail} — and the restatement was ` +
+        `RECORDED. Their remainders now read what the venue shows. This is NOT a ` +
+        `qualification: the work is done, and the line does not reprint on the next ` +
+        `import unless the venue moves again.`,
+    );
+  }
+
+  const message = [...notices, `Imported ${csvPath}: ${counts}.`].join("\n") + `\n`;
+
+  // A ROW NOBODY COULD READ IS THE ONLY THING LEFT THAT QUALIFIES AN IMPORT (#181). A
+  // restatement qualified while it was deferred; it is recorded here, so it does not.
+  return {
+    outcome:
+      unweighed.length === 0
+        ? { status: "imported", ...write }
+        : { status: "imported-partial", ...write },
+    message,
+  };
+}

--- a/apps/tui/src/import-orders.test.ts
+++ b/apps/tui/src/import-orders.test.ts
@@ -14,6 +14,7 @@ import { dirname, join, resolve } from "node:path";
 import { appendOrders, loadOrders, resolveOrdersPath } from "@numisma/preferences";
 import {
   BITGET_OPEN_ORDERS_HEADER,
+  buildOrderFillObserved,
   parseBitgetOpenOrdersCsv,
   parseFundReview,
   pickRestingOrdersAsOf,
@@ -632,13 +633,14 @@ describe("a restated partial is skipped per rung (#199)", () => {
     expect(await readFile(first.ordersPath, "utf8")).toBe(before);
   });
 
-  it("REFUSES a partial that moved DOWN — the direction is what makes the skip safe", async () => {
+  it("REFUSES a partial that moved DOWN — its OWN refusal since #181", async () => {
     const first = await harness({ csv: ladder(PARTLY_FILLED) });
     await importBitgetOpenOrders({ csvPath: first.csvPath, io: first.io });
     const before = await readFile(first.ordersPath, "utf8");
 
-    // A fill does not un-fill. Whatever this is, the file would be left UNDER-stating
-    // the encumbrance — the permissive direction — so it gets #174's total refusal.
+    // A fill does not un-fill, so this is a contradiction rather than the ordinary life
+    // of a rung — and since #181 it is refused under its OWN token, because the remedy
+    // `changed-claim` prints is wrong for it. See the split's own describe below.
     await writeFile(
       first.csvPath,
       ladder(partlyFilledRung("100", "10", "4", "2020-01-01 10:00:00")),
@@ -646,7 +648,7 @@ describe("a restated partial is skipped per rung (#199)", () => {
     );
     const outcome = await importBitgetOpenOrders({ csvPath: first.csvPath, io: first.io });
 
-    expect(outcome).toMatchObject({ status: "rejected", reason: "changed-claim" });
+    expect(outcome).toMatchObject({ status: "rejected", reason: "backwards-claim" });
     expect(await readFile(first.ordersPath, "utf8")).toBe(before);
 
     // THE MESSAGE, not just the reason. `quantity` is IDENTICAL here (10 both times),
@@ -655,7 +657,7 @@ describe("a restated partial is skipped per rung (#199)", () => {
     // survived a release. The operator is owed the disagreement that actually refused.
     if (outcome.status !== "rejected") throw new Error("expected a refusal");
     expect(outcome.message).not.toContain("different SIZE");
-    expect(outcome.message).toContain("observedFilledQuantity 6 → 4");
+    expect(outcome.message).toContain("filled 6 → 4");
   });
 
   it("REFUSES a restatement the file's OWN fill lines have already overtaken", async () => {
@@ -756,6 +758,222 @@ describe("a restated partial is skipped per rung (#199)", () => {
     expect(line).not.toContain("available reads LOW");
     expect(line).toContain("committed never reads LOW and available never reads HIGH");
     expect(line).toContain("the file still claims 2, the venue holds 2");
+  });
+});
+
+/**
+ * #181 slice #208 — detection re-based on the LATEST OBSERVATION, and the refusal split.
+ *
+ * END TO END, THROUGH THE IMPORT, and that is the point of putting these here rather than
+ * only at `detectChangedClaims`. The claim is not "the comparison returns an empty array";
+ * it is that the import ADMITS the rung, WRITES NOTHING, and COUNTS IT AS ALREADY KNOWN —
+ * three facts about three different layers, and idempotency is the conjunction of them.
+ * The unit-level basis, tie-break and epsilon cases are in the engine's
+ * `detection-basis.test.ts`.
+ *
+ * THE OBSERVATION LINES ARE HAND-APPENDED, deliberately. Slice #208 changes what is
+ * DETECTED and what is REFUSED, not what is written — the import does not construct an
+ * observation until slice #210 — so a test that waited for the writer would be testing
+ * nothing until then. `appendOrders` over a line built by `buildOrderFillObserved` is the
+ * same file the writer will produce, and the constructor is what makes that claim true
+ * rather than hopeful.
+ */
+describe("detection is re-based on the latest observation (#181)", () => {
+  const PARTLY_FILLED = partlyFilledRung("100", "10", "6", "2020-01-01 10:00:00");
+
+  /** The observation line for the rung on disk, built through the total constructor. */
+  async function recordObservation(
+    ordersPath: string,
+    id: string,
+    observedAt: string,
+    observedFilledQuantity: number,
+  ): Promise<void> {
+    const built = buildOrderFillObserved({
+      id,
+      observedAt,
+      currency: "USD",
+      observedFilledQuantity,
+    });
+    if (built.status !== "ok") throw new Error(`fixture must build: ${built.message}`);
+    await appendOrders(ordersPath, [built.record]);
+  }
+
+  /** The file after one import of `PARTLY_FILLED` plus one recorded restatement to 8. */
+  async function fileWithRecordedRestatement(): Promise<{
+    harness: Harness;
+    id: string;
+    before: string;
+  }> {
+    const first = await harness({
+      csv: ladder(PARTLY_FILLED),
+      reserves: [{ id: "reserve-a", amount: 5000 }],
+    });
+    await importBitgetOpenOrders({ csvPath: first.csvPath, io: first.io });
+    const [id] = await idsOnDisk(first.ordersPath);
+    if (id === undefined) throw new Error("expected the rung on disk");
+    await recordObservation(first.ordersPath, id, "2020-01-02T09:00:00", 8);
+    return { harness: first, id, before: await readFile(first.ordersPath, "utf8") };
+  }
+
+  it("re-imports an export whose restatement is ALREADY RECORDED with no difference", async () => {
+    // THE CASE THE PLACEMENT-LINE BASIS GOT WRONG FOREVER. Against the placement line's 6
+    // this export reads as a fresh restatement on every import for the life of the rung —
+    // the rung is skipped, the RESTATED line reprints, and the operator is told about work
+    // that was done days ago. Against the latest observation it reads as nothing new.
+    const { harness: first, before } = await fileWithRecordedRestatement();
+    await writeFile(
+      first.csvPath,
+      ladder(partlyFilledRung("100", "10", "8", "2020-01-01 10:00:00")),
+      "utf8",
+    );
+
+    const outcome = await importBitgetOpenOrders({ csvPath: first.csvPath, io: first.io });
+
+    // ADMITTED, not skipped: the unqualified status, and an EMPTY `restated`.
+    expect(outcome).toMatchObject({
+      status: "imported",
+      appended: 0,
+      alreadyKnown: 1,
+      restated: [],
+    });
+    // WROTE NOTHING — byte-identical, not merely "no new orders".
+    expect(await readFile(first.ordersPath, "utf8")).toBe(before);
+    // And the operator is told nothing about a restatement, because there was not one.
+    expect(first.outputs.join("\n")).not.toContain("RESTATED");
+  });
+
+  it("still SKIPS when the venue has moved PAST the recorded restatement", async () => {
+    // The re-base must not blind the detector: 9 against a recorded 8 is a NEW
+    // restatement and gets #199's per-rung skip, on the new basis rather than the old.
+    const { harness: first, before } = await fileWithRecordedRestatement();
+    await writeFile(
+      first.csvPath,
+      ladder(partlyFilledRung("100", "10", "9", "2020-01-01 10:00:00")),
+      "utf8",
+    );
+
+    const outcome = await importBitgetOpenOrders({ csvPath: first.csvPath, io: first.io });
+
+    expect(outcome).toMatchObject({ status: "imported-partial" });
+    if (outcome.status !== "imported-partial") throw new Error("expected a partial import");
+    // `known` is the LATEST OBSERVATION — 8, not the placement line's 6.
+    expect(outcome.restated).toMatchObject([{ known: 8, observed: 9 }]);
+    expect(await readFile(first.ordersPath, "utf8")).toBe(before);
+  });
+
+  it("REFUSES an export BELOW the latest observation, and names the export not the rung", async () => {
+    // THE DISCRIMINATING CASE for the whole split. 7 is ABOVE the placement line's 6 and
+    // BELOW the recorded 8, so the old basis read it as a restatement that moved UP and
+    // refused it — correctly — with advice to CANCEL THE RUNG AT THE VENUE. That advice
+    // destroys a live rung in response to someone selecting yesterday's CSV.
+    const { harness: first, before } = await fileWithRecordedRestatement();
+    await writeFile(
+      first.csvPath,
+      ladder(partlyFilledRung("100", "10", "7", "2020-01-01 10:00:00")),
+      "utf8",
+    );
+
+    const outcome = await importBitgetOpenOrders({ csvPath: first.csvPath, io: first.io });
+
+    expect(outcome).toMatchObject({ status: "rejected", reason: "backwards-claim" });
+    expect(await readFile(first.ordersPath, "utf8")).toBe(before);
+    if (outcome.status !== "rejected") throw new Error("expected a refusal");
+
+    // THE WORDING IS THE DELIVERABLE. It names a stale or mistaken export and the remedy
+    // is to export again.
+    expect(outcome.message).toContain("LESS filled");
+    expect(outcome.message).toContain("filled 8 → 7");
+    expect(outcome.message).toContain("Re-export");
+    // AND IT MUST NOT SEND ANYONE TO THE VENUE. This is the assertion the slice exists
+    // for: a refusal over a wrong CSV that tells the operator to cancel or re-place costs
+    // a live rung, which is worse than the mistake it is reporting.
+    expect(outcome.message).not.toContain("Cancel the rung");
+    expect(outcome.message).not.toContain("re-place");
+  });
+
+  it("keeps TODAY'S refusal for a figure at or above the observation but below consumed", async () => {
+    // The other side of the partition — `latest observation <= export < consumed`, the
+    // fund having BOOKED past what the venue shows. Same file, same rung, one `orderFilled`
+    // line: observation 8, booked 2 more, so `consumed` is 10 and the rung is retired. The
+    // export's 9 is ABOVE the observation, so it is not backwards; it is #174's hazard,
+    // and it keeps #174's wording and #174's exit.
+    //
+    // AT the observation — the interval's closed end — there is no DIFFERENCE for the
+    // partition to classify at all, and that is unchanged by this slice rather than a hole
+    // it opens: an export agreeing with what the file last observed has always been a
+    // re-sighting, whatever the fund booked afterwards.
+    const { harness: first, id, before: withObservation } = await fileWithRecordedRestatement();
+    await appendOrders(first.ordersPath, [
+      {
+        id,
+        observedAt: "2020-01-03T09:00:00",
+        kind: "orderFilled",
+        currency: "USD",
+        filledQuantity: 2,
+      },
+    ]);
+    expect(withObservation).not.toBe(await readFile(first.ordersPath, "utf8"));
+    expect(await remainingOnDisk(first.ordersPath)).toEqual([]);
+    const before = await readFile(first.ordersPath, "utf8");
+
+    await writeFile(
+      first.csvPath,
+      ladder(partlyFilledRung("100", "10", "9", "2020-01-01 10:00:00")),
+      "utf8",
+    );
+    const outcome = await importBitgetOpenOrders({ csvPath: first.csvPath, io: first.io });
+
+    expect(outcome).toMatchObject({ status: "rejected", reason: "changed-claim" });
+    expect(await readFile(first.ordersPath, "utf8")).toBe(before);
+    if (outcome.status !== "rejected") throw new Error("expected a refusal");
+    // TODAY'S WORDING, UNCHANGED — including the remedy, which is the right one here.
+    expect(outcome.message).toContain("the file would claim 0 where the venue still holds 1");
+    expect(outcome.message).toContain("Cancel the rung at the venue");
+  });
+
+  it("REFUSES THE WHOLE BATCH on a `quantity` difference, whatever the partial does", async () => {
+    // Unchanged by the split, and asserted against a file that carries an observation so
+    // the re-base cannot quietly demote it: `quantity` 10 → 12 with the partial EQUAL to
+    // the recorded observation, and the batch still goes as `changed-claim`.
+    const { harness: first, before } = await fileWithRecordedRestatement();
+    await writeFile(
+      first.csvPath,
+      ladder(partlyFilledRung("100", "12", "8", "2020-01-01 10:00:00")),
+      "utf8",
+    );
+    const outcome = await importBitgetOpenOrders({ csvPath: first.csvPath, io: first.io });
+
+    expect(outcome).toMatchObject({ status: "rejected", reason: "changed-claim" });
+    expect(await readFile(first.ordersPath, "utf8")).toBe(before);
+    if (outcome.status !== "rejected") throw new Error("expected a refusal");
+    expect(outcome.message).toContain("quantity 10 → 12");
+  });
+
+  it("writes NOTHING for a filled difference below the epsilon", async () => {
+    // Float noise is not an observation. Under an exact comparison this reports a
+    // difference, and once a difference means a permanent line on an append-only file
+    // that is a file that grows on an import which observed nothing real.
+    const first = await harness({
+      csv: ladder(PARTLY_FILLED),
+      reserves: [{ id: "reserve-a", amount: 5000 }],
+    });
+    await importBitgetOpenOrders({ csvPath: first.csvPath, io: first.io });
+    const before = await readFile(first.ordersPath, "utf8");
+
+    await writeFile(
+      first.csvPath,
+      ladder(partlyFilledRung("100", "10", "6.0000000001", "2020-01-01 10:00:00")),
+      "utf8",
+    );
+    const outcome = await importBitgetOpenOrders({ csvPath: first.csvPath, io: first.io });
+
+    expect(outcome).toMatchObject({
+      status: "imported",
+      appended: 0,
+      alreadyKnown: 1,
+      restated: [],
+    });
+    expect(await readFile(first.ordersPath, "utf8")).toBe(before);
   });
 });
 

--- a/apps/tui/src/import-orders.test.ts
+++ b/apps/tui/src/import-orders.test.ts
@@ -128,6 +128,20 @@ interface Harness {
   io: OrdersImportIo;
   csvPath: string;
   ordersPath: string;
+  /**
+   * MOVE THE FROZEN CLOCK (#181) — the seam `OrdersImportIo.now` exists for, and until
+   * this slice nothing in the suite had ever touched it.
+   *
+   * That is not a tidiness point. Every import in the suite shared one wall-clock instant
+   * whose SECOND nobody controlled, so the suite ran permanently inside the precondition
+   * of the same-second bug and could never distinguish "two observations, one stamp,
+   * both kept" from "two observations, one stamp, one silently dropped". Holding the
+   * stamp still is what makes that distinguishable.
+   *
+   * Takes the stamp shape the file itself uses, LOCAL and second-granular, so a test
+   * reads the same string it will find on disk.
+   */
+  setClock: (stamp: string) => void;
   asked: string[];
   errors: string[];
   /** Everything the flow told the OPERATOR on the normal channel — merges included. */
@@ -201,6 +215,9 @@ async function harness(options: HarnessOptions = {}): Promise<Harness> {
   const outputs: string[] = [];
   const script = options.answers ?? ["reserve-a", "n"];
   let answers = [...script];
+  // FROZEN by default and movable by the test. A default of "now" would leave every
+  // stamped line depending on the second the suite happened to run in.
+  let clock = new Date("2026-06-01T09:00:00");
 
   return {
     csvPath,
@@ -208,8 +225,12 @@ async function harness(options: HarnessOptions = {}): Promise<Harness> {
     asked,
     errors,
     outputs,
+    setClock: (stamp) => {
+      clock = new Date(stamp);
+    },
     io: {
       readExport: (path) => readFile(path, "utf8"),
+      now: () => clock,
       ordersPath,
       loadOrders: (path) => loadOrders(path, { warn: () => {} }),
       appendOrders,
@@ -383,30 +404,42 @@ describe("one id identifies exactly ONE claim (#174)", () => {
 });
 
 /**
- * #199 — a rung the venue filled FURTHER costs ITS OWN rung, not the whole batch.
+ * #199 → #181 — a rung the venue filled FURTHER is RECORDED, not skipped.
  *
  * The id is synthesized from the submission stamp, so a rung that fills between two
- * exports returns under the same id with a larger `filled_quantity`. Refusing the batch
- * over it blocked every unrelated new rung in every later export from that venue,
- * indefinitely, with no local remedy: nothing is written on a refusal, so recording the
- * fill repaired `committed`/`available` and left the placement line — and therefore the
- * refusal — exactly where it was. The only exits were at the venue.
+ * exports returns under the same id with a larger `filled_quantity`. #174 refused the
+ * whole batch over it, which blocked every unrelated new rung in every later export from
+ * that venue, indefinitely and with no local remedy. #199 narrowed that to a per-rung
+ * SKIP, which unblocked the batch and left the file permanently stale. #181 writes the
+ * figure down: an `orderFillObserved` line the selector folds as a new `consumed`
+ * baseline, so the file's remainder becomes the venue's.
  *
- * The split is safe for THIS FIELD AND NO OTHER, and the direction is the whole argument.
- * A stale partial makes the file believe more is still resting than is, so the guard
- * reads the encumbrance HIGH — it can refuse a fundable batch and can never admit an
- * unfundable one. A stale `quantity` points the other way and stays a total refusal.
+ * THE COUNTING VOCABULARY SPLITS HERE, and it is why these assertions changed rather than
+ * being ported. `appended` and `alreadyKnown` used to be derived by DIFFERENT rules from
+ * the same list — one counting lines, the other contorted to count orders — so the moment
+ * an import could write a second kind of line, a pure-observation import reported
+ * `1 order(s) appended` about ZERO orders. `appended` now counts ORDERS and observations
+ * are counted separately, so every assertion that pinned the old reading is restated
+ * below with its reason beside it rather than quietly edited.
  */
-describe("a restated partial is skipped per rung (#199)", () => {
+describe("a restated partial is recorded as an observation (#181)", () => {
   /** The rung of the traced case: 10 units at 100, the venue showing 6 already filled. */
   const PARTLY_FILLED = partlyFilledRung("100", "10", "6", "2020-01-01 10:00:00");
 
-  it("SKIPS the restated rung and imports every other rung in the export", async () => {
+  /** The file after one import of `PARTLY_FILLED`, with the rung's id in hand. */
+  async function fileWithRestingRung(): Promise<{ first: Harness; restedId: string }> {
     const first = await harness({
       csv: ladder(PARTLY_FILLED),
       reserves: [{ id: "reserve-a", amount: 5000 }],
     });
     await importBitgetOpenOrders({ csvPath: first.csvPath, io: first.io });
+    const [restedId] = await idsOnDisk(first.ordersPath);
+    if (restedId === undefined) throw new Error("expected the rung on disk");
+    return { first, restedId };
+  }
+
+  it("RECORDS the restatement and imports every other rung in the export", async () => {
+    const { first } = await fileWithRestingRung();
 
     // The same rung filled further at the venue, PLUS an unrelated new rung — which is
     // the whole point: that new rung used to be blocked with no local way to clear it.
@@ -421,18 +454,22 @@ describe("a restated partial is skipped per rung (#199)", () => {
     const outcome = await importBitgetOpenOrders({ csvPath: first.csvPath, io: first.io });
 
     expect(outcome).not.toMatchObject({ status: "rejected" });
-    // The new rung landed. The restated one is NOT `alreadyKnown` — it is not a
-    // re-sighting, and calling it one is the silence #174 named.
+    // WAS `appended: 1, alreadyKnown: 0` AND STILL IS — but for a reason worth restating,
+    // because the batch now writes TWO lines and the number did not move. `appended`
+    // counts ORDERS: the new rung is one claim on capital, and the observation is none.
+    // The restated rung is not `alreadyKnown` either — it is not a re-sighting.
     expect(outcome).toMatchObject({ appended: 1, alreadyKnown: 0 });
-    expect(await idsOnDisk(first.ordersPath)).toHaveLength(2);
+    if (outcome.status === "rejected") throw new Error("expected a successful import");
+    expect(outcome.observations).toHaveLength(1);
+    // THREE LINES on disk for TWO rungs: the observation shares its rung's id, which is
+    // exactly why the append key carries `kind` as well.
+    expect(await idsOnDisk(first.ordersPath)).toHaveLength(3);
+    // And the file now claims what the venue holds: 2 on the restated rung, 1 on the new.
+    expect(await remainingOnDisk(first.ordersPath)).toEqual([2, 1]);
   });
 
-  it("QUALIFIES the status rather than reporting an unqualified success", async () => {
-    const first = await harness({
-      csv: ladder(PARTLY_FILLED),
-      reserves: [{ id: "reserve-a", amount: 5000 }],
-    });
-    await importBitgetOpenOrders({ csvPath: first.csvPath, io: first.io });
+  it("does NOT qualify the status — the work is done, not deferred", async () => {
+    const { first, restedId } = await fileWithRestingRung();
 
     await writeFile(
       first.csvPath,
@@ -444,34 +481,24 @@ describe("a restated partial is skipped per rung (#199)", () => {
     );
     const outcome = await importBitgetOpenOrders({ csvPath: first.csvPath, io: first.io });
 
-    // `imported` now means every row read AND nothing restated — a strengthened
-    // invariant, so the status keeps meaning what a reader who opens no second field
-    // assumes it means.
-    expect(outcome).not.toMatchObject({ status: "imported" });
-    expect(outcome).toMatchObject({ status: "imported-partial", appended: 1 });
-    if (outcome.status !== "imported-partial") throw new Error("expected a partial import");
-    expect(outcome.restated).toEqual([
-      // Both remainders ride along, and here they are the strictly-over case: the file
-      // still claims the 4 its placement line implies, the venue holds 2.
-      {
-        id: expect.stringContaining(":100:"),
-        known: 6,
-        observed: 8,
-        remainingOnFile: 4,
-        remainingAtVenue: 2,
-      },
-    ]);
+    // THE INVERSION OF #199's ASSERTION, and the reason is the whole slice. #199 asserted
+    // `not imported` / `imported-partial`, because a restatement was a DEFERRAL: a rung
+    // read perfectly and then not written down, which a status calling itself unqualified
+    // would be hiding. The line is written now, so it defers nothing and the union widens
+    // back. That is a gap closing, not precision lost.
+    expect(outcome).toMatchObject({ status: "imported", appended: 1 });
+    if (outcome.status !== "imported") throw new Error("expected an unqualified import");
+    // NO REMAINDERS ON THE ENTRY. #199 carried both because they were the safety argument
+    // for a SKIP; the line lands now, so the file's remainder IS the venue's and the pair
+    // would print one number twice.
+    expect(outcome.observations).toEqual([{ id: restedId, known: 6, observed: 8 }]);
     // NOT absorbed into `skips`: `leavesRungUnweighed` is a predicate over PARSER
-    // problems, and this rung was read perfectly — it is weighed, and weighed HIGH.
+    // problems, and this rung was read perfectly.
     expect(outcome.skips).toHaveLength(0);
   });
 
-  it("LEADS its own line with the restatement and names the OPPOSITE money direction", async () => {
-    const first = await harness({
-      csv: ladder(PARTLY_FILLED),
-      reserves: [{ id: "reserve-a", amount: 5000 }],
-    });
-    await importBitgetOpenOrders({ csvPath: first.csvPath, io: first.io });
+  it("LEADS its own line with what was OBSERVED and what was recorded", async () => {
+    const { first } = await fileWithRestingRung();
 
     await writeFile(
       first.csvPath,
@@ -483,30 +510,31 @@ describe("a restated partial is skipped per rung (#199)", () => {
     );
     await importBitgetOpenOrders({ csvPath: first.csvPath, io: first.io });
 
-    const line = first.outputs.find((message) => message.includes("RESTATED"));
+    const line = first.outputs.find((message) => message.includes("OBSERVED"));
     expect(line).toBeDefined();
-    // The qualification OPENS the line, and the counts follow it.
-    expect(line?.startsWith("RESTATED")).toBe(true);
-    expect(line).toContain("1 order(s) appended");
-    // Its own direction, which is the REVERSE of an unread row's. Stated as a FLOOR
-    // rather than an inequality: the skip class now admits the EXACT case (the file's
-    // own fill lines having caught the venue up), where `committed` is neither high nor
-    // low, so the only claim true of every entry is that it is never understated.
-    expect(line).toContain("committed never reads LOW and available never reads HIGH");
-    expect(line).not.toContain("available reads HIGH");
-    // Both figures, and the honest consequence: this recurs until the venue resolves it.
+    // The notice OPENS the line, and the counts follow it.
+    expect(line?.startsWith("OBSERVED")).toBe(true);
     expect(line).toContain("filled 6 → 8");
-    expect(line).toContain("REPRINTS");
+    expect(line).toContain("RECORDED");
+    // WAS `expect(line).toContain("REPRINTS")`. #199's line had to promise it would come
+    // back on every import until the venue resolved the rung, because nothing was written
+    // and the condition survived the import. It is written now, so the promise is false
+    // and its absence is the assertion.
+    expect(line).not.toContain("REPRINTS");
+    // And it no longer describes a stale file, because the file is not stale.
+    expect(line).not.toContain("committed never reads LOW");
+    // WAS `1 order(s) appended` FOR A BATCH THAT WROTE ONE ORDER AND ONE OBSERVATION —
+    // true here by luck rather than by rule, since one of each happens to make the old
+    // line-count and the new order-count agree. Both figures are asserted now, so the
+    // rule is pinned rather than the coincidence.
+    expect(line).toContain("1 order(s) appended");
+    expect(line).toContain("1 observation(s) recorded");
   });
 
-  it("reports BOTH lines when one export is qualified both ways at once", async () => {
-    // The case that killed the third-status option: a sum type can say only ONE of
-    // these, so one qualification would drop silently. Two fields say both.
-    const first = await harness({
-      csv: ladder(PARTLY_FILLED),
-      reserves: [{ id: "reserve-a", amount: 5000 }],
-    });
-    await importBitgetOpenOrders({ csvPath: first.csvPath, io: first.io });
+  it("reports BOTH notices when one export carries an unread row too", async () => {
+    // A row nobody could read is now the ONLY thing that qualifies an import, so this is
+    // the case where a notice and a qualification appear together and must not merge.
+    const { first } = await fileWithRestingRung();
 
     await writeFile(
       first.csvPath,
@@ -522,34 +550,43 @@ describe("a restated partial is skipped per rung (#199)", () => {
     expect(outcome).toMatchObject({ status: "imported-partial", appended: 1 });
     if (outcome.status !== "imported-partial") throw new Error("expected a partial import");
     expect(outcome.skips).toHaveLength(1);
-    expect(outcome.restated).toHaveLength(1);
+    expect(outcome.observations).toHaveLength(1);
 
     const message = first.outputs.find((line) => line.includes("could not be read"));
     expect(message).toBeDefined();
-    // BOTH qualifications, each on its own line, each naming its own direction — and the
-    // unread row leads, being the one we can say least about.
+    // The unread row leads, being the one thing here we can say least about.
     expect(message?.startsWith("INCOMPLETE")).toBe(true);
-    expect(message).toContain("\nRESTATED");
+    expect(message).toContain("\nOBSERVED");
     expect(message).toContain("available reads HIGH");
-    expect(message).toContain("committed never reads LOW and available never reads HIGH");
-    // The counts follow both, once.
+    // WAS `1 order(s) appended` ALONE. Same rewrite as the line above, same reason: the
+    // batch wrote one order and one observation, and the report must say both.
     expect(message).toContain("1 order(s) appended");
+    expect(message).toContain("1 observation(s) recorded");
   });
 
-  it("keeps `restated` EMPTY on the unqualified status", async () => {
-    const { csvPath, io } = await harness();
+  it("renders the observation clause AT ZERO on an import that observed nothing", async () => {
+    const { csvPath, io, outputs } = await harness();
     const outcome = await importBitgetOpenOrders({ csvPath, io });
     expect(outcome).toMatchObject({ status: "imported", appended: 2 });
     if (outcome.status !== "imported") throw new Error("expected a clean import");
-    expect(outcome.restated).toEqual([]);
+    expect(outcome.observations).toEqual([]);
+    // ALWAYS, INCLUDING AT ZERO. A clause that appears only when it is non-zero is two
+    // shapes for a reader to learn and one more place for the two exits to diverge — and
+    // the zero is informative in its own right: this import created claims and observed
+    // nothing.
+    const line = outputs.find((message) => message.startsWith("Imported"));
+    expect(line).toContain("0 observation(s) recorded");
   });
 
-  it("leaves the restated rung's line on file at the OLDER, more conservative partial", async () => {
-    const first = await harness({
-      csv: ladder(PARTLY_FILLED),
-      reserves: [{ id: "reserve-a", amount: 5000 }],
-    });
-    await importBitgetOpenOrders({ csvPath: first.csvPath, io: first.io });
+  it("leaves the PLACEMENT line at the older partial and corrects the remainder on a second line", async () => {
+    // THE ASSERTION THAT HALF-SURVIVED #199, kept rather than deleted because its premise
+    // is still true and its MEANING has inverted. The placement line genuinely does still
+    // read the older partial — `orders.jsonl` is append-only and nothing rewrites it — and
+    // under #199 that was the whole story: the file stayed stale, deliberately, on the
+    // conservative side. It is now the FIRST of two observations, and the second one
+    // carries the correction, so the same durable line proves the opposite thing: the
+    // repair rides on a new line rather than on an edit.
+    const { first } = await fileWithRestingRung();
 
     await writeFile(
       first.csvPath,
@@ -558,30 +595,36 @@ describe("a restated partial is skipped per rung (#199)", () => {
     );
     await importBitgetOpenOrders({ csvPath: first.csvPath, io: first.io });
 
-    // `orders.jsonl` is append-only and a second placement line is ignored by the
-    // selector, so the skip cannot repair the figure — and must not pretend to. The rung
-    // still claims 4 (10 less the partial of 6 on file), NOT the 2 the venue now shows.
-    const remaining = await remainingOnDisk(first.ordersPath);
-    expect(remaining).toEqual([4]);
-    expect(remaining).not.toContain(2);
-    // No second placement line was appended for it, and no fill was synthesized.
     const load = await loadOrders(first.ordersPath, { warn: () => {} });
     if (load.status !== "loaded") throw new Error("expected a loaded sidecar");
-    expect(load.records).toHaveLength(1);
+    // TWO lines: the untouched placement and the observation that supersedes its figure.
+    expect(load.records).toHaveLength(2);
+    const placed = load.records.filter((record) => record.kind === "orderPlaced");
+    expect(placed).toHaveLength(1);
+    // STILL 6 — the older partial, exactly as #199 asserted, and for the same reason.
+    expect(placed[0]).toMatchObject({ observedFilledQuantity: 6 });
+    // WAS `expect(remaining).toEqual([4])` — the file claiming 4 while the venue held 2,
+    // which was #199's conservative staleness and is the figure that has moved. The fold
+    // takes the LATEST observation as the `consumed` baseline, so the remainder is now the
+    // venue's own 2 and the 4 it used to read is what this slice removed.
+    expect(await remainingOnDisk(first.ordersPath)).toEqual([2]);
+    // And no fill was synthesized: an `orderFilled` line is half of a fill act and would
+    // brick the fill flow. The second line is an observation.
+    expect(load.records.some((record) => record.kind === "orderFilled")).toBe(false);
   });
 
-  it("reports the qualification without prompting when EVERY rung is restated", async () => {
-    // The empty-batch path (#200 review). A one-rung export that filled further leaves
-    // NOTHING admitted, and the flow used to carry straight on: two prompts for the
-    // funding reserve of a batch of zero orders, a coverage guard over a book this
-    // import does not change, an append of nothing.
-    const first = await harness({
-      csv: ladder(PARTLY_FILLED),
-      reserves: [{ id: "reserve-a", amount: 5000 }],
-    });
-    await importBitgetOpenOrders({ csvPath: first.csvPath, io: first.io });
+  it("writes the observation WITHOUT prompting or guarding when EVERY rung is restated", async () => {
+    // WAS `reports the qualification without prompting`, and the qualification is what
+    // changed: this import writes N lines and reports an unqualified success. #199's
+    // version asserted the file was byte-identical afterwards, which is now the one thing
+    // it must not be.
+    const { first } = await fileWithRestingRung();
     const before = await readFile(first.ordersPath, "utf8");
     const askedByTheFirstImport = first.asked.length;
+    // A reserve that could not fund the book already on file. If the guard ran on this
+    // path it would refuse `over-committed` — over a PRE-EXISTING condition this import
+    // does not create and, no declaration having been prompted for, could not fix.
+    first.io.fundReview = async () => syntheticFund([{ id: "reserve-a", amount: 1 }]);
 
     await writeFile(
       first.csvPath,
@@ -590,38 +633,112 @@ describe("a restated partial is skipped per rung (#199)", () => {
     );
     const outcome = await importBitgetOpenOrders({ csvPath: first.csvPath, io: first.io });
 
-    // Still a qualified success, and still NOT the unqualified one: `restated` is
-    // non-empty by construction on this path, since an export with no readable rows at
-    // all was already refused as `no-orders` further up.
-    expect(outcome).not.toMatchObject({ status: "imported" });
-    expect(outcome).toMatchObject({ status: "imported-partial", appended: 0, alreadyKnown: 0 });
-    if (outcome.status !== "imported-partial") throw new Error("expected a partial import");
-    expect(outcome.restated).toHaveLength(1);
-    expect(await readFile(first.ordersPath, "utf8")).toBe(before);
-    // The operator still gets the whole qualification — the short-circuit skips the
-    // prompt and the guard, never the reporting.
-    const line = first.outputs.find((message) => message.includes("RESTATED"));
+    // Not refused, and not qualified: the guard was skipped and the work was done.
+    expect(outcome).toMatchObject({ status: "imported", appended: 0, alreadyKnown: 0 });
+    if (outcome.status !== "imported") throw new Error("expected an unqualified import");
+    expect(outcome.observations).toHaveLength(1);
+    // THE FILE GREW. #199 asserted byte-equality here; the whole slice is that it no
+    // longer holds.
+    expect(await readFile(first.ordersPath, "utf8")).not.toBe(before);
+    expect(await remainingOnDisk(first.ordersPath)).toEqual([2]);
+
+    // ZERO ORDERS AND ONE OBSERVATION, in one line. This is the pair the old vocabulary
+    // could not say: it reported `1 order(s) appended` about an import that created no
+    // claim on capital at all.
+    const line = first.outputs.find((message) => message.includes("OBSERVED"));
     expect(line).toBeDefined();
     expect(line).toContain("0 order(s) appended");
+    expect(line).toContain("1 observation(s) recorded");
 
-    // NOTHING WAS ASKED, and that is what makes the blank-answer refusal unreachable.
-    // "Funding reserve for this batch:" over a batch of zero orders has no honest
-    // answer, and the honest reply — a blank line — used to return
-    // `rejected`/`no-reserve-declared`: a refusal reported over an import that had
-    // nothing to refuse and nothing to fund.
+    // NOTHING WAS ASKED. "Funding reserve for this batch:" over a batch of zero orders has
+    // no honest answer, and the honest reply — a blank line — used to come back as
+    // `no-reserve-declared`: a refusal over an import with nothing to fund.
     expect(first.asked.length).toBe(askedByTheFirstImport);
   });
 
-  it("REFUSES the batch when the same claim also changed its quantity", async () => {
-    const first = await harness({
-      csv: ladder(PARTLY_FILLED),
-      reserves: [{ id: "reserve-a", amount: 5000 }],
-    });
+  it("writes the orders and the observations in ONE append call", async () => {
+    const { first } = await fileWithRestingRung();
+    let appendCalls = 0;
+    const realAppend = first.io.appendOrders;
+    first.io.appendOrders = async (path, records) => {
+      appendCalls += 1;
+      await realAppend(path, records);
+    };
+
+    await writeFile(
+      first.csvPath,
+      ladder(
+        partlyFilledRung("100", "10", "8", "2020-01-01 10:00:00"),
+        rung("90", "1", "2020-01-01 11:00:00"),
+      ),
+      "utf8",
+    );
     await importBitgetOpenOrders({ csvPath: first.csvPath, io: first.io });
+
+    // ONE lock, one temp write, one rename. The selector sorts at READ time, so there is
+    // no ordering reason to split the two kinds across two writes — and a split write is
+    // a window in which the file holds an observation whose placement never landed.
+    expect(appendCalls).toBe(1);
+    expect(await idsOnDisk(first.ordersPath)).toHaveLength(3);
+  });
+
+  it("weighs the observation in the funding guard, so it cannot refuse over freed capital", async () => {
+    const { first } = await fileWithRestingRung();
+    // The book on file encumbers 400 — the rung's stale remainder of 4 at 100. The
+    // restatement frees 200 of that, and the new rung wants 90, so the import needs 290.
+    // A 300 reserve funds the import and does NOT fund the stale reading of it.
+    first.io.fundReview = async () => syntheticFund([{ id: "reserve-a", amount: 300 }]);
+
+    await writeFile(
+      first.csvPath,
+      ladder(
+        partlyFilledRung("100", "10", "8", "2020-01-01 10:00:00"),
+        rung("90", "1", "2020-01-01 11:00:00"),
+      ),
+      "utf8",
+    );
+    const outcome = await importBitgetOpenOrders({ csvPath: first.csvPath, io: first.io });
+
+    // Excluded from the guard's view, the restated rung would still weigh 400 and the
+    // batch would be refused `over-committed` — over capital this very import is about to
+    // free. Observations only ever REDUCE a remainder, so they belong in the reading.
+    expect(outcome).toMatchObject({ status: "imported", appended: 1 });
+  });
+
+  it("marks a restated rung as ON FILE in an attribution refusal — the mark is placement ids only", async () => {
+    const { first, restedId } = await fileWithRestingRung();
+    // `reserve-a` stops being fundable, so BOTH rungs of the resting book are unmatched:
+    // the one this export just declared, and the restated one already on file.
+    first.io.fundReview = async () =>
+      syntheticFund([{ id: "reserve-a", amount: 5000, executionMode: "paper" }]);
+
+    await writeFile(
+      first.csvPath,
+      ladder(
+        partlyFilledRung("100", "10", "8", "2020-01-01 10:00:00"),
+        rung("90", "1", "2020-01-01 11:00:00"),
+      ),
+      "utf8",
+    );
+    const outcome = await importBitgetOpenOrders({ csvPath: first.csvPath, io: first.io });
+
+    expect(outcome).toMatchObject({ status: "rejected", reason: "unattributed" });
+    if (outcome.status !== "rejected") throw new Error("expected a refusal");
+    // THE MARK CARRIES PLACEMENT IDS ONLY. An observation shares its rung's id, so adding
+    // the observations to the batch set would un-mark the restated rung and invite the
+    // operator to fix it by re-declaring — but its `fundingReserveId` comes from its
+    // original placement line and `declareFunding` never touches it, so that is a loop
+    // that changes nothing.
+    expect(outcome.message).toContain(`${restedId} — on file`);
+  });
+
+  it("REFUSES the batch when the same claim also changed its quantity", async () => {
+    const { first } = await fileWithRestingRung();
     const before = await readFile(first.ordersPath, "utf8");
 
     // Both fields at once. `quantity` is not in the synthesized id, so this is the SAME
-    // claim — and carrying the safe difference does not make the dangerous one safe.
+    // claim — and carrying the safe difference does not make the dangerous one safe. The
+    // observation verb does not help: it carries no `quantity`, deliberately.
     await writeFile(
       first.csvPath,
       ladder(partlyFilledRung("100", "12", "8", "2020-01-01 10:00:00")),
@@ -662,27 +779,17 @@ describe("a restated partial is skipped per rung (#199)", () => {
 
   it("REFUSES a restatement the file's OWN fill lines have already overtaken", async () => {
     // THE PROBE for the inverted guard. The partition used to read only the placement
-    // lines, so it concluded "the file over-states, therefore skipping is safe" without
-    // ever asking what the funding guard actually weighs — which is
-    // `pickRestingOrdersAsOf`, fill lines and all.
+    // lines, so it concluded "the file over-states, therefore this is safe" without ever
+    // asking what the funding guard actually weighs — which is `pickRestingOrdersAsOf`,
+    // fill lines and all.
     //
     // The money argument, in figures: the file records placed 10 / filled 6, the
     // operator then runs the fill flow and records the remaining 4, retiring the rung.
     // The file now counts ZERO resting. The venue's next export shows filled 8 — 2 units
-    // STILL RESTING and funded by a reserve the book believes is free. Skipping this
-    // rung would make `available` read HIGH, the direction that costs money, which is
-    // precisely #174's hazard wearing #199's clothes.
-    const first = await harness({
-      csv: ladder(PARTLY_FILLED),
-      reserves: [{ id: "reserve-a", amount: 5000 }],
-    });
-    await importBitgetOpenOrders({ csvPath: first.csvPath, io: first.io });
-
-    // The id is DERIVED from what landed, never hand-written: it is synthesized from
-    // `(pair, side, price, submittedAt)` and spelling it out here would pin a test to a
-    // format the ingest owns.
-    const [restedId] = await idsOnDisk(first.ordersPath);
-    if (restedId === undefined) throw new Error("expected the rung on disk");
+    // STILL RESTING and funded by a reserve the book believes is free. RECORDING an
+    // observation here would not repair that: the fund has BOOKED units the venue does
+    // not corroborate, so the two statements contradict rather than supersede.
+    const { first, restedId } = await fileWithRestingRung();
     await appendOrders(first.ordersPath, [
       {
         id: restedId,
@@ -710,19 +817,11 @@ describe("a restated partial is skipped per rung (#199)", () => {
     expect(outcome.message).toContain("the file would claim 0 where the venue still holds 2");
   });
 
-  it("SKIPS the restatement when the recorded fill left the file EXACTLY level", async () => {
+  it("RECORDS the restatement when the recorded fill left the file EXACTLY level", async () => {
     // The other side of the same reading. Here the operator recorded the fill the venue
-    // actually took — 2 units — so the file claims 2 and the venue holds 2. Nothing is
-    // over-stated and nothing is under-stated, and the skip is still safe because the
-    // test the class is defined by is `fileRemaining >= venueRemaining`, not `>`.
-    const first = await harness({
-      csv: ladder(PARTLY_FILLED),
-      reserves: [{ id: "reserve-a", amount: 5000 }],
-    });
-    await importBitgetOpenOrders({ csvPath: first.csvPath, io: first.io });
-
-    const [restedId] = await idsOnDisk(first.ordersPath);
-    if (restedId === undefined) throw new Error("expected the rung on disk");
+    // actually took — 2 units — so the file claims 2 and the venue holds 2. The class is
+    // defined by `fileRemaining >= venueRemaining`, not `>`, and the observation lands.
+    const { first, restedId } = await fileWithRestingRung();
     await appendOrders(first.ordersPath, [
       {
         id: restedId,
@@ -741,23 +840,121 @@ describe("a restated partial is skipped per rung (#199)", () => {
     );
     const outcome = await importBitgetOpenOrders({ csvPath: first.csvPath, io: first.io });
 
-    expect(outcome).toMatchObject({ status: "imported-partial" });
-    if (outcome.status !== "imported-partial") throw new Error("expected a partial import");
-    expect(outcome.restated).toEqual([
-      { id: restedId, known: 6, observed: 8, remainingOnFile: 2, remainingAtVenue: 2 },
-    ]);
+    expect(outcome).toMatchObject({ status: "imported" });
+    if (outcome.status !== "imported") throw new Error("expected an unqualified import");
+    // WAS `{ id, known: 6, observed: 8, remainingOnFile: 2, remainingAtVenue: 2 }`, and
+    // the remainders are gone from the entry rather than merely unasserted: they existed
+    // to let an operator audit a SKIP, and this rung is not skipped.
+    expect(outcome.observations).toEqual([{ id: restedId, known: 6, observed: 8 }]);
+    // THE FOLD IS NOT MONOTONIC AND THIS IS THE CASE THAT SHOWS IT: the observation SETS
+    // `consumed` to 8, and the 2 already booked against the rung do not add to it. The
+    // remainder stays 2 — the venue's own figure — rather than dropping to 0.
+    expect(await remainingOnDisk(first.ordersPath)).toEqual([2]);
 
-    // The wording has to survive this case, which is the whole reason it changed: an
-    // EXACT rung is not over-stated, so a line claiming `committed` reads HIGH and
-    // `available` reads LOW would be flatly false about it — and that line reprints on
-    // every import by design, so a falsehood there is a falsehood the operator reads
-    // forever.
-    const line = first.outputs.find((message) => message.includes("RESTATED"));
+    // The old wording promised a stale file and both remainders; neither is true now.
+    const line = first.outputs.find((message) => message.includes("OBSERVED"));
     expect(line).toBeDefined();
-    expect(line).not.toContain("committed reads HIGH");
-    expect(line).not.toContain("available reads LOW");
-    expect(line).toContain("committed never reads LOW and available never reads HIGH");
-    expect(line).toContain("the file still claims 2, the venue holds 2");
+    expect(line).not.toContain("the file still claims 2, the venue holds 2");
+    expect(line).toContain("filled 6 → 8");
+  });
+});
+
+/**
+ * #181 slice #210 — the same-second case, and the append key it forced.
+ *
+ * ONE BATCH STAMP AT SECOND RESOLUTION plus `observedAt` in the append key means two
+ * imports inside one second key IDENTICALLY, so the second import's observation is
+ * filtered out as a repeat while the operator is told it was RECORDED and a successful
+ * status comes back. Honesty and information loss rather than money loss — and ordinary
+ * to reach: two exports back to back, or any scripted loop.
+ *
+ * THIS IS THE FIRST SECOND STAMP ANYWHERE IN THE SUITE, and that is the finding, not the
+ * fixture. `OrdersImportIo.now` was introduced correctly and no test had ever overridden
+ * it, so every import in the suite shared one uncontrolled wall-clock instant — the suite
+ * ran permanently inside the precondition of this bug and could read green over it
+ * forever. Freezing the clock is what makes the two cases distinguishable at all.
+ */
+describe("two imports inside ONE second (#181)", () => {
+  const PARTLY_FILLED = partlyFilledRung("100", "10", "6", "2020-01-01 10:00:00");
+
+  it("keeps BOTH observations when the figure MOVES inside one second", async () => {
+    const first = await harness({
+      csv: ladder(PARTLY_FILLED),
+      reserves: [{ id: "reserve-a", amount: 5000 }],
+    });
+    // ONE INSTANT for all three imports. Nothing advances it, so every observation this
+    // test writes carries a byte-identical stamp.
+    first.setClock("2026-06-01T09:00:00");
+    await importBitgetOpenOrders({ csvPath: first.csvPath, io: first.io });
+
+    await writeFile(
+      first.csvPath,
+      ladder(partlyFilledRung("100", "10", "8", "2020-01-01 10:00:00")),
+      "utf8",
+    );
+    await importBitgetOpenOrders({ csvPath: first.csvPath, io: first.io });
+
+    await writeFile(
+      first.csvPath,
+      ladder(partlyFilledRung("100", "10", "9", "2020-01-01 10:00:00")),
+      "utf8",
+    );
+    const second = await importBitgetOpenOrders({ csvPath: first.csvPath, io: first.io });
+
+    const load = await loadOrders(first.ordersPath, { warn: () => {} });
+    if (load.status !== "loaded") throw new Error("expected a loaded sidecar");
+    const observed = load.records.filter((record) => record.kind === "orderFillObserved");
+    // BOTH LINES ON DISK, in the order they were written. 8 and 9 are different facts;
+    // only a key on the FIGURE can say so, because the stamps are equal.
+    expect(observed.map((record) => record.observedFilledQuantity)).toEqual([8, 9]);
+    // AND THE STAMPS REALLY ARE EQUAL — the precondition this case is about. Asserted, so
+    // the test cannot quietly stop exercising the collision if the clock ever moves.
+    expect(new Set(observed.map((record) => record.observedAt)).size).toBe(1);
+    expect(observed.every((record) => record.observedAt === "2026-06-01T09:00:00")).toBe(true);
+
+    // The fold's sort is STABLE, so file order breaks the equal-stamp tie and replays
+    // 8 then 9 — the batch stamp's own argument working as written.
+    expect(await remainingOnDisk(first.ordersPath)).toEqual([1]);
+
+    // AND THE REPORT NAMES EXACTLY WHAT WAS WRITTEN. Under the stamp key this said
+    // `1 observation(s) recorded` about a line that had been filtered out.
+    expect(second).toMatchObject({ status: "imported", appended: 0, alreadyKnown: 0 });
+    if (second.status !== "imported") throw new Error("expected an unqualified import");
+    expect(second.observations).toEqual([
+      { id: observed[0]?.id, known: 8, observed: 9 },
+    ]);
+  });
+
+  it("reports no observation at all when the figure did NOT move", async () => {
+    // The dedupe side of the same key. Idempotency is decided one layer above the append
+    // filter — `detectChangedClaims` compares against the LATEST observation and reports
+    // no difference — so nothing is even built. What the report must not do is name a
+    // recorded observation for an import that observed nothing new.
+    const first = await harness({
+      csv: ladder(PARTLY_FILLED),
+      reserves: [{ id: "reserve-a", amount: 5000 }],
+    });
+    first.setClock("2026-06-01T09:00:00");
+    await importBitgetOpenOrders({ csvPath: first.csvPath, io: first.io });
+
+    await writeFile(
+      first.csvPath,
+      ladder(partlyFilledRung("100", "10", "8", "2020-01-01 10:00:00")),
+      "utf8",
+    );
+    await importBitgetOpenOrders({ csvPath: first.csvPath, io: first.io });
+    const before = await readFile(first.ordersPath, "utf8");
+
+    // The SAME export again, in the same second.
+    const second = await importBitgetOpenOrders({ csvPath: first.csvPath, io: first.io });
+
+    expect(second).toMatchObject({ status: "imported", appended: 0, alreadyKnown: 1 });
+    if (second.status !== "imported") throw new Error("expected an unqualified import");
+    expect(second.observations).toEqual([]);
+    // BYTE-IDENTICAL: two observations asserting the same figure are the same fact.
+    expect(await readFile(first.ordersPath, "utf8")).toBe(before);
+    const line = first.outputs.at(-1);
+    expect(line).toContain("0 observation(s) recorded");
   });
 });
 
@@ -829,12 +1026,12 @@ describe("detection is re-based on the latest observation (#181)", () => {
 
     const outcome = await importBitgetOpenOrders({ csvPath: first.csvPath, io: first.io });
 
-    // ADMITTED, not skipped: the unqualified status, and an EMPTY `restated`.
+    // ADMITTED, not restated: the unqualified status, and NO observation recorded.
     expect(outcome).toMatchObject({
       status: "imported",
       appended: 0,
       alreadyKnown: 1,
-      restated: [],
+      observations: [],
     });
     // WROTE NOTHING — byte-identical, not merely "no new orders".
     expect(await readFile(first.ordersPath, "utf8")).toBe(before);
@@ -842,9 +1039,9 @@ describe("detection is re-based on the latest observation (#181)", () => {
     expect(first.outputs.join("\n")).not.toContain("RESTATED");
   });
 
-  it("still SKIPS when the venue has moved PAST the recorded restatement", async () => {
+  it("still DETECTS when the venue has moved PAST the recorded restatement", async () => {
     // The re-base must not blind the detector: 9 against a recorded 8 is a NEW
-    // restatement and gets #199's per-rung skip, on the new basis rather than the old.
+    // restatement, on the new basis rather than the old.
     const { harness: first, before } = await fileWithRecordedRestatement();
     await writeFile(
       first.csvPath,
@@ -854,11 +1051,14 @@ describe("detection is re-based on the latest observation (#181)", () => {
 
     const outcome = await importBitgetOpenOrders({ csvPath: first.csvPath, io: first.io });
 
-    expect(outcome).toMatchObject({ status: "imported-partial" });
-    if (outcome.status !== "imported-partial") throw new Error("expected a partial import");
-    // `known` is the LATEST OBSERVATION — 8, not the placement line's 6.
-    expect(outcome.restated).toMatchObject([{ known: 8, observed: 9 }]);
-    expect(await readFile(first.ordersPath, "utf8")).toBe(before);
+    // WAS `imported-partial` with the rung SKIPPED and the file byte-identical. Slice
+    // #210 writes the line, so the status widens and the file grows — what this test
+    // still pins, and all it ever pinned, is the BASIS: 8, not the placement line's 6.
+    expect(outcome).toMatchObject({ status: "imported" });
+    if (outcome.status !== "imported") throw new Error("expected an unqualified import");
+    expect(outcome.observations).toMatchObject([{ known: 8, observed: 9 }]);
+    expect(await readFile(first.ordersPath, "utf8")).not.toBe(before);
+    expect(await remainingOnDisk(first.ordersPath)).toEqual([1]);
   });
 
   it("REFUSES an export BELOW the latest observation, and names the export not the rung", async () => {
@@ -971,7 +1171,7 @@ describe("detection is re-based on the latest observation (#181)", () => {
       status: "imported",
       appended: 0,
       alreadyKnown: 1,
-      restated: [],
+      observations: [],
     });
     expect(await readFile(first.ordersPath, "utf8")).toBe(before);
   });
@@ -1300,7 +1500,16 @@ describe("a rung that filled before the import is not a gap in the read", () => 
     if (outcome.status !== "imported") throw new Error("expected a clean import");
     expect(outputs.some((message) => message.includes("INCOMPLETE"))).toBe(false);
     expect(
-      outputs.some((message) => message.startsWith(`Imported ${csvPath}: 2 order(s) appended, 0 already known.`)),
+      // THE COUNTS LINE CARRIES THREE FIGURES NOW (#181). The observation clause renders
+      // ALWAYS, including at zero, so a clean order-only import states plainly that it
+      // observed nothing — rather than leaving the reader to infer it from a missing
+      // clause they have to know to look for.
+      outputs.some((message) =>
+        message.startsWith(
+          `Imported ${csvPath}: 2 order(s) appended, 0 already known, ` +
+            `0 observation(s) recorded.`,
+        ),
+      ),
     ).toBe(true);
     // The skip is still CARRIED and still REPORTED — only the discrimination changed.
     expect(outcome.skips).toHaveLength(1);

--- a/apps/tui/src/import-orders.ts
+++ b/apps/tui/src/import-orders.ts
@@ -74,14 +74,17 @@ export type OrdersImportRejection =
    * the file claiming LESS than the venue still holds (#174).
    *
    * NOT "a different `quantity`", which is what this said until the #200 review: that is
-   * the commonest member, not the definition, and it left the branch's own proudest case
-   * — a partial that moved DOWN, `quantity` identical — described by a sentence that is
-   * false about it. Two disagreements land here:
+   * the commonest member, not the definition. Two disagreements land here:
    *
    *   - a different `quantity`, the venue having amended the size (or the two simply
    *     disagreeing about it);
    *   - a restated partial the file's OWN fill lines have already overtaken, so what the
-   *     file still counts as resting is smaller than the remainder the venue shows.
+   *     file still counts as resting is smaller than the remainder the venue shows —
+   *     `latest observation <= export figure < consumed`.
+   *
+   * A PARTIAL THAT MOVED DOWN NO LONGER LANDS HERE (#181). It is the other half of the
+   * split — see {@link OrdersImportRejection}'s `backwards-claim` — and it left because the
+   * remedy this member prints is wrong for it, not because it stopped being a refusal.
    *
    * Refused rather than recorded, and this is the ONE place the "proceed with the
    * arithmetic" reasoning behind the within-batch merge does not extend. Recording a
@@ -104,6 +107,30 @@ export type OrdersImportRejection =
    * way the leftover staleness points, not about the change itself.
    */
   | "changed-claim"
+  /**
+   * THE EXPORT'S FILLED COLUMN WENT BACKWARDS: a row names a claim already on file and
+   * shows it LESS filled than the file's LATEST OBSERVATION of it (#181).
+   *
+   * SPLIT OUT OF `changed-claim`, and the reason is the remedy rather than the arithmetic.
+   * A fill does not un-fill, so this cannot be the venue reporting the ordinary life of a
+   * rung; the likeliest cause by far is the FILE the operator selected — yesterday's
+   * export, or the wrong one — and the second likeliest is a venue rendering fault. Both
+   * are repaired by exporting again. `changed-claim`'s remedy is to CANCEL the rung at the
+   * venue or re-place it, and printing that here told an operator to destroy a live rung
+   * over a wrong CSV: the refusal was right and the advice was worse than the mistake.
+   *
+   * DISJOINT FROM `changed-claim` BY CONSTRUCTION, not by ordering luck: `consumed` is the
+   * latest observation plus every `orderFilled` booked since, so `consumed >= latest
+   * observation` always holds and the two conditions partition the line at that figure.
+   * The argument, with the fold citation, is on `partitionChangedClaims`.
+   *
+   * STILL A TOTAL REFUSAL, and nothing is written. The direction that reaches here leaves
+   * the file claiming NO LESS than the venue holds — the conservative side — so the case
+   * for refusing is not the funding hazard `changed-claim` names. It is that the two
+   * statements cannot both be true, and this build will not record a contradiction into an
+   * append-only file to get an import past.
+   */
+  | "backwards-claim"
   /**
    * ATTRIBUTION FAILED: at least one rung of the whole resting book cannot be placed
    * against a fundable reserve. ONE rejection may name rungs of BOTH classes the engine
@@ -160,13 +187,36 @@ export type OrdersImportRejection =
  * file's remainder below the venue's and INVERT the safety claim while the partials still
  * read as "moved up". Those rungs are refused as `changed-claim`; only a rung whose
  * remainder on file is at least the venue's reaches this type. A partial moving DOWN is
- * excluded by the same test rather than by a rule of its own — the algebra is on
- * `partitionChangedClaims` — and it is a venue contradiction besides (a fill does not
- * un-fill).
+ * refused too, and since #181 by a rule of its OWN — `backwards-claim`, taken before the
+ * remainder test, because a fill does not un-fill and the remedy that case is owed is
+ * nothing like this one's. The algebra for both is on `partitionChangedClaims`.
  */
+/**
+ * A rung the export shows LESS filled than the file's latest observation of it (#181) —
+ * the refusal `backwards-claim` is raised over.
+ *
+ * TWO FIGURES AND NO REMAINDERS, unlike {@link RestatedPartial}. The remainders are what
+ * makes a per-rung skip safe, so that type carries them to let the operator check the
+ * claim; this one is refused on the two partials ALONE, because they are already a
+ * contradiction and no third figure makes them less of one. Printing a remainder here
+ * would send the operator after a disagreement this refusal does not have.
+ */
+interface BackwardsClaim {
+  id: string;
+  /** The file's latest observation — see {@link RestatedPartial.known} for the basis. */
+  known: number;
+  /** The SMALLER partial the export shows. */
+  observed: number;
+}
+
 export interface RestatedPartial {
   id: string;
-  /** The partial the placement line on file records. */
+  /**
+   * The file's LATEST OBSERVATION of this rung's partial — a later `orderFillObserved`
+   * line when one exists, else the placement line's own figure, else `0` (#181). Was "the
+   * partial the placement line records", which stopped being the same number the moment a
+   * restatement could be written down.
+   */
   known: number;
   /** The larger partial the venue's export now shows. */
   observed: number;
@@ -489,31 +539,77 @@ function isAffirmative(answer: string): boolean {
  *
  * THE SKIP CLASS IS DECIDED BY THE REMAINDER THE GUARD ACTUALLY WEIGHS, which is why
  * `resting` is a parameter rather than something this could work out from `changed`
- * (#200 review). `detectChangedClaims` is fed only the `orderPlaced` lines, so reasoning
- * from its two figures answers a question nobody downstream asks: `pickRestingOrdersAsOf`
- * replays `orderFilled` and `orderCancelled` too, and a fill already recorded against the
- * rung can shrink the file's remainder BELOW the venue's while the partials still read as
- * "moved up". The traced case: file holds placed 10 / filled 6, the operator runs the
- * fill flow and accepts the default remainder of 4, retiring the rung — the file now
- * counts ZERO resting — and the venue's next export shows filled 8, i.e. 2 units still
- * resting. Skipping that would make `available` read HIGH, which is #174's own hazard.
+ * (#200 review). A difference is a statement about the venue's column; the guard weighs
+ * `pickRestingOrdersAsOf`, which replays `orderFilled` and `orderCancelled` too, so a fill
+ * already recorded against the rung can shrink the file's remainder BELOW the venue's
+ * while the partials still read as "moved up". The traced case: file holds placed 10 /
+ * filled 6, the operator runs the fill flow and accepts the default remainder of 4,
+ * retiring the rung — the file now counts ZERO resting — and the venue's next export shows
+ * filled 8, i.e. 2 units still resting. Skipping that would make `available` read HIGH,
+ * which is #174's own hazard.
  *
- * Three things must hold, and anything else refuses the batch:
+ * Three things must hold for a per-rung skip, and anything else refuses the batch:
  *
  *  1. NO `quantity` DIFFERENCE — unchanged policy, and not merely because of today's
  *     encumbrance. `placed.quantity` is the ORIGINAL size a cumulative venue reading is
  *     compared against (#176), so a stale one corrupts every future comparison of this
- *     rung, not just this guard's sum. It is the one figure nothing may go stale on.
+ *     rung, not just this guard's sum. It is the one figure nothing may go stale on. It
+ *     refuses the WHOLE BATCH, and it refuses it whichever way the partial points.
  *  2. EVERY REMAINING difference is `observedFilledQuantity` — today that means exactly
  *     one, since `detectChangedClaims` emits only those two fields and never an empty
  *     list, so nothing can fail this test until a third field exists. Guarded rather than
  *     asserted precisely so that third field lands in the REFUSAL class by default
  *     instead of silently riding in beside a safe fill as a per-rung skip.
- *  3. `fileRemaining >= venueRemaining`. This SUBSUMES the down-check that used to sit
- *     here, exactly rather than approximately, which is why that branch is gone: when the
- *     partial moved down, `fileRemaining <= quantity − known < quantity − observed =
- *     venueRemaining`, so a downward partial cannot pass this test by any route. The `<=`
- *     on the left is where later fill lines live; they only make it stricter.
+ *  3. `fileRemaining >= venueRemaining`. The `<=` on the left is where later fill lines
+ *     live; they only make it stricter.
+ *
+ * THE REFUSAL SPLITS TWO WAYS, AND THE TWO CANNOT OVERLAP (#181). One refusal used to
+ * serve two conditions that are not the same animal, and the wrong one is actively
+ * harmful: an operator who imports YESTERDAY's export against a file holding an observed 6
+ * was refused correctly and then told to cancel the rung at the venue or re-place it —
+ * advice that destroys a live rung in response to someone picking the wrong CSV.
+ *
+ *   - `backwards` — the export figure is BELOW the latest observation. A fill does not
+ *     un-fill, so the column went backwards and the likeliest cause is the file, not the
+ *     book: an older export, or not the export the operator meant. It gets its own wording
+ *     and NEVER tells anyone to touch the rung at the venue.
+ *   - `amended` — `latest observation <= export figure < consumed`. The fund has BOOKED
+ *     beyond what the venue shows, so calling the row already known would leave the file
+ *     claiming LESS than the venue still holds. Today's wording, today's exit.
+ *
+ * WHY THEY CANNOT BOTH FIRE, stated here because the split relies on it: `consumed >=
+ * latest observation` ALWAYS holds. The fold SETs `consumed` to the latest observation and
+ * `orderFilled` only ever ADDS to it, so `consumed` is that observation plus a
+ * non-negative sum of bookings made since. The two intervals are therefore
+ * `[0, latestObserved)` and `[latestObserved, consumed)` — adjacent, disjoint, and empty
+ * only when they should be. The `backwards` test is taken FIRST so the partition reads in
+ * the same order the argument does; either order gives the same answer.
+ *
+ * THE CLOSED END OF THE SECOND INTERVAL IS NOT REACHED FROM HERE, and that is unchanged by
+ * the split rather than a hole it opens. An export exactly AT the latest observation is not
+ * a DIFFERENCE, so no `ChangedClaim` is raised for it and this function never sees it —
+ * whatever the fund booked afterwards. That is the same reading a re-import of an unchanged
+ * export has always had, and widening this to every observed row would turn an ordinary
+ * re-import into a batch refusal.
+ *
+ * AN EXPORT FIGURE ABOVE THE PLACED QUANTITY GETS NO CHECK, AND THAT IS THE DECISION. It
+ * is unreachable, by two gates upstream of this line:
+ *
+ *   - the VENUE's own export cannot render `filled_quantity > quantity` on the same row —
+ *     the two columns come from one order and a venue that filled more than it placed
+ *     would be contradicting itself, not reporting; and
+ *   - `parseBitgetOpenOrdersCsv`'s own admission gate drops any row whose remainder is not
+ *     POSITIVE — `quantity − filled_quantity <= 0` is a `not-resting` SKIP — so a
+ *     hand-edited CSV never reaches this partition as a claim at all. `mergeCollidingClaims`
+ *     preserves that, summing both columns of a collision and so both sides of the same
+ *     inequality.
+ *
+ * If such a line ever did reach the file anyway, the fold degrades correctly rather than
+ * lying: `remaining = quantity − consumed` goes negative, `pickRestingOrdersAsOf` drops
+ * the rung (`remaining > 0` is its resting test), and the fill-admission ceiling
+ * `min(remainingQuantity, quantity − bookedFills(id))` cannot authorize anything. Adding a
+ * runtime check here would put a third opinion about the same impossibility in the one
+ * place least able to explain it; RECORDING WHY IT CANNOT ARRIVE is the deliverable.
  *
  * An id ABSENT from `resting` reads as `0`, not as a missing case: absent means the
  * stream already retired the claim — its fills exhausted it, or a cancellation took it —
@@ -525,9 +621,11 @@ function partitionChangedClaims(
   observed: readonly BitgetOpenOrder[],
 ): {
   amended: ChangedClaim[];
+  backwards: BackwardsClaim[];
   restated: RestatedPartial[];
 } {
   const amended: ChangedClaim[] = [];
+  const backwards: BackwardsClaim[] = [];
   const restated: RestatedPartial[] = [];
 
   for (const claim of changed) {
@@ -548,6 +646,13 @@ function partitionChangedClaims(
       amended.push(claim);
       continue;
     }
+    // `fill.known` IS the latest observation (see `ClaimDifference`), so this is the
+    // backwards test exactly as the argument above states it — and the difference exists
+    // at all only because the two figures are further apart than `QUANTITY_EPSILON`.
+    if (fill.observed < fill.known) {
+      backwards.push({ id: claim.id, known: fill.known, observed: fill.observed });
+      continue;
+    }
     if (remainders.onFile < remainders.atVenue) {
       amended.push(claim);
       continue;
@@ -561,7 +666,7 @@ function partitionChangedClaims(
     });
   }
 
-  return { amended, restated };
+  return { amended, backwards, restated };
 }
 
 /**
@@ -696,19 +801,24 @@ export async function importBitgetOpenOrders(
   // before the guard — the guard would read the claim's size off the file, not off this
   // row (a repeat placement is ignored by the selector), so proceeding would check
   // coverage against a book the export no longer describes.
-  const changed = detectChangedClaims(
-    existingRecords.filter(
-      (record): record is OrderPlacedRecord => record.kind === "orderPlaced",
-    ),
-    orders,
-  );
+  // THE WHOLE STREAM, not the placement lines (#181). The comparison basis is the LATEST
+  // observation, so an export whose restatement is already on file agrees with it and
+  // reports no difference — which is what makes a re-import idempotent one layer above the
+  // append filter.
+  const changed = detectChangedClaims(existingRecords, orders);
   // The SAME reading the `O1` guard takes below, over `[...existingRecords, ...records]`
   // — and for these already-known ids the two agree by construction, because a repeat
   // placement line is ignored by the selector, so this batch's own records cannot move
   // the remainder of a rung already on file. Taken here because the partition needs it
   // before anything is prompted for or built.
   const restingOnFile = pickRestingOrdersAsOf(existingRecords);
-  const { amended, restated } = partitionChangedClaims(changed, restingOnFile, orders);
+  const { amended, backwards, restated } = partitionChangedClaims(changed, restingOnFile, orders);
+  // TWO REFUSALS, AND `amended` GOES FIRST. Per RUNG the two conditions cannot both hold —
+  // that is the partition's own argument — but a BATCH can raise one of each over different
+  // rungs, and then something has to be printed first. `amended` wins because it is the
+  // one with a funding hazard behind it: a batch carrying an amended `quantity` is refused
+  // with exactly the token and the message it was refused with before this split, whatever
+  // else the export also got wrong.
   if (amended.length > 0) {
     const detail = amended
       .map((claim) => {
@@ -738,6 +848,22 @@ export async function importBitgetOpenOrders(
         `still holds, so the guard would admit a batch the reserve cannot fund. Cancel the ` +
         `rung at the venue and record the cancellation, or re-place it at a different price ` +
         `so it arrives as a new claim`,
+    );
+  }
+
+  if (backwards.length > 0) {
+    const detail = backwards
+      .map((claim) => `${claim.id} (filled ${claim.known} → ${claim.observed})`)
+      .join("; ");
+    return reject(
+      io,
+      "backwards-claim",
+      `${csvPath} shows ${plural(backwards.length, "rung")} LESS filled than this file has ` +
+        `already observed — ${detail}. A fill does not un-fill, so these two statements ` +
+        `cannot both be true and nothing was written. The likeliest cause is the export ` +
+        `itself: an OLDER one, or not the one you meant. Re-export the open orders from the ` +
+        `venue and import that. Nothing here needs doing at the venue — the rungs on file ` +
+        `are untouched and still resting`,
     );
   }
 

--- a/apps/tui/src/import-orders.ts
+++ b/apps/tui/src/import-orders.ts
@@ -9,7 +9,7 @@
  * `O1` reject — is testable without a terminal, a real export or the real data dir.
  *
  * THE ORDERING IS THE CONTRACT: parse → merge id collisions → load the sidecar → refuse
- * changed claims → skip the restated rungs → prompt → check coverage → append. The
+ * changed claims → record the restated rungs → prompt → check coverage → append. The
  * coverage check is the LAST thing before the only write, and every refusal before it
  * returns having written nothing at all. `orders.jsonl` is append-only, so a
  * wrong claim written here is not edited away later — it costs a compensating line
@@ -247,9 +247,9 @@ interface BackwardsClaim {
  * What an import that REFUSED NOTHING reports, in the two shapes it can honestly take.
  *
  * Not "an import that WROTE" (#200 review): an export whose every readable rung was
- * restated writes no line at all and still reports here, because the flow reached its end
- * with nothing refused. Writing is what these outcomes usually DO; not refusing is what
- * they all MEAN.
+ * already on file saying the same thing writes no line at all and still reports here,
+ * because the flow reached its end with nothing refused. Writing is what these outcomes
+ * usually DO; not refusing is what they all MEAN.
  */
 interface OrdersImportWrite {
   /**
@@ -600,13 +600,26 @@ function isAffirmative(answer: string): boolean {
  *     beyond what the venue shows, so calling the row already known would leave the file
  *     claiming LESS than the venue still holds. Today's wording, today's exit.
  *
- * WHY THEY CANNOT BOTH FIRE, stated here because the split relies on it: `consumed >=
- * latest observation` ALWAYS holds. The fold SETs `consumed` to the latest observation and
- * `orderFilled` only ever ADDS to it, so `consumed` is that observation plus a
- * non-negative sum of bookings made since. The two intervals are therefore
- * `[0, latestObserved)` and `[latestObserved, consumed)` — adjacent, disjoint, and empty
- * only when they should be. The `backwards` test is taken FIRST so the partition reads in
- * the same order the argument does; either order gives the same answer.
+ * THE ORDER OF THE TWO TESTS IS LOAD-BEARING, NOT PRESENTATIONAL, and the two outcome
+ * classes are disjoint only BECAUSE `backwards` is taken first. `consumed >= latest
+ * observation` ALWAYS holds — the fold SETs `consumed` to the latest observation and
+ * `orderFilled` only ever ADDS to it, so `consumed` is that observation plus a non-negative
+ * sum of bookings made since — and that is exactly what makes the two PREDICATES a superset
+ * relation rather than a partition. `backwards` fires on `export figure < latest
+ * observation`. `amended`'s remainder test reduces to `export figure < consumed`, because
+ * the `quantity` branch further down has already taken every claim whose placed size
+ * differs, so `quantity` is equal on both sides and cancels out of
+ * `onFile < atVenue`. `[0, consumed)` therefore CONTAINS `[0, latestObserved)`: THE
+ * PREDICATES OVERLAP, and only the `continue` after the `backwards` push separates them.
+ * Placed 10, the file's latest observation 6, the export showing 4: both tests are true,
+ * and the order alone decides which one the operator is told.
+ *
+ * The intervals the two OUTCOMES occupy — `[0, latestObserved)` and
+ * `[latestObserved, consumed)`, adjacent and disjoint — describe the classes AFTER that
+ * ordering; they are not a property of the predicates and must not be read as one.
+ * Reordering the tests is therefore not a rearrangement of the same answer: every backwards
+ * claim would fall into `amended` and be handed the cancel-the-rung-at-the-venue advice
+ * #208 exists to keep it away from — the exact harm the split above was made to remove.
  *
  * THE CLOSED END OF THE SECOND INTERVAL IS NOT REACHED FROM HERE, and that is unchanged by
  * the split rather than a hole it opens. An export exactly AT the latest observation is not
@@ -1164,6 +1177,11 @@ export async function importBitgetOpenOrders(
  * WHY `kind` IS IN THE KEY AT ALL: an observation shares its rung's id, so an id-only key
  * would read the first observation of a known rung as a repeat of its placement line and
  * drop it — the whole feature, filtered out by its own dedupe.
+ *
+ * KNOWINGLY OPEN, tracked on #212 — THIS KEY ANSWERS *"is this figure already recorded?"*,
+ * but the filter at its one call site needs *"is this figure still the rung's CURRENT
+ * claim?"*: `alreadyOnFile` is built from EVERY existing record, so a figure some later
+ * line already superseded still filters a legitimate re-assertion of it.
  */
 function appendKey(record: OrderRecord): string {
   return record.kind === "orderFillObserved"

--- a/apps/tui/src/import-orders.ts
+++ b/apps/tui/src/import-orders.ts
@@ -17,9 +17,11 @@
  * warnings the operator can walk past.
  */
 import {
+  buildOrderFillObserved,
   buildOrderPlacedRecords,
   checkFundingCoverage,
   detectChangedClaims,
+  formatObservedAt,
   leavesRungUnweighed,
   mergeCollidingClaims,
   parseBitgetOpenOrdersCsv,
@@ -28,6 +30,7 @@ import {
   type BitgetRowSkip,
   type ChangedClaim,
   type MergedOrderClaim,
+  type OrderFillObservedRecord,
   type OrderPlacedRecord,
   type OrderRecord,
   type FundReviewData,
@@ -42,6 +45,21 @@ import { renderSkipMessage } from "./skip-message.js";
 export interface OrdersImportIo {
   /** Read the venue's export. Rejects (throws) if it is unreadable; we catch it. */
   readExport: (path: string) => Promise<string>;
+  /**
+   * THE CLOCK, injected (#181, `D3`). An observation line is stamped with the IMPORT
+   * MOMENT — the instant this look at the venue happened — and never with the export row's
+   * own `timestamp` column. That column is the SUBMISSION stamp and an id component
+   * (`bitget.ts`), so a line stamped from it would sort to the placement's own instant,
+   * where `pickRestingOrdersAsOf` has no tie-break and would replay the two in an order
+   * nothing decides.
+   *
+   * ONE EXPORT IS ONE LOOK, so every observation of a batch shares one stamp, and the
+   * stamp is second-granular because {@link isObservedAtStamp} is the shape the whole
+   * repo string-compares. Two imports inside one second therefore carry the SAME stamp,
+   * and nothing downstream may depend on the stamp to tell them apart — see the append
+   * key at {@link appendKey}, which keys an observation on what it ASSERTS.
+   */
+  now: () => Date;
   /** The sidecar's resolved path — resolved by the caller, never by this flow. */
   ordersPath: string;
   loadOrders: (path: string) => Promise<OrdersLoad>;
@@ -88,11 +106,15 @@ export type OrdersImportRejection =
    * remedy this member prints is wrong for it, not because it stopped being a refusal.
    *
    * Refused rather than recorded, and this is the ONE place the "proceed with the
-   * arithmetic" reasoning behind the within-batch merge does not extend. Recording a
-   * change needs a verb this build does not have: a second `orderPlaced` line is ignored
-   * by `pickRestingOrdersAsOf` by construction (that guard is what makes re-import
-   * idempotent), and an observation verb is a later design that must not be pre-empted
-   * by one invented here, in an append-only file, to get past this import.
+   * arithmetic" reasoning behind the within-batch merge does not extend. THE OBSERVATION
+   * VERB EXISTS NOW (#181) and does not help here, which is the point: an
+   * `orderFillObserved` line restates ONE figure — the venue's cumulative fill — and
+   * neither member landing here is that. An amended `quantity` is the one figure nothing
+   * may go stale on and the verb deliberately carries no copy of it; a restatement the
+   * file's own fill lines have already overtaken is a contradiction between the book and
+   * the venue, and recording it would write the contradiction down rather than settle it.
+   * A second `orderPlaced` line remains ignored by `pickRestingOrdersAsOf` by construction
+   * (that guard is what makes re-import idempotent), so there is no verb here either way.
    *
    * NARROWED BY #199, and the DIRECTION is the whole reason. Refusing the batch never
    * repaired the stale line — nothing is written on a refusal — so what the refusal
@@ -103,9 +125,9 @@ export type OrdersImportRejection =
    * REMAINDER the guard actually weighs — `pickRestingOrdersAsOf` over the whole stream,
    * fill and cancellation lines included — not off the placement line alone, because a
    * recorded fill can flip a restatement from the safe side to this one. A restatement
-   * that leaves the file claiming NO LESS than the venue holds is handled per rung
-   * instead — see {@link RestatedPartial}. The argument for refusing here is about which
-   * way the leftover staleness points, not about the change itself.
+   * that leaves the file claiming NO LESS than the venue holds is RECORDED per rung
+   * instead — see {@link RecordedObservation}. The argument for refusing here is about
+   * which way the leftover staleness points, not about the change itself.
    */
   | "changed-claim"
   /**
@@ -166,51 +188,32 @@ export type OrdersImportRejection =
   | "write-failed";
 
 /**
- * A rung the venue has filled FURTHER since its placement line was written (#199).
+ * A rung the venue has filled FURTHER since the file last observed it, RECORDED (#181).
  *
  * The id is synthesized from the SUBMISSION stamp, so a rung that fills between two
  * exports comes back under the same id carrying a larger `filled_quantity`. That is not
- * an amendment and not a re-sighting — it is the ordinary life of a resting ladder — but
- * the placement line cannot be rewritten (`orders.jsonl` is append-only and a second
- * placement line is ignored by the selector), so the file keeps the OLDER partial until
- * the observation verb #181 designs exists.
+ * an amendment and not a re-sighting — it is the ordinary life of a resting ladder — and
+ * it now gets its own durable line: an `orderFillObserved`, stamped with the IMPORT
+ * moment, which `pickRestingOrdersAsOf` folds as a new `consumed` baseline.
  *
- * Carrying the stale figure is safe in a way an amended `quantity` is not, and only
- * because of the direction: what the file still counts as resting is NO LESS than what
- * the venue actually holds, so the encumbrance it computes is never too small. That can
- * refuse a batch the reserve could have funded; it can never admit one it cannot. So the
- * rung is skipped and the rest of the export imports normally, rather than the whole
- * batch being refused over it.
+ * IT REPLACES `RestatedPartial` RATHER THAN REPURPOSING IT (#199 → #181). That type
+ * carried BOTH remainders because the pair WAS the safety argument for a per-rung SKIP:
+ * printing them let an operator check that the stale line still encumbered no less than
+ * the venue held. There is no skip left to justify, and after the observation lands the
+ * pair is redundant by construction — the file's remainder becomes `quantity − observed`,
+ * which is exactly the venue's. What an operator still wants is the one thing this
+ * carries: what the file knew, and what it now records.
  *
- * THE DIRECTION IS READ OFF THE REMAINDER, not off the two partials (#200 review). The
- * guard downstream weighs `pickRestingOrdersAsOf`, which replays fills and cancellations
- * as well as placements, so a fill already recorded against this rung can shrink the
- * file's remainder below the venue's and INVERT the safety claim while the partials still
- * read as "moved up". Those rungs are refused as `changed-claim`; only a rung whose
- * remainder on file is at least the venue's reaches this type. A partial moving DOWN is
- * refused too, and since #181 by a rule of its OWN — `backwards-claim`, taken before the
- * remainder test, because a fill does not un-fill and the remedy that case is owed is
- * nothing like this one's. The algebra for both is on `partitionChangedClaims`.
+ * IT IS NOT A QUALIFICATION. A restatement qualified the status while it was a DEFERRAL —
+ * a rung read perfectly and then not written down — and this build writes it down. See
+ * {@link OrdersImportOutcome}'s `imported` member for what that does to the union.
+ *
+ * THE DIRECTION IS STILL READ OFF THE REMAINDER, not off the two figures (#200 review).
+ * A restatement the file's OWN fill lines have already overtaken is not a restatement at
+ * all — the fund has BOOKED units the venue does not corroborate — and those rungs stay a
+ * batch-wide `changed-claim` refusal. The algebra is on `partitionChangedClaims`.
  */
-/**
- * A rung the export shows LESS filled than the file's latest observation of it (#181) —
- * the refusal `backwards-claim` is raised over.
- *
- * TWO FIGURES AND NO REMAINDERS, unlike {@link RestatedPartial}. The remainders are what
- * makes a per-rung skip safe, so that type carries them to let the operator check the
- * claim; this one is refused on the two partials ALONE, because they are already a
- * contradiction and no third figure makes them less of one. Printing a remainder here
- * would send the operator after a disagreement this refusal does not have.
- */
-interface BackwardsClaim {
-  id: string;
-  /** The file's latest observation — see {@link RestatedPartial.known} for the basis. */
-  known: number;
-  /** The SMALLER partial the export shows. */
-  observed: number;
-}
-
-export interface RestatedPartial {
+export interface RecordedObservation {
   id: string;
   /**
    * The file's LATEST OBSERVATION of this rung's partial — a later `orderFillObserved`
@@ -219,20 +222,25 @@ export interface RestatedPartial {
    * restatement could be written down.
    */
   known: number;
-  /** The larger partial the venue's export now shows. */
+  /** The larger cumulative partial the venue's export now shows, and what was written. */
   observed: number;
-  /**
-   * What this rung STILL CLAIMS on file — the selector's remainder, net of the placement
-   * line's own partial and every `orderFilled` line since, and `0` when the stream has
-   * already retired the id.
-   *
-   * Carried rather than left implicit because it, not `known`, is what makes the skip
-   * safe: this pair IS the safety argument, and printing both lets an operator check the
-   * claim instead of taking it on faith.
-   */
-  remainingOnFile: number;
-  /** What the venue's export says is still resting: `quantity` less its filled figure. */
-  remainingAtVenue: number;
+}
+
+/**
+ * A rung the export shows LESS filled than the file's latest observation of it (#181) —
+ * the refusal `backwards-claim` is raised over.
+ *
+ * SPELLED SEPARATELY FROM {@link RecordedObservation} even though the two carry the same
+ * three fields, because they are opposite outcomes of the same comparison: one names a
+ * line this import WROTE, the other a line it REFUSED to write. Collapsing them into one
+ * type would let a refusal be handed to the reporter that describes what was recorded.
+ */
+interface BackwardsClaim {
+  id: string;
+  /** The file's latest observation — see {@link RecordedObservation.known} for the basis. */
+  known: number;
+  /** The SMALLER partial the export shows. */
+  observed: number;
 }
 
 /**
@@ -245,11 +253,19 @@ export interface RestatedPartial {
  */
 interface OrdersImportWrite {
   /**
-   * Lines actually appended. ZERO in two different ways, and the distinction is visible
-   * only in the other fields: every rung was already known — the same export imported
-   * twice, so `alreadyKnown` carries them — or nothing was admitted at all, every
-   * readable rung having been restated, so `alreadyKnown` is 0 too and `restated` holds
-   * them.
+   * ORDERS appended — placement lines, and never a line count (#181). The two were the
+   * same number until an import could write a second kind, and the moment it could, a
+   * pure-observation import reported `1 order(s) appended` about ZERO orders.
+   *
+   * `appended` KEEPS MEANING ORDERS because that is the question the number is read for:
+   * *how many claims on my capital did this import create?* An observation creates none —
+   * it only ever REDUCES what a rung still claims — so counting it here would answer that
+   * question wrongly in the direction that matters. Observations are counted by
+   * {@link observations}, whose length IS the count.
+   *
+   * ZERO in three different ways now, and the other fields tell them apart: every rung was
+   * already known (`alreadyKnown` carries them), every readable rung was restated
+   * (`observations` carries them), or the export named nothing this build admitted.
    */
   appended: number;
   /**
@@ -257,39 +273,50 @@ interface OrdersImportWrite {
    * thing about it — the id components plus `quantity` and the observed partial.
    *
    * A row that differs NEVER reaches this count, whichever way it goes: it either
-   * refuses the whole batch as `changed-claim` (#174) or is skipped per rung and
-   * reported in `restated` (#199). Calling either one "already known" is the silence
-   * #174 named — it reports "nothing to do" about a rung the file now describes wrongly.
+   * refuses the whole batch as `changed-claim` / `backwards-claim` (#174, #181) or is
+   * recorded as an observation and reported in {@link observations} (#181). Calling
+   * either one "already known" is the silence #174 named — it reports "nothing to do"
+   * about a rung the file now describes wrongly.
    */
   alreadyKnown: number;
   /**
    * The export rows this build could not read — NOT empty on `imported`, and the
-   * asymmetry with `restated` is deliberate rather than an oversight. A `not-resting` row
-   * was read COMPLETELY and the parser's finding about it is that nothing is still
-   * claimed, so it rides here and qualifies nothing (#184). What `imported` promises
-   * about this field is that none of its entries left a rung UNWEIGHED — that is
-   * `leavesRungUnweighed`'s question, not this array's length.
+   * asymmetry with {@link observations} is deliberate rather than an oversight. A
+   * `not-resting` row was read COMPLETELY and the parser's finding about it is that
+   * nothing is still claimed, so it rides here and qualifies nothing (#184). What
+   * `imported` promises about this field is that none of its entries left a rung
+   * UNWEIGHED — that is `leavesRungUnweighed`'s question, not this array's length.
    */
   skips: BitgetRowSkip[];
   /**
-   * The rungs skipped because the venue has restated their partial (#199). EMPTY on
-   * `imported`, by construction — the one field whose own length decides the status,
-   * because every entry in it is a qualification and `skips` needs a predicate to say
-   * which of its entries are.
+   * The restatements this import RECORDED — exactly one `orderFillObserved` line each
+   * (#181), and never a superset of what was written.
    *
-   * A SECOND FIELD RATHER THAN A THIRD STATUS, and that is the load-bearing choice: an
-   * export can carry an unreadable row AND a restated rung at once, and a sum type can
-   * say only one of those, so a third member would drop one qualification silently. Two
-   * fields under one qualified status say both.
+   * DERIVED FROM THE LINES THAT WERE WRITTEN, not from the decision that proposed them,
+   * and that is the whole shape of `report`. A decision the append filter did not let
+   * through is ABSENT here, so the operator is never told a line was RECORDED that is not
+   * on disk. The `known`/`observed` pair is the one thing joined back from the decision —
+   * the written line carries the new figure, and only the decision remembers the old one.
+   *
+   * NOT A QUALIFICATION, unlike the `restated` field it replaces. That field's own length
+   * decided the status, because a skipped rung was work DEFERRED; this one records work
+   * DONE, so `imported` widens back over it. A reader who never opens this field is not
+   * misled by one, which is the test that decides what may qualify a status.
    */
-  restated: RestatedPartial[];
+  observations: RecordedObservation[];
 }
 
 export type OrdersImportOutcome =
   /**
-   * Every row of the export was read AND nothing was restated. The unqualified success,
-   * and the only one — its invariant STRENGTHENED by #199 rather than widened, so the
-   * status keeps meaning what a reader who never opens a second field assumes it means.
+   * Every row of the export was read. The unqualified success, and the only one.
+   *
+   * ITS INVARIANT WIDENS BACK HERE (#199 → #181), and this union has never shrunk before,
+   * so it is worth saying plainly: this is a GAP CLOSING, not precision lost. #199
+   * strengthened the member to "every row read AND nothing restated" because a
+   * restatement was then a DEFERRAL — a rung read perfectly and then not written down —
+   * and a status that called that unqualified would be lying to the reader who opens no
+   * second field. The restatement is now RECORDED, so it defers nothing and qualifies
+   * nothing, and the only thing left qualifying an import is a row nobody could read.
    */
   | ({ status: "imported" } & OrdersImportWrite)
   /**
@@ -303,20 +330,15 @@ export type OrdersImportOutcome =
    * used to make and which an export of nothing but restated rungs falsifies while still
    * being a perfectly honest run. The CLI exits 0 either way (`D3`).
    *
-   * TWO qualifications reach it, with OPPOSITE money directions, each carrying its own
-   * field and printing its own operator line:
+   * ONE qualification reaches it now (#181): `skips` — a row was not read, so a rung
+   * resting at the venue is `committed` that nobody counted and `available` reads HIGH.
+   * A restated rung used to be the second, and it is a RECORDED line rather than a
+   * deferral since #181, so it no longer qualifies anything.
    *
-   * - `skips` — a row was not read, so a rung resting at the venue is `committed` that
-   *   nobody counted and `available` reads HIGH.
-   * - `restated` — a rung was read perfectly and its partial on file is stale, so what
-   *   the file still claims is NO LESS than the venue holds: `committed` never reads LOW
-   *   and `available` never reads HIGH. (Never LOW, rather than always HIGH: a fill
-   *   already recorded against the rung can leave the two exactly level, and that case is
-   *   in the skip class too.)
-   *
-   * That opposition is why `restated` could not reuse `skips`: `leavesRungUnweighed` is
-   * a predicate over PARSER problems, and a restated rung is not unweighed — it is
-   * weighed, and never weighed short.
+   * STILL A DISTINCT MEMBER RATHER THAN A PREDICATE OVER `skips`, because `skips` is
+   * heterogeneous: a `not-resting` row was read completely and qualifies nothing, so the
+   * status is decided by `leavesRungUnweighed` over the entries rather than by the
+   * array's length. It is still a SUCCESS, and the test is that NOTHING WAS REFUSED.
    */
   | ({ status: "imported-partial" } & OrdersImportWrite)
   | { status: "rejected"; reason: OrdersImportRejection; message: string };
@@ -623,11 +645,11 @@ function partitionChangedClaims(
 ): {
   amended: ChangedClaim[];
   backwards: BackwardsClaim[];
-  restated: RestatedPartial[];
+  restated: RecordedObservation[];
 } {
   const amended: ChangedClaim[] = [];
   const backwards: BackwardsClaim[] = [];
-  const restated: RestatedPartial[] = [];
+  const restated: RecordedObservation[] = [];
 
   for (const claim of changed) {
     if (claim.differences.some((difference) => difference.field === "quantity")) {
@@ -658,13 +680,13 @@ function partitionChangedClaims(
       amended.push(claim);
       continue;
     }
-    restated.push({
-      id: claim.id,
-      known: fill.known,
-      observed: fill.observed,
-      remainingOnFile: remainders.onFile,
-      remainingAtVenue: remainders.atVenue,
-    });
+    // THE REMAINDERS ARE WEIGHED AND NOT CARRIED (#181). They still DECIDE the class —
+    // `remainders.onFile < remainders.atVenue` is the test directly above — but they were
+    // carried onto the outcome to let an operator audit a SKIP's safety claim, and this
+    // build writes the observation instead of skipping. Once the line lands, the file's
+    // remainder IS the venue's, so the pair would print two equal numbers and invite an
+    // audit of nothing.
+    restated.push({ id: claim.id, known: fill.known, observed: fill.observed });
   }
 
   return { amended, backwards, restated };
@@ -865,22 +887,112 @@ export async function importBitgetOpenOrders(
     );
   }
 
-  // THE PER-RUNG SKIP (#199). The restated rung is dropped from THIS batch and its line
-  // on file is left exactly as it was — so the guard below still weighs it, at a remainder
-  // no smaller than the venue's, which is the conservative reading. Everything after this
-  // point sees `admitted`: the rung is not prompted for, not built into a record, and not
-  // counted as `alreadyKnown`, because it is not a re-sighting.
+  // THE RESTATED RUNG LEAVES THE PLACEMENT PATH AND TAKES THE OBSERVATION PATH (#181).
+  // It is already on file under this id, so it is not prompted for and not built into a
+  // second placement record — the selector ignores a repeat placement line anyway. It is
+  // not `alreadyKnown` either: it is not a re-sighting, it is new information, and this
+  // build records it rather than skipping it.
   const restatedIds = new Set(restated.map((claim) => claim.id));
   const admitted = orders.filter((order) => !restatedIds.has(order.id));
 
+  // ONE STAMP FOR THE WHOLE BATCH: one export is one look at the venue, so every
+  // observation this import writes was observed at the same moment. Read from the
+  // injected clock exactly once — a second read could straddle a second boundary and
+  // scatter one look across two instants.
+  const observedAt = formatObservedAt(io.now());
+
+  // A SEPARATE ARRAY FROM `records`, and the separation is load-bearing twice over.
+  // It rides INTO the funding guard — an observation only ever REDUCES a remainder, so
+  // leaving it out would let the guard refuse over capital this very import is about to
+  // free. It stays OUT of the attribution mark, which exists to say which rungs a
+  // re-declaration cannot fix: a restated rung's `fundingReserveId` comes from its
+  // original placement line and `declareFunding` never touches it, so marking it would
+  // send the operator round a loop that changes nothing.
+  //
+  // BUILT THROUGH THE TOTAL CONSTRUCTOR, from the EXPORT ROW rather than from `restated`,
+  // so the figure and the currency come off the same row the decision was made on and no
+  // field needs a default. `filledQuantity` is REQUIRED on a `BitgetOpenOrder`, so there
+  // is no `?? 0` here and could not be one: the parser admits a row only when
+  // `quantity − filledQuantity > 0`, having read both columns.
+  const observations: OrderFillObservedRecord[] = [];
+  for (const order of orders) {
+    if (!restatedIds.has(order.id)) {
+      continue;
+    }
+    const built = buildOrderFillObserved({
+      id: order.id,
+      observedAt,
+      currency: order.currency,
+      observedFilledQuantity: order.filledQuantity,
+    });
+    if (built.status === "ok") {
+      observations.push(built.record);
+      continue;
+    }
+    // UNREACHABLE, AND HANDLED ANYWAY — that is what makes the constructor total rather
+    // than decorative. A rung reaches `restated` only because its figure moved UP from
+    // what the file knew, and the file's floor is 0, so the figure is positive; the stamp
+    // comes from `formatObservedAt` and the currency from a parsed row. If one ever did
+    // refuse, the line is NOT written and — because `report` describes the lines that were
+    // written — the operator is not told it was recorded. The refusal is loud rather than
+    // silent, on the channel every other per-row problem in this flow uses.
+    io.err(
+      `${order.id} skipped — the restatement could not be recorded: ${built.message}`,
+    );
+  }
+
+  // The old figure lives ONLY in the decision — the written line carries the new one and
+  // nothing else — so this is the one thing `report` joins back out of `restated`, and it
+  // joins rather than iterates: a decision with no line on disk is never reached.
+  const knownFigures = new Map(restated.map((claim) => [claim.id, claim.known] as const));
+
   /**
-   * THE ONE TAIL, reached by both exits (#200 review). Extracted rather than duplicated
-   * at the short-circuit below, because a qualification added to one exit and forgotten
-   * on the other is exactly the silent half-report this whole flow is built to refuse.
+   * THE REPORT, FED THE LINES THAT WERE ACTUALLY WRITTEN (#181).
+   *
+   * It used to be handed two bare numbers from ABOVE the write and then reach past its own
+   * parameter list into the DECISION array for the rest — so it described what the flow
+   * DECIDED while the file held what the append filter LET THROUGH. One defect with three
+   * faces, and the visible one was a dropped line surfacing as a confident `RECORDED`.
+   *
+   * Every count and every operator line is now derived HERE, from `written`. `placements`
+   * is passed as an ARRAY rather than as a count for the same reason: `alreadyKnown` is
+   * "what this batch proposed, less what landed", and both halves of that subtraction must
+   * be counted by one rule in one place. The only thing read out of the decision is the
+   * `known` figure joined per line, because the line itself cannot remember it.
+   *
+   * ONE `io.out`, reached by every exit, so the `OBSERVED —` detail is constructed once BY
+   * CONSTRUCTION rather than by discipline. It was written out verbatim at two exits
+   * before, eight lines under a comment stating the very invariant that duplication breaks.
    */
-  const report = (appended: number, alreadyKnown: number): OrdersImportOutcome => {
-    const counts = `${appended} order(s) appended, ${alreadyKnown} already known`;
-    const write = { appended, alreadyKnown, skips: parsed.skips, restated };
+  const report = (
+    written: readonly OrderRecord[],
+    placements: readonly OrderPlacedRecord[],
+  ): OrdersImportOutcome => {
+    const appended = written.filter((record) => record.kind === "orderPlaced").length;
+    const alreadyKnown = placements.length - appended;
+    const observed: RecordedObservation[] = [];
+    for (const record of written) {
+      if (record.kind !== "orderFillObserved") {
+        continue;
+      }
+      const known = knownFigures.get(record.id);
+      // A written observation with no decision behind it cannot exist — every one of them
+      // was built from a `restated` entry a few lines above. Dropped rather than defaulted
+      // if it ever did: inventing a `known` would print an arithmetic nobody performed.
+      if (known !== undefined) {
+        observed.push({ id: record.id, known, observed: record.observedFilledQuantity });
+      }
+    }
+
+    // THE OBSERVATION CLAUSE RENDERS ALWAYS, INCLUDING AT ZERO. A clause that appears
+    // conditionally is two shapes for a reader to learn and two for a test to assert, and
+    // it is one more place for the two exits to diverge again. `appended` counts ORDERS,
+    // so a pure-observation import reads `0 order(s) appended` beside a non-zero
+    // observation count — which is the honest pair, not a contradiction.
+    const counts =
+      `${appended} order(s) appended, ${alreadyKnown} already known, ` +
+      `${observed.length} observation(s) recorded`;
+    const write = { appended, alreadyKnown, skips: parsed.skips, observations: observed };
 
     // NOT `parsed.skips.length` (#184). `skips` is heterogeneous, and a `not-resting` row
     // was read COMPLETELY — the parser's finding about it is that nothing is still
@@ -890,23 +1002,16 @@ export async function importBitgetOpenOrders(
     // every one of them.
     const unweighed = parsed.skips.filter((entry) => leavesRungUnweighed(entry.problem));
 
-    if (unweighed.length === 0 && restated.length === 0) {
-      io.out(`Imported ${csvPath}: ${counts}.\n`);
-      return { status: "imported", ...write };
-    }
-
-    // EVERY QUALIFICATION GETS ITS OWN LINE, EACH OPENING ON THE GAP AND NAMING ITS OWN
-    // MONEY DIRECTION (`D3`, #177; #199). The counts follow all of them, once — they used
-    // to be the whole line, with the qualification a suffix (`..., 1 row(s) skipped.`) in
-    // exactly the position an operator skims past. An export qualified BOTH ways prints
-    // BOTH lines; that case is why this is two fields and not a third status.
+    // EACH NOTICE GETS ITS OWN LINE, OPENING ON WHAT IT IS ABOUT (`D3`, #177; #199). The
+    // counts follow all of them, once — they used to be the whole line, with the notice a
+    // suffix (`..., 1 row(s) skipped.`) in exactly the position an operator skims past.
     //
-    // Unread rows lead, because they are the qualification we know least about: a restated
-    // rung was read perfectly and we can state its figures, an unread one we cannot.
-    const qualifications: string[] = [];
+    // Unread rows lead, because they are the one thing here we know least about: a
+    // restatement was read perfectly and we can state its figures, an unread row we cannot.
+    const notices: string[] = [];
 
     if (unweighed.length > 0) {
-      qualifications.push(
+      notices.push(
         `INCOMPLETE — ${unweighed.length} row(s) of ${csvPath} could not be read, so that ` +
           `many rung(s) resting at the venue are NOT counted as committed and available reads ` +
           `HIGH by whatever they encumber. Re-export and re-import to pick the missing ` +
@@ -914,103 +1019,106 @@ export async function importBitgetOpenOrders(
       );
     }
 
-    if (restated.length > 0) {
-      // BOTH REMAINDERS, not just the two partials: the remainders are what the skip was
-      // decided on, so printing them lets the operator check the safety claim the rest of
-      // this line makes rather than take it on faith.
-      const detail = restated
-        .map(
-          (claim) =>
-            `${claim.id} (filled ${claim.known} → ${claim.observed}; the file still claims ` +
-            `${claim.remainingOnFile}, the venue holds ${claim.remainingAtVenue})`,
-        )
+    if (observed.length > 0) {
+      // BOTH FIGURES AND NO REMAINDERS. The remainders were printed while the rung was
+      // SKIPPED, because they were the safety argument an operator was owed a way to
+      // check; the line is written now, so the file's remainder IS the venue's and the
+      // pair would print the same number twice.
+      const detail = observed
+        .map((claim) => `${claim.id} (filled ${claim.known} → ${claim.observed})`)
         .join("; ");
-      qualifications.push(
-        `RESTATED — ${restated.length} rung(s) of ${csvPath} have filled FURTHER at the ` +
-          `venue since this file recorded them — ${detail} — and were SKIPPED; every other ` +
-          `rung imported normally. Their lines on file still read the OLDER partial, so they ` +
-          `encumber NO LESS than the venue still holds: committed never reads LOW and ` +
-          `available never reads HIGH. That is the safe direction — it can refuse a batch ` +
-          `you could fund, never fund one you cannot — but it is not free, and recording the ` +
-          `restatement needs an observation verb this build does not have. This line ` +
-          `REPRINTS on every import until the rung fills out or is cancelled at the venue.`,
+      notices.push(
+        `OBSERVED — ${observed.length} rung(s) of ${csvPath} have filled FURTHER at the ` +
+          `venue since this file last observed them — ${detail} — and the restatement was ` +
+          `RECORDED. Their remainders now read what the venue shows. This is NOT a ` +
+          `qualification: the work is done, and the line does not reprint on the next ` +
+          `import unless the venue moves again.`,
       );
     }
 
-    io.out(`${qualifications.join("\n")}\nImported ${csvPath}: ${counts}.\n`);
+    io.out([...notices, `Imported ${csvPath}: ${counts}.`].join("\n") + `\n`);
 
-    return { status: "imported-partial", ...write };
+    // A ROW NOBODY COULD READ IS THE ONLY THING LEFT THAT QUALIFIES AN IMPORT (#181). A
+    // restatement qualified while it was deferred; it is recorded here, so it does not.
+    return unweighed.length === 0
+      ? { status: "imported", ...write }
+      : { status: "imported-partial", ...write };
   };
 
-  // NOTHING LEFT TO IMPORT — every readable rung of this export was restated (#200
-  // review). Reported here rather than walked through the rest of the flow, which used to
-  // prompt TWICE for the funding reserve of a batch of ZERO orders and then, on the only
-  // honest answer to that question — a blank line — return `no-reserve-declared`: a
-  // refusal raised over an import that had nothing to fund and nothing to refuse.
+  // AN OBSERVATIONS-ONLY IMPORT SKIPS BOTH THE PROMPT AND THE GUARD. There is nothing to
+  // attribute — every rung here is already on file under its own placement line, with a
+  // `fundingReserveId` `declareFunding` would not touch — so prompting would ask a
+  // question with no honest answer, and the honest answer (a blank line) used to come back
+  // as `no-reserve-declared`: a refusal over an import with nothing to fund. A guard here
+  // would weigh only the book already on file, raising a NEW refusal over a PRE-EXISTING
+  // condition, unfixable because no declaration was prompted for.
   //
-  // The status is honest BY CONSTRUCTION rather than by choice. An export with no readable
-  // rows at all was already refused as `no-orders` above, and `admitted` is `orders` less
-  // the restated ids, so an empty `admitted` means `restated` is non-empty — this path
-  // cannot reach the unqualified `imported`, and `report` does not have to be told so.
-  //
-  // NO COVERAGE GUARD HERE, deliberately. It would weigh only the book already on file,
-  // which this import does not change by a single line, so a refusal from it would be a
-  // NEW refusal raised over a PRE-EXISTING condition — and unfixable at that, since we
-  // did not prompt for the declaration that is the only thing the operator could correct.
-  if (admitted.length === 0) {
-    return report(0, 0);
-  }
+  // AND THE `nothing-to-import` SHORT-CIRCUIT THAT USED TO SIT HERE IS GONE. An export of
+  // nothing but restated rungs now writes N observation lines — the most useful import
+  // this flow can perform — so exiting early over it would skip the feature's best case.
+  const records: OrderPlacedRecord[] = [];
+  if (admitted.length > 0) {
+    const declaration = await declareFunding(io, admitted);
+    if (declaration === undefined) {
+      return reject(io, "no-reserve-declared", "no funding reserve was declared for this batch");
+    }
+    records.push(...buildOrderPlacedRecords(admitted, declaration));
 
-  const declaration = await declareFunding(io, admitted);
-  if (declaration === undefined) {
-    return reject(io, "no-reserve-declared", "no funding reserve was declared for this batch");
-  }
-
-  const records = buildOrderPlacedRecords(admitted, declaration);
-
-  // `O1`. Coverage is checked over the WHOLE resting book — what is already on file plus
-  // this batch — because a reserve funds every claim against it, not one import's slice.
-  // The selector dedupes by id, so a re-import does not double-count the same rung.
-  const resting = pickRestingOrdersAsOf([...existingRecords, ...records]);
-  const coverage = checkFundingCoverage(resting, await io.fundReview());
-  if (coverage.status === "unattributed") {
-    // ONE refusal for BOTH classes. Cross-currency funding is not designed and an
-    // unadmitted reserve cannot fund a live claim; either way the rung is refused here
-    // and in the report, and the operator is told about every one of them at once rather
-    // than paying a second full pass — declaration prompt included — to learn the second
-    // class (#179).
+    // `O1`. Coverage is checked over the WHOLE resting book — what is already on file plus
+    // this batch — because a reserve funds every claim against it, not one import's slice.
+    // The selector dedupes by id, so a re-import does not double-count the same rung.
     //
-    // `records` is passed so the message can mark which listed rungs are NOT this batch's:
-    // `resting` above is the whole book, and only the caller knows which half the operator
-    // just exported.
-    return reject(
-      io,
-      "unattributed",
-      renderUnattributedRefusal(
-        coverage.unmatched,
-        new Set(records.map((record) => record.id)),
-      ),
-    );
-  }
-  if (coverage.status === "over-committed") {
-    const detail = coverage.shortfalls
-      .map(
-        (shortfall) =>
-          `${shortfall.fundingReserveId}: committed ${shortfall.committed} against a balance ` +
-          `of ${shortfall.balance} (slack ${shortfall.slack})`,
-      )
-      .join("; ");
-    return reject(
-      io,
-      "over-committed",
-      `the declared reserve cannot fund this book — ${detail}. The venue would not have ` +
-        `accepted these orders against that balance, so the ATTRIBUTION is wrong; fix the ` +
-        `declaration rather than the file`,
-    );
+    // THE OBSERVATIONS RIDE IN. Excluded, the guard would weigh the restated rungs at their
+    // STALE remainders and could return `over-committed` over capital this very import is
+    // about to free — a false refusal, in the direction of blocking legitimate work.
+    const resting = pickRestingOrdersAsOf([...existingRecords, ...records, ...observations]);
+    const coverage = checkFundingCoverage(resting, await io.fundReview());
+    if (coverage.status === "unattributed") {
+      // ONE refusal for BOTH classes. Cross-currency funding is not designed and an
+      // unadmitted reserve cannot fund a live claim; either way the rung is refused here
+      // and in the report, and the operator is told about every one of them at once rather
+      // than paying a second full pass — declaration prompt included — to learn the second
+      // class (#179).
+      //
+      // PLACEMENT IDS ONLY in the mark. `resting` above is the whole book, and the mark
+      // says which listed rungs are NOT this batch's to re-declare. An observation carries
+      // no `fundingReserveId` and the prompt never offered one for it, so marking a
+      // restated rung as "this batch's" would point the operator at a declaration that
+      // does not exist.
+      return reject(
+        io,
+        "unattributed",
+        renderUnattributedRefusal(
+          coverage.unmatched,
+          new Set(records.map((record) => record.id)),
+        ),
+      );
+    }
+    if (coverage.status === "over-committed") {
+      const detail = coverage.shortfalls
+        .map(
+          (shortfall) =>
+            `${shortfall.fundingReserveId}: committed ${shortfall.committed} against a balance ` +
+            `of ${shortfall.balance} (slack ${shortfall.slack})`,
+        )
+        .join("; ");
+      return reject(
+        io,
+        "over-committed",
+        `the declared reserve cannot fund this book — ${detail}. The venue would not have ` +
+          `accepted these orders against that balance, so the ATTRIBUTION is wrong; fix the ` +
+          `declaration rather than the file`,
+      );
+    }
   }
 
-  const known = new Set(existingRecords.map((record) => record.id));
-  const fresh: OrderPlacedRecord[] = records.filter((record) => !known.has(record.id));
+  // ONE `appendOrders` CALL for both kinds: one lock, one temp write, one `rename`. There
+  // is no ordering reason to split them — the selector sorts by `observedAt` at READ time,
+  // so the file's byte order cannot change what it means.
+  const alreadyOnFile = new Set(existingRecords.map((record) => appendKey(record)));
+  const fresh: OrderRecord[] = [...records, ...observations].filter(
+    (record) => !alreadyOnFile.has(appendKey(record)),
+  );
   try {
     await io.appendOrders(io.ordersPath, fresh);
   } catch (error) {
@@ -1021,5 +1129,44 @@ export async function importBitgetOpenOrders(
     return reject(io, "write-failed", `could not append to ${io.ordersPath}: ${detail}`);
   }
 
-  return report(fresh.length, records.length - fresh.length);
+  return report(fresh, records);
+}
+
+/**
+ * THE APPEND FILTER'S KEY — what makes a line a REPEAT of one already on file (#181).
+ *
+ * KEYED ON WHAT THE LINE ASSERTS, not on when it was looked at, and the two kinds assert
+ * different things:
+ *
+ *   - `orderFillObserved` → `(kind, id, observedFilledQuantity)`. Two observations of the
+ *     same cumulative figure are the SAME FACT stated twice and dedupe; 8 then 9 are
+ *     genuine movement and both land.
+ *   - everything else → `(kind, id, observedAt)`. For a placement this is exactly
+ *     equivalent to keying on the id alone, since `synthesizeOrderId` already includes
+ *     `observedAt`, so repeat-placement dedupe is unchanged.
+ *
+ * WHY NOT `observedAt` FOR AN OBSERVATION, which is what an id-and-stamp key would give.
+ * One export is one look, so a whole batch shares one second-granular stamp — and two
+ * imports inside the SAME second would then key identically, so the second import's
+ * observation was silently dropped while the operator was told it was RECORDED and a
+ * successful status came back. Honesty and information loss rather than money loss, and
+ * ordinary to reach: two exports back to back, or any scripted loop.
+ *
+ * MILLISECOND PRECISION WAS REJECTED as the fix, not overlooked. `isObservedAtStamp`
+ * validates `YYYY-MM-DDTHH:MM:SS`, the stamp is string-compared across the whole repo and
+ * is a component of a durable event id — and milliseconds only SHRINK the collision
+ * window rather than closing it, while keying on the figure closes it.
+ *
+ * THE EQUAL STAMPS ARE FINE DOWNSTREAM. `pickRestingOrdersAsOf` sorts stably, so file
+ * order breaks the tie and replays 8 then 9 — the batch stamp's own argument working as
+ * written.
+ *
+ * WHY `kind` IS IN THE KEY AT ALL: an observation shares its rung's id, so an id-only key
+ * would read the first observation of a known rung as a repeat of its placement line and
+ * drop it — the whole feature, filtered out by its own dedupe.
+ */
+function appendKey(record: OrderRecord): string {
+  return record.kind === "orderFillObserved"
+    ? `${record.kind} ${record.id} ${record.observedFilledQuantity}`
+    : `${record.kind} ${record.id} ${record.observedAt}`;
 }

--- a/apps/tui/src/import-orders.ts
+++ b/apps/tui/src/import-orders.ts
@@ -38,6 +38,11 @@ import {
   type UnmatchedRung,
 } from "@numisma/engine";
 import type { OrdersLoad } from "@numisma/preferences";
+import {
+  reportOrdersImport,
+  type OrdersImportRecorded,
+  type RecordedObservation,
+} from "./import-orders-report.js";
 import { plural } from "./plural.js";
 import { renderSkipMessage } from "./skip-message.js";
 
@@ -188,45 +193,6 @@ export type OrdersImportRejection =
   | "write-failed";
 
 /**
- * A rung the venue has filled FURTHER since the file last observed it, RECORDED (#181).
- *
- * The id is synthesized from the SUBMISSION stamp, so a rung that fills between two
- * exports comes back under the same id carrying a larger `filled_quantity`. That is not
- * an amendment and not a re-sighting — it is the ordinary life of a resting ladder — and
- * it now gets its own durable line: an `orderFillObserved`, stamped with the IMPORT
- * moment, which `pickRestingOrdersAsOf` folds as a new `consumed` baseline.
- *
- * IT REPLACES `RestatedPartial` RATHER THAN REPURPOSING IT (#199 → #181). That type
- * carried BOTH remainders because the pair WAS the safety argument for a per-rung SKIP:
- * printing them let an operator check that the stale line still encumbered no less than
- * the venue held. There is no skip left to justify, and after the observation lands the
- * pair is redundant by construction — the file's remainder becomes `quantity − observed`,
- * which is exactly the venue's. What an operator still wants is the one thing this
- * carries: what the file knew, and what it now records.
- *
- * IT IS NOT A QUALIFICATION. A restatement qualified the status while it was a DEFERRAL —
- * a rung read perfectly and then not written down — and this build writes it down. See
- * {@link OrdersImportOutcome}'s `imported` member for what that does to the union.
- *
- * THE DIRECTION IS STILL READ OFF THE REMAINDER, not off the two figures (#200 review).
- * A restatement the file's OWN fill lines have already overtaken is not a restatement at
- * all — the fund has BOOKED units the venue does not corroborate — and those rungs stay a
- * batch-wide `changed-claim` refusal. The algebra is on `partitionChangedClaims`.
- */
-export interface RecordedObservation {
-  id: string;
-  /**
-   * The file's LATEST OBSERVATION of this rung's partial — a later `orderFillObserved`
-   * line when one exists, else the placement line's own figure, else `0` (#181). Was "the
-   * partial the placement line records", which stopped being the same number the moment a
-   * restatement could be written down.
-   */
-  known: number;
-  /** The larger cumulative partial the venue's export now shows, and what was written. */
-  observed: number;
-}
-
-/**
  * A rung the export shows LESS filled than the file's latest observation of it (#181) —
  * the refusal `backwards-claim` is raised over.
  *
@@ -244,104 +210,22 @@ interface BackwardsClaim {
 }
 
 /**
- * What an import that REFUSED NOTHING reports, in the two shapes it can honestly take.
+ * WHAT AN IMPORT REPORTS — the two recorded shapes, plus the refusal.
  *
- * Not "an import that WROTE" (#200 review): an export whose every readable rung was
- * already on file saying the same thing writes no line at all and still reports here,
- * because the flow reached its end with nothing refused. Writing is what these outcomes
- * usually DO; not refusing is what they all MEAN.
+ * The recorded half lives in `./import-orders-report.js`, beside the rule that decides
+ * between its two members, and is re-exported here so this module's public surface is
+ * unchanged: `OrdersImportOutcome` and {@link RecordedObservation} are still importable
+ * from `./import-orders.js`, which is the only path the CLI and the tests know.
+ *
+ * THE REFUSAL STAYS HERE because it is this shell's own vocabulary — every member of
+ * {@link OrdersImportRejection} names a guard in this file, and nothing the reporter does
+ * can reach one. The reporter is only ever called after the write.
  */
-interface OrdersImportWrite {
-  /**
-   * ORDERS appended — placement lines, and never a line count (#181). The two were the
-   * same number until an import could write a second kind, and the moment it could, a
-   * pure-observation import reported `1 order(s) appended` about ZERO orders.
-   *
-   * `appended` KEEPS MEANING ORDERS because that is the question the number is read for:
-   * *how many claims on my capital did this import create?* An observation creates none —
-   * it only ever REDUCES what a rung still claims — so counting it here would answer that
-   * question wrongly in the direction that matters. Observations are counted by
-   * {@link observations}, whose length IS the count.
-   *
-   * ZERO in three different ways now, and the other fields tell them apart: every rung was
-   * already known (`alreadyKnown` carries them), every readable rung was restated
-   * (`observations` carries them), or the export named nothing this build admitted.
-   */
-  appended: number;
-  /**
-   * Rungs already in the sidecar under the same synthesized id AND saying the same
-   * thing about it — the id components plus `quantity` and the observed partial.
-   *
-   * A row that differs NEVER reaches this count, whichever way it goes: it either
-   * refuses the whole batch as `changed-claim` / `backwards-claim` (#174, #181) or is
-   * recorded as an observation and reported in {@link observations} (#181). Calling
-   * either one "already known" is the silence #174 named — it reports "nothing to do"
-   * about a rung the file now describes wrongly.
-   */
-  alreadyKnown: number;
-  /**
-   * The export rows this build could not read — NOT empty on `imported`, and the
-   * asymmetry with {@link observations} is deliberate rather than an oversight. A
-   * `not-resting` row was read COMPLETELY and the parser's finding about it is that
-   * nothing is still claimed, so it rides here and qualifies nothing (#184). What
-   * `imported` promises about this field is that none of its entries left a rung
-   * UNWEIGHED — that is `leavesRungUnweighed`'s question, not this array's length.
-   */
-  skips: BitgetRowSkip[];
-  /**
-   * The restatements this import RECORDED — exactly one `orderFillObserved` line each
-   * (#181), and never a superset of what was written.
-   *
-   * DERIVED FROM THE LINES THAT WERE WRITTEN, not from the decision that proposed them,
-   * and that is the whole shape of `report`. A decision the append filter did not let
-   * through is ABSENT here, so the operator is never told a line was RECORDED that is not
-   * on disk. The `known`/`observed` pair is the one thing joined back from the decision —
-   * the written line carries the new figure, and only the decision remembers the old one.
-   *
-   * NOT A QUALIFICATION, unlike the `restated` field it replaces. That field's own length
-   * decided the status, because a skipped rung was work DEFERRED; this one records work
-   * DONE, so `imported` widens back over it. A reader who never opens this field is not
-   * misled by one, which is the test that decides what may qualify a status.
-   */
-  observations: RecordedObservation[];
-}
-
 export type OrdersImportOutcome =
-  /**
-   * Every row of the export was read. The unqualified success, and the only one.
-   *
-   * ITS INVARIANT WIDENS BACK HERE (#199 → #181), and this union has never shrunk before,
-   * so it is worth saying plainly: this is a GAP CLOSING, not precision lost. #199
-   * strengthened the member to "every row read AND nothing restated" because a
-   * restatement was then a DEFERRAL — a rung read perfectly and then not written down —
-   * and a status that called that unqualified would be lying to the reader who opens no
-   * second field. The restatement is now RECORDED, so it defers nothing and qualifies
-   * nothing, and the only thing left qualifying an import is a row nobody could read.
-   */
-  | ({ status: "imported" } & OrdersImportWrite)
-  /**
-   * The import ran to its end, and SOMETHING ABOUT THE EXPORT WAS QUALIFIED (`D3`, #177;
-   * #199).
-   *
-   * A DISTINCT MEMBER, not `imported` carrying a non-empty field. A shape that forces
-   * every reader to open a second field to discover the first was qualified is a type
-   * that lies to the reader who does not. It is still a SUCCESS, and the test is that
-   * NOTHING WAS REFUSED — not that lines were written, which is the weaker claim this
-   * used to make and which an export of nothing but restated rungs falsifies while still
-   * being a perfectly honest run. The CLI exits 0 either way (`D3`).
-   *
-   * ONE qualification reaches it now (#181): `skips` — a row was not read, so a rung
-   * resting at the venue is `committed` that nobody counted and `available` reads HIGH.
-   * A restated rung used to be the second, and it is a RECORDED line rather than a
-   * deferral since #181, so it no longer qualifies anything.
-   *
-   * STILL A DISTINCT MEMBER RATHER THAN A PREDICATE OVER `skips`, because `skips` is
-   * heterogeneous: a `not-resting` row was read completely and qualifies nothing, so the
-   * status is decided by `leavesRungUnweighed` over the entries rather than by the
-   * array's length. It is still a SUCCESS, and the test is that NOTHING WAS REFUSED.
-   */
-  | ({ status: "imported-partial" } & OrdersImportWrite)
+  | OrdersImportRecorded
   | { status: "rejected"; reason: OrdersImportRejection; message: string };
+
+export type { RecordedObservation };
 
 export interface OrdersImportOptions {
   csvPath: string;
@@ -946,117 +830,18 @@ export async function importBitgetOpenOrders(
     // than decorative. A rung reaches `restated` only because its figure moved UP from
     // what the file knew, and the file's floor is 0, so the figure is positive; the stamp
     // comes from `formatObservedAt` and the currency from a parsed row. If one ever did
-    // refuse, the line is NOT written and — because `report` describes the lines that were
-    // written — the operator is not told it was recorded. The refusal is loud rather than
+    // refuse, the line is NOT written and — because `reportOrdersImport` describes the lines
+    // that were written — the operator is not told it was recorded. The refusal is loud rather than
     // silent, on the channel every other per-row problem in this flow uses.
     io.err(
       `${order.id} skipped — the restatement could not be recorded: ${built.message}`,
     );
   }
 
-  // The old figure lives ONLY in the decision — the written line carries the new one and
-  // nothing else — so this is the one thing `report` joins back out of `restated`, and it
-  // joins rather than iterates: a decision with no line on disk is never reached.
+  // THE JOIN, NOT THE ITERATION: `reportOrdersImport` is handed this Map and the lines that
+  // were WRITTEN, so a decision with no line on disk is never reached. See that module's
+  // header for why the reporter takes the map rather than `restated` itself.
   const knownFigures = new Map(restated.map((claim) => [claim.id, claim.known] as const));
-
-  /**
-   * THE REPORT, FED THE LINES THAT WERE ACTUALLY WRITTEN (#181).
-   *
-   * It used to be handed two bare numbers from ABOVE the write and then reach past its own
-   * parameter list into the DECISION array for the rest — so it described what the flow
-   * DECIDED while the file held what the append filter LET THROUGH. One defect with three
-   * faces, and the visible one was a dropped line surfacing as a confident `RECORDED`.
-   *
-   * Every count and every operator line is now derived HERE, from `written`. `placements`
-   * is passed as an ARRAY rather than as a count for the same reason: `alreadyKnown` is
-   * "what this batch proposed, less what landed", and both halves of that subtraction must
-   * be counted by one rule in one place. The only thing read out of the decision is the
-   * `known` figure joined per line, because the line itself cannot remember it.
-   *
-   * ONE `io.out`, reached by every exit, so the `OBSERVED —` detail is constructed once BY
-   * CONSTRUCTION rather than by discipline. It was written out verbatim at two exits
-   * before, eight lines under a comment stating the very invariant that duplication breaks.
-   */
-  const report = (
-    written: readonly OrderRecord[],
-    placements: readonly OrderPlacedRecord[],
-  ): OrdersImportOutcome => {
-    const appended = written.filter((record) => record.kind === "orderPlaced").length;
-    const alreadyKnown = placements.length - appended;
-    const observed: RecordedObservation[] = [];
-    for (const record of written) {
-      if (record.kind !== "orderFillObserved") {
-        continue;
-      }
-      const known = knownFigures.get(record.id);
-      // A written observation with no decision behind it cannot exist — every one of them
-      // was built from a `restated` entry a few lines above. Dropped rather than defaulted
-      // if it ever did: inventing a `known` would print an arithmetic nobody performed.
-      if (known !== undefined) {
-        observed.push({ id: record.id, known, observed: record.observedFilledQuantity });
-      }
-    }
-
-    // THE OBSERVATION CLAUSE RENDERS ALWAYS, INCLUDING AT ZERO. A clause that appears
-    // conditionally is two shapes for a reader to learn and two for a test to assert, and
-    // it is one more place for the two exits to diverge again. `appended` counts ORDERS,
-    // so a pure-observation import reads `0 order(s) appended` beside a non-zero
-    // observation count — which is the honest pair, not a contradiction.
-    const counts =
-      `${appended} order(s) appended, ${alreadyKnown} already known, ` +
-      `${observed.length} observation(s) recorded`;
-    const write = { appended, alreadyKnown, skips: parsed.skips, observations: observed };
-
-    // NOT `parsed.skips.length` (#184). `skips` is heterogeneous, and a `not-resting` row
-    // was read COMPLETELY — the parser's finding about it is that nothing is still
-    // claimed. The gap this line warns about is rungs we could not weigh, so both the
-    // discrimination and the count below run through the engine's predicate rather than
-    // the raw total. `outcome.skips` still carries every skip and stderr still reports
-    // every one of them.
-    const unweighed = parsed.skips.filter((entry) => leavesRungUnweighed(entry.problem));
-
-    // EACH NOTICE GETS ITS OWN LINE, OPENING ON WHAT IT IS ABOUT (`D3`, #177; #199). The
-    // counts follow all of them, once — they used to be the whole line, with the notice a
-    // suffix (`..., 1 row(s) skipped.`) in exactly the position an operator skims past.
-    //
-    // Unread rows lead, because they are the one thing here we know least about: a
-    // restatement was read perfectly and we can state its figures, an unread row we cannot.
-    const notices: string[] = [];
-
-    if (unweighed.length > 0) {
-      notices.push(
-        `INCOMPLETE — ${unweighed.length} row(s) of ${csvPath} could not be read, so that ` +
-          `many rung(s) resting at the venue are NOT counted as committed and available reads ` +
-          `HIGH by whatever they encumber. Re-export and re-import to pick the missing ` +
-          `rung(s) up; the reasons are on the error channel above.`,
-      );
-    }
-
-    if (observed.length > 0) {
-      // BOTH FIGURES AND NO REMAINDERS. The remainders were printed while the rung was
-      // SKIPPED, because they were the safety argument an operator was owed a way to
-      // check; the line is written now, so the file's remainder IS the venue's and the
-      // pair would print the same number twice.
-      const detail = observed
-        .map((claim) => `${claim.id} (filled ${claim.known} → ${claim.observed})`)
-        .join("; ");
-      notices.push(
-        `OBSERVED — ${observed.length} rung(s) of ${csvPath} have filled FURTHER at the ` +
-          `venue since this file last observed them — ${detail} — and the restatement was ` +
-          `RECORDED. Their remainders now read what the venue shows. This is NOT a ` +
-          `qualification: the work is done, and the line does not reprint on the next ` +
-          `import unless the venue moves again.`,
-      );
-    }
-
-    io.out([...notices, `Imported ${csvPath}: ${counts}.`].join("\n") + `\n`);
-
-    // A ROW NOBODY COULD READ IS THE ONLY THING LEFT THAT QUALIFIES AN IMPORT (#181). A
-    // restatement qualified while it was deferred; it is recorded here, so it does not.
-    return unweighed.length === 0
-      ? { status: "imported", ...write }
-      : { status: "imported-partial", ...write };
-  };
 
   // AN OBSERVATIONS-ONLY IMPORT SKIPS BOTH THE PROMPT AND THE GUARD. There is nothing to
   // attribute — every rung here is already on file under its own placement line, with a
@@ -1142,7 +927,19 @@ export async function importBitgetOpenOrders(
     return reject(io, "write-failed", `could not append to ${io.ordersPath}: ${detail}`);
   }
 
-  return report(fresh, records);
+  // THE WRITE IS THE SHELL'S, THE WORDS ARE THE RULE'S (ADR-001). `reportOrdersImport` is a
+  // pure function of what landed, so it returns the message rather than printing it, and
+  // this — the one `io.out` of the whole flow, reached by the one exit that gets here —
+  // is where it is spoken.
+  const { outcome, message } = reportOrdersImport({
+    written: fresh,
+    placements: records,
+    knownFigures,
+    skips: parsed.skips,
+    csvPath,
+  });
+  io.out(message);
+  return outcome;
 }
 
 /**

--- a/apps/tui/src/import-orders.ts
+++ b/apps/tui/src/import-orders.ts
@@ -36,6 +36,7 @@ import {
 } from "@numisma/engine";
 import type { OrdersLoad } from "@numisma/preferences";
 import { plural } from "./plural.js";
+import { renderSkipMessage } from "./skip-message.js";
 
 /** Everything this flow touches that is not a pure function, in one injectable bag. */
 export interface OrdersImportIo {
@@ -788,12 +789,9 @@ export async function importBitgetOpenOrders(
     return reject(io, "unreadable-sidecar", `could not read ${io.ordersPath}: ${existing.message}`);
   }
   if (existing.status === "loaded" && existing.skips.length > 0) {
-    return reject(
-      io,
-      "unreadable-sidecar-lines",
-      `${io.ordersPath} has ${existing.skips.length} line(s) this build cannot read, so the ` +
-        `committed sum would be computed over a partially-read book`,
-    );
+    // Same refusal, same reason code, same exit — one shared sentence (#181). Nothing is
+    // appended over a partially-read book either way.
+    return reject(io, "unreadable-sidecar-lines", renderSkipMessage(io.ordersPath, existing.skips));
   }
   const existingRecords: OrderRecord[] = existing.status === "loaded" ? existing.records : [];
 

--- a/apps/tui/src/record-fill.test.ts
+++ b/apps/tui/src/record-fill.test.ts
@@ -18,6 +18,7 @@
 import { describe, expect, it } from "vitest";
 import {
   buildCompositionReport,
+  buildOrderFillObserved,
   committedRungs,
   foldEvents,
   parseFundReview,
@@ -925,5 +926,102 @@ describe("the cash-debited override is weighed against the reserve's available",
 
     const outcome = expectRecorded(await recordFill(harness.io));
     expect(outcome.act.event.funding.amount).toBe(400 * 10);
+  });
+});
+
+// ---------------------------------------------------------------------------------------
+// THE BOOKED-FILLS CEILING (#181, slice #207) — seam `S-C`, at the gate that lets a lot
+// and a cash leg into `events.jsonl`.
+//
+// Slice #206 made `consumed` NON-MONOTONIC: an `orderFillObserved` SETS the baseline, so
+// an observation below it takes a retired rung's `remainingQuantity` from zero back to
+// positive. `remainingQuantity` is therefore a REPORT and not an AUTHORIZATION, and this
+// flow was using it as one. The gate is now
+//
+//     admissible = min(rung.remainingQuantity, rung.quantity − bookedFills(id))
+//
+// and NEITHER ADMISSION GATE HAD EVER SEEN THIS RECORD KIND before these cases.
+describe("the fill recorder ceilings admission at the rung's PLACED quantity", () => {
+  it("refuses a resurrected rung instead of booking a SECOND lot and cash leg", async () => {
+    // Fill the top rung in full, honestly, through the real flow — so the 10 booked units
+    // have a real lot and a real funding leg answering for them in the log.
+    const first = new Harness({ answers: openTopRungAnswers() });
+    expectRecorded(await recordFill(first.io));
+    expect(pickRestingOrdersAsOf(first.orderRecords()).map((order) => order.placed.id)).toEqual([
+      "rung-300",
+      "rung-200",
+    ]);
+
+    // Now the hand-authored line. `appendOrders` constrains no kind and this flow's own
+    // torn-act guidance instructs hand-authoring, so this is a reachable file state and
+    // not a contrived one. It asserts the venue showed 3 filled — BELOW what the fund has
+    // already booked — which SETS `consumed` back to 3 and resurrects the rung at 7.
+    const observation = buildOrderFillObserved({
+      id: "rung-400",
+      observedAt: "2026-01-06T09:00:00",
+      currency: "USD",
+      observedFilledQuantity: 3,
+    });
+    if (observation.status !== "ok") throw new Error("synthetic observation refused");
+
+    const second = new Harness({
+      records: [...first.orderRecords(), observation.record],
+      events: first.logEvents(),
+      answers: [
+        "rung-400", // the resurrected rung is genuinely back on the list
+        "2026-01-07T12:00:00",
+        "", // defaults to the 7 the fold reports as still resting
+      ],
+    });
+    const ordersBefore = second.ordersImage;
+    const logBefore = second.logImage;
+
+    // The fold really does offer it — this is not a case where the rung is simply absent.
+    expect(pickRestingOrdersAsOf(second.orderRecords()).map((order) => order.placed.id)).toContain(
+      "rung-400",
+    );
+
+    const outcome = await recordFill(second.io);
+
+    expect(outcome.status).toBe("rejected");
+    if (outcome.status !== "rejected") throw new Error("expected a rejection");
+    expect(outcome.reason).toBe("exceeds-booked-fills");
+    // Actionable: it names the placed size, what is already booked, and the repair.
+    expect(outcome.message).toContain("placed for 10");
+    expect(outcome.message).toContain("10 is already booked");
+    expect(outcome.message).toContain("orderFillObserved");
+    // Both files byte-identical. Every refusal in this flow writes nothing.
+    expect(second.ordersImage).toBe(ordersBefore);
+    expect(second.logImage).toBe(logBefore);
+  });
+
+  it("is a NO-OP on an ordinary partial — placed 10, venue showed 2, nothing booked", async () => {
+    // The no-regression property, at the gate rather than in the arithmetic. `consumed` is
+    // 2 off the placement line and nothing is booked, so the headroom is the full 10 and
+    // the remainder of 8 is what binds — exactly the figure admitted before this slice.
+    const records = ladderRecords().map((record) =>
+      record.id === "rung-400" ? { ...record, observedFilledQuantity: 2 } : record,
+    );
+    const harness = new Harness({ records, answers: openTopRungAnswers() });
+
+    const outcome = expectRecorded(await recordFill(harness.io));
+
+    expect(outcome.act.order.filledQuantity).toBe(8);
+    expect(outcome.act.event.funding.amount).toBe(400 * 8);
+  });
+
+  it("keeps the remainder refusal's own trigger and WORDING unchanged", async () => {
+    // The `min`'s other term. When the remainder binds — every ordinary stream — the
+    // operator must meet the refusal they always met, word for word.
+    const harness = new Harness({
+      answers: ["rung-400", "2026-01-05T12:00:00", "11"],
+    });
+
+    const outcome = await recordFill(harness.io);
+
+    expect(outcome.status).toBe("rejected");
+    if (outcome.status !== "rejected") throw new Error("expected a rejection");
+    expect(outcome.reason).toBe("bad-quantity");
+    expect(outcome.message).toBe("11 exceeds the 10 still claimed by this rung");
   });
 });

--- a/apps/tui/src/record-fill.ts
+++ b/apps/tui/src/record-fill.ts
@@ -79,6 +79,7 @@ import {
 } from "@numisma/engine";
 import type { OrdersLoad } from "@numisma/preferences";
 import { nextLogImage, serializeEvent } from "./event-store.js";
+import { renderSkipMessage } from "./skip-message.js";
 
 /** Everything this act touches that is not a pure function, in one injectable bag. */
 export interface RecordFillIo {
@@ -330,12 +331,10 @@ export async function recordFill(io: RecordFillIo): Promise<RecordFillOutcome> {
     return reject(io, "unreadable-sidecar", `could not read ${io.ordersPath}: ${load.message}`);
   }
   if (load.status === "loaded" && load.skips.length > 0) {
-    return reject(
-      io,
-      "unreadable-sidecar-lines",
-      `${io.ordersPath} has ${load.skips.length} line(s) this build cannot read, so the resting ` +
-        `book monotonicity would reason over is only partly known`,
-    );
+    // Same refusal, same reason code, same exit — one shared sentence (#181). A fill is
+    // still withheld over a partially-read book; the operator is just told which of the
+    // two problems they actually have.
+    return reject(io, "unreadable-sidecar-lines", renderSkipMessage(io.ordersPath, load.skips));
   }
   const records: OrderRecord[] = load.status === "loaded" ? load.records : [];
 

--- a/apps/tui/src/record-fill.ts
+++ b/apps/tui/src/record-fill.ts
@@ -51,6 +51,7 @@
  * the speculative sidecar that is behind.
  */
 import {
+  bookedFills,
   buildEventReference,
   buildFillAct,
   committedRungs,
@@ -108,6 +109,15 @@ export type RecordFillRejection =
   | "unknown-rung"
   | "bad-timestamp"
   | "bad-quantity"
+  /**
+   * The requested quantity fits what the rung REPORTS as still resting, and still exceeds
+   * what it may BOOK: total booked fills would pass the placed quantity (#181). Separated
+   * from `bad-quantity` for the same reason `unknown-order` is separated from `not-resting`
+   * in `cancel-order.ts` — the quantity is not the operator's mistake here, the sidecar's
+   * latest observation is, and the two want different next moves. Reachable only on a rung
+   * a backwards observation resurrected.
+   */
+  | "exceeds-booked-fills"
   | "impossible-verdict"
   | "verdict-contradicts-operator"
   /**
@@ -385,11 +395,61 @@ export async function recordFill(io: RecordFillIo): Promise<RecordFillOutcome> {
   if (!Number.isFinite(filledQuantity) || filledQuantity <= 0) {
     return reject(io, "bad-quantity", `'${quantityAnswer}' is not a positive quantity`);
   }
-  if (filledQuantity > filled.remainingQuantity) {
+
+  // THE ADMISSION CEILING (#181) — the gate that lets a lot and a cash leg into
+  // `events.jsonl`, and the ONE place policy about it lives.
+  //
+  //     admissible = min(remainingQuantity, quantity − bookedFills(id))
+  //
+  // WHY `remainingQuantity` ALONE IS NO LONGER SUFFICIENT. The selector folds ONE
+  // `consumed` baseline per rung and an `orderFillObserved` line SETS it, so `consumed` is
+  // NOT MONOTONIC: an observation asserting a figure BELOW the baseline takes `remaining`
+  // from zero back to positive and a retired rung RESURRECTS. That is deliberate and
+  // correct arithmetic — see `select.ts`, invariant 2 — but it means `remainingQuantity` is
+  // a REPORT of what is still encumbered, not an AUTHORIZATION to book against it.
+  //
+  // Traced on a rung placed at 10 with all 10 booked: an observation of 3 makes the fold
+  // report 7 still resting, and the old gate would have authorized 7 more units — TOTAL
+  // BOOKED FILLS OF 17 AGAINST A PLACED 10, two lots and two cash legs the venue never
+  // filled, in a log with NO REVERSAL VERB. The invariant that closes it is not "was this
+  // rung ever exhausted" — exhaustion history would push state back into a fold that must
+  // stay pure — but the simpler and stronger one: a rung's TOTAL BOOKED FILLS MAY NEVER
+  // EXCEED ITS PLACED QUANTITY.
+  //
+  // ON EVERY ORDINARY STREAM THIS IS A PROVABLE NO-OP. Placement and observation only ever
+  // set the baseline at or above what the fund has booked, so `consumed ≥ bookedFills`
+  // holds on any stream the import path can produce, therefore
+  // `remainingQuantity ≤ quantity − bookedFills` and the `min` never binds. It binds ONLY
+  // in the resurrection case, which is why this ships without re-testing every existing
+  // fill path: nothing admissible before became inadmissible.
+  //
+  // NOT A HYPOTHETICAL REACHABILITY. `appendOrders` is typed over the whole record union
+  // and constrains no kind, and this flow's OWN torn-act guidance above instructs
+  // hand-authoring a missing half. Hand-editing this file is a documented operator
+  // procedure. (A validating write seam on `appendOrders` would bound this class at the
+  // file rather than at each caller. It is a real want and its own increment.)
+  const booked = bookedFills(records, filled.orderId);
+  const headroom = filled.quantity - booked;
+  const ceiling = Math.min(filled.remainingQuantity, headroom);
+  if (filledQuantity > ceiling) {
+    // WHICH TERM BOUND DECIDES WHICH REFUSAL. When the remainder binds — every ordinary
+    // stream — the operator meets the refusal they always met, unchanged. The second
+    // wording is reachable only on a resurrected rung, and it is a different problem
+    // needing a different next move, so it says so rather than blaming the quantity.
     return reject(
       io,
-      "bad-quantity",
-      `${filledQuantity} exceeds the ${filled.remainingQuantity} still claimed by this rung`,
+      ceiling === filled.remainingQuantity ? "bad-quantity" : "exceeds-booked-fills",
+      ceiling === filled.remainingQuantity
+        ? `${filledQuantity} exceeds the ${filled.remainingQuantity} still claimed by this rung`
+        : `${filledQuantity} exceeds the ${headroom} this rung can still book: it was ` +
+          `placed for ${filled.quantity} and ${booked} is already booked as filled against ` +
+          `it. ${io.ordersPath} reports ${filled.remainingQuantity} still resting because its ` +
+          `latest observation of this rung asserts LESS than the fund has already booked, ` +
+          `which resurrects a rung the fund exhausted rather than re-opening one the venue ` +
+          `re-opened. Recording against it would put a second lot and a second cash leg in ` +
+          `${io.eventsPath} for capital already spent, and that log has no reversal verb. ` +
+          `Append a correct orderFillObserved line for '${filled.orderId}' — one at or above ` +
+          `${booked} — and record the fill after that`,
     );
   }
 

--- a/apps/tui/src/skip-message-shells.test.ts
+++ b/apps/tui/src/skip-message-shells.test.ts
@@ -213,6 +213,10 @@ const SHELLS: Shell[] = [
         csvPath,
         io: {
           readExport: async () => syntheticExport(),
+          // Frozen, and never reached: this case refuses over an unreadable sidecar long
+          // before an observation could be stamped. Supplied because the seam is required,
+          // not because the refusal depends on it.
+          now: () => new Date("2026-01-01T09:00:00"),
           ordersPath: ORDERS_PATH,
           loadOrders: async () => loadedWith(skips),
           appendOrders: async () => {

--- a/apps/tui/src/skip-message-shells.test.ts
+++ b/apps/tui/src/skip-message-shells.test.ts
@@ -1,0 +1,279 @@
+/**
+ * THE FOUR SHELLS, ASSERTED TOGETHER (#181).
+ *
+ * `renderSkipMessage` is unit-tested next door. This file exists because the defect it
+ * closes was never in one shell's wording — it was that FOUR shells each carried their
+ * own, and all four flattened `unknown-kind` into "unreadable". Testing one shell and
+ * eyeballing the other three is the exact reading that let the divergence live, so every
+ * shell that refuses on a skip is driven here, through its real entry point, and asserted
+ * on both halves of the claim:
+ *
+ *   - it STILL REFUSES, with the same rejection token as before — nothing here renders a
+ *     committed figure that was previously withheld; and
+ *   - it says the line came from a NEWER BUILD, and does not call the file unreadable.
+ *
+ * A fifth shell added later that hand-writes its own sentence will not be caught by a
+ * compiler, so a reviewer meeting this table is the guard. `SHELLS` is the checklist.
+ *
+ * EVERY FIXTURE IS SYNTHETIC (`O7`): invented pair, round prices, round sizes.
+ */
+import { mkdtemp, rm, writeFile } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join, resolve } from "node:path";
+import {
+  BITGET_OPEN_ORDERS_HEADER,
+  parseFundReview,
+  type FundReviewData,
+  type OrderRecord,
+  type PortfolioEvent,
+} from "@numisma/engine";
+import type { OrderSkip, OrdersLoad } from "@numisma/preferences";
+import { afterEach, describe, expect, it } from "vitest";
+import { loadAvailableCapital } from "./available-capital.js";
+import { cancelOrder } from "./cancel-order.js";
+import { importBitgetOpenOrders } from "./import-orders.js";
+import { recordFill } from "./record-fill.js";
+
+const ORDERS_PATH = "/synthetic/orders.jsonl";
+const EVENTS_PATH = "/synthetic/events.jsonl";
+const RESERVE = "reserve-capital";
+
+const createdDirs: string[] = [];
+
+afterEach(async () => {
+  await Promise.all(createdDirs.map((dir) => rm(dir, { recursive: true, force: true })));
+  createdDirs.length = 0;
+});
+
+/** A line whose `kind` this build does not know — the whole point of the slice. */
+const UNKNOWN_KIND: OrderSkip = {
+  line: 4,
+  problem: "unknown-kind",
+  message: 'unknown kind "orderRepriced"',
+};
+
+/** A line that really is broken, kept beside it so the two never collapse. */
+const MALFORMED: OrderSkip = {
+  line: 2,
+  problem: "malformed",
+  message: "id must be a non-empty string",
+};
+
+const RUNG: OrderRecord = {
+  id: "rung-0",
+  observedAt: "2026-01-02T10:00:00",
+  kind: "orderPlaced",
+  currency: "USD",
+  symbol: "XYZ/USDT",
+  side: "buy",
+  price: 100,
+  quantity: 2,
+  fundingReserveId: RESERVE,
+};
+
+function syntheticFund(): FundReviewData {
+  const parsed = parseFundReview({
+    fund: { id: "synthetic-fund", name: "Synthetic Fund", baseCurrency: "USD" },
+    review: { asOf: "2026-01-31", usdMxn: 20 },
+    portfolios: [{ id: "core", name: "Core" }],
+    accounts: [{ id: "venue-usd", name: "Synthetic Venue", platform: "BITGET", currency: "USD" }],
+    instruments: [{ id: "test-usd", name: "Test Asset", symbol: "XYZ", currency: "USD" }],
+    reserves: [
+      {
+        id: RESERVE,
+        portfolioId: "core",
+        tempo: "Capital",
+        executionMode: "live",
+        accountId: "venue-usd",
+        currency: "USD",
+        amount: 1000,
+      },
+    ],
+    positions: [],
+  });
+  if (parsed.kind !== "ok") throw new Error("synthetic fixture must parse");
+  return parsed.value;
+}
+
+function loadedWith(skips: OrderSkip[]): OrdersLoad {
+  return { status: "loaded", path: ORDERS_PATH, records: [RUNG], skips };
+}
+
+/** A one-rung synthetic export, so the import reaches the sidecar load at all. */
+function syntheticExport(): string {
+  const fields: Record<string, string> = {
+    timestamp: "2020-01-01 10:00:00",
+    pair: "XYZ/USDT",
+    time_in_force: "GTC",
+    order_type: "Limit",
+    side: "Buy",
+    price: "1000",
+    quantity: "0.1",
+    trigger_price: "-- / --",
+    order_value: "0",
+    filled_quantity: "0",
+    total_quantity: "0.1",
+    filled_percent: "0.00%",
+    status: "Unfilled",
+    action: "Cancel",
+  };
+  const row = BITGET_OPEN_ORDERS_HEADER.map((column) => fields[column] ?? "").join(",");
+  return [BITGET_OPEN_ORDERS_HEADER.join(","), row, ""].join("\n");
+}
+
+/** What a shell told the operator, and the token it refused under. */
+interface Refusal {
+  reason: string;
+  message: string;
+}
+
+/**
+ * One shell, reduced to the only thing this file cares about: hand it a skip list, get
+ * back the refusal. Every entry drives the shell's REAL exported entry point — a stub
+ * that reimplements the refusal would assert nothing.
+ */
+interface Shell {
+  name: string;
+  /** The rejection token this shell has always used; asserted unchanged. */
+  reason: string;
+  refuse: (skips: OrderSkip[]) => Promise<Refusal>;
+}
+
+const SHELLS: Shell[] = [
+  {
+    name: "availableCapital",
+    // Not a rejection token — this shell reports `refused` as its status.
+    reason: "refused",
+    refuse: async (skips) => {
+      const section = await loadAvailableCapital(syntheticFund(), {
+        ordersPath: ORDERS_PATH,
+        loadOrders: async () => loadedWith(skips),
+      });
+      if (section.status !== "refused") throw new Error(`expected refusal, got ${section.status}`);
+      return { reason: section.status, message: section.message };
+    },
+  },
+  {
+    name: "cancelOrder",
+    reason: "unreadable-sidecar-lines",
+    refuse: async (skips) => {
+      const outcome = await cancelOrder({
+        orderId: RUNG.id,
+        io: {
+          ordersPath: ORDERS_PATH,
+          loadOrders: async () => loadedWith(skips),
+          appendOrders: async () => {
+            throw new Error("must not write");
+          },
+          now: () => new Date("2026-02-01T10:00:00Z"),
+          out: () => {},
+          err: () => {},
+        },
+      });
+      if (outcome.status !== "rejected") throw new Error("expected a rejection");
+      return { reason: outcome.reason, message: outcome.message };
+    },
+  },
+  {
+    name: "recordFill",
+    reason: "unreadable-sidecar-lines",
+    refuse: async (skips) => {
+      const outcome = await recordFill({
+        ordersPath: ORDERS_PATH,
+        eventsPath: EVENTS_PATH,
+        loadOrders: async () => loadedWith(skips),
+        appendOrders: async () => {
+          throw new Error("must not write");
+        },
+        readLogImage: async () => undefined,
+        writeLogImage: async () => {
+          throw new Error("must not write");
+        },
+        restoreLogImage: async () => {},
+        loadGenesis: async () => syntheticFund(),
+        loadLogEvents: async (): Promise<PortfolioEvent[]> => [],
+        loadFolded: async () => syntheticFund(),
+        ask: async () => "",
+        out: () => {},
+        err: () => {},
+      });
+      if (outcome.status !== "rejected") throw new Error("expected a rejection");
+      return { reason: outcome.reason, message: outcome.message };
+    },
+  },
+  {
+    name: "importBitgetOpenOrders",
+    reason: "unreadable-sidecar-lines",
+    refuse: async (skips) => {
+      const dir = await mkdtemp(resolve(tmpdir(), "numisma-skip-shells-"));
+      createdDirs.push(dir);
+      const csvPath = join(dir, "open-orders.csv");
+      await writeFile(csvPath, syntheticExport(), "utf8");
+      const outcome = await importBitgetOpenOrders({
+        csvPath,
+        io: {
+          readExport: async () => syntheticExport(),
+          ordersPath: ORDERS_PATH,
+          loadOrders: async () => loadedWith(skips),
+          appendOrders: async () => {
+            throw new Error("must not write");
+          },
+          fundReview: async () => syntheticFund(),
+          ask: async () => "",
+          out: () => {},
+          err: () => {},
+        },
+      });
+      if (outcome.status !== "rejected") throw new Error("expected a rejection");
+      return { reason: outcome.reason, message: outcome.message };
+    },
+  },
+];
+
+describe("every shell that refuses on a skip renders ONE shared message", () => {
+  it("covers all four shells — the list itself is the checklist", () => {
+    expect(SHELLS.map((shell) => shell.name)).toEqual([
+      "availableCapital",
+      "cancelOrder",
+      "recordFill",
+      "importBitgetOpenOrders",
+    ]);
+  });
+
+  for (const shell of SHELLS) {
+    describe(shell.name, () => {
+      it("tells the operator an unknown-kind line came from a NEWER BUILD", async () => {
+        const refusal = await shell.refuse([UNKNOWN_KIND]);
+        expect(refusal.message).toContain("1 line(s) written by a newer build than this one");
+        expect(refusal.message).toContain("update this reader");
+        // The defect, stated as an assertion: a well-formed line from a newer build must
+        // never be reported as an unreadable file. That sends the operator to edit the
+        // line instead of updating the build.
+        expect(refusal.message).not.toContain("unreadable");
+        expect(refusal.message).not.toContain("cannot read");
+      });
+
+      it("STILL REFUSES on an unknown-kind skip, under the same token as before", async () => {
+        // The refusal stands and this slice is what proves it was right: an older build
+        // that read past the observation line would print the stale partial as a
+        // committed figure. No shell renders a figure it previously withheld.
+        const refusal = await shell.refuse([UNKNOWN_KIND]);
+        expect(refusal.reason).toBe(shell.reason);
+      });
+
+      it("still refuses a malformed skip, in today's wording", async () => {
+        const refusal = await shell.refuse([MALFORMED]);
+        expect(refusal.reason).toBe(shell.reason);
+        expect(refusal.message).toContain("1 unreadable line(s)");
+        expect(refusal.message).not.toContain("newer build");
+      });
+
+      it("renders BOTH classes at once, each with its own count", async () => {
+        const refusal = await shell.refuse([MALFORMED, UNKNOWN_KIND, { ...UNKNOWN_KIND, line: 9 }]);
+        expect(refusal.reason).toBe(shell.reason);
+        expect(refusal.message).toContain("1 unreadable line(s)");
+        expect(refusal.message).toContain("2 line(s) written by a newer build than this one");
+      });
+    });
+  }
+});

--- a/apps/tui/src/skip-message.test.ts
+++ b/apps/tui/src/skip-message.test.ts
@@ -1,0 +1,54 @@
+// The skip message is BEHAVIOUR, not decoration (#209). Four shells refuse on a skip and
+// all four used to render `malformed` and `unknown-kind` as the same "unreadable line(s)"
+// sentence — telling the operator the file is wrong when the file is fine and it is the
+// READER that is out of date. These tests pin the two wordings and then assert them at
+// all four shells, because the defect was precisely that the four diverged.
+import { describe, expect, it } from "vitest";
+import type { OrderSkip } from "@numisma/preferences";
+import { renderSkipMessage } from "./skip-message.js";
+
+const malformed = (line: number): OrderSkip => ({
+  line,
+  problem: "malformed",
+  message: "id must be a non-empty string",
+});
+
+const unknownKind = (line: number): OrderSkip => ({
+  line,
+  problem: "unknown-kind",
+  message: 'unknown kind "orderRepriced"',
+});
+
+describe("renderSkipMessage", () => {
+  it("renders a malformed skip as today's wording — the file is wrong", () => {
+    const message = renderSkipMessage("/data/orders.jsonl", [malformed(2)]);
+    expect(message).toContain("/data/orders.jsonl");
+    expect(message).toContain("1 unreadable line(s)");
+    expect(message).toContain("understate what is encumbered");
+  });
+
+  it("renders an unknown-kind skip as a newer build, NOT as an unreadable file", () => {
+    const message = renderSkipMessage("/data/orders.jsonl", [unknownKind(7)]);
+    expect(message).toContain("1 line(s) written by a newer build than this one");
+    expect(message).toContain("update this reader");
+    // The whole point: the file is fine. Saying otherwise sends the operator to edit a
+    // well-formed line.
+    expect(message).not.toContain("unreadable");
+  });
+
+  it("renders BOTH classes at once, each with its own count — neither collapses", () => {
+    const message = renderSkipMessage("/data/orders.jsonl", [
+      malformed(2),
+      unknownKind(7),
+      unknownKind(9),
+    ]);
+    expect(message).toContain("1 unreadable line(s)");
+    expect(message).toContain("2 line(s) written by a newer build than this one");
+  });
+
+  it("counts every line of a class, not just the first", () => {
+    const message = renderSkipMessage("/data/orders.jsonl", [malformed(1), malformed(4)]);
+    expect(message).toContain("2 unreadable line(s)");
+    expect(message).not.toContain("newer build");
+  });
+});

--- a/apps/tui/src/skip-message.ts
+++ b/apps/tui/src/skip-message.ts
@@ -1,0 +1,75 @@
+import type { OrderSkip } from "@numisma/preferences";
+
+/**
+ * THE ONE PLACE A SKIPPED SIDECAR LINE IS PUT INTO WORDS (#181).
+ *
+ * Four TUI shells refuse to render a committed figure over a partially-read book —
+ * `availableCapitalSection`, `cancelOrder`, `recordFill` and `importOrders`. Each used to
+ * write its own sentence, and all four flattened the parser's two problem classes into
+ * one: "N unreadable line(s)". One logical change to that wording cost four edits, and
+ * the flattening was itself the defect.
+ *
+ * THE TWO CLASSES ARE OPPOSITE FACTS, and this is the first increment where the
+ * difference lands on a number. A build older than #181 meets an `orderFillObserved`
+ * line, skips it as an unknown kind, and — absent the refusal — would compute the rung's
+ * committed figure from placement minus booked fills alone: the STALE PARTIAL, printed as
+ * if it were current. Nothing is wrong with the file; the READER is behind. Telling the
+ * operator the line is unreadable sends them to edit a well-formed line and leaves the
+ * actual fix — update the build — unsaid.
+ *
+ * The refusal itself is unchanged and stands: every shell still withholds the figure on
+ * any skip, of either class. This function changes only what the operator is told about
+ * WHY, and therefore what they do next.
+ *
+ * `parseOrderRecord`'s docstrings are correct as written and are deliberately untouched:
+ * the parser has always drawn this distinction. The loss was one layer out, here.
+ */
+export function renderSkipMessage(path: string, skips: readonly OrderSkip[]): string {
+  let malformed = 0;
+  let unknownKind = 0;
+  for (const skip of skips) {
+    switch (skip.problem) {
+      case "malformed": {
+        malformed += 1;
+        break;
+      }
+      case "unknown-kind": {
+        unknownKind += 1;
+        break;
+      }
+      default: {
+        // A problem class added to `OrderRecordProblem` and never taught to this renderer
+        // would typecheck fine and render as NOTHING — the operator would be refused with
+        // a sentence that names no reason. This latch makes that a COMPILE failure, which
+        // is the whole reason the wording lives in one function instead of four.
+        const _never: never = skip.problem;
+        void _never;
+        break;
+      }
+    }
+  }
+
+  const sentences: string[] = [];
+  if (malformed > 0) {
+    // Today's wording, unchanged. This class means what it has always meant: the file is
+    // wrong, and a figure over it would understate the encumbrance.
+    sentences.push(
+      `${path} has ${malformed} unreadable line(s); a committed figure over a ` +
+        `partially-read book would understate what is encumbered.`,
+    );
+  }
+  if (unknownKind > 0) {
+    // Forward-compatible wording. Note what it does NOT say: not "unreadable", not "the
+    // file is wrong". The named next move is updating the reader, because that is the one
+    // that works.
+    sentences.push(
+      `${path} has ${unknownKind} line(s) written by a newer build than this one; ` +
+        `update this reader before a committed figure is trusted from it.`,
+    );
+  }
+
+  // Both classes at once is ordinary — one hand-edited line in a file a newer build also
+  // wrote — so both sentences are rendered, each with its own count. Neither is folded
+  // into the other's number.
+  return sentences.join(" ");
+}

--- a/context/ubiquitous-language.md
+++ b/context/ubiquitous-language.md
@@ -14,6 +14,8 @@
 | **Capital Tier** | A capital provenance classification that tracks generated capital lineage.                       | tranche            |
 | **Reserve**      | The Tempo for liquidity and opportunity readiness.                                               | cash bucket        |
 | **Order**        | A claim on capital that has not yet become a transaction. A resting order encumbers **availability**, never **value** — it is what the venue shows, not what the Fund did. | trade, fill, transaction |
+| **Observation**  | What the venue SHOWED about a resting Order at a moment — a cumulative reading, restated whenever a later export moves it. It has no Lot and no cash leg behind it, and it never reaches the event log. | fill, partial fill |
+| **Fill**         | What the Fund DID against a resting Order — a booked act with a Lot and a cash leg, recorded in the event log. Every Fill implies an Observation; no Observation is ever a Fill. | observation, execution |
 
 A resting **Order** never changes a number that already exists. It adds a
 **third** number: a Reserve's **value** is unchanged and NAV-safe, its

--- a/packages/engine/src/index.ts
+++ b/packages/engine/src/index.ts
@@ -123,6 +123,10 @@ export {
 // The `orders.jsonl` sidecar (ADR-013) — recorded BESIDE the log, never in it. The
 // record contract and the pure as-of selector only; the file IO lives in
 // `@numisma/preferences`, per ADR-001.
+// MANUAL BLOCK, and saying so is the point: this list is NOT derived from the
+// `OrderRecord` union, so a kind added to the union is exported only if it is added HERE
+// too. A missing entry is not a type error anywhere — it just leaves the new record
+// unnameable outside the package.
 export type {
   OrderKind,
   OrderSide,
@@ -130,12 +134,16 @@ export type {
   OrderPlacedRecord,
   OrderCancelledRecord,
   OrderFilledRecord,
+  OrderFillObservedRecord,
+  ObservedFillClaim,
+  OrderFillObservedBuild,
   OrderRecordProblem,
   OrderRecordParse,
 } from "./orders/records.js";
 export {
   serializeOrderRecord,
   parseOrderRecord,
+  buildOrderFillObserved,
   isObservedAtStamp,
   formatObservedAt,
 } from "./orders/records.js";

--- a/packages/engine/src/index.ts
+++ b/packages/engine/src/index.ts
@@ -148,7 +148,7 @@ export {
   formatObservedAt,
 } from "./orders/records.js";
 export type { RestingOrder } from "./orders/select.js";
-export { pickRestingOrdersAsOf } from "./orders/select.js";
+export { bookedFills, pickRestingOrdersAsOf } from "./orders/select.js";
 // Ingest: the PURE Bitget open-orders parse and the venue-neutral join to the one
 // declared field. The IO shell — reading the export, prompting, appending — is the
 // TUI's, per ADR-001.

--- a/packages/engine/src/orders-not-events.test.ts
+++ b/packages/engine/src/orders-not-events.test.ts
@@ -10,7 +10,7 @@
 import { describe, expect, it } from "vitest";
 import { EVENT_SCHEMA_VERSION, parseEvent } from "./events/parse.js";
 import type { PortfolioEvent } from "./events/types.js";
-import { parseOrderRecord, serializeOrderRecord } from "./orders/records.js";
+import { buildOrderFillObserved, parseOrderRecord, serializeOrderRecord } from "./orders/records.js";
 import type { OrderPlacedRecord } from "./orders/records.js";
 import { buildFillAct, fillEventId } from "./orders/fill.js";
 
@@ -56,6 +56,21 @@ describe("O4 — the orders sidecar leaves the durable log untouched", () => {
     const line = serializeOrderRecord(SYNTHETIC_ORDER);
     const result = parseEvent(JSON.parse(line));
     expect(result.kind).toBe("event-error");
+
+    // FED THE NEWEST KIND, not just the placement line this test was written with (#181).
+    // A new record kind is the one way this obligation could quietly stop holding, and a
+    // version of this assertion that never touches the new kind proves nothing about it.
+    const observation = buildOrderFillObserved({
+      id: SYNTHETIC_ORDER.id,
+      observedAt: "2026-01-02T10:00:00",
+      currency: "USD",
+      observedFilledQuantity: 0.5,
+    });
+    if (observation.status !== "ok") {
+      throw new Error(`fixture refused: ${observation.message}`);
+    }
+    const observationLine = serializeOrderRecord(observation.record);
+    expect(parseEvent(JSON.parse(observationLine)).kind).toBe("event-error");
   });
 
   it("parseEvent still rejects the line if someone hands it a schemaVersion", () => {

--- a/packages/engine/src/orders/booked-fills.test.ts
+++ b/packages/engine/src/orders/booked-fills.test.ts
@@ -1,0 +1,181 @@
+/**
+ * THE BOOKED-FILLS CEILING, PURE HALF (#181, slice #207) — seam `S-C`.
+ *
+ * Slice #206 made `consumed` NON-MONOTONIC on purpose: an `orderFillObserved` SETS the
+ * baseline, so an observation below it takes a retired rung's `remainingQuantity` from
+ * zero back to positive. That is the right arithmetic and it is not reversed. What it
+ * costs is that `remainingQuantity` stopped being an AUTHORIZATION — and the fill
+ * recorder used it as one.
+ *
+ * `bookedFills` is the second term of the gate that replaces it:
+ *
+ *     admissible = min(rung.remainingQuantity, rung.quantity − bookedFills(id))
+ *
+ * This file pins the pure function and, more importantly, THE PROPERTY THAT MAKES THE
+ * GATE SAFE TO SHIP: on every stream the import path can produce, `consumed ≥
+ * bookedFills`, so `quantity − bookedFills ≥ remainingQuantity` and the `min` NEVER
+ * BINDS. It binds only in the resurrection case. Both directions are asserted here, so
+ * "provable no-op" is a test rather than a claim in a spec.
+ *
+ * Synthetic throughout: invented pair, round sizes, round prices.
+ */
+import { describe, expect, it } from "vitest";
+import {
+  buildOrderFillObserved,
+  type OrderFillObservedRecord,
+  type OrderFilledRecord,
+  type OrderPlacedRecord,
+  type OrderRecord,
+} from "./records.js";
+import { bookedFills, pickRestingOrdersAsOf } from "./select.js";
+
+const RUNG = "rung-synthetic";
+const OTHER = "rung-synthetic-other";
+
+function placed(
+  id: string,
+  observedAt: string,
+  quantity: number,
+  observedFilledQuantity?: number,
+): OrderPlacedRecord {
+  return {
+    id,
+    observedAt,
+    kind: "orderPlaced",
+    currency: "USD",
+    symbol: "TEST/USD",
+    side: "buy",
+    price: 100,
+    quantity,
+    ...(observedFilledQuantity === undefined ? {} : { observedFilledQuantity }),
+    fundingReserveId: "reserve-synthetic",
+  };
+}
+
+function booked(id: string, observedAt: string, filledQuantity: number): OrderFilledRecord {
+  return { id, observedAt, kind: "orderFilled", currency: "USD", filledQuantity };
+}
+
+/** Through the constructor — there is no other way to build one (slice #206). */
+function observed(
+  id: string,
+  observedAt: string,
+  observedFilledQuantity: number,
+): OrderFillObservedRecord {
+  const built = buildOrderFillObserved({
+    id,
+    observedAt,
+    currency: "USD",
+    observedFilledQuantity,
+  });
+  if (built.status !== "ok") {
+    throw new Error(`synthetic observation refused: ${built.message}`);
+  }
+  return built.record;
+}
+
+/** What the rung reports as still resting, or `undefined` when it is not resting at all. */
+function remainingOf(records: OrderRecord[], id: string): number | undefined {
+  return pickRestingOrdersAsOf(records).find((order) => order.placed.id === id)
+    ?.remainingQuantity;
+}
+
+describe("bookedFills — what the FUND actually booked, and nothing else", () => {
+  it("sums the rung's orderFilled lines", () => {
+    const records: OrderRecord[] = [
+      placed(RUNG, "2026-01-02T09:00:00", 10),
+      booked(RUNG, "2026-01-03T10:00:00", 4),
+      booked(RUNG, "2026-01-04T10:00:00", 6),
+    ];
+    expect(bookedFills(records, RUNG)).toBe(10);
+  });
+
+  it("counts NO observation — neither the placement line's partial nor a restatement", () => {
+    // The whole point of the ceiling. An observation is what the VENUE SHOWED; only an
+    // `orderFilled` line has a lot and a cash leg behind it. Counting an observation here
+    // would make the ceiling move with the very figure it exists to be independent of.
+    const records: OrderRecord[] = [
+      placed(RUNG, "2026-01-02T09:00:00", 10, 2),
+      observed(RUNG, "2026-01-03T10:00:00", 6),
+    ];
+    expect(bookedFills(records, RUNG)).toBe(0);
+  });
+
+  it("counts only the named rung, and a cancellation does not discharge what was booked", () => {
+    const records: OrderRecord[] = [
+      placed(RUNG, "2026-01-02T09:00:00", 10),
+      placed(OTHER, "2026-01-02T09:00:01", 10),
+      booked(RUNG, "2026-01-03T10:00:00", 3),
+      booked(OTHER, "2026-01-03T10:00:01", 7),
+      { id: RUNG, observedAt: "2026-01-04T10:00:00", kind: "orderCancelled", currency: "USD" },
+    ];
+    // A cancellation retires the CLAIM. It does not un-buy the lot: the cash left and the
+    // asset arrived, so the fund's booked total is still 3 and the ceiling still knows it.
+    expect(bookedFills(records, RUNG)).toBe(3);
+    expect(bookedFills(records, OTHER)).toBe(7);
+  });
+
+  it("is TOTAL — an id it has never met sums to zero rather than throwing", () => {
+    expect(bookedFills([], "no-such-rung")).toBe(0);
+    expect(bookedFills([placed(RUNG, "2026-01-02T09:00:00", 10)], "no-such-rung")).toBe(0);
+  });
+
+  it("is PURE — it does not touch the array it is given", () => {
+    const records: OrderRecord[] = [
+      placed(RUNG, "2026-01-02T09:00:00", 10),
+      booked(RUNG, "2026-01-03T10:00:00", 4),
+    ];
+    const before = JSON.stringify(records);
+    bookedFills(records, RUNG);
+    expect(JSON.stringify(records)).toBe(before);
+  });
+});
+
+describe("the ceiling is a PROVABLE NO-OP on every stream the import path can produce", () => {
+  it("does not bind on an ordinary partial: placed 10, venue showed 2, nothing booked", () => {
+    // The AC's ordinary stream. `consumed` is 2 off the placement line, nothing is booked,
+    // so the headroom is the full 10 and the remainder of 8 is what binds — exactly the
+    // figure the gate used before this slice. Admission is unchanged.
+    const records: OrderRecord[] = [placed(RUNG, "2026-01-02T09:00:00", 10, 2)];
+    const remaining = remainingOf(records, RUNG);
+
+    expect(remaining).toBe(8);
+    expect(bookedFills(records, RUNG)).toBe(0);
+    expect(10 - bookedFills(records, RUNG)).toBeGreaterThanOrEqual(remaining ?? 0);
+  });
+
+  it("does not bind across an ordinary observe-then-book interleaving", () => {
+    // Placed 10, venue observed 6, the fund then booked 1 of its own. `consumed` is 7 and
+    // `bookedFills` is 1, so headroom 9 ≥ remainder 3. The `min` still never binds.
+    const records: OrderRecord[] = [
+      placed(RUNG, "2026-01-02T09:00:00", 10, 2),
+      observed(RUNG, "2026-01-03T10:00:00", 6),
+      booked(RUNG, "2026-01-04T10:00:00", 1),
+    ];
+    const remaining = remainingOf(records, RUNG);
+
+    expect(remaining).toBe(3);
+    expect(bookedFills(records, RUNG)).toBe(1);
+    expect(10 - bookedFills(records, RUNG)).toBeGreaterThanOrEqual(remaining ?? 0);
+  });
+
+  it("BINDS only when a backwards observation resurrects a rung the fund already exhausted", () => {
+    // The one geometry the gate exists for. The rung was placed at 10 and the fund booked
+    // all 10 — two files, a lot and a cash leg. A hand-authored observation asserting 3
+    // then SETS `consumed` back to 3, so the fold honestly reports 7 still resting.
+    //
+    // Trusting that 7 would authorize 7 more units, taking total booked fills to 17
+    // against a placed 10, in a log with no reversal verb. The headroom is 0.
+    const records: OrderRecord[] = [
+      placed(RUNG, "2026-01-02T09:00:00", 10),
+      booked(RUNG, "2026-01-03T10:00:00", 10),
+      observed(RUNG, "2026-01-04T10:00:00", 3),
+    ];
+    const remaining = remainingOf(records, RUNG);
+
+    expect(remaining).toBe(7);
+    expect(bookedFills(records, RUNG)).toBe(10);
+    expect(10 - bookedFills(records, RUNG)).toBe(0);
+    expect(Math.min(remaining ?? 0, 10 - bookedFills(records, RUNG))).toBe(0);
+  });
+});

--- a/packages/engine/src/orders/committed.ts
+++ b/packages/engine/src/orders/committed.ts
@@ -84,7 +84,18 @@ export interface CommittedRung {
    * #176 was.
    */
   quantity: number;
-  /** What is STILL claimed: `quantity − filled_quantity`, per `./select.ts`. */
+  /**
+   * What is STILL claimed: `quantity − consumed`, per `./select.ts`.
+   *
+   * A REPORT, NOT AN AUTHORIZATION, and it carries {@link RestingOrder.remainingQuantity}'s
+   * warning unchanged because flattening the row does not flatten the meaning. `consumed`
+   * is NOT MONOTONIC, so this figure can go UP as well as down and a retired rung can
+   * reappear with a positive remainder. Encumbrance is what it answers for — the committed
+   * figure below is derived from it and is right. A caller asking instead "how much may I
+   * still BOOK against this rung" must apply the booked-fills ceiling at its own boundary
+   * (`bookedFills`, `./select.ts`); this number alone would let a backwards observation
+   * authorize a second lot and cash leg against capital already spent.
+   */
   remainingQuantity: number;
   fundingReserveId: string;
   /** `price × remainingQuantity` — the encumbrance, in `currency`. */

--- a/packages/engine/src/orders/detection-basis.test.ts
+++ b/packages/engine/src/orders/detection-basis.test.ts
@@ -1,0 +1,166 @@
+/**
+ * THE DETECTION SEAM (#181, slice #208) — what `detectChangedClaims` compares against.
+ *
+ * `S-D`. The function's INPUT widened to the whole record stream and its BASIS became the
+ * latest observation, and those are two claims a caller cannot check for itself: the TUI's
+ * end-to-end suite can prove that an already-recorded restatement stops being re-reported,
+ * but it cannot reach the equal-stamp tie-break or the epsilon floor without contriving an
+ * export around each. Those live here, at the interface, where the figures are the whole
+ * fixture.
+ *
+ * WHY THE TIE-BREAK IS PINNED AT ALL. It is not arithmetic — it is an AGREEMENT. The
+ * selector's stable sort makes the LAST line in file order win an equal-stamp tie, so a
+ * detector that resolved the tie the other way would compare against a figure the fold
+ * does not hold, and the two would disagree about which observation is current in exactly
+ * the case nobody would think to look at.
+ *
+ * Synthetic throughout: invented pair, round sizes, round prices.
+ */
+import { describe, expect, it } from "vitest";
+import { detectChangedClaims, type ObservedOpenOrder } from "./ingest.js";
+import {
+  buildOrderFillObserved,
+  type OrderFillObservedRecord,
+  type OrderPlacedRecord,
+  type OrderRecord,
+} from "./records.js";
+import { pickRestingOrdersAsOf } from "./select.js";
+
+const RUNG = "rung-synthetic";
+
+function placed(
+  observedAt: string,
+  quantity: number,
+  observedFilledQuantity?: number,
+): OrderPlacedRecord {
+  return {
+    id: RUNG,
+    observedAt,
+    kind: "orderPlaced",
+    currency: "USD",
+    symbol: "TEST/USD",
+    side: "buy",
+    price: 100,
+    quantity,
+    ...(observedFilledQuantity === undefined ? {} : { observedFilledQuantity }),
+    fundingReserveId: "reserve-synthetic",
+  };
+}
+
+/** Built THROUGH THE CONSTRUCTOR — the witness makes a literal untypeable (#206). */
+function observed(observedAt: string, observedFilledQuantity: number): OrderFillObservedRecord {
+  const built = buildOrderFillObserved({
+    id: RUNG,
+    observedAt,
+    currency: "USD",
+    observedFilledQuantity,
+  });
+  if (built.status !== "ok") throw new Error(`fixture must build: ${built.message}`);
+  return built.record;
+}
+
+/** The export's row for the same rung: 10 units at 100, filled as given. */
+function exported(quantity: number, filledQuantity: number): ObservedOpenOrder {
+  return {
+    id: RUNG,
+    observedAt: "2026-01-01T10:00:00",
+    currency: "USD",
+    symbol: "TEST/USD",
+    side: "buy",
+    price: 100,
+    quantity,
+    filledQuantity,
+  };
+}
+
+describe("detectChangedClaims compares against the LATEST observation (#181)", () => {
+  it("reports NO difference when the file already carries the restatement", () => {
+    // THE CASE THE PLACEMENT-LINE BASIS GOT WRONG FOREVER. The venue restated 6 → 8, the
+    // observation was recorded, and the SAME export is imported again. Against the
+    // placement line's 6 this reads as a fresh restatement on every import for the life of
+    // the rung; against the latest observation it reads as what it is — nothing new.
+    const stream: OrderRecord[] = [placed("2026-01-01T10:00:00", 10, 6), observed("2026-01-02T09:00:00", 8)];
+    expect(detectChangedClaims(stream, [exported(10, 8)])).toEqual([]);
+  });
+
+  it("still reports a difference when the venue has moved PAST the latest observation", () => {
+    const stream: OrderRecord[] = [placed("2026-01-01T10:00:00", 10, 6), observed("2026-01-02T09:00:00", 8)];
+    expect(detectChangedClaims(stream, [exported(10, 9)])).toEqual([
+      { id: RUNG, differences: [{ field: "observedFilledQuantity", known: 8, observed: 9 }] },
+    ]);
+  });
+
+  it("falls back to the placement line's own figure, then to 0", () => {
+    const withFigure: OrderRecord[] = [placed("2026-01-01T10:00:00", 10, 6)];
+    expect(detectChangedClaims(withFigure, [exported(10, 6)])).toEqual([]);
+
+    // No figure at all reads as nothing filled — the same `?? 0` the fold takes, not a
+    // missing case.
+    const without: OrderRecord[] = [placed("2026-01-01T10:00:00", 10)];
+    expect(detectChangedClaims(without, [exported(10, 0)])).toEqual([]);
+    expect(detectChangedClaims(without, [exported(10, 1)])).toEqual([
+      { id: RUNG, differences: [{ field: "observedFilledQuantity", known: 0, observed: 1 }] },
+    ]);
+  });
+
+  it("resolves an equal-stamp tie to the LAST line in file order — as the fold does", () => {
+    // Two observations at the SAME second. The selector sorts stably, so the last line
+    // wins there; detection must land on the same one or the two disagree about which
+    // observation is current.
+    const stream: OrderRecord[] = [
+      placed("2026-01-01T10:00:00", 10, 6),
+      observed("2026-01-02T09:00:00", 8),
+      observed("2026-01-02T09:00:00", 7),
+    ];
+    expect(detectChangedClaims(stream, [exported(10, 7)])).toEqual([]);
+    expect(detectChangedClaims(stream, [exported(10, 8)])).toEqual([
+      { id: RUNG, differences: [{ field: "observedFilledQuantity", known: 7, observed: 8 }] },
+    ]);
+
+    // THE AGREEMENT ITSELF, asserted rather than described: the fold folds the same
+    // stream to a remainder of 3, i.e. `consumed` 7 — the same line detection chose.
+    expect(pickRestingOrdersAsOf(stream).map((order) => order.remainingQuantity)).toEqual([3]);
+  });
+
+  it("takes the latest observation by STAMP, not by position", () => {
+    const stream: OrderRecord[] = [
+      placed("2026-01-01T10:00:00", 10, 6),
+      observed("2026-01-03T09:00:00", 8),
+      observed("2026-01-02T09:00:00", 7),
+    ];
+    expect(detectChangedClaims(stream, [exported(10, 8)])).toEqual([]);
+  });
+
+  it("ignores `orderFilled` and `orderCancelled` — they are not observations", () => {
+    // What the FUND booked is not what the VENUE showed. A fill line moves `consumed`,
+    // which is the partition's business downstream, and must not move the figure the
+    // export is compared against.
+    const stream: OrderRecord[] = [
+      placed("2026-01-01T10:00:00", 10, 6),
+      { id: RUNG, observedAt: "2026-01-02T09:00:00", kind: "orderFilled", currency: "USD", filledQuantity: 4 },
+    ];
+    expect(detectChangedClaims(stream, [exported(10, 6)])).toEqual([]);
+  });
+});
+
+describe("the epsilon is on the FILLED comparison only (#181)", () => {
+  it("reports no difference for a filled gap below the noise floor", () => {
+    const stream: OrderRecord[] = [placed("2026-01-01T10:00:00", 10, 6)];
+    expect(detectChangedClaims(stream, [exported(10, 6 + 1e-12)])).toEqual([]);
+  });
+
+  it("still reports a filled gap above it", () => {
+    const stream: OrderRecord[] = [placed("2026-01-01T10:00:00", 10, 6)];
+    expect(detectChangedClaims(stream, [exported(10, 6.5)])).toHaveLength(1);
+  });
+
+  it("keeps `quantity` EXACT — the one figure nothing may go stale on", () => {
+    // No floor here, deliberately: `quantity` is one authored number against another
+    // rather than a comparison with a folded figure, so there is nothing for a floor to
+    // absorb, and this refuses the whole batch (#174) where the filled test would not.
+    const stream: OrderRecord[] = [placed("2026-01-01T10:00:00", 10, 6)];
+    expect(detectChangedClaims(stream, [exported(10 + 1e-12, 6)])).toEqual([
+      { id: RUNG, differences: [{ field: "quantity", known: 10, observed: 10 + 1e-12 }] },
+    ]);
+  });
+});

--- a/packages/engine/src/orders/fill.ts
+++ b/packages/engine/src/orders/fill.ts
@@ -102,6 +102,14 @@ export function reconcileFillActs(
 ): TornFillAct[] {
   const fillsOnFile = new Set(
     records
+      // `orderFilled` ONLY, and the EXCLUSION of `orderFillObserved` is DELIBERATE (#181).
+      // An observation is what the VENUE SHOWED about a row; it has no lot and no cash leg
+      // behind it and must never be paired with one. Routed in here, the first restatement
+      // an operator imported would read as a permanent `fill-without-lot` torn act — and
+      // the fill flow refuses to record anything while one is outstanding, so it would
+      // brick on first occurrence, with no verb in `PortfolioEventType` able to discharge
+      // it. This line is load-bearing for the argument that a torn state cannot be created
+      // by an import.
       .filter((record): record is OrderFilledRecord => record.kind === "orderFilled")
       .map((record) => fillEventId(record.id, record.observedAt)),
   );

--- a/packages/engine/src/orders/ingest.ts
+++ b/packages/engine/src/orders/ingest.ts
@@ -13,7 +13,8 @@
 import type { Currency, FundReviewData } from "../contracts.js";
 import { attributeRungs, type UnmatchedRung } from "./attribution.js";
 import { isNegativeSlack } from "./committed.js";
-import type { OrderPlacedRecord, OrderSide } from "./records.js";
+import { QUANTITY_EPSILON } from "./monotonicity.js";
+import type { OrderPlacedRecord, OrderRecord, OrderSide } from "./records.js";
 import type { RestingOrder } from "./select.js";
 
 /**
@@ -203,6 +204,13 @@ export function mergeCollidingClaims<T extends ObservedOpenOrder>(
 /** One field of a known claim that the venue is now rendering differently. */
 export interface ClaimDifference {
   field: "quantity" | "observedFilledQuantity";
+  /**
+   * WHAT THE FILE SAYS, on each field's own basis (#181): for `quantity`, the FIRST
+   * placement line's size; for `observedFilledQuantity`, the LATEST OBSERVATION — a later
+   * `orderFillObserved` when the file carries one, else the placement line's own figure,
+   * else `0`. Not "the placement line's figure", which is what this was while placements
+   * were the only observation on the file.
+   */
   known: number;
   observed: number;
 }
@@ -221,31 +229,88 @@ export interface ChangedClaim {
  * change is not a re-sighting: folding it into `alreadyKnown` reported "nothing to do"
  * about a rung whose size on file is now wrong, which is exactly the silence #174 names.
  *
+ * THE INPUT IS THE WHOLE RECORD STREAM, NOT THE PLACEMENT LINES (#181). This took only
+ * `orderPlaced` records while placements were the only thing on the file, and compared the
+ * export against the PLACEMENT LINE's own figure. With `orderFillObserved` lines on the
+ * file the placement line is merely the FIRST observation, so that basis re-reports every
+ * already-recorded restatement forever — the import would say "the venue restated this"
+ * about a restatement the file already carries, on every import, permanently. IDEMPOTENCY
+ * LIVES HERE, one layer above the append filter: no key shape at the write can repair a
+ * comparison that reports a difference where there is none, because the report is written
+ * from the decision, not from the line.
+ *
+ * THE COMPARISON BASIS is therefore the fold's own unification applied to the comparison:
+ *
+ *     latest observation ?? the placement line's own observed figure ?? 0
+ *
+ * — the same three-way reading `pickRestingOrdersAsOf` folds into one `consumed` baseline.
+ * `quantity` keeps its own basis: the FIRST placement line, because a repeat placement is
+ * ignored by the selector and an observation carries no `quantity` at all (deliberately —
+ * see `OrderFillObservedRecord`; a second copy of the one figure nothing may go
+ * stale on is the drift the batch refusal exists to prevent).
+ *
+ * AN EXPORT FIGURE ABOVE THE PLACED QUANTITY GETS NO CHECK HERE, AND THAT IS THE DECISION
+ * — see the partition rule in `apps/tui/src/import-orders.ts`, which states why it cannot
+ * arrive and names both gates that make it so.
+ *
+ * TIES ON EQUAL STAMPS RESOLVE TO THE LAST LINE IN FILE ORDER — `>=` on the scan below,
+ * over the records in the order the caller holds them. That is exactly the tie-break the
+ * selector's STABLE sort gives the fold, so detection and the fold can never disagree
+ * about which observation is current. Choosing `>` here would be a second, silently
+ * different rule for the same question.
+ *
+ * THE EPSILON IS ON THE FILLED COMPARISON ONLY, and `quantity` keeps EXACT equality. Exact
+ * inequality was harmless while a difference meant a SKIP; once a difference means a
+ * permanent line on an append-only file, float noise below the meaningful floor would grow
+ * the file on an import that observed nothing real. `quantity` is not compared to a folded
+ * figure — it is one authored number against another — so there is nothing for a floor to
+ * absorb there, and an exact test is the stricter and more honest one.
+ *
  * KNOWN LIMIT, stated rather than papered over: the sidecar persists neither
  * `orderType`, `timeInForce` nor `triggerPrice` — `KEY_ORDER.orderPlaced` in `records.ts`
  * is ten fields and none of them is a descriptor — so a change confined to those cannot be
  * detected here. There is nothing on file to compare against.
  *
- * Accepted for increment two, deliberately: no descriptor moves the encumbrance, which is
- * `price * quantity`, so the funding guard stays correct across such a change. Closing it
- * means WIDENING the durable record, and that is not free — every line already on file
- * carries no descriptors, so every re-imported row would differ from its known claim and an
- * UNCHANGED batch would refuse on every rung until a migration rewrote an append-only file.
- * That widening belongs with the observation verb #181 designs, which is the next thing to
- * decide what a later sighting of a known rung may carry. When these fields are persisted,
- * compare them here too.
+ * Accepted deliberately: no descriptor moves the encumbrance, which is `price * quantity`,
+ * so the funding guard stays correct across such a change. Closing it means WIDENING the
+ * durable record, and that is not free — every line already on file carries no descriptors,
+ * so every re-imported row would differ from its known claim and an UNCHANGED batch would
+ * refuse on every rung until a migration rewrote an append-only file. That widening is
+ * issue #205's question, and #205 is where the decision about what a later sighting of a
+ * known rung may carry belongs. When these fields are persisted, compare them here too.
  */
 export function detectChangedClaims(
-  known: readonly OrderPlacedRecord[],
+  known: readonly OrderRecord[],
   observed: readonly ObservedOpenOrder[],
 ): ChangedClaim[] {
   const placedById = new Map<string, OrderPlacedRecord>();
+  // The latest observation per id, and the stamp it was made at — the stamp is kept only
+  // to compare the NEXT candidate against, never returned.
+  const latestObserved = new Map<string, { observedAt: string; quantity: number }>();
   for (const record of known) {
-    // FIRST placement wins, matching `pickRestingOrdersAsOf`: a repeat placement line is
-    // ignored there, so it must not be what a change is measured against here.
-    if (!placedById.has(record.id)) {
-      placedById.set(record.id, record);
+    if (record.kind === "orderPlaced") {
+      // FIRST placement wins, matching `pickRestingOrdersAsOf`: a repeat placement line is
+      // ignored there, so it must not be what a change is measured against here.
+      if (!placedById.has(record.id)) {
+        placedById.set(record.id, record);
+      }
+      continue;
     }
+    if (record.kind === "orderFillObserved") {
+      const seen = latestObserved.get(record.id);
+      // `>=` — the LAST line in file order wins an equal-stamp tie, as above.
+      if (seen === undefined || record.observedAt >= seen.observedAt) {
+        latestObserved.set(record.id, {
+          observedAt: record.observedAt,
+          quantity: record.observedFilledQuantity,
+        });
+      }
+    }
+    // `orderFilled` and `orderCancelled` are deliberately not read here. This function
+    // answers "does the export AGREE with what the file last OBSERVED", which is a
+    // question about the venue's column; what the fund has BOOKED against the rung, and
+    // whether the claim was retired, is what the caller's partition weighs next, off
+    // `pickRestingOrdersAsOf`.
   }
 
   const changed: ChangedClaim[] = [];
@@ -258,9 +323,10 @@ export function detectChangedClaims(
     if (placed.quantity !== order.quantity) {
       differences.push({ field: "quantity", known: placed.quantity, observed: order.quantity });
     }
-    const knownFilled = placed.observedFilledQuantity ?? 0;
+    const knownFilled =
+      latestObserved.get(order.id)?.quantity ?? placed.observedFilledQuantity ?? 0;
     const observedFilled = order.filledQuantity ?? 0;
-    if (knownFilled !== observedFilled) {
+    if (Math.abs(knownFilled - observedFilled) > QUANTITY_EPSILON) {
       differences.push({
         field: "observedFilledQuantity",
         known: knownFilled,

--- a/packages/engine/src/orders/ingest.ts
+++ b/packages/engine/src/orders/ingest.ts
@@ -505,19 +505,24 @@ export type FundingCoverage =
  * KNOWINGLY OPEN, tracked on #203 — A SKIPPED EXPORT ROW IS NEVER PERSISTED. The gap was
  * argued and accepted on #183, which is CLOSED because what it owed was a decision; the
  * citations above are to that decision and stay pointed at it. This one is different: it
- * names a cost still being paid, so it points at an OPEN issue. `OrderRecord`
- * is exactly three kinds — `orderPlaced`, `orderCancelled`, `orderFilled`
- * (`./records.ts:132`) — and `appendOrders` (`packages/preferences/src/orders.ts:244`)
- * writes only fresh `orderPlaced` rows. There is no record for "line N of the export
- * could not be read": the skip reaches stderr and the returned outcome, then dies with
- * the process. So `orders.jsonl` carries no trace that the rung exists, and every later
- * reader — tomorrow's available-capital report, any adherence question about that date —
- * sees a book that looks complete, with nothing to warn it otherwise. Persisting the gap
- * was CONSIDERED AND REJECTED: a skipped row has no id, because the id is synthesized
- * from venue, pair, side, price and submitted-at (`synthesizeOrderId`, :119) and those
- * are the very tokens that failed to parse. An un-idable durable "something was here"
- * could never be matched to a later import and so could never be RETIRED — a permanent
- * blot on every future report with no verb to close it.
+ * names a cost still being paid, so it points at an OPEN issue. `OrderRecord` is four
+ * kinds — `orderPlaced`, `orderCancelled`, `orderFilled` and `orderFillObserved`
+ * (`OrderRecord` in `./records.ts`, cited BY NAME for the reason the paragraph above
+ * gives; that line number had already drifted once) — and `appendOrders`
+ * (`packages/preferences/src/orders.ts:244`) writes fresh `orderPlaced` and
+ * `orderFillObserved` rows. NEITHER ADDITION GIVES THE SKIP A HOME, which is the first
+ * thing a reader who counts four kinds will want ruled out: an observation restates a rung
+ * ALREADY placed and finds it BY ID, so it is reachable only for a row that parsed. There
+ * is no record for "line N of the export could not be read": the skip reaches stderr and
+ * the returned outcome, then dies with the process. So `orders.jsonl` carries no trace
+ * that the rung exists, and every later reader — tomorrow's available-capital report, any
+ * adherence question about that date — sees a book that looks complete, with nothing to
+ * warn it otherwise. Persisting the gap was CONSIDERED AND REJECTED: a skipped row has no
+ * id, because the id is synthesized from venue, pair, side, price and submitted-at
+ * (`synthesizeOrderId`, :119) and those are the very tokens that failed to parse. An
+ * un-idable durable "something was here" could never be matched to a later import and so
+ * could never be RETIRED — a permanent blot on every future report with no verb to close
+ * it.
  */
 export function checkFundingCoverage(
   resting: readonly RestingOrder[],

--- a/packages/engine/src/orders/monotonicity.ts
+++ b/packages/engine/src/orders/monotonicity.ts
@@ -35,8 +35,13 @@ import type { RestingOrder } from "./select.js";
  * Pure float noise floor for comparing observed quantities. NOT a business tolerance:
  * quantities are the venue's own authoritative column and a real partial is orders of
  * magnitude larger than this.
+ *
+ * EXPORTED so `./ingest.js` compares the venue's filled figure against the file's on the
+ * SAME floor this module already uses (#181). Two independently-chosen noise floors for
+ * the same column is the drift `./committed.ts` keeps one formula to avoid; one constant
+ * with one argument behind it is the whole point.
  */
-const QUANTITY_EPSILON = 1e-9;
+export const QUANTITY_EPSILON = 1e-9;
 
 /**
  * What the venue STILL SHOWS for one rung at the observation moment. A rung that was

--- a/packages/engine/src/orders/observation-verb.test.ts
+++ b/packages/engine/src/orders/observation-verb.test.ts
@@ -1,0 +1,391 @@
+/**
+ * THE OBSERVATION VERB (#181, slice #206) — the record kind and the unified fold.
+ *
+ * Two seams, and this file is the whole test surface for both: `S-A` the record
+ * contract (`./records.ts`) and `S-B` the selector (`./select.ts`). The slice has no
+ * operator-facing caller until the import path is re-implemented, which is deliberate —
+ * the selector's own interface is what four production adapters already cross, so it is
+ * the thing worth pinning, and everything downstream is arithmetic this file either
+ * caught or did not.
+ *
+ * THE THREE DISCRIMINATING CASES are the point. #181's own headline case passes on every
+ * fold the design considered and rejected, so on its own it decides nothing; the second
+ * and third are what actually pin SET-not-add and order-sensitivity.
+ *
+ * Synthetic throughout: invented pair, round sizes, round prices. No real rung, price,
+ * size or balance appears here.
+ */
+import { describe, expect, it } from "vitest";
+import { committedRungs } from "./committed.js";
+import {
+  buildOrderFillObserved,
+  parseOrderRecord,
+  serializeOrderRecord,
+  type OrderFillObservedRecord,
+  type OrderFilledRecord,
+  type OrderPlacedRecord,
+  type OrderRecord,
+} from "./records.js";
+import { pickRestingOrdersAsOf, type RestingOrder } from "./select.js";
+
+const RUNG = "rung-synthetic";
+
+function placed(
+  observedAt: string,
+  quantity: number,
+  observedFilledQuantity?: number,
+): OrderPlacedRecord {
+  return {
+    id: RUNG,
+    observedAt,
+    kind: "orderPlaced",
+    currency: "USD",
+    symbol: "TEST/USD",
+    side: "buy",
+    price: 100,
+    quantity,
+    ...(observedFilledQuantity === undefined ? {} : { observedFilledQuantity }),
+    fundingReserveId: "reserve-synthetic",
+  };
+}
+
+/**
+ * The observation line, built THROUGH THE CONSTRUCTOR — there is no other way to build
+ * one, and that is enforced by the compiler rather than by this comment. A test that
+ * could hand-roll the literal would be testing a shape the writer cannot actually
+ * produce.
+ */
+function observed(observedAt: string, observedFilledQuantity: number): OrderFillObservedRecord {
+  const built = buildOrderFillObserved({
+    id: RUNG,
+    observedAt,
+    currency: "USD",
+    observedFilledQuantity,
+  });
+  if (built.status !== "ok") {
+    throw new Error(`fixture refused: ${built.message}`);
+  }
+  return built.record;
+}
+
+function filled(observedAt: string, filledQuantity: number): OrderFilledRecord {
+  return { id: RUNG, observedAt, kind: "orderFilled", currency: "USD", filledQuantity };
+}
+
+function remainingOf(records: OrderRecord[]): number[] {
+  return pickRestingOrdersAsOf(records).map((order) => order.remainingQuantity);
+}
+
+describe("S-B the fold — the three discriminating cases, verbatim", () => {
+  it("Q10, P2, C6 leaves 4 resting, and the committed figure reads 400", () => {
+    const records: OrderRecord[] = [
+      placed("2026-01-01T10:00:00", 10, 2),
+      observed("2026-01-02T10:00:00", 6),
+    ];
+
+    const resting = pickRestingOrdersAsOf(records);
+    expect(resting.map((order) => order.remainingQuantity)).toEqual([4]);
+    // Through the committed-rungs read, not recomputed here: the encumbrance the four
+    // TUI shells actually render is what the increment is for.
+    expect(committedRungs(resting).map((rung) => rung.committed)).toEqual([400]);
+  });
+
+  it("SET SUBSUMES prior fills rather than double-subtracting them: Q10, P2, F3, then C8 leaves 2", () => {
+    const records: OrderRecord[] = [
+      placed("2026-01-01T10:00:00", 10, 2),
+      filled("2026-01-02T10:00:00", 3),
+      observed("2026-01-03T10:00:00", 8),
+    ];
+
+    // A fold that SUBTRACTED the observation would read 10 − 2 − 3 − 8 and go negative.
+    // An order-insensitive `Q − max(P + F, C)` also reads 2 here, which is exactly why
+    // this case cannot decide the fold on its own — the next one does.
+    expect(remainingOf(records)).toEqual([2]);
+  });
+
+  it("THE FOLD IS ORDER-SENSITIVE: Q10, P2, C6, THEN F1 leaves 3", () => {
+    const records: OrderRecord[] = [
+      placed("2026-01-01T10:00:00", 10, 2),
+      observed("2026-01-02T10:00:00", 6),
+      filled("2026-01-03T10:00:00", 1),
+    ];
+
+    // THE discriminating assertion. `Q − max(P + F, C)` gives 4 here and 4 is wrong: the
+    // observation restated the baseline at 6, and a real fill of 1 consumed one more unit
+    // AFTER it. Replayed in `observedAt` order there is exactly one answer, and nothing
+    // else in the suite catches a fold that reads 4.
+    expect(remainingOf(records)).toEqual([3]);
+  });
+});
+
+describe("S-B the fold — the no-regression property, asserted rather than assumed", () => {
+  /**
+   * THE PREVIOUS FOLD, transcribed verbatim from the commit this slice replaces.
+   *
+   * The claim "a stream with no observation line reads exactly as it did" is worth
+   * nothing as prose, and worth nothing as a handful of remembered numbers either. So the
+   * old arithmetic is kept here and both folds are run over the same streams, compared as
+   * SERIALIZED OUTPUT — byte-identical, not merely numerically close.
+   */
+  function previousFold(records: OrderRecord[]): RestingOrder[] {
+    const eligible = records
+      .slice()
+      .sort((a, b) => (a.observedAt < b.observedAt ? -1 : a.observedAt > b.observedAt ? 1 : 0));
+    const resting = new Map<string, RestingOrder>();
+    for (const record of eligible) {
+      if (record.kind === "orderPlaced") {
+        if (!resting.has(record.id)) {
+          const remaining = record.quantity - (record.observedFilledQuantity ?? 0);
+          if (remaining > 0) {
+            resting.set(record.id, { placed: record, remainingQuantity: remaining });
+          }
+        }
+      } else if (record.kind === "orderCancelled") {
+        resting.delete(record.id);
+      } else if (record.kind === "orderFilled") {
+        const open = resting.get(record.id);
+        if (open) {
+          const remaining = open.remainingQuantity - record.filledQuantity;
+          if (remaining > 0) {
+            resting.set(record.id, { placed: open.placed, remainingQuantity: remaining });
+          } else {
+            resting.delete(record.id);
+          }
+        }
+      }
+    }
+    return [...resting.values()];
+  }
+
+  const cancelled = (observedAt: string) =>
+    ({ id: RUNG, observedAt, kind: "orderCancelled", currency: "USD" }) as const;
+
+  const STREAMS: Record<string, OrderRecord[]> = {
+    "a bare placement": [placed("2026-01-01T10:00:00", 10)],
+    "a placement carrying its own partial": [placed("2026-01-01T10:00:00", 10, 2)],
+    "a partial then a fill": [placed("2026-01-01T10:00:00", 10, 2), filled("2026-01-02T10:00:00", 3)],
+    "a fill that exhausts the rung": [
+      placed("2026-01-01T10:00:00", 10),
+      filled("2026-01-02T10:00:00", 10),
+    ],
+    "two fills that exhaust the rung": [
+      placed("2026-01-01T10:00:00", 10),
+      filled("2026-01-02T10:00:00", 6),
+      filled("2026-01-03T10:00:00", 4),
+    ],
+    "a cancellation": [placed("2026-01-01T10:00:00", 10, 2), cancelled("2026-01-02T10:00:00")],
+    "a repeat placement line of a known id": [
+      placed("2026-01-01T10:00:00", 10, 2),
+      placed("2026-01-01T10:00:00", 10, 5),
+    ],
+    "a re-placement after a cancellation": [
+      placed("2026-01-01T10:00:00", 10),
+      cancelled("2026-01-02T10:00:00"),
+      placed("2026-01-03T10:00:00", 10),
+    ],
+    "a fully-filled placement line": [placed("2026-01-01T10:00:00", 10, 10)],
+    "a fill naming an id that was never placed": [filled("2026-01-02T10:00:00", 3)],
+    "lines arriving out of file order": [
+      filled("2026-01-03T10:00:00", 3),
+      placed("2026-01-01T10:00:00", 10, 2),
+    ],
+    // ORDER OF THE RETURNED LIST, not just the numbers in it. Both folds emit map
+    // insertion order, and every caller downstream renders the rungs in the order given.
+    "three rungs, one of them partly filled and one cancelled": [
+      { ...placed("2026-01-01T10:00:00", 10), id: "rung-a" },
+      { ...placed("2026-01-01T10:00:01", 4, 1), id: "rung-b" },
+      { ...placed("2026-01-01T10:00:02", 6), id: "rung-c" },
+      { ...filled("2026-01-02T10:00:00", 2), id: "rung-a" },
+      { id: "rung-c", observedAt: "2026-01-02T10:00:01", kind: "orderCancelled", currency: "USD" },
+    ],
+  };
+
+  for (const [name, stream] of Object.entries(STREAMS)) {
+    it(`reads byte-identically to the previous fold: ${name}`, () => {
+      expect(JSON.stringify(pickRestingOrdersAsOf(stream))).toBe(
+        JSON.stringify(previousFold(stream)),
+      );
+    });
+  }
+
+  it("DIVERGES on exactly one stream, and the divergence is the relocation", () => {
+    // The one place the two folds disagree with no observation line in sight, named
+    // rather than discovered later. The old fold DELETED a rung on exhaustion, so a
+    // repeat placement line after a full fill found no entry and re-inserted the claim at
+    // FULL SIZE — resurrection, silently, off a line the selector otherwise ignores by
+    // design. The new fold keeps the rung and its baseline, so the repeat line is ignored
+    // as a repeat line always is.
+    //
+    // Resurrection is RELOCATED by this slice, not introduced: it now happens only where
+    // an observation deliberately restates the baseline, and never off a duplicate.
+    const stream: OrderRecord[] = [
+      placed("2026-01-01T10:00:00", 10),
+      filled("2026-01-02T10:00:00", 10),
+      placed("2026-01-03T10:00:00", 10),
+    ];
+    expect(previousFold(stream).map((order) => order.remainingQuantity)).toEqual([10]);
+    expect(remainingOf(stream)).toEqual([]);
+  });
+});
+
+describe("S-B the fold — consumed is NOT monotonic, and the fold resurrects deliberately", () => {
+  it("an observation BELOW the current baseline takes remaining from zero back to positive", () => {
+    const exhausted: OrderRecord[] = [
+      placed("2026-01-01T10:00:00", 10),
+      filled("2026-01-02T10:00:00", 10),
+    ];
+    expect(remainingOf(exhausted)).toEqual([]);
+
+    // THE PROPERTY, ASSERTED IN THE DIRECTION IT ACTUALLY MATTERS. A hand-authored
+    // observation of 3 over a rung with 10 already consumed SETs the baseline back to 3,
+    // and 7 units read as resting again. This is intended behaviour of a pure fold, and
+    // the reason `remainingQuantity` is a REPORT and not an authorization: what may still
+    // be acted on is decided at the fill-admission gate, not here.
+    expect(remainingOf([...exhausted, observed("2026-01-03T10:00:00", 3)])).toEqual([7]);
+  });
+
+  it("a cancellation retires the rung outright, and nothing later resurrects it", () => {
+    const records: OrderRecord[] = [
+      placed("2026-01-01T10:00:00", 10, 2),
+      { id: RUNG, observedAt: "2026-01-02T10:00:00", kind: "orderCancelled", currency: "USD" },
+      observed("2026-01-03T10:00:00", 3),
+    ];
+    // Retirement is the one irreversible step: an observation about a rung that left the
+    // book cannot re-place it, because a placement is the only thing that can.
+    expect(remainingOf(records)).toEqual([]);
+  });
+});
+
+describe("S-B the fold — an observation cannot invent a claim", () => {
+  it("an observation naming an id that was never placed folds to nothing", () => {
+    expect(remainingOf([observed("2026-01-02T10:00:00", 6)])).toEqual([]);
+  });
+
+  it("an observation that exhausts the rung retires it", () => {
+    expect(
+      remainingOf([placed("2026-01-01T10:00:00", 10, 2), observed("2026-01-02T10:00:00", 10)]),
+    ).toEqual([]);
+  });
+
+  it("an observation after the as-of boundary is not read", () => {
+    const records: OrderRecord[] = [
+      placed("2026-01-01T10:00:00", 10, 2),
+      observed("2026-01-05T10:00:00", 6),
+    ];
+    expect(pickRestingOrdersAsOf(records, "2026-01-03").map((o) => o.remainingQuantity)).toEqual([
+      8,
+    ]);
+    expect(pickRestingOrdersAsOf(records, "2026-01-05").map((o) => o.remainingQuantity)).toEqual([
+      4,
+    ]);
+  });
+});
+
+describe("S-A the record — five keys, byte-equal round trip, required and positive", () => {
+  const line = observed("2026-01-02T10:00:00", 6);
+
+  it("round-trips BYTE-EQUAL through the canonical key order", () => {
+    const serialized = serializeOrderRecord(line);
+    expect(serialized).toBe(
+      `{"id":"rung-synthetic","observedAt":"2026-01-02T10:00:00","kind":"orderFillObserved",` +
+        `"currency":"USD","observedFilledQuantity":6}`,
+    );
+    const parsed = parseOrderRecord(JSON.parse(serialized));
+    if (parsed.status !== "ok") {
+      throw new Error(`expected a record, got ${parsed.problem}: ${parsed.message}`);
+    }
+    expect(serializeOrderRecord(parsed.record)).toBe(serialized);
+    expect(parsed.record).toEqual(line);
+  });
+
+  it("carries FIVE keys and NO copy of quantity", () => {
+    // Quantity is the one figure nothing may go stale on. A second copy here would
+    // manufacture exactly the drift the batch refusal exists to prevent.
+    expect(Object.keys(JSON.parse(serializeOrderRecord(line)))).toEqual([
+      "id",
+      "observedAt",
+      "kind",
+      "currency",
+      "observedFilledQuantity",
+    ]);
+  });
+
+  it("is a KNOWN kind — never skipped as forward-compatibility noise", () => {
+    const parsed = parseOrderRecord(JSON.parse(serializeOrderRecord(line)));
+    expect(parsed.status).toBe("ok");
+  });
+
+  it("rejects a zero, negative, absent or non-finite figure as MALFORMED — never reads it as zero", () => {
+    const base = JSON.parse(serializeOrderRecord(line)) as Record<string, unknown>;
+    const bad: Array<[string, Record<string, unknown>]> = [
+      ["zero", { ...base, observedFilledQuantity: 0 }],
+      ["negative", { ...base, observedFilledQuantity: -1 }],
+      ["NaN", { ...base, observedFilledQuantity: Number.NaN }],
+      ["Infinity", { ...base, observedFilledQuantity: Number.POSITIVE_INFINITY }],
+      ["a string", { ...base, observedFilledQuantity: "6" }],
+      ["null", { ...base, observedFilledQuantity: null }],
+    ];
+    const absent = { ...base };
+    delete absent.observedFilledQuantity;
+    bad.push(["absent", absent]);
+
+    for (const [name, candidate] of bad) {
+      expect(parseOrderRecord(candidate), name).toMatchObject({
+        status: "skip",
+        problem: "malformed",
+      });
+    }
+  });
+});
+
+describe("S-A the record — the TOTAL constructor is the only way in", () => {
+  it("refuses a non-positive figure instead of writing a line that reads back malformed", () => {
+    // THE DEFECT THIS CLOSES. A `?? 0` fallback over an object literal is a LIVE BRANCH,
+    // however it is annotated: a zero serializes cleanly and then reads back as
+    // `malformed` on every subsequent load, at which point all four shells refuse to
+    // render a committed figure at all. One bad line poisons the readability of the book.
+    for (const figure of [0, -1, Number.NaN, Number.POSITIVE_INFINITY]) {
+      expect(
+        buildOrderFillObserved({
+          id: RUNG,
+          observedAt: "2026-01-02T10:00:00",
+          currency: "USD",
+          observedFilledQuantity: figure,
+        }).status,
+      ).toBe("refused");
+    }
+  });
+
+  it("refuses a bad stamp BEFORE it reaches an append-only file", () => {
+    expect(
+      buildOrderFillObserved({
+        id: RUNG,
+        observedAt: "2026-01-02",
+        currency: "USD",
+        observedFilledQuantity: 6,
+      }).status,
+    ).toBe("refused");
+  });
+
+  it("refuses an empty id", () => {
+    expect(
+      buildOrderFillObserved({
+        id: "  ",
+        observedAt: "2026-01-02T10:00:00",
+        currency: "USD",
+        observedFilledQuantity: 6,
+      }).status,
+    ).toBe("refused");
+  });
+
+  it("is TOTAL: it answers for every input rather than throwing on some of them", () => {
+    expect(() =>
+      buildOrderFillObserved({
+        id: "",
+        observedAt: "nonsense",
+        currency: "USD",
+        observedFilledQuantity: -1,
+      }),
+    ).not.toThrow();
+  });
+});

--- a/packages/engine/src/orders/records.ts
+++ b/packages/engine/src/orders/records.ts
@@ -32,7 +32,7 @@ import type { Currency } from "../contracts.js";
  * `orderFilled` is declared here because the selector must know a filled rung stops
  * resting; WRITING one is the atomic two-file fill act, which is a later slice.
  */
-export type OrderKind = "orderPlaced" | "orderCancelled" | "orderFilled";
+export type OrderKind = "orderPlaced" | "orderCancelled" | "orderFilled" | "orderFillObserved";
 
 /** Which side of the book the claim rests on. Resting sells are named, not designed. */
 export type OrderSide = "buy" | "sell";
@@ -95,27 +95,24 @@ export interface OrderPlacedRecord extends OrderRecordBase {
    *     and a cash leg behind it. This is something the venue SHOWED about the row at the
    *     moment it was observed. Collapsing them into one verb would lose that.
    *
-   * KNOWN LIMIT, named rather than papered over: the id is synthesized from the venue's
-   * SUBMISSION stamp, so a later export showing the same rung further filled arrives under
-   * the same id, and THIS FIELD CANNOT BE UPDATED — the file is append-only and a second
-   * placement line is ignored by the selector. So the value here is the partial as of the
-   * FIRST import that saw the rung, not the venue's current one, until the observation
-   * verb #181 designs exists.
+   * THIS FIELD IS THE FIRST OBSERVATION, NOT THE ONLY ONE (#181). The id is synthesized
+   * from the venue's SUBMISSION stamp, so a later export showing the same rung further
+   * filled arrives under the SAME id — the ordinary life of a ladder, not an amendment.
+   * The file is append-only and a second placement line is ignored by the selector, so
+   * this value is never rewritten. It does not need to be: an
+   * {@link OrderFillObservedRecord} states the venue's later figure on its own line, and
+   * `./select.ts` folds this field and every observation since into ONE `consumed`
+   * baseline on the same cumulative basis. The value here is the partial as of the first
+   * import that saw the rung; the SELECTOR's answer is as of the latest line.
    *
-   * The handling of that has moved twice. It was originally SKIPPED AS ALREADY KNOWN,
-   * silently. #174 made it a `changed-claim` refusal — loud, with nothing written — which
-   * fixed the silence and created a worse problem: the refusal is batch-wide, so one
-   * further-filled rung blocked every unrelated new rung in every later export from that
-   * venue, indefinitely. THE EXIT THIS PARAGRAPH USED TO NAME — "the operator records the
-   * fill" — DOES NOT WORK, and never did: `recordFill` appends an `orderFilled` line and
-   * never rewrites this one, so it repairs `committed`/`available` and leaves the refusal
-   * exactly where it was.
-   *
-   * Since #199 the rung is SKIPPED PER RUNG and reported as `restated`: the rest of the
-   * export imports, and this field keeps the older partial. That is safe only because of
-   * the direction — a stale partial over-states what is still resting, so the funding
-   * guard reads the encumbrance HIGH and can only ever be too strict. A stale `quantity`
-   * points the other way and is still a total refusal.
+   * The handling of a restatement moved three times, and the history is kept because the
+   * append-only file makes the shape permanent. It was originally SKIPPED AS ALREADY
+   * KNOWN, silently. #174 made it a `changed-claim` refusal — loud, with nothing written —
+   * which fixed the silence and created a worse problem: the refusal was batch-wide, so
+   * one further-filled rung blocked every unrelated new rung in every later export from
+   * that venue, indefinitely. #199 narrowed that to a PER-RUNG skip reported as
+   * `restated`, which stopped the collateral damage and still left this field holding a
+   * figure the venue had moved past. #181 records the restatement instead.
    */
   observedFilledQuantity?: number;
   /**
@@ -143,7 +140,75 @@ export interface OrderFilledRecord extends OrderRecordBase {
   filledQuantity: number;
 }
 
-export type OrderRecord = OrderPlacedRecord | OrderCancelledRecord | OrderFilledRecord;
+/**
+ * A type-only witness that a record came through {@link buildOrderFillObserved}.
+ *
+ * It exists at COMPILE TIME ONLY — `declare const` emits nothing, the key never appears
+ * on a real object, and `serializeOrderRecord` writes `KEY_ORDER` rather than the
+ * caller's keys, so no line on disk carries a trace of it. What it buys is that
+ * "constructed only through the constructor" is checked by `pnpm typecheck` instead of
+ * asserted by a comment: an object literal of the right shape is NOT assignable to
+ * {@link OrderFillObservedRecord}, so the `?? 0`-over-a-literal defect this slice exists
+ * to close cannot be written at all.
+ */
+declare const OBSERVED_THROUGH_CONSTRUCTOR: unique symbol;
+
+/**
+ * THE VENUE SHOWED THIS ROW FURTHER FILLED (#181) — the observation verb.
+ *
+ * WHY A NEW KIND, AND NOT ONE OF THE THREE ALREADY HERE. Not a synthesized `orderFilled`:
+ * that line is HALF OF A FILL ACT, paired by `reconcileFillActs` with a lot in
+ * `events.jsonl`, so one written at import would read as a permanent `fill-without-lot`
+ * torn act and brick the fill flow (`./fill.ts` excludes this kind deliberately, and says
+ * so). Not a repeat `orderPlaced` either: `./select.ts` ignores a second placement line
+ * for a known id BY DESIGN — that is what makes a re-import idempotent — so a restatement
+ * carried that way would be unreachable.
+ *
+ * `observedFilledQuantity` REUSES THE PLACEMENT LINE'S FIELD NAME because it asserts the
+ * SAME FACT at a later moment: cumulative since the rung was placed, one basis (#176).
+ * A second name would make that illegible in the one artifact where it matters — the
+ * file itself. `./select.ts` folds both into one `consumed` baseline.
+ *
+ * NO COPY OF `quantity`. Quantity is the one figure nothing may go stale on, and a second
+ * copy of it manufactures exactly the drift the import's batch refusal exists to prevent.
+ * A reader that needs the placed size joins to the `orderPlaced` line by id.
+ */
+export interface OrderFillObservedRecord extends OrderRecordBase {
+  kind: "orderFillObserved";
+  /**
+   * The venue's CUMULATIVE filled quantity for this rung as of `observedAt` — REQUIRED
+   * and POSITIVE. A line is only ever written because the figure moved UP, so absent and
+   * zero are both unreachable and both mean the writer failed to say what it observed.
+   */
+  observedFilledQuantity: number;
+  /** Compile-time only; see {@link OBSERVED_THROUGH_CONSTRUCTOR}. Never on disk. */
+  readonly [OBSERVED_THROUGH_CONSTRUCTOR]: never;
+}
+
+export type OrderRecord =
+  | OrderPlacedRecord
+  | OrderCancelledRecord
+  | OrderFilledRecord
+  | OrderFillObservedRecord;
+
+/** What the writer asserts. Every field is required — there is no absent figure to fall back over. */
+export interface ObservedFillClaim {
+  id: string;
+  observedAt: string;
+  currency: Currency;
+  observedFilledQuantity: number;
+}
+
+/**
+ * The outcome of building an observation line. A REFUSAL IS A VALUE the caller must
+ * handle, which is what makes the constructor total: it is defined on every input, it
+ * never throws, and there is no path on which it returns a record it could not justify.
+ */
+export type OrderFillObservedBuild =
+  | { status: "ok"; record: OrderFillObservedRecord }
+  | { status: "refused"; message: string };
+
+/** Built below, beside the validators it shares with {@link parseOrderRecord}. */
 
 /**
  * Every `OrderKind` the union knows, as a runtime value derived from the union itself:
@@ -155,6 +220,7 @@ const KNOWN_KINDS: Record<OrderKind, true> = {
   orderPlaced: true,
   orderCancelled: true,
   orderFilled: true,
+  orderFillObserved: true,
 };
 
 const CURRENCIES: Record<Currency, true> = { USD: true, MXN: true };
@@ -217,6 +283,9 @@ const KEY_ORDER: Record<OrderKind, readonly string[]> = {
   ],
   orderCancelled: ["id", "observedAt", "kind", "currency"],
   orderFilled: ["id", "observedAt", "kind", "currency", "filledQuantity"],
+  // FIVE KEYS. No `quantity`, no `symbol`, no `price` — an observation restates ONE fact
+  // and joins to its placement line by id for the rest.
+  orderFillObserved: ["id", "observedAt", "kind", "currency", "observedFilledQuantity"],
 };
 
 /** Serialize ONE record to its canonical JSON line (no trailing newline). */
@@ -246,6 +315,54 @@ function isNonEmptyString(value: unknown): value is string {
 
 function isFinitePositive(value: unknown): value is number {
   return typeof value === "number" && Number.isFinite(value) && value > 0;
+}
+
+/**
+ * THE ONLY WAY TO BUILD AN OBSERVATION LINE (#181). Total: every input gets an answer.
+ *
+ * WHAT THIS REPLACES, AND WHY IT IS A FUNCTION RATHER THAN A COMMENT. The shape this
+ * supersedes was an object literal with a `?? 0` fallback annotated "positive by
+ * construction". The annotation was false — the fallback was a LIVE BRANCH — and the
+ * failure mode is asymmetric: a zero SERIALIZES CLEANLY and only reads back as
+ * `malformed` on every subsequent load, at which point the four TUI shells refuse to
+ * render a committed figure at all. One bad line poisons the readability of the whole
+ * book, and an append-only file has no way to take it back.
+ *
+ * So the figure is checked HERE, before the line can exist, on the same rule
+ * {@link parseOrderRecord} applies on the way back in — it lives beside that reader and
+ * shares its validators, so the write gate and the read gate cannot drift. The stamp and
+ * the id are checked for the same reason {@link isObservedAtStamp} exists at all: the
+ * reader is the last line of defence, but by the time it runs the line is on disk.
+ */
+export function buildOrderFillObserved(claim: ObservedFillClaim): OrderFillObservedBuild {
+  if (!isNonEmptyString(claim.id)) {
+    return { status: "refused", message: "id must be a non-empty string" };
+  }
+  if (!isObservedAtStamp(claim.observedAt)) {
+    return { status: "refused", message: "observedAt must be YYYY-MM-DDTHH:MM:SS" };
+  }
+  if (!(claim.currency in CURRENCIES)) {
+    return { status: "refused", message: "currency must be a known currency" };
+  }
+  if (!isFinitePositive(claim.observedFilledQuantity)) {
+    return {
+      status: "refused",
+      message: "observedFilledQuantity must be a finite positive number",
+    };
+  }
+  return {
+    status: "ok",
+    // The one cast in the module, and the reason the witness works: it is unforgeable
+    // outside these lines, so every `OrderFillObservedRecord` anywhere passed the checks
+    // directly above.
+    record: {
+      id: claim.id,
+      observedAt: claim.observedAt,
+      kind: "orderFillObserved",
+      currency: claim.currency,
+      observedFilledQuantity: claim.observedFilledQuantity,
+    } as OrderFillObservedRecord,
+  };
 }
 
 /**
@@ -358,6 +475,24 @@ export function parseOrderRecord(value: unknown): OrderRecordParse {
         status: "ok",
         record: { ...base, kind: "orderFilled", filledQuantity: value.filledQuantity },
       };
+    }
+    case "orderFillObserved": {
+      // THE SAME GATE THE WRITER PASSED, and not a second copy of it: the reader routes
+      // through the constructor, so "required and finite-positive" is stated once. A
+      // refusal here is `malformed` — a line that fails to say what it observed is
+      // corruption, not a forward-compatibility problem, and it is NEVER read as zero.
+      const built = buildOrderFillObserved({
+        id: base.id,
+        observedAt: base.observedAt,
+        currency: base.currency,
+        // `as number` is the untrusted value going INTO the gate, not past it: the
+        // constructor's own check is what decides, on exactly this value.
+        observedFilledQuantity: value.observedFilledQuantity as number,
+      });
+      if (built.status !== "ok") {
+        return { status: "skip", problem: "malformed", message: built.message };
+      }
+      return { status: "ok", record: built.record };
     }
   }
 }

--- a/packages/engine/src/orders/select.ts
+++ b/packages/engine/src/orders/select.ts
@@ -174,3 +174,45 @@ export function pickRestingOrdersAsOf(records: OrderRecord[], asOf?: string): Re
   }
   return resting;
 }
+
+/**
+ * WHAT THE FUND HAS ACTUALLY BOOKED against one rung: the sum of its `orderFilled`
+ * quantities. PURE and TOTAL — an id this stream never met sums to 0.
+ *
+ * THIS IS THE SECOND TERM OF THE FILL-ADMISSION CEILING, and it exists because
+ * {@link pickRestingOrdersAsOf}'s `remainingQuantity` is a REPORT and not an
+ * AUTHORIZATION (invariant 2 above). A caller deciding how much it may still BOOK against
+ * a rung asks:
+ *
+ *     admissible = min(rung.remainingQuantity, rung.quantity − bookedFills(records, id))
+ *
+ * and the invariant that protects is that a rung's TOTAL BOOKED FILLS MAY NEVER EXCEED ITS
+ * PLACED QUANTITY. Without it, a backwards observation that resurrects an exhausted rung
+ * would authorize a second lot and a second cash leg into `events.jsonl` — a log with no
+ * reversal verb — for capital already spent.
+ *
+ * ONLY `orderFilled` COUNTS, AND THAT IS THE WHOLE POINT. An observation, whether the
+ * placement line's own `observedFilledQuantity` or a later `orderFillObserved`, is what
+ * the VENUE SHOWED; only an `orderFilled` line is something the FUND DID, with a lot and a
+ * cash leg answering for it. Counting an observation here would make the ceiling move with
+ * the very figure it exists to be independent of, and it would be no ceiling at all. A
+ * cancellation does not subtract either: retiring the CLAIM does not un-buy the lot.
+ *
+ * NO `asOf` BOUND, DELIBERATELY. This is not an as-of question. Capital that left the fund
+ * is spent whatever window the caller is looking through, so bounding this would let a
+ * narrow window hide a booking and re-open the gap. The ceiling is computed over the WHOLE
+ * stream the caller holds.
+ *
+ * ONE FUNCTION, NOT A RULE EACH CALLER RESTATES — the same discipline `./committed.ts`
+ * holds for the committed formula, and for the same reason: two independently-maintained
+ * copies of an authorization rule that silently drift is the defect class, not the fix.
+ */
+export function bookedFills(records: readonly OrderRecord[], id: string): number {
+  let total = 0;
+  for (const record of records) {
+    if (record.kind === "orderFilled" && record.id === id) {
+      total += record.filledQuantity;
+    }
+  }
+  return total;
+}

--- a/packages/engine/src/orders/select.ts
+++ b/packages/engine/src/orders/select.ts
@@ -18,9 +18,18 @@ import type { OrderPlacedRecord, OrderRecord } from "./records.js";
  *
  * `remainingQuantity` is NET OF EVERYTHING OBSERVED: the placement line's own
  * `observedFilledQuantity` (what the venue already showed filled when the rung was
- * imported) and every `orderFilled` line since. The ORIGINAL size stays on
- * `placed.quantity`, and that distinction is load-bearing — a cumulative venue reading is
- * compared against the original, never against this (#176).
+ * imported), every later `orderFillObserved` restating that figure, and every
+ * `orderFilled` line the fund booked. The ORIGINAL size stays on `placed.quantity`, and
+ * that distinction is load-bearing — a cumulative venue reading is compared against the
+ * original, never against this (#176).
+ *
+ * IT IS A REPORT, NOT AN AUTHORIZATION, and the difference is not pedantry. `consumed` is
+ * NOT MONOTONIC (see {@link pickRestingOrdersAsOf}), so this figure can go UP as well as
+ * down. A caller asking "how much is still encumbered" is asking the right question of
+ * it. A caller asking "how much may I still book against this rung" is not, and must
+ * apply the booked-fills ceiling at its own boundary — this number alone would let a
+ * backwards observation authorize a second lot and cash leg against an already-exhausted
+ * rung.
  */
 export interface RestingOrder {
   placed: OrderPlacedRecord;
@@ -42,17 +51,46 @@ function upperBound(asOf: string): string {
  * PURE selector: the orders still resting as of `asOf` (or as of the whole stream when
  * `asOf` is omitted), in the order they were placed.
  *
- * A claim rests until it is observed to leave the book: `orderCancelled` retires it
- * outright, and `orderFilled` retires only the quantity it names — the remainder keeps
- * resting, and the claim is retired when the quantity is exhausted. Nothing is inferred
- * from an ABSENCE: a rung that simply stops appearing in the venue's export has no line
- * here and stays resting until an observation says otherwise (ADR-013, `D12`).
+ * ONE `consumed` BASELINE PER RUNG, folded in ONE PASS (#181). Four verbs move it:
  *
- * Lines are replayed in `observedAt` order rather than file order, so a sidecar whose
- * appends arrived out of order still replays deterministically — the same contract
- * `pickPolicyAsOf` holds for a non-monotonic preferences file. A state-change line
- * naming an id that was never placed (or placed after the boundary) is ignored; it
- * cannot invent a resting claim.
+ *   - `orderPlaced`      SETS it — the first observation; absent reads as 0.
+ *   - `orderFillObserved` SETS it — a later observation of the SAME cumulative figure.
+ *   - `orderFilled`      ADDS to it — a delta, something the fund DID.
+ *   - `orderCancelled`   retires the rung outright.
+ *
+ * and `remainingQuantity = quantity − consumed`. A rung with nothing still claimed is not
+ * resting at all — a fully filled row is not a claim on capital. Nothing is inferred from
+ * an ABSENCE: a rung that simply stops appearing in the venue's export has no line here
+ * and stays resting until an observation says otherwise (ADR-013, `D12`).
+ *
+ * INVARIANT 1 — THE REPLAY ORDER *IS* THE CONTRACT, NOT AN IMPLEMENTATION DETAIL. Lines
+ * are replayed in `observedAt` order rather than file order, so a sidecar whose appends
+ * arrived out of order still replays deterministically — the same contract
+ * `pickPolicyAsOf` holds for a non-monotonic preferences file. But the fold is also
+ * ORDER-SENSITIVE, which is a stronger statement and the one that gets forgotten: a rung
+ * placed at 10 with 2 already filled, then OBSERVED at 6, then FILLED for 1 more, has 3
+ * remaining. Every order-insensitive formulation of the same four rules — `max` of the
+ * observations against the sum of the fills being the tempting one — reads 4 on that
+ * stream, and 4 is wrong. Do not reformulate this into something that can be computed
+ * from unordered sets; it cannot.
+ *
+ * INVARIANT 2 — `consumed` IS NOT MONOTONIC, SO `remainingQuantity` IS A REPORT AND NOT
+ * AN AUTHORIZATION. Because an observation SETS the baseline, one asserting a figure
+ * BELOW the current baseline takes `remaining` from zero back to positive: THE FOLD
+ * RESURRECTS A RETIRED RUNG, deliberately. That is stated rather than prevented, for two
+ * reasons. It is RELOCATED, not introduced — the previous fold let a repeat `orderPlaced`
+ * line re-insert a retired rung at FULL SIZE, silently, off a line it otherwise ignores
+ * by design. And latching retirement instead would be irreversible by construction: this
+ * is an append-only file with no reversal verb, so a rung latched in error would be
+ * permanently un-fillable AND un-cancellable, where resurrection is recoverable.
+ *
+ * The consequence — that a resurrected rung must not authorize a second lot and cash leg
+ * against capital already spent — is closed at the FILL-ADMISSION boundary, where the
+ * booked-fills ceiling lives, and not here. This fold stays PURE arithmetic over the
+ * stream so that policy has exactly one home.
+ *
+ * A state-change line naming an id that was never placed (or placed after the boundary)
+ * is ignored; it cannot invent a resting claim.
  */
 export function pickRestingOrdersAsOf(records: OrderRecord[], asOf?: string): RestingOrder[] {
   const bound = asOf === undefined ? undefined : upperBound(asOf);
@@ -61,7 +99,12 @@ export function pickRestingOrdersAsOf(records: OrderRecord[], asOf?: string): Re
     .slice()
     .sort((a, b) => (a.observedAt < b.observedAt ? -1 : a.observedAt > b.observedAt ? 1 : 0));
 
-  const resting = new Map<string, RestingOrder>();
+  // The placement line and its running baseline, together — one entry per rung the fold
+  // has met. A rung stays here once exhausted rather than being deleted, which is what
+  // lets a later line move the baseline in either direction; only `orderCancelled`
+  // removes an entry, because only a cancellation says the claim LEFT THE BOOK.
+  const rungs = new Map<string, { placed: OrderPlacedRecord; consumed: number }>();
+
   for (const record of eligible) {
     switch (record.kind) {
       case "orderPlaced": {
@@ -70,36 +113,64 @@ export function pickRestingOrdersAsOf(records: OrderRecord[], asOf?: string): Re
         // double-counting the ladder — and it is what makes the partial carried ON this
         // line idempotent, where a synthesized `orderFilled` line would be subtracted
         // once per copy (#173).
-        if (!resting.has(record.id)) {
-          // A rung the venue already showed partly filled at placement rests only for its
-          // REMAINDER. Nothing still claimed means it is not resting at all — a fully
-          // filled row is not a claim on capital.
-          const remaining = record.quantity - (record.observedFilledQuantity ?? 0);
-          if (remaining > 0) {
-            resting.set(record.id, { placed: record, remainingQuantity: remaining });
-          }
+        if (!rungs.has(record.id)) {
+          // THE FIRST OBSERVATION, on the same cumulative basis as every later one.
+          // Absent reads as nothing filled (#173).
+          rungs.set(record.id, { placed: record, consumed: record.observedFilledQuantity ?? 0 });
         }
         break;
       }
       case "orderCancelled": {
-        resting.delete(record.id);
+        rungs.delete(record.id);
         break;
       }
       case "orderFilled": {
-        const open = resting.get(record.id);
-        if (!open) {
-          break;
+        // ADD — a delta, as it always was: something the fund DID, with a lot and a cash
+        // leg behind it. Nothing to add it to means the line names an id never placed
+        // here, and no line may invent a resting claim.
+        const rung = rungs.get(record.id);
+        if (rung) {
+          rung.consumed += record.filledQuantity;
         }
-        const remaining = open.remainingQuantity - record.filledQuantity;
-        if (remaining > 0) {
-          resting.set(record.id, { placed: open.placed, remainingQuantity: remaining });
-        } else {
-          resting.delete(record.id);
+        break;
+      }
+      case "orderFillObserved": {
+        // SET, not add, and not `max`. The venue's figure is CUMULATIVE since placement,
+        // so it REPLACES the baseline rather than stacking on it — which is what makes an
+        // interleaving safe: observed 6, filled 1, observed 8 folds to 6 → 7 → 8, and the
+        // fill is neither lost nor counted twice, because the next observation is a fresh
+        // baseline rather than an adjustment to the old one.
+        //
+        // `max` was considered and refused. On a backwards observation it keeps the
+        // HIGHER `consumed`, so `remaining` stays low, `committed` reads LOW and
+        // `available` reads HIGH — the money-losing direction. Plain SET raises the
+        // remainder instead, which is the conservative answer and the arithmetically
+        // honest one.
+        const rung = rungs.get(record.id);
+        if (rung) {
+          rung.consumed = record.observedFilledQuantity;
         }
+        break;
+      }
+      default: {
+        // A kind added to `OrderKind` and never taught to this fold would typecheck fine
+        // and fold to NOTHING — the single most likely way a new verb ships broken, and it
+        // presents identically to a line that was never appended. This latch turns that
+        // into a compile error. Compile-time only: an unknown kind cannot reach here at
+        // runtime, because `parseOrderRecord` refuses it first.
+        const _never: never = record;
+        void _never;
         break;
       }
     }
   }
 
-  return [...resting.values()];
+  const resting: RestingOrder[] = [];
+  for (const { placed, consumed } of rungs.values()) {
+    const remaining = placed.quantity - consumed;
+    if (remaining > 0) {
+      resting.push({ placed, remainingQuantity: remaining });
+    }
+  }
+  return resting;
 }


### PR DESCRIPTION
## Summary

Implements spec #181 — updates a rung's observed partial when a later export shows it further filled. Five slices land together:

- **#206** — the `orderFillObserved` record kind + its total constructor, and the unified `consumed` fold (placement SETs, observation SETs, fill ADDs, cancel retires).
- **#207** — `bookedFills` and the fill-admission ceiling `min(remainingQuantity, quantity − bookedFills(id))`, so a resurrected rung cannot book a second lot.
- **#208** — change detection re-based on the latest observation, and the refusal split by direction (`backwards-claim` vs `changed-claim`).
- **#209** — one shared skip renderer adopted by all four TUI shells, distinguishing a newer-build line from a malformed one.
- **#210** — the report is fed the lines actually written; the counting vocabulary splits; the append key is on what an observation asserts; the clock is wired at both adapters.

Descriptor widening remains open and unscheduled — see #205; slice 3 re-points a code comment to cite it, and that is the only coupling.

## Verification

- `pnpm typecheck` clean across all six packages
- `pnpm test` — 1206 passed / 19 skipped (the 19 are pre-existing Postgres integration gates that need `NUMISMA_TEST_DATABASE_URL`)
- Zero files changed under `apps/web`
- Named contract tests green: `funding-parity`, `orders-stay-off-the-wire`, `orders-not-events`

## Test plan

- [x] `pnpm typecheck`
- [x] `pnpm test`
- [x] Contract tests: `funding-parity`, `orders-stay-off-the-wire`, `orders-not-events`

Closes #206
Closes #207
Closes #208
Closes #209
Closes #210
Closes #181
