### PR TITLE
refactor(engine,event-store,preferences): document the isRecord/isRecordObject and readOptional duplication decisions

### DIFF
--- a/packages/engine/src/internal.ts
+++ b/packages/engine/src/internal.ts
@@ -118,6 +118,33 @@ export function isPositiveNumber(value: unknown): value is number {
   return typeof value === "number" && Number.isFinite(value) && value > 0;
 }
 
+/**
+ * True for any non-null object — INCLUDING arrays, DELIBERATELY.
+ *
+ * Every caller (`parse.ts`, `events/parse.ts`) follows the guard with a read of a NAMED
+ * DOMAIN FIELD — `fund`, `id`, `asOf` — and an array answers all of those `undefined`.
+ * The checks on those fields then refuse it and SAY WHICH FIELD, which tells the operator
+ * more than a blanket "not an object" would, so tightening this predicate would buy
+ * nothing here and cost attribution.
+ *
+ * Where that is NOT true — where the very first field check would misattribute an array
+ * to a field problem — use {@link isRecordObject}, which additionally rejects arrays.
+ */
 export function isRecord(value: unknown): value is Record<string, unknown> {
   return typeof value === "object" && value !== null;
+}
+
+/**
+ * {@link isRecord} plus `!Array.isArray` — the STRICT sibling. The two are separate on
+ * purpose; neither is a stale copy of the other.
+ *
+ * `parseOrderRecord` (`./orders/records.ts`) is the caller that needs the strictness. Its
+ * first field check is `id`, so under the loose predicate an array line would fall through
+ * and be refused as `id must be a non-empty string` — a message that sends the reader
+ * looking for a missing id in a line that never had a place to put one. The strict
+ * predicate refuses it up front as `record must be a JSON object`, which is what actually
+ * went wrong.
+ */
+export function isRecordObject(value: unknown): value is Record<string, unknown> {
+  return typeof value === "object" && value !== null && !Array.isArray(value);
 }

--- a/packages/engine/src/orders/records.test.ts
+++ b/packages/engine/src/orders/records.test.ts
@@ -1,0 +1,53 @@
+/**
+ * THE RECORD CONTRACT'S REFUSALS (`./records.ts`) — the cases whose whole value is the
+ * MESSAGE, not the status.
+ *
+ * `parseOrderRecord` refuses an array line through `isRecordObject`, the strict half of
+ * the engine kernel's predicate pair (`../internal.ts`). Its loose sibling `isRecord`
+ * passes arrays deliberately, and nothing but this file stops a future reader from
+ * concluding the two are duplicates and collapsing them: under the loose predicate an
+ * array still SKIPS as `malformed`, so a status-only assertion stays green while the
+ * operator's message silently degrades to `id must be a non-empty string` — a hunt for a
+ * missing field in a line that has no fields.
+ *
+ * Synthetic throughout: invented pair, round sizes, round prices.
+ */
+import { describe, expect, it } from "vitest";
+import { parseOrderRecord } from "./records.js";
+
+describe("parseOrderRecord refuses a non-object line attributably", () => {
+  it("names the shape, not a field, for an array line", () => {
+    expect(parseOrderRecord([])).toEqual({
+      status: "skip",
+      problem: "malformed",
+      message: "record must be a JSON object",
+    });
+  });
+
+  it("names the shape for an array WRAPPING a valid record — it is never unwrapped", () => {
+    expect(
+      parseOrderRecord([
+        {
+          id: "rung-synthetic",
+          observedAt: "2026-01-01T09:30:00",
+          kind: "orderCancelled",
+          currency: "USD",
+        },
+      ]),
+    ).toEqual({
+      status: "skip",
+      problem: "malformed",
+      message: "record must be a JSON object",
+    });
+  });
+
+  it("refuses a genuine object with a missing id by FIELD, not by shape", () => {
+    // The contrast case: this is the message the array cases must NOT produce. Without it,
+    // the two above would pin "some refusal happens" rather than "the shape check fires".
+    expect(parseOrderRecord({ observedAt: "2026-01-01T09:30:00" })).toEqual({
+      status: "skip",
+      problem: "malformed",
+      message: "id must be a non-empty string",
+    });
+  });
+});

--- a/packages/engine/src/orders/records.ts
+++ b/packages/engine/src/orders/records.ts
@@ -23,6 +23,10 @@
  * `@numisma/preferences`; the as-of selector lives in `./select.ts`.
  */
 import type { Currency } from "../contracts.js";
+// The STRICT record predicate — arrays refused, not waved through. It lives in the
+// engine's kernel beside its loose sibling `isRecord` so the contrast between them is
+// stated once, in one place, rather than rediscovered here.
+import { isRecordObject } from "../internal.js";
 
 /**
  * The lifecycle verbs of the sidecar (`S2`): one line per order placed, one further
@@ -304,10 +308,6 @@ export type OrderRecordProblem = "unknown-kind" | "malformed";
 export type OrderRecordParse =
   | { status: "ok"; record: OrderRecord }
   | { status: "skip"; problem: OrderRecordProblem; message: string };
-
-function isRecordObject(value: unknown): value is Record<string, unknown> {
-  return typeof value === "object" && value !== null && !Array.isArray(value);
-}
 
 function isNonEmptyString(value: unknown): value is string {
   return typeof value === "string" && value.trim() !== "";

--- a/packages/event-store/src/event-store.ts
+++ b/packages/event-store/src/event-store.ts
@@ -199,8 +199,18 @@ export async function loadFoldedReview(
 
 /**
  * Read a file that may not exist, mapping ENOENT to `undefined` and rethrowing every
- * other IO error. Exported: the TUI's ingest and migration paths read the inbox and
- * the log through the same helper, so this package owns the single definition.
+ * other IO error.
+ *
+ * THE CANONICAL DEFINITION — the one other packages import. The TUI's ingest and
+ * migration paths read the inbox and the log through it (`apps/tui/src/event-store.ts`,
+ * `record-fill-cli.ts`), and the price feed reads its own INBOX through it
+ * (`apps/price-feed/src/inbox.ts`) — a file this package never touches, which is fine:
+ * the helper carries no log-specific policy, only "ENOENT means absent".
+ *
+ * IT IS NOT THE ONLY DEFINITION REPO-WIDE, DELIBERATELY. `@numisma/preferences` keeps a
+ * private copy rather than take a dependency on this package; the reasoning lives beside
+ * that copy (`packages/preferences/src/orders.ts`, #198). Do not "fix" the duplication by
+ * pointing that module here.
  */
 export async function readOptional(filePath: string): Promise<string | undefined> {
   try {

--- a/packages/preferences/src/orders.ts
+++ b/packages/preferences/src/orders.ts
@@ -155,6 +155,22 @@ function tempPathFor(path: string): string {
   return `${path}.${process.pid}.${tempCounter}.tmp`;
 }
 
+/**
+ * Read a file that may not exist, mapping ENOENT to `undefined`.
+ *
+ * A DELIBERATE PRIVATE COPY OF `@numisma/event-store`'s `readOptional`, NOT DRIFT (#198).
+ * Importing the canonical one would draw a permanent `@numisma/preferences ->
+ * @numisma/event-store` edge — this package's only dependency today is `@numisma/engine`.
+ * ADR-013 makes the sidecar's separation from the durable log load-bearing: an `Order` is
+ * recorded BESIDE `events.jsonl`, `parseEvent` never sees one, and the module that writes
+ * `orders.jsonl` has no business knowing the event store exists.
+ *
+ * The duplication is affordable because the helper carries ZERO POLICY — its entire
+ * content is "ENOENT means absent", a rule of the filesystem rather than of either file
+ * format. There is nothing here that can drift into disagreeing with the other copy.
+ * #141 once required exactly one definition repo-wide; that criterion is retired, because
+ * counting definitions was the wrong test for a policy-free adapter.
+ */
 async function readOptional(path: string): Promise<string | undefined> {
   try {
     return await readFile(path, "utf8");


### PR DESCRIPTION
## What this is

#198 asked to dedupe `isRecordObject` (`packages/engine/src/orders/records.ts`) into `isRecord` (`packages/engine/src/internal.ts`) on the premise that the two were byte-identical copies. That premise is false: `isRecordObject` also refuses `!Array.isArray`, so the predicates accept different input, not the same input twice. Collapsing them onto one behavior would either let an array line fall through `parseOrderRecord`'s object guard, or make every other `isRecord` caller start rejecting arrays it currently tolerates on purpose.

The decision made instead: give the two predicates one home in the engine kernel, side by side, each docstringed with why it exists and what it would break to use the wrong one. The full reasoning is posted as a comment on #198: https://github.com/AmetAlvirde/numisma/issues/198#issuecomment-5220830292

`readOptional` gets the same treatment on the `event-store` / `preferences` side — comments only, no code change. `event-store.ts` previously claimed "this package owns the single definition," which was also false once `preferences/src/orders.ts` kept its own copy. That copy is deliberate: importing the canonical `readOptional` would draw a permanent `@numisma/preferences -> @numisma/event-store` dependency edge, and ADR-013 makes the sidecar's separation from the durable log load-bearing. #141's original "exactly one definition repo-wide" criterion is retired by this PR — definition count was the wrong test for an adapter that carries zero policy (its entire content is "ENOENT means absent"), so there's nothing in it that can drift out of agreement.

## Commits

1. `refactor(engine): give isRecord a documented strict sibling, not the #198 dedupe` — moves `isRecordObject` up beside `isRecord` in `internal.ts`, documents the contrast, keeps both off the public surface (`index.ts` re-exports neither). Adds `packages/engine/src/orders/records.test.ts`, which pins `parseOrderRecord`'s array refusal to the message `record must be a JSON object`. Nothing guarded this message before: under the loose predicate an array line still skips with status `malformed`, so a status-only assertion would stay green while the operator-facing message silently degraded to `id must be a non-empty string` — sending the reader looking for a missing id in a line that never had a place to put one.
2. `docs(event-store,preferences): record why readOptional stays duplicated` — corrects the false "owns the single definition" claim and records the decision beside the `preferences` copy.

## Follow-up noted, not fixed here

Found during this build and deliberately left out of scope: `parseEvent` in `packages/engine/src/events/parse.ts` also lets arrays through `isRecord` and only refuses them at the `id` check — the same misattribution `isRecordObject` exists to prevent on the sidecar side. No issue opened for it; recording it here so it isn't lost.

## Verification

Ran by the requester before this PR was opened: `pnpm typecheck` (exit 0, all six packages) and `pnpm test` (1220 passed / 19 skipped — pre-existing Postgres gates; baseline was 1217/19).

Closes #198
