### PR TITLE
ci(startup-smoke): gate startup smoke and Bun setup to PRs targeting main

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -89,3 +89,42 @@ jobs:
         # which flake on slower CI runners under full-suite parallel load. This is
         # a CI-runner mitigation, not a change to any assertion.
         run: pnpm test -- --testTimeout=30000
+
+      # ---------------------------------------------------------------------
+      # The startup smoke (#196). Closes the hole that produced #140: the
+      # smoke's fixture went stale against the event schema, `parseEvent`
+      # refused the `PositionOpened`, `pnpm smoke:startup` exited 1 — and every
+      # check above stayed green, because nothing here ran it. It was caught by
+      # hand. These two steps are the CI half of that gate.
+      #
+      # A BARE `smoke:startup` STEP, not `pnpm verify`. `verify` is
+      # `typecheck && test && smoke:startup`, and the first two already ran as
+      # their own steps above; a `verify` step would run both a second time and
+      # collapse three distinct failures into one red step. The operator's
+      # one-command path (#195) is unaffected — this is CI's decomposition of
+      # the same chain, not a competing one.
+      #
+      # GATED TO PRs TARGETING `main`. `on:` above is `push: ["**"]` plus
+      # `pull_request`, so an ungated step would boot the renderer on every push
+      # to every branch. The gate lives on the steps rather than on `on:` so no
+      # existing coverage is withdrawn: pushes still run typecheck, build and
+      # the full suite exactly as before.
+      # ---------------------------------------------------------------------
+      - name: Install Bun (the startup smoke runs on Bun, not Node)
+        # `smoke:startup` is `bun apps/tui/src/smoke-startup-openTui.ts` —
+        # openTUI needs Bun, which is why this is a Bun script and not a vitest
+        # test. Pinned like pnpm and Node above rather than floating on latest.
+        if: github.event_name == 'pull_request' && github.base_ref == 'main'
+        uses: oven-sh/setup-bun@v2
+        with:
+          bun-version: 1.3.3
+
+      - name: "Startup smoke (real openTUI render path — the #140 gate)"
+        # Drives `prepareStartup` (ingest → report → fold) through `mountApp` on
+        # openTUI's TEST renderer against a throwaway on-disk event store in a
+        # temp dir — no TTY required, and it never reads the real data dir.
+        #
+        # The name is QUOTED because it contains a `#`: unquoted, YAML would read
+        # that as a comment and silently truncate the name mid-word.
+        if: github.event_name == 'pull_request' && github.base_ref == 'main'
+        run: pnpm smoke:startup


### PR DESCRIPTION
## What

CI never ran `pnpm smoke:startup` and had no Bun setup step, so the exact hole around the #140 episode was still open in the pipeline. This PR appends two gated steps to the end of the CI job:

- **Install Bun** (`oven-sh/setup-bun@v2`, pinned to `1.3.3`)
- **Startup smoke** (`pnpm smoke:startup`)

Both run only `if: github.event_name == 'pull_request' && github.base_ref == 'main'`.

Closes #196

## Decisions

- **A bare `smoke:startup` step, not `pnpm verify`.** `verify` chains `typecheck && test && smoke:startup`, and the first two already run as their own steps earlier in the job. A `verify` step here would rerun both and collapse three distinct failures into one red step. The operator-facing one-command path described around #195 is unaffected — this is CI's own decomposition of the same chain, not a competing one.
- **Gated to PRs targeting `main`, on the steps rather than on `on:`.** `main` currently has no branch protection, so a workflow-level restriction risked leaving a direct push to `main` unchecked. Gating the two new steps (instead of the workflow trigger) means no existing coverage is withdrawn: pushes still run typecheck, build, and the full suite exactly as before.

## Self-verifying property

Because this PR targets `main`, its own CI run exercises the newly gated steps — the wiring is demonstrated on this PR before merge, not left to be discovered on the next one.

## Verification

- `pnpm smoke:startup` run locally: passes, exits clean, isolated to a temp dir (never touches the real data dir).
- Workflow YAML parsed and asserted: 10 steps total, exactly the two new ones gated, `on:` unchanged (`push: ["**"]` plus `pull_request`).
- No typecheck/test changes needed — this touches only CI YAML, no source.
