### PR TITLE
fix(tui): scope append filter to each rung's latest observation

### DIFF
--- a/apps/tui/src/import-orders.test.ts
+++ b/apps/tui/src/import-orders.test.ts
@@ -959,6 +959,113 @@ describe("two imports inside ONE second (#181)", () => {
 });
 
 /**
+ * #181 slice #212 — the append filter is scoped to the rung's LATEST observation.
+ *
+ * THE KEY ANSWERS "is this figure already recorded?"; the filter needs "is this figure
+ * still the rung's CURRENT claim?". Built from EVERY existing record, `alreadyOnFile`
+ * answered the first question in the second's place: a figure some later line had already
+ * superseded still filtered a legitimate re-assertion of it, and — because the report
+ * describes the lines that were WRITTEN — the operator was told `0 observation(s)
+ * recorded` about an observation the flow had just decided to record.
+ */
+describe("the append filter reads the LATEST observation, not the whole history (#212)", () => {
+  const PARTLY_FILLED = partlyFilledRung("100", "10", "6", "2020-01-01 10:00:00");
+
+  it("LANDS a re-assertion of a figure a later observation had superseded", async () => {
+    const first = await harness({
+      csv: ladder(PARTLY_FILLED),
+      reserves: [{ id: "reserve-a", amount: 5000 }],
+    });
+    // 1. The rung goes on file: placed 10, the venue showing 6 filled.
+    first.setClock("2026-06-01T09:00:00");
+    await importBitgetOpenOrders({ csvPath: first.csvPath, io: first.io });
+    const [id] = await idsOnDisk(first.ordersPath);
+    if (id === undefined) throw new Error("expected the rung on disk");
+
+    // 2. An import observes 8. `orderFillObserved <id> 8` is now on file.
+    await writeFile(
+      first.csvPath,
+      ladder(partlyFilledRung("100", "10", "8", "2020-01-01 10:00:00")),
+      "utf8",
+    );
+    await importBitgetOpenOrders({ csvPath: first.csvPath, io: first.io });
+    expect(await remainingOnDisk(first.ordersPath)).toEqual([2]);
+
+    // 3. A hand-authored observation asserting 5, at a LATER stamp, supersedes it. The
+    //    file's current claim about this rung is 5 filled, 5 still resting — the 8 is
+    //    history now, and history is exactly what the filter must stop reading.
+    const built = buildOrderFillObserved({
+      id,
+      observedAt: "2026-06-01T10:00:00",
+      currency: "USD",
+      observedFilledQuantity: 5,
+    });
+    if (built.status !== "ok") throw new Error(`fixture must build: ${built.message}`);
+    await appendOrders(first.ordersPath, [built.record]);
+    expect(await remainingOnDisk(first.ordersPath)).toEqual([5]);
+    const before = await readFile(first.ordersPath, "utf8");
+
+    // 4. The venue's next export shows 8 again. Against the latest observation that is a
+    //    RESTATEMENT — 8 is above 5, and the file's 5 resting covers the venue's 2 — so
+    //    the observation is built and must be WRITTEN.
+    first.setClock("2026-06-01T11:00:00");
+    const outcome = await importBitgetOpenOrders({ csvPath: first.csvPath, io: first.io });
+
+    expect(outcome).toMatchObject({ status: "imported" });
+    if (outcome.status !== "imported") throw new Error("expected an unqualified import");
+    expect(outcome.observations).toEqual([{ id, known: 5, observed: 8 }]);
+
+    // THE LINE IS ON DISK — the whole point. Under the old filter the file was
+    // byte-identical here and the operator was told nothing was recorded.
+    expect(await readFile(first.ordersPath, "utf8")).not.toBe(before);
+    const load = await loadOrders(first.ordersPath, { warn: () => {} });
+    if (load.status !== "loaded") throw new Error("expected a loaded sidecar");
+    const observed = load.records.filter((record) => record.kind === "orderFillObserved");
+    expect(observed.map((record) => record.observedFilledQuantity)).toEqual([8, 5, 8]);
+    expect(observed.at(-1)?.observedAt).toBe("2026-06-01T11:00:00");
+    // And the rung now claims what the venue holds: 10 placed, 8 observed filled.
+    expect(await remainingOnDisk(first.ordersPath)).toEqual([2]);
+    expect(first.outputs.at(-1)).toContain("1 observation(s) recorded");
+  });
+
+  it("still FILTERS the ordinary repeat — the same export twice, one line written", async () => {
+    // THE DEDUPE THAT MUST NOT REGRESS, on both kinds at once: the placement line from the
+    // first import and the observation line from the second. The third import re-states a
+    // figure that IS still the rung's latest, so nothing is built and nothing is written.
+    const first = await harness({
+      csv: ladder(PARTLY_FILLED),
+      reserves: [{ id: "reserve-a", amount: 5000 }],
+    });
+    first.setClock("2026-06-01T09:00:00");
+    await importBitgetOpenOrders({ csvPath: first.csvPath, io: first.io });
+
+    await writeFile(
+      first.csvPath,
+      ladder(partlyFilledRung("100", "10", "8", "2020-01-01 10:00:00")),
+      "utf8",
+    );
+    await importBitgetOpenOrders({ csvPath: first.csvPath, io: first.io });
+    const before = await readFile(first.ordersPath, "utf8");
+
+    // The SAME export again, and again at a LATER second — so the stamp cannot be what
+    // filters it. Only the figure can.
+    first.setClock("2026-06-01T11:00:00");
+    const outcome = await importBitgetOpenOrders({ csvPath: first.csvPath, io: first.io });
+
+    expect(outcome).toMatchObject({ status: "imported", appended: 0, alreadyKnown: 1 });
+    if (outcome.status !== "imported") throw new Error("expected an unqualified import");
+    expect(outcome.observations).toEqual([]);
+    expect(await readFile(first.ordersPath, "utf8")).toBe(before);
+    const load = await loadOrders(first.ordersPath, { warn: () => {} });
+    if (load.status !== "loaded") throw new Error("expected a loaded sidecar");
+    expect(load.records.map((record) => record.kind)).toEqual([
+      "orderPlaced",
+      "orderFillObserved",
+    ]);
+  });
+});
+
+/**
  * #181 slice #208 — detection re-based on the LATEST OBSERVATION, and the refusal split.
  *
  * END TO END, THROUGH THE IMPORT, and that is the point of putting these here rather than

--- a/apps/tui/src/import-orders.ts
+++ b/apps/tui/src/import-orders.ts
@@ -913,9 +913,46 @@ export async function importBitgetOpenOrders(
   // ONE `appendOrders` CALL for both kinds: one lock, one temp write, one `rename`. There
   // is no ordering reason to split them — the selector sorts by `observedAt` at READ time,
   // so the file's byte order cannot change what it means.
-  const alreadyOnFile = new Set(existingRecords.map((record) => appendKey(record)));
+  // THE SET IS THE RUNG'S CURRENT CLAIM, NOT ITS WHOLE HISTORY (#212). `appendKey` is a
+  // pure function of ONE record and structurally cannot see what came after it, so it can
+  // only answer *"is this figure already recorded?"*; what the filter must answer is *"is
+  // this figure still the rung's CURRENT claim?"*. The scoping therefore lives HERE, in
+  // what the set is built from, and the key is left alone.
+  //
+  // The two questions part company the moment one observation supersedes another: observe
+  // 8, record a backwards restatement of 5, and the venue's next export of 8 is a
+  // legitimate RE-ASSERTION that a whole-history set drops as a repeat. Nothing lands —
+  // and the report describes the lines that were WRITTEN, so the operator is told
+  // `0 observation(s) recorded` about an observation this flow had just decided to record.
+  //
+  // ONLY THE LATEST OBSERVATION PER RUNG goes in, by the SAME last-wins-by-stamp rule
+  // `detectChangedClaims` uses — `>=`, so the last line in file order wins an equal-stamp
+  // tie. That function is what decides an observation is worth building; were the two to
+  // disagree about which figure is current, one layer would build a line the other refused
+  // to write. Every other kind goes in whole, which for a placement is equivalent to
+  // keying on the id alone, since `synthesizeOrderId` already includes `observedAt`.
+  const latestObserved = new Map<string, OrderFillObservedRecord>();
+  const currentOnFile = new Set<string>();
+  for (const record of existingRecords) {
+    if (record.kind !== "orderFillObserved") {
+      currentOnFile.add(appendKey(record));
+      continue;
+    }
+    const seen = latestObserved.get(record.id);
+    if (seen === undefined || record.observedAt >= seen.observedAt) {
+      latestObserved.set(record.id, record);
+    }
+  }
+  for (const record of latestObserved.values()) {
+    currentOnFile.add(appendKey(record));
+  }
+  // ONE SET, BUILT ONCE, over both arrays in a single pass — so a second line for the same
+  // rung inside ONE batch would not see the first. It cannot arise: `mergeCollidingClaims`
+  // has already summed id collisions, so `orders` holds at most one row per id, and
+  // `records` and `observations` are derived from it by complementary filters on
+  // `restatedIds`. Re-keying per record would buy nothing and cost a quadratic pass.
   const fresh: OrderRecord[] = [...records, ...observations].filter(
-    (record) => !alreadyOnFile.has(appendKey(record)),
+    (record) => !currentOnFile.has(appendKey(record)),
   );
   try {
     await io.appendOrders(io.ordersPath, fresh);
@@ -975,10 +1012,13 @@ export async function importBitgetOpenOrders(
  * would read the first observation of a known rung as a repeat of its placement line and
  * drop it — the whole feature, filtered out by its own dedupe.
  *
- * KNOWINGLY OPEN, tracked on #212 — THIS KEY ANSWERS *"is this figure already recorded?"*,
- * but the filter at its one call site needs *"is this figure still the rung's CURRENT
- * claim?"*: `alreadyOnFile` is built from EVERY existing record, so a figure some later
- * line already superseded still filters a legitimate re-assertion of it.
+ * ONE OF TWO QUESTIONS, AND THE CALL SITE ANSWERS THE OTHER. This key answers *"is this
+ * figure already recorded?"* — all a pure function of ONE record can answer, since nothing
+ * in a record says what came after it. *"Is this figure still the rung's CURRENT claim?"*
+ * is answered where it can be: the filter builds its set from the LATEST observation per
+ * rung rather than from every existing record, so a superseded figure no longer filters a
+ * legitimate re-assertion of it. Keep the scoping there; widening this key to reach for
+ * history would only move the second question somewhere it still cannot be answered.
  */
 function appendKey(record: OrderRecord): string {
   return record.kind === "orderFillObserved"


### PR DESCRIPTION
## Defect

`importBitgetOpenOrders`'s append filter built its `alreadyOnFile` dedupe set from **every** existing record on file. `appendKey` is a pure function of one record, so it can only answer "is this figure already recorded?" — it cannot see whether a later line superseded it.

## Reachable trace

A rung is observed at 8, then a backwards restatement to 5 is recorded. The venue's next export re-asserts 8 — a legitimate re-assertion of the current claim. The old filter's whole-history set still contains the key for the earlier "8" observation, so the re-assertion is dropped as a repeat. Nothing is written, and the report (which describes lines actually written) tells the operator `0 observation(s) recorded` for an observation the flow had just decided to record.

## What changed

- `apps/tui/src/import-orders.ts`: the filter now scopes its dedupe set to each rung's **latest** observation only, using the same last-wins-by-stamp (`>=`) rule `detectChangedClaims` already uses to decide an observation is worth building. Every other record kind still goes into the set whole. `appendKey` itself is unchanged; its docstring is rewritten to say which of the two questions it answers ("is this figure already recorded?") and that the call site now answers the other ("is this figure still current?").
- `apps/tui/src/import-orders.test.ts`: two new cases — a superseded figure that gets re-asserted now lands, and the ordinary repeat-of-current-claim case still filters as before.

Same-second idempotence is preserved: two lines for the same rung's observation with equal `observedAt` still resolve to a single current claim via the `>=` tie rule, so re-running an import that produced no new information still writes nothing new.

Closes #212