### PR TITLE
Persist and compare the placement descriptors on the order-placed record

### DIFF
--- a/apps/tui/src/import-orders.test.ts
+++ b/apps/tui/src/import-orders.test.ts
@@ -1284,6 +1284,261 @@ describe("detection is re-based on the latest observation (#181)", () => {
   });
 });
 
+/**
+ * #205 — THE PLACEMENT DESCRIPTORS, END TO END OVER A REAL FILE.
+ *
+ * The widening's whole premise is that it costs no migration: `orderType`, `timeInForce`
+ * and `triggerPrice` are optional on the record and compared only when the line being
+ * compared against carries them, so every line already on an append-only file keeps
+ * reading exactly as it did. The first case here is that premise, stated directly.
+ *
+ * The refusal cases are about the REMEDY. A descriptor difference has no funding hazard —
+ * the encumbrance is `price × quantity` and no descriptor is in that product — so it must
+ * not be handed `changed-claim`'s cancel-the-rung-at-the-venue advice, which would destroy
+ * a live rung over a discrepancy that costs nothing. Assertions are on the MESSAGE, because
+ * the message is the whole reason the class exists.
+ */
+describe("the placement descriptors (#205)", () => {
+  /** One synthetic rung, with the venue's placement descriptors under the test's control. */
+  function describedRung(
+    price: string,
+    quantity: string,
+    at: string,
+    descriptors: { orderType?: string; timeInForce?: string; triggerPrice?: string } = {},
+  ): string {
+    const fields: Record<string, string> = {
+      timestamp: at,
+      pair: "XYZ/USDT",
+      time_in_force: descriptors.timeInForce ?? "GTC",
+      order_type: descriptors.orderType ?? "Limit",
+      side: "Buy",
+      price,
+      quantity,
+      trigger_price: descriptors.triggerPrice ?? "-- / --",
+      order_value: "0",
+      filled_quantity: "0",
+      total_quantity: quantity,
+      filled_percent: "0.00%",
+      status: "Unfilled",
+      action: "Cancel",
+    };
+    return BITGET_OPEN_ORDERS_HEADER.map((column) => fields[column] ?? "").join(",");
+  }
+
+  /** The placement line as it was written BEFORE this widening: ten keys, no descriptors. */
+  async function seedPreWideningLine(ordersPath: string, csvText: string): Promise<string> {
+    const parsed = parseBitgetOpenOrdersCsv(csvText);
+    if (parsed.status !== "ok") throw new Error("fixture must parse");
+    const [order] = parsed.orders;
+    if (order === undefined) throw new Error("fixture must carry one row");
+    const record: OrderRecord = {
+      id: order.id,
+      observedAt: order.observedAt,
+      kind: "orderPlaced",
+      currency: order.currency,
+      symbol: order.symbol,
+      side: order.side,
+      price: order.price,
+      quantity: order.quantity,
+      fundingReserveId: "reserve-a",
+    };
+    await appendOrders(ordersPath, [record]);
+    return order.id;
+  }
+
+  /** The placement record on disk for one id, read back through the real loader. */
+  async function placedOnDisk(path: string, id: string): Promise<OrderRecord> {
+    const load = await loadOrders(path, { warn: () => {} });
+    if (load.status !== "loaded") throw new Error(`expected a loaded sidecar, got ${load.status}`);
+    const record = load.records.find(
+      (candidate) => candidate.id === id && candidate.kind === "orderPlaced",
+    );
+    if (record === undefined) throw new Error("expected the placement line on disk");
+    return record;
+  }
+
+  it("reads a PRE-WIDENING file against a descriptor-carrying export with NO difference", async () => {
+    // THE HEADLINE PROPERTY, and the whole reason the fields are optional. The file holds
+    // a line written before descriptors existed; the export carries all three. If absence
+    // were coalesced to `""` and `0`, this import would refuse on the rung — and so would
+    // every re-import of every unchanged export, on every rung, until a migration rewrote
+    // an append-only file.
+    const csv = ladder(describedRung("1000", "0.1", "2020-01-01 10:00:00", { triggerPrice: "900" }));
+    const first = await harness({ csv });
+    await seedPreWideningLine(first.ordersPath, csv);
+    const before = await readFile(first.ordersPath, "utf8");
+
+    const outcome = await importBitgetOpenOrders({ csvPath: first.csvPath, io: first.io });
+
+    expect(outcome).not.toMatchObject({ status: "rejected" });
+    expect(outcome).toMatchObject({ status: "imported", appended: 0, alreadyKnown: 1 });
+    // Nothing written, byte for byte — the pre-widening line is not re-shaped either.
+    expect(await readFile(first.ordersPath, "utf8")).toBe(before);
+    expect(first.errors.join("\n")).not.toContain("REFUSED");
+  });
+
+  it("WRITES the descriptors and reads them back off the real file", async () => {
+    const first = await harness({
+      csv: ladder(
+        describedRung("1000", "0.1", "2020-01-01 10:00:00", {
+          orderType: "Limit",
+          timeInForce: "GTC",
+          triggerPrice: "900",
+        }),
+      ),
+    });
+    await importBitgetOpenOrders({ csvPath: first.csvPath, io: first.io });
+
+    const [id] = await idsOnDisk(first.ordersPath);
+    if (id === undefined) throw new Error("expected the rung on disk");
+    // Through `loadOrders`/`parseOrderRecord`, not off the in-memory record: a descriptor
+    // missing from `KEY_ORDER.orderPlaced` never reaches the file at all.
+    expect(await placedOnDisk(first.ordersPath, id)).toMatchObject({
+      orderType: "Limit",
+      timeInForce: "GTC",
+      triggerPrice: 900,
+    });
+  });
+
+  it("writes NO `triggerPrice` key for the venue's blank sentinel", async () => {
+    const first = await harness({
+      csv: ladder(describedRung("1000", "0.1", "2020-01-01 10:00:00")),
+    });
+    await importBitgetOpenOrders({ csvPath: first.csvPath, io: first.io });
+
+    const raw = await readFile(first.ordersPath, "utf8");
+    expect(raw).not.toContain("triggerPrice");
+    expect(raw).not.toContain("null");
+    const [id] = await idsOnDisk(first.ordersPath);
+    if (id === undefined) throw new Error("expected the rung on disk");
+    expect(await placedOnDisk(first.ordersPath, id)).not.toHaveProperty("triggerPrice");
+  });
+
+  it("REFUSES a changed descriptor with its OWN token and NO cancel-the-rung advice", async () => {
+    const first = await harness({
+      csv: ladder(
+        describedRung("1000", "0.1", "2020-01-01 10:00:00", { timeInForce: "GTC" }),
+      ),
+    });
+    await importBitgetOpenOrders({ csvPath: first.csvPath, io: first.io });
+    const before = await readFile(first.ordersPath, "utf8");
+
+    // The SAME rung by every id component and by size, described differently.
+    await writeFile(
+      first.csvPath,
+      ladder(describedRung("1000", "0.1", "2020-01-01 10:00:00", { timeInForce: "IOC" })),
+      "utf8",
+    );
+    const outcome = await importBitgetOpenOrders({ csvPath: first.csvPath, io: first.io });
+
+    expect(outcome).toMatchObject({ status: "rejected", reason: "descriptor-changed" });
+    expect(await readFile(first.ordersPath, "utf8")).toBe(before);
+    if (outcome.status !== "rejected") throw new Error("expected a refusal");
+
+    // THE WORDING IS THE DELIVERABLE. It names the rung, the field and both values.
+    expect(outcome.message).toContain("timeInForce GTC → IOC");
+    // It says plainly that no money moved, which is what justifies not sending anyone to
+    // the venue.
+    expect(outcome.message).toContain("price × quantity");
+    // And the remedy is to reconcile the file with the venue.
+    expect(outcome.message).toContain("Reconcile the export");
+    // THE ASSERTION THE CLASS EXISTS FOR: `changed-claim`'s remedy destroys a live rung,
+    // and it is justified by a funding hazard a descriptor cannot create.
+    expect(outcome.message).not.toContain("Cancel the rung");
+    expect(outcome.message).not.toContain("re-place");
+  });
+
+  it("names a changed `triggerPrice` as a figure pair", async () => {
+    const first = await harness({
+      csv: ladder(describedRung("1000", "0.1", "2020-01-01 10:00:00", { triggerPrice: "900" })),
+    });
+    await importBitgetOpenOrders({ csvPath: first.csvPath, io: first.io });
+
+    await writeFile(
+      first.csvPath,
+      ladder(describedRung("1000", "0.1", "2020-01-01 10:00:00", { triggerPrice: "950" })),
+      "utf8",
+    );
+    const outcome = await importBitgetOpenOrders({ csvPath: first.csvPath, io: first.io });
+
+    expect(outcome).toMatchObject({ status: "rejected", reason: "descriptor-changed" });
+    if (outcome.status !== "rejected") throw new Error("expected a refusal");
+    expect(outcome.message).toContain("triggerPrice 900 → 950");
+  });
+
+  it("keeps `amended` for a `quantity` difference even when a descriptor ALSO differs", async () => {
+    // A funding hazard outranks everything: `quantity` is the figure the encumbrance is
+    // computed from, so this rung is refused with exactly the token and the message it was
+    // refused with before the descriptors existed — cancel-the-rung advice included,
+    // because there it IS the right remedy.
+    const first = await harness({
+      csv: ladder(describedRung("1000", "0.1", "2020-01-01 10:00:00", { timeInForce: "GTC" })),
+      reserves: [{ id: "reserve-a", amount: 5000 }],
+    });
+    await importBitgetOpenOrders({ csvPath: first.csvPath, io: first.io });
+    const before = await readFile(first.ordersPath, "utf8");
+
+    await writeFile(
+      first.csvPath,
+      ladder(describedRung("1000", "0.5", "2020-01-01 10:00:00", { timeInForce: "IOC" })),
+      "utf8",
+    );
+    const outcome = await importBitgetOpenOrders({ csvPath: first.csvPath, io: first.io });
+
+    expect(outcome).toMatchObject({ status: "rejected", reason: "changed-claim" });
+    expect(await readFile(first.ordersPath, "utf8")).toBe(before);
+    if (outcome.status !== "rejected") throw new Error("expected a refusal");
+    expect(outcome.message).toContain("quantity 0.1 → 0.5");
+    expect(outcome.message).toContain("Cancel the rung at the venue");
+  });
+
+  it("takes a rung whose descriptor AND fill both moved into the descriptor class", async () => {
+    // The mixed claim. It must not ride into the permissive per-rung skip beside a safe
+    // fill — that is what the partition's length guard protects — and it must not be told
+    // to cancel a live rung either, because this wording is the accurate one for it.
+    const first = await harness({
+      csv: ladder(
+        partlyFilledRung("100", "10", "6", "2020-01-01 10:00:00"),
+      ),
+      reserves: [{ id: "reserve-a", amount: 5000 }],
+    });
+    await importBitgetOpenOrders({ csvPath: first.csvPath, io: first.io });
+    const before = await readFile(first.ordersPath, "utf8");
+
+    // The same rung, filled further AND re-described. `partlyFilledRung` writes `GTC`, so
+    // this row disagrees on `time_in_force` as well as on `filled_quantity`.
+    const mixed = BITGET_OPEN_ORDERS_HEADER.map(
+      (column) =>
+        ({
+          timestamp: "2020-01-01 10:00:00",
+          pair: "XYZ/USDT",
+          time_in_force: "IOC",
+          order_type: "Limit",
+          side: "Buy",
+          price: "100",
+          quantity: "10",
+          trigger_price: "-- / --",
+          order_value: "0",
+          filled_quantity: "8",
+          total_quantity: "10",
+          filled_percent: "80.00%",
+          status: "PartiallyFilled",
+          action: "Cancel",
+        })[column] ?? "",
+    ).join(",");
+    await writeFile(first.csvPath, ladder(mixed), "utf8");
+    const outcome = await importBitgetOpenOrders({ csvPath: first.csvPath, io: first.io });
+
+    expect(outcome).toMatchObject({ status: "rejected", reason: "descriptor-changed" });
+    // NOTHING WRITTEN — not the observation either, which a skip-class reading would have
+    // recorded while quietly ignoring the descriptor.
+    expect(await readFile(first.ordersPath, "utf8")).toBe(before);
+    if (outcome.status !== "rejected") throw new Error("expected a refusal");
+    expect(outcome.message).toContain("timeInForce GTC → IOC");
+    expect(outcome.message).not.toContain("Cancel the rung");
+  });
+});
+
 describe("a re-priced rung round-trips as cancel-and-place", () => {
   it("drops the old id and gains a new one, with no re-price branch anywhere", async () => {
     const first = await harness();

--- a/apps/tui/src/import-orders.ts
+++ b/apps/tui/src/import-orders.ts
@@ -22,6 +22,8 @@ import {
   checkFundingCoverage,
   detectChangedClaims,
   formatObservedAt,
+  isDescriptorDifference,
+  isFilledDifference,
   leavesRungUnweighed,
   mergeCollidingClaims,
   parseBitgetOpenOrdersCsv,
@@ -159,6 +161,35 @@ export type OrdersImportRejection =
    * append-only file to get an import past.
    */
   | "backwards-claim"
+  /**
+   * A ROW DESCRIBES A KNOWN RUNG'S PLACEMENT DIFFERENTLY (#205): its `orderType`,
+   * `timeInForce` or `triggerPrice` disagrees with what the placement line on file
+   * recorded, and nothing about the rung's SIZE or PRICE does.
+   *
+   * ITS OWN CLASS BECAUSE THE REMEDY IS ITS OWN, which is the same argument that split
+   * `backwards-claim` out of `changed-claim` (#208) and it applies here with more force.
+   * `changed-claim` ends by telling the operator to CANCEL the rung at the venue or
+   * re-place it — destructive advice, justified there by a funding hazard: a file claiming
+   * LESS than the venue still holds leaves the guard free to admit a batch the reserve
+   * cannot fund. THAT HAZARD CANNOT EXIST HERE. The encumbrance is `price * quantity` and
+   * no descriptor is in it, so a descriptor difference moves no money in either direction
+   * and the funding guard's reading of this book is exactly as correct as it was. Handing
+   * cancel-the-rung to someone whose `trigger_price` merely differs would destroy a live
+   * rung over a discrepancy that costs nothing.
+   *
+   * STILL A TOTAL REFUSAL, and nothing is written — for `backwards-claim`'s reason rather
+   * than `changed-claim`'s: the file and the venue are saying two different things about
+   * one rung, and this build will not record a contradiction into an append-only file to
+   * get an import past. A second `orderPlaced` line would be ignored by the selector
+   * anyway, so there is no verb here even if there were an appetite for one.
+   *
+   * IT WINS OVER A FILL DIFFERENCE ON THE SAME RUNG. A claim carrying both is refused
+   * here, not as an amendment: this wording is accurate for it and `changed-claim`'s
+   * remedy is not. What it must NOT do is ride into the permissive per-rung skip class
+   * beside a safe fill, which is exactly what `partitionChangedClaims`' length guard was
+   * built to prevent.
+   */
+  | "descriptor-changed"
   /**
    * ATTRIBUTION FAILED: at least one rung of the whole resting book cannot be placed
    * against a fundable reserve. ONE rejection may name rungs of BOTH classes the engine
@@ -462,11 +493,11 @@ function isAffirmative(answer: string): boolean {
  *     compared against (#176), so a stale one corrupts every future comparison of this
  *     rung, not just this guard's sum. It is the one figure nothing may go stale on. It
  *     refuses the WHOLE BATCH, and it refuses it whichever way the partial points.
- *  2. EVERY REMAINING difference is `observedFilledQuantity` — today that means exactly
- *     one, since `detectChangedClaims` emits only those two fields and never an empty
- *     list, so nothing can fail this test until a third field exists. Guarded rather than
- *     asserted precisely so that third field lands in the REFUSAL class by default
- *     instead of silently riding in beside a safe fill as a per-rung skip.
+ *  2. EVERY REMAINING difference is `observedFilledQuantity`. The third, fourth and fifth
+ *     fields ARRIVED (#205) — the placement descriptors — and they are taken by their own
+ *     branch above this one rather than by this guard. The guard stays exactly as it was,
+ *     for the sixth: an unknown difference must land in a REFUSAL class by default instead
+ *     of silently riding in beside a safe fill as a per-rung skip.
  *  3. `fileRemaining >= venueRemaining`. The `<=` on the left is where later fill lines
  *     live; they only make it stricter.
  *
@@ -534,6 +565,22 @@ function isAffirmative(answer: string): boolean {
  * An id ABSENT from `resting` reads as `0`, not as a missing case: absent means the
  * stream already retired the claim — its fills exhausted it, or a cancellation took it —
  * and zero is the honest statement of what the file now counts against that rung.
+ *
+ * A FOURTH CLASS, AND THE ROUTING IS BY HAZARD (#205). The placement descriptors —
+ * `orderType`, `timeInForce`, `triggerPrice` — are compared now, and a difference in one
+ * must not be handed `amended`'s cancel-the-rung remedy, which is justified by a funding
+ * hazard that cannot arise from a field the encumbrance does not contain. The three tests
+ * run in this order and the order is the argument:
+ *
+ *  1. ANY `quantity` DIFFERENCE → `amended`, exactly as before. A funding hazard outranks
+ *     everything, so a rung whose size changed is refused with today's token and today's
+ *     message whatever else it also disagrees about.
+ *  2. OTHERWISE ANY DESCRIPTOR DIFFERENCE → `descriptors`, EVEN IF a fill difference rides
+ *     along on the same claim. Two things follow from taking it here. The wording the
+ *     operator gets is accurate for that claim, where `amended`'s is not; and a mixed
+ *     claim still cannot reach the permissive per-rung skip below, which is what the
+ *     length guard in test 2 of the skip rule exists to protect.
+ *  3. OTHERWISE the fill logic, untouched.
  */
 function partitionChangedClaims(
   changed: readonly ChangedClaim[],
@@ -542,10 +589,12 @@ function partitionChangedClaims(
 ): {
   amended: ChangedClaim[];
   backwards: BackwardsClaim[];
+  descriptors: ChangedClaim[];
   restated: RecordedObservation[];
 } {
   const amended: ChangedClaim[] = [];
   const backwards: BackwardsClaim[] = [];
+  const descriptors: ChangedClaim[] = [];
   const restated: RecordedObservation[] = [];
 
   for (const claim of changed) {
@@ -553,9 +602,13 @@ function partitionChangedClaims(
       amended.push(claim);
       continue;
     }
-    const fill = claim.differences.find(
-      (difference) => difference.field === "observedFilledQuantity",
-    );
+    // The predicate is the ENGINE's, beside the field union it reads, so this boundary
+    // cannot fall out of step with the list of fields a descriptor difference can name.
+    if (claim.differences.some(isDescriptorDifference)) {
+      descriptors.push(claim);
+      continue;
+    }
+    const fill = claim.differences.find(isFilledDifference);
     const remainders = weighRemainders(claim.id, resting, observed);
     // The restatement must be the ONLY difference left, not merely one of them. The
     // `quantity` branch above already took the field that exists today, so this length
@@ -586,7 +639,7 @@ function partitionChangedClaims(
     restated.push({ id: claim.id, known: fill.known, observed: fill.observed });
   }
 
-  return { amended, backwards, restated };
+  return { amended, backwards, descriptors, restated };
 }
 
 /**
@@ -729,13 +782,23 @@ export async function importBitgetOpenOrders(
   // the remainder of a rung already on file. Taken here because the partition needs it
   // before anything is prompted for or built.
   const restingOnFile = pickRestingOrdersAsOf(existingRecords);
-  const { amended, backwards, restated } = partitionChangedClaims(changed, restingOnFile, orders);
-  // TWO REFUSALS, AND `amended` GOES FIRST. Per RUNG the two conditions cannot both hold —
-  // that is the partition's own argument — but a BATCH can raise one of each over different
-  // rungs, and then something has to be printed first. `amended` wins because it is the
-  // one with a funding hazard behind it: a batch carrying an amended `quantity` is refused
-  // with exactly the token and the message it was refused with before this split, whatever
-  // else the export also got wrong.
+  const { amended, backwards, descriptors, restated } = partitionChangedClaims(
+    changed,
+    restingOnFile,
+    orders,
+  );
+  // THREE REFUSALS, ORDERED BY HAZARD, AND `amended` STILL GOES FIRST. Per RUNG the
+  // conditions cannot both hold — that is the partition's own argument — but a BATCH can
+  // raise one of each over different rungs, and then something has to be printed first.
+  // `amended` wins because it is the one with a funding hazard behind it: a batch carrying
+  // an amended `quantity` is refused with exactly the token and the message it was refused
+  // with before this split, whatever else the export also got wrong.
+  //
+  // `descriptors` GOES LAST for the same reasoning read the other way (#205): it is the
+  // one class with NO funding hazard at all, because the encumbrance is `price * quantity`
+  // and no descriptor is in it. `backwards` sits between them — no funding hazard either,
+  // but it says the operator may be holding the wrong export, which casts doubt on every
+  // other row of the batch in a way a differing `time_in_force` does not.
   if (amended.length > 0) {
     const detail = amended
       .map((claim) => {
@@ -781,6 +844,34 @@ export async function importBitgetOpenOrders(
         `itself: an OLDER one, or not the one you meant. Re-export the open orders from the ` +
         `venue and import that. Nothing here needs doing at the venue — the rungs on file ` +
         `are untouched and still resting`,
+    );
+  }
+
+  if (descriptors.length > 0) {
+    // The SAME detail template the amendment refusal renders, over the same
+    // `ClaimDifference` union — `known` and `observed` are a number pair or a string pair
+    // depending on the field, and the template is well-typed over both.
+    const detail = descriptors
+      .map((claim) => {
+        const differences = claim.differences
+          .map((difference) => `${difference.field} ${difference.known} → ${difference.observed}`)
+          .join(", ");
+        return `${claim.id} (${differences})`;
+      })
+      .join("; ");
+    return reject(
+      io,
+      "descriptor-changed",
+      `${csvPath} describes ${plural(descriptors.length, "rung")} as PLACED differently ` +
+        `from the placement line already on file — ${detail}. NOTHING ABOUT THE MONEY ` +
+        `MOVED: what a rung encumbers is price × quantity, no descriptor is in that ` +
+        `product, and neither the size nor the price of these rungs changed — so the ` +
+        `funding guard's reading of this book is exactly as correct as it was, and ` +
+        `nothing was written. The file and the venue are simply saying two different ` +
+        `things about one rung, and this build will not record a contradiction into an ` +
+        `append-only file. Reconcile the export against the venue's open-orders screen and ` +
+        `import the one that matches it. Nothing here needs doing at the venue — the rungs ` +
+        `on file are untouched and still resting`,
     );
   }
 

--- a/packages/engine/src/index.ts
+++ b/packages/engine/src/index.ts
@@ -176,11 +176,17 @@ export {
   checkFundingCoverage,
   mergeCollidingClaims,
   detectChangedClaims,
+  isDescriptorDifference,
+  isFilledDifference,
 } from "./orders/ingest.js";
 export type {
   MergedOrderClaim,
   ChangedClaim,
   ClaimDifference,
+  NumericClaimDifference,
+  TextClaimDifference,
+  NumericClaimField,
+  TextClaimField,
 } from "./orders/ingest.js";
 export type {
   BitgetOpenOrder,

--- a/packages/engine/src/orders/bitget-ingest.test.ts
+++ b/packages/engine/src/orders/bitget-ingest.test.ts
@@ -261,6 +261,116 @@ describe("the null sentinel and the authoritative column (testing decision 4)", 
   });
 });
 
+/**
+ * #205 — THE DESCRIPTORS SURVIVE THE WRITE.
+ *
+ * These are the `KEY_ORDER` guard. `serializeOrderRecord` copies ONLY the keys named in
+ * `KEY_ORDER.orderPlaced`, so a field added to `OrderPlacedRecord` and forgotten there is
+ * dropped at write with a green `pnpm typecheck` and no other failing test — the value is
+ * on the object in memory and absent from every line on disk. Asserting the round trip
+ * (build → serialize → parse) rather than the record's own properties is what makes that
+ * omission fail here.
+ */
+describe("the placement descriptors round-trip through the record contract (#205)", () => {
+  function placedFrom(overrides: Partial<Record<string, string>> = {}) {
+    const [record] = buildOrderPlacedRecords(okOrders(csv(row(overrides))), {
+      fundingReserveId: "reserve-a",
+    });
+    if (!record) throw new Error("expected one record");
+    return record;
+  }
+
+  it("carries `orderType` and `timeInForce` from the export's own columns onto the line", () => {
+    const record = placedFrom({ order_type: "Limit", time_in_force: "GTC" });
+    const line = serializeOrderRecord(record);
+    const parsed = parseOrderRecord(JSON.parse(line));
+    expect(parsed.status).toBe("ok");
+    if (parsed.status !== "ok") return;
+    // THROUGH the line, not off the in-memory record: a missing `KEY_ORDER` entry fails
+    // exactly here.
+    expect(parsed.record).toMatchObject({ orderType: "Limit", timeInForce: "GTC" });
+    // Byte-equal on the way back out, which is what `KEY_ORDER` exists to guarantee.
+    expect(serializeOrderRecord(parsed.record)).toBe(line);
+  });
+
+  it("carries a rendered `triggerPrice` as a NUMBER", () => {
+    const record = placedFrom({ trigger_price: "1100" });
+    const parsed = parseOrderRecord(JSON.parse(serializeOrderRecord(record)));
+    expect(parsed.status).toBe("ok");
+    if (parsed.status !== "ok") return;
+    expect(parsed.record).toMatchObject({ triggerPrice: 1100 });
+  });
+
+  it("OMITS `triggerPrice` for the blank sentinel rather than writing `null`", () => {
+    // The observed row carries `null` — the venue positively rendering "no trigger". The
+    // record has no honest spelling for that, and a written `null` would be a third state
+    // every later reader of an append-only file would have to interpret.
+    const record = placedFrom({ trigger_price: "-- / --" });
+    expect(record).not.toHaveProperty("triggerPrice");
+    const line = serializeOrderRecord(record);
+    expect(line).not.toContain("triggerPrice");
+    expect(line).not.toContain("null");
+  });
+
+  it("writes NO descriptor key at all when the venue rendered the cells blank", () => {
+    // A blank is not a descriptor: absence is the only honest spelling of "we were never
+    // told", and it is what keeps the comparison from manufacturing a difference.
+    const record = placedFrom({ order_type: "", time_in_force: "  " });
+    expect(record).not.toHaveProperty("orderType");
+    expect(record).not.toHaveProperty("timeInForce");
+    const line = serializeOrderRecord(record);
+    expect(line).not.toContain("orderType");
+    expect(line).not.toContain("timeInForce");
+  });
+
+  it("keeps a pre-widening line byte-identical on a re-serialize", () => {
+    // The line every existing rung on the file looks like: ten keys, no descriptors. It
+    // must still read and re-write to exactly the same bytes.
+    const line = JSON.stringify({
+      id: "bitget:XYZUSDT:buy:1000:2020-01-01T10:00:00",
+      observedAt: "2020-01-01T10:00:00",
+      kind: "orderPlaced",
+      currency: "USD",
+      symbol: "XYZUSDT",
+      side: "buy",
+      price: 1000,
+      quantity: 0.1,
+      fundingReserveId: "reserve-a",
+    });
+    const parsed = parseOrderRecord(JSON.parse(line));
+    expect(parsed.status).toBe("ok");
+    if (parsed.status !== "ok") return;
+    expect(serializeOrderRecord(parsed.record)).toBe(line);
+  });
+
+  it("skips a line whose descriptor is present but empty, on the SAME gate the writer passed", () => {
+    // The asymmetry that makes the shared gate worth having: a blank descriptor serializes
+    // cleanly and only fails on the way back in, taking the whole placement line with it.
+    const base = {
+      id: "bitget:XYZUSDT:buy:1000:2020-01-01T10:00:00",
+      observedAt: "2020-01-01T10:00:00",
+      kind: "orderPlaced",
+      currency: "USD",
+      symbol: "XYZUSDT",
+      side: "buy",
+      price: 1000,
+      quantity: 0.1,
+      fundingReserveId: "reserve-a",
+    };
+    expect(parseOrderRecord({ ...base, orderType: "" })).toMatchObject({
+      status: "skip",
+      problem: "malformed",
+    });
+    expect(parseOrderRecord({ ...base, triggerPrice: 0 })).toMatchObject({
+      status: "skip",
+      problem: "malformed",
+    });
+    // An UNKNOWN key is still ignored, not refused — an older build reading a newer line
+    // degrades gracefully, and that is unchanged.
+    expect(parseOrderRecord({ ...base, someLaterDescriptor: "x" }).status).toBe("ok");
+  });
+});
+
 describe("`canonicalDecimal` refuses ambiguous comma placement (#177)", () => {
   it("refuses a token whose comma is not in a thousands position", () => {
     // A decimal comma, not a group separator. Stripping it read `10,50` as `1050` — a

--- a/packages/engine/src/orders/detection-basis.test.ts
+++ b/packages/engine/src/orders/detection-basis.test.ts
@@ -32,6 +32,8 @@ function placed(
   observedAt: string,
   quantity: number,
   observedFilledQuantity?: number,
+  /** The #205 descriptors, absent by default — which is the shape of every existing line. */
+  descriptors: Descriptors = {},
 ): OrderPlacedRecord {
   return {
     id: RUNG,
@@ -43,8 +45,15 @@ function placed(
     price: 100,
     quantity,
     ...(observedFilledQuantity === undefined ? {} : { observedFilledQuantity }),
+    ...descriptors,
     fundingReserveId: "reserve-synthetic",
   };
+}
+
+interface Descriptors {
+  orderType?: string;
+  timeInForce?: string;
+  triggerPrice?: number;
 }
 
 /** Built THROUGH THE CONSTRUCTOR — the witness makes a literal untypeable (#206). */
@@ -71,6 +80,15 @@ function exported(quantity: number, filledQuantity: number): ObservedOpenOrder {
     quantity,
     filledQuantity,
   };
+}
+
+/** The same export row, plus whatever the venue says about how the rung was placed. */
+function exportedWith(descriptors: {
+  orderType?: string;
+  timeInForce?: string;
+  triggerPrice?: number | null;
+}): ObservedOpenOrder {
+  return { ...exported(10, 0), ...descriptors };
 }
 
 describe("detectChangedClaims compares against the LATEST observation (#181)", () => {
@@ -161,6 +179,89 @@ describe("the epsilon is on the FILLED comparison only (#181)", () => {
     const stream: OrderRecord[] = [placed("2026-01-01T10:00:00", 10, 6)];
     expect(detectChangedClaims(stream, [exported(10 + 1e-12, 6)])).toEqual([
       { id: RUNG, differences: [{ field: "quantity", known: 10, observed: 10 + 1e-12 }] },
+    ]);
+  });
+});
+
+/**
+ * THE PLACEMENT DESCRIPTORS AND THEIR OWN CONVENTION (#205).
+ *
+ * The comparison rule here DIVERGES from `observedFilledQuantity`'s, which coalesces
+ * (`?? 0`) and is pinned above — deliberately, and the contrast is the point. A fill figure
+ * has a meaningful zero, so an absent one is a real claim about the venue and DOES raise a
+ * difference. A descriptor has no meaningful empty value, so an absent one can only mean
+ * *we never recorded this* — and coalescing it would report a difference on every line
+ * written before the widening, refusing an unchanged batch on every rung until a migration
+ * rewrote an append-only file.
+ *
+ * Synthetic throughout: invented pair, round sizes, round prices, invented descriptors.
+ */
+describe("the placement descriptors are compared only when PRESENT (#205)", () => {
+  it("reports NOTHING for a pre-widening line against an export that carries all three", () => {
+    // THE NO-MIGRATION PROPERTY, at the seam that decides it. Every line already on the
+    // file looks exactly like this one: no `orderType`, no `timeInForce`, no
+    // `triggerPrice`. If absence were coalesced, this single assertion would be a
+    // difference on all three fields — i.e. a refused batch on every rung of every
+    // re-import, forever.
+    const stream: OrderRecord[] = [placed("2026-01-01T10:00:00", 10)];
+    expect(
+      detectChangedClaims(stream, [
+        exportedWith({ orderType: "Limit", timeInForce: "GTC", triggerPrice: 90 }),
+      ]),
+    ).toEqual([]);
+  });
+
+  it("reports a difference once the FILE carries the descriptor too", () => {
+    const stream: OrderRecord[] = [
+      placed("2026-01-01T10:00:00", 10, undefined, { orderType: "Limit", timeInForce: "GTC" }),
+    ];
+    expect(
+      detectChangedClaims(stream, [exportedWith({ orderType: "Limit", timeInForce: "IOC" })]),
+    ).toEqual([{ id: RUNG, differences: [{ field: "timeInForce", known: "GTC", observed: "IOC" }] }]);
+  });
+
+  it("compares `triggerPrice` as a NUMBER, exactly, and reports both sides", () => {
+    const stream: OrderRecord[] = [placed("2026-01-01T10:00:00", 10, undefined, { triggerPrice: 90 })];
+    expect(detectChangedClaims(stream, [exportedWith({ triggerPrice: 90 })])).toEqual([]);
+    expect(detectChangedClaims(stream, [exportedWith({ triggerPrice: 95 })])).toEqual([
+      { id: RUNG, differences: [{ field: "triggerPrice", known: 90, observed: 95 }] },
+    ]);
+  });
+
+  it("treats the venue's BLANK trigger as absent rather than as a change to zero", () => {
+    // `null` is the sentinel the parser produces for `-- / --`. There is no honest figure
+    // to render as the `observed` side of a difference, and reading it as `0` would refuse
+    // a batch over a rung the venue simply never triggered.
+    const stream: OrderRecord[] = [placed("2026-01-01T10:00:00", 10, undefined, { triggerPrice: 90 })];
+    expect(detectChangedClaims(stream, [exportedWith({ triggerPrice: null })])).toEqual([]);
+  });
+
+  it("KNOWN LIMIT, asserted rather than described: a rung that GAINS a descriptor is not detected", () => {
+    // Absent on file means there is nothing to compare, so this is the one direction the
+    // widening does not close. It is the same gap every pre-widening line already had, and
+    // it closes for every rung placed from here on — the placement line will carry the
+    // descriptor. Pinned so that a later change of mind about it is a deliberate one.
+    const stream: OrderRecord[] = [placed("2026-01-01T10:00:00", 10, undefined, { orderType: "Limit" })];
+    expect(detectChangedClaims(stream, [exportedWith({ orderType: "Limit", timeInForce: "IOC" })])).toEqual(
+      [],
+    );
+  });
+
+  it("reports a descriptor difference BESIDE a fill difference, not instead of it", () => {
+    // Both land on the one claim. Which refusal class that claim goes to is the import
+    // boundary's decision; the detector's job is to say everything it found.
+    const stream: OrderRecord[] = [
+      placed("2026-01-01T10:00:00", 10, 6, { timeInForce: "GTC" }),
+    ];
+    const differing: ObservedOpenOrder = { ...exported(10, 8), timeInForce: "IOC" };
+    expect(detectChangedClaims(stream, [differing])).toEqual([
+      {
+        id: RUNG,
+        differences: [
+          { field: "observedFilledQuantity", known: 6, observed: 8 },
+          { field: "timeInForce", known: "GTC", observed: "IOC" },
+        ],
+      },
     ]);
   });
 });

--- a/packages/engine/src/orders/ingest.ts
+++ b/packages/engine/src/orders/ingest.ts
@@ -230,18 +230,90 @@ export function mergeCollidingClaims<T extends ObservedOpenOrder>(
   return { orders: [...byId.values()].map((entry) => entry.order), merges };
 }
 
-/** One field of a known claim that the venue is now rendering differently. */
-export interface ClaimDifference {
-  field: "quantity" | "observedFilledQuantity";
+/**
+ * The fields a difference may be reported over that carry a NUMBER on both sides.
+ *
+ * `triggerPrice` is here and not with the string descriptors because it is a price: the
+ * refusal detail renders it as a figure, and a comparison over its rendered spelling
+ * would make `1100` and `1100.00` a difference.
+ */
+export type NumericClaimField = "quantity" | "observedFilledQuantity" | "triggerPrice";
+
+/** The descriptor fields that carry a STRING on both sides. */
+export type TextClaimField = "orderType" | "timeInForce";
+
+/**
+ * One field of a known claim that the venue is now rendering differently.
+ *
+ * A DISCRIMINATED UNION OVER `field`, not one interface with `known: string | number`
+ * (#205). Two of the placement descriptors are strings, and widening the single shape
+ * would have made `fill.known` a `string | number` at every site that reads it
+ * numerically — `partitionChangedClaims` compares it against a remainder — so the
+ * comparison would have needed a cast or a non-null assertion to stay compilable, which
+ * is precisely the check being given up. Narrowing by `field` keeps it a `number` at the
+ * type level with no cast at all.
+ *
+ * BOTH MEMBERS RENDER THE SAME WAY: `` `${field} ${known} → ${observed}` `` is well-typed
+ * over the union, so the refusal detail template is shared rather than branched.
+ */
+export interface NumericClaimDifference {
+  field: NumericClaimField;
   /**
    * WHAT THE FILE SAYS, on each field's own basis (#181): for `quantity`, the FIRST
    * placement line's size; for `observedFilledQuantity`, the LATEST OBSERVATION — a later
    * `orderFillObserved` when the file carries one, else the placement line's own figure,
    * else `0`. Not "the placement line's figure", which is what this was while placements
-   * were the only observation on the file.
+   * were the only observation on the file. For `triggerPrice`, the placement line's own
+   * value, which is the only line that carries one.
    */
   known: number;
   observed: number;
+}
+
+export interface TextClaimDifference {
+  field: TextClaimField;
+  known: string;
+  observed: string;
+}
+
+export type ClaimDifference = NumericClaimDifference | TextClaimDifference;
+
+/**
+ * The three placement descriptors, as a runtime value derived from the union above: a
+ * field added to {@link TextClaimField} with no entry here fails `pnpm typecheck`, and so
+ * does an entry here that is not one of the descriptor fields.
+ */
+const DESCRIPTOR_FIELDS: Record<TextClaimField | "triggerPrice", true> = {
+  orderType: true,
+  timeInForce: true,
+  triggerPrice: true,
+};
+
+/**
+ * Is this difference about HOW the rung was placed rather than about WHAT it claims?
+ *
+ * Lives here, beside the union it reads, so the boundary that routes a difference to a
+ * refusal class cannot drift from the field list — the same reason `leavesRungUnweighed`
+ * sits beside `BitgetRowProblem` rather than at its consumer.
+ */
+export function isDescriptorDifference(difference: ClaimDifference): boolean {
+  return difference.field in DESCRIPTOR_FIELDS;
+}
+
+/**
+ * The restatement difference, as a TYPE PREDICATE.
+ *
+ * It exists because `Array.prototype.find` cannot narrow a union on its own, and the one
+ * caller — `partitionChangedClaims` at the import boundary — reads `known` NUMERICALLY
+ * against a remainder. A bare `find` there would hand back a `ClaimDifference` whose
+ * `known` is `string | number`, and the shortest way past that is a cast or a `!`, which
+ * is exactly the check the discriminated union was chosen to keep. Narrowing here states
+ * the relation between the field and its value shape once, beside the union.
+ */
+export function isFilledDifference(
+  difference: ClaimDifference,
+): difference is NumericClaimDifference {
+  return difference.field === "observedFilledQuantity";
 }
 
 /** A row that names a claim already on file, but does NOT say the same thing about it. */
@@ -295,18 +367,36 @@ export interface ChangedClaim {
  * figure — it is one authored number against another — so there is nothing for a floor to
  * absorb there, and an exact test is the stricter and more honest one.
  *
- * KNOWN LIMIT, stated rather than papered over: the sidecar persists neither
- * `orderType`, `timeInForce` nor `triggerPrice` — `KEY_ORDER.orderPlaced` in `records.ts`
- * is ten fields and none of them is a descriptor — so a change confined to those cannot be
- * detected here. There is nothing on file to compare against.
+ * THE PLACEMENT DESCRIPTORS ARE PERSISTED AND ARE COMPARED HERE (#205). `orderType`,
+ * `timeInForce` and `triggerPrice` are optional fields on `OrderPlacedRecord` and members
+ * of `KEY_ORDER.orderPlaced`, and a difference in one is reported like any other.
  *
- * Accepted deliberately: no descriptor moves the encumbrance, which is `price * quantity`,
- * so the funding guard stays correct across such a change. Closing it means WIDENING the
- * durable record, and that is not free — every line already on file carries no descriptors,
- * so every re-imported row would differ from its known claim and an UNCHANGED batch would
- * refuse on every rung until a migration rewrote an append-only file. That widening is
- * issue #205's question, and #205 is where the decision about what a later sighting of a
- * known rung may carry belongs. When these fields are persisted, compare them here too.
+ * THEY ARE COMPARED ONLY WHEN BOTH SIDES CARRY THEM, and that is a NEW convention this
+ * file now holds two of — the contrast with `observedFilledQuantity` directly below is the
+ * point, not an inconsistency to be tidied away. A fill figure COALESCES (`?? 0`) and so an
+ * absent one DOES raise a difference, because zero is a real claim about the venue:
+ * "nothing filled" is something the export can say. A descriptor has no meaningful empty
+ * value, so an absent one can only mean *we never recorded this* — never *the order had no
+ * time-in-force* — and coalescing it to `""` would report a difference on every line
+ * written before this widening, refusing an UNCHANGED batch on every rung until a
+ * migration rewrote an append-only file. Compare-when-present is what makes the widening
+ * cost no migration at all: every existing line simply has nothing to compare.
+ *
+ * KNOWN LIMIT, in the place its predecessor stood so the next reader finds a true
+ * statement where a false one used to be: a rung whose descriptor is ABSENT on file and
+ * PRESENT in the export raises no difference, so a rung that later GAINS a trigger price
+ * cannot be detected. That is the same gap every pre-widening line already had rather than
+ * a new hole, and it closes for a rung the moment a placement line carrying the descriptor
+ * exists — which is every rung imported from here on. A `triggerPrice` the venue renders
+ * as its blank sentinel is `null` on the observed row and is likewise not compared: `null`
+ * is the venue saying there is no trigger, and there is no honest figure to render as the
+ * `observed` side of a difference.
+ *
+ * Accepted for the same reason the gap was acceptable before: no descriptor moves the
+ * encumbrance, which is `price * quantity`, so the funding guard stays correct across
+ * such a change. That is also why a descriptor difference does NOT refuse as an
+ * amendment — see `partitionChangedClaims` in `apps/tui/src/import-orders.ts`, which
+ * routes it to its own class with its own wording.
  */
 export function detectChangedClaims(
   known: readonly OrderRecord[],
@@ -360,6 +450,44 @@ export function detectChangedClaims(
         field: "observedFilledQuantity",
         known: knownFilled,
         observed: observedFilled,
+      });
+    }
+    // COMPARE-WHEN-PRESENT, on BOTH sides — the argument is in the docstring above. An
+    // absent descriptor is not a value to be defaulted; it is the absence of a recording,
+    // and there is no `known → observed` pair to be made out of it.
+    if (
+      placed.orderType !== undefined &&
+      order.orderType !== undefined &&
+      placed.orderType !== order.orderType
+    ) {
+      differences.push({ field: "orderType", known: placed.orderType, observed: order.orderType });
+    }
+    if (
+      placed.timeInForce !== undefined &&
+      order.timeInForce !== undefined &&
+      placed.timeInForce !== order.timeInForce
+    ) {
+      differences.push({
+        field: "timeInForce",
+        known: placed.timeInForce,
+        observed: order.timeInForce,
+      });
+    }
+    // `null` is the venue's own "there is no trigger here" and is treated as absent, for
+    // the reason the docstring gives: it has no honest spelling as the `observed` side of
+    // a difference. EXACT equality, like `quantity` and unlike the filled figure: this is
+    // one authored number against another rather than a comparison with a folded figure,
+    // so there is nothing for a floor to absorb.
+    if (
+      placed.triggerPrice !== undefined &&
+      order.triggerPrice !== undefined &&
+      order.triggerPrice !== null &&
+      placed.triggerPrice !== order.triggerPrice
+    ) {
+      differences.push({
+        field: "triggerPrice",
+        known: placed.triggerPrice,
+        observed: order.triggerPrice,
       });
     }
     if (differences.length > 0) {

--- a/packages/engine/src/orders/ingest.ts
+++ b/packages/engine/src/orders/ingest.ts
@@ -14,6 +14,9 @@ import type { Currency, FundReviewData } from "../contracts.js";
 import { attributeRungs, type UnmatchedRung } from "./attribution.js";
 import { isNegativeSlack } from "./committed.js";
 import { QUANTITY_EPSILON } from "./monotonicity.js";
+// The DESCRIPTOR GATES, shared with `parseOrderRecord` so the write gate and the read gate
+// are one rule rather than two copies that can drift (#205).
+import { isDescriptorText, isTriggerPrice } from "./records.js";
 import type { OrderPlacedRecord, OrderRecord, OrderSide } from "./records.js";
 import type { RestingOrder } from "./select.js";
 
@@ -37,6 +40,32 @@ export interface ObservedOpenOrder {
    * dropped, which is exactly what #173 was.
    */
   filledQuantity?: number;
+  /**
+   * THE PLACEMENT DESCRIPTORS (#205) — how the venue says the rung was placed, as opposed
+   * to what it claims. All three are OPTIONAL here and optional on the record, and the
+   * optionality carries the meaning: a venue that does not report one omits it, and an
+   * omission says *"we never recorded this"* — never *"the order had no time-in-force"*.
+   *
+   * They are declared on the VENUE-NEUTRAL type rather than only on `BitgetOpenOrder`
+   * because the record they feed is venue-neutral: without them here the values were
+   * present at runtime and unreachable through {@link buildOrderPlacedRecords}' declared
+   * parameter type. Narrowing that parameter to the Bitget row instead would have pulled
+   * "what this venue's rendered table looks like" back across the seam this module's
+   * header draws.
+   *
+   * NONE OF THEM MOVES THE ENCUMBRANCE, which is `price * quantity`. That is why a
+   * difference in one is refused with its own wording rather than with the amendment
+   * refusal's cancel-the-rung remedy — see `partitionChangedClaims` in the TUI.
+   */
+  orderType?: string;
+  timeInForce?: string;
+  /**
+   * `null` is the venue POSITIVELY rendering "there is no trigger on this rung" (Bitget
+   * draws it `-- / --`); `undefined` is this build never having been told. Both omit the
+   * field from the record, because the record has no honest spelling for either and a
+   * written `null` would be a third state every later reader would have to interpret.
+   */
+  triggerPrice?: number | null;
 }
 
 /**
@@ -385,6 +414,20 @@ export function buildOrderPlacedRecords(
     ...(order.filledQuantity !== undefined && order.filledQuantity > 0
       ? { observedFilledQuantity: order.filledQuantity }
       : {}),
+    // THE DESCRIPTORS, ON THE SAME CONDITIONAL-SPREAD IDIOM (#205) and on the SAME GATE
+    // the reader applies on the way back in — `records.ts` refuses a blank descriptor and
+    // a non-positive `triggerPrice` as malformed, so writing one would put a line on an
+    // append-only file that every later load skips. Stating the rule twice is the point:
+    // the write gate and the read gate must not drift, exactly as `buildOrderFillObserved`
+    // argues for the observation line.
+    //
+    // An absent, blank or `null` value writes NO KEY. It is not `""` and not `null`: a
+    // descriptor has no meaningful empty value, so absence is the only honest spelling of
+    // "we were never told", and the field's own comparison is skipped rather than
+    // manufacturing a difference out of it.
+    ...(isDescriptorText(order.orderType) ? { orderType: order.orderType } : {}),
+    ...(isDescriptorText(order.timeInForce) ? { timeInForce: order.timeInForce } : {}),
+    ...(isTriggerPrice(order.triggerPrice) ? { triggerPrice: order.triggerPrice } : {}),
     fundingReserveId: attribution.overrides?.[order.id] ?? attribution.fundingReserveId,
   }));
 }

--- a/packages/engine/src/orders/records.ts
+++ b/packages/engine/src/orders/records.ts
@@ -120,6 +120,35 @@ export interface OrderPlacedRecord extends OrderRecordBase {
    */
   observedFilledQuantity?: number;
   /**
+   * THE PLACEMENT DESCRIPTORS (#205) — how the venue says the rung was PLACED, beside the
+   * `price`/`quantity` pair that says what it CLAIMS.
+   *
+   * ALL THREE ARE OPTIONAL AND THAT IS THE WHOLE DESIGN. Every line written before this
+   * widening carries none of them, and the detector compares a descriptor only when the
+   * line it is comparing against actually has one — so no existing line reads as a
+   * difference, no re-import of an unchanged export refuses, and the append-only file
+   * needs no migration. An absent field is never read as `""` or as `0`: absence means
+   * *"we were never told"*, and a descriptor has no meaningful empty value to be defaulted
+   * to. `serializeOrderRecord` drops an `undefined`, so a rung with no descriptors
+   * serializes to exactly the bytes it always did.
+   *
+   * NONE OF THEM MOVES THE ENCUMBRANCE, which is `price * quantity`. That is why they are
+   * safe to widen into and why a difference in one is not the funding hazard the amendment
+   * refusal exists for.
+   *
+   * DELIBERATELY NOT ON `OrderFillObservedRecord` (#181 `D7`), and not "until #205 lands":
+   * an observation restates ONE fact — the venue's cumulative fill — and a copy of a
+   * descriptor there would be a second place for it to go stale.
+   */
+  orderType?: string;
+  timeInForce?: string;
+  /**
+   * ABSENT, never `null`. The venue renders "no trigger" as a sentinel, the parser turns
+   * that into `null` on the observed row, and the writer omits the key rather than putting
+   * a third state on disk that every later reader would have to interpret.
+   */
+  triggerPrice?: number;
+  /**
    * The one DECLARED field at placement (`Q9`): which reserve the claim encumbers. The
    * venue has never heard of a Reserve, so this cannot be observed. Notably absent: a
    * target `positionId` (the Position cannot exist until the first fill, so naming it
@@ -280,8 +309,17 @@ const KEY_ORDER: Record<OrderKind, readonly string[]> = {
     "side",
     "price",
     "quantity",
+    // THE WHITELIST IS THE WRITE (#205). `serializeOrderRecord` copies ONLY the keys named
+    // here, so a field added to `OrderPlacedRecord` and forgotten in this list is DROPPED
+    // at write with a green typecheck and no failing test. The descriptors are pinned by a
+    // round trip through a real file rather than by a type — see the `#205` cases in
+    // `./bitget-ingest.test.ts`.
+    "orderType",
+    "timeInForce",
+    "triggerPrice",
     // Absent when nothing had filled: `JSON.stringify` drops an `undefined` value, so a
-    // rung with no partial serializes to exactly the bytes it always did.
+    // rung with no partial serializes to exactly the bytes it always did — which is
+    // equally true of the three descriptors above.
     "observedFilledQuantity",
     "fundingReserveId",
   ],
@@ -315,6 +353,30 @@ function isNonEmptyString(value: unknown): value is string {
 
 function isFinitePositive(value: unknown): value is number {
   return typeof value === "number" && Number.isFinite(value) && value > 0;
+}
+
+/**
+ * THE DESCRIPTOR GATES (#205), exported so the WRITER asks exactly the question this
+ * reader will ask on the way back in.
+ *
+ * The asymmetry that makes this worth a shared function rather than a comment is the one
+ * {@link buildOrderFillObserved} names: a blank `orderType` or a zero `triggerPrice`
+ * SERIALIZES CLEANLY and only reads back as `malformed` on every subsequent load, at which
+ * point the whole line — the rung's placement, its size, its funding reserve — is skipped
+ * by every reader of an append-only file that cannot take it back.
+ *
+ * A BLANK IS NOT A DESCRIPTOR. The venue renders these cells for a human, so an empty one
+ * says nothing was rendered, and the record's own convention is that an unrecorded
+ * descriptor is ABSENT rather than empty (see `ObservedOpenOrder` in `./ingest.ts`). A
+ * `triggerPrice` of zero is the same fact in numeric clothing: no rung triggers at zero,
+ * so the figure is a rendering artifact, not a price.
+ */
+export function isDescriptorText(value: unknown): value is string {
+  return isNonEmptyString(value);
+}
+
+export function isTriggerPrice(value: unknown): value is number {
+  return isFinitePositive(value);
 }
 
 /**
@@ -445,6 +507,32 @@ export function parseOrderRecord(value: unknown): OrderRecordParse {
           message: "observedFilledQuantity must be a non-negative number when present",
         };
       }
+      // THE DESCRIPTORS (#205) — optional, and checked ONLY when present, on the same
+      // gates the writer passed. A line from an OLDER build carries none of them and reads
+      // back exactly as it always did; a line from a NEWER build carrying a fourth
+      // descriptor this reader has never heard of still parses, because an unknown key is
+      // ignored here and that graceful degradation is deliberate.
+      if (value.orderType !== undefined && !isDescriptorText(value.orderType)) {
+        return {
+          status: "skip",
+          problem: "malformed",
+          message: "orderType must be a non-empty string when present",
+        };
+      }
+      if (value.timeInForce !== undefined && !isDescriptorText(value.timeInForce)) {
+        return {
+          status: "skip",
+          problem: "malformed",
+          message: "timeInForce must be a non-empty string when present",
+        };
+      }
+      if (value.triggerPrice !== undefined && !isTriggerPrice(value.triggerPrice)) {
+        return {
+          status: "skip",
+          problem: "malformed",
+          message: "triggerPrice must be a positive number when present",
+        };
+      }
       return {
         status: "ok",
         record: {
@@ -454,6 +542,9 @@ export function parseOrderRecord(value: unknown): OrderRecordParse {
           side: value.side,
           price: value.price,
           quantity: value.quantity,
+          ...(isDescriptorText(value.orderType) ? { orderType: value.orderType } : {}),
+          ...(isDescriptorText(value.timeInForce) ? { timeInForce: value.timeInForce } : {}),
+          ...(isTriggerPrice(value.triggerPrice) ? { triggerPrice: value.triggerPrice } : {}),
           ...(value.observedFilledQuantity !== undefined && value.observedFilledQuantity > 0
             ? { observedFilledQuantity: value.observedFilledQuantity }
             : {}),


### PR DESCRIPTION
## Summary

`orderPlaced` gains three optional venue descriptors — `orderType`, `timeInForce`, `triggerPrice` — sourced from Bitget export columns the parser already read, and the detector now compares them against a later sighting of the same rung.

**The blocker that turned out not to hold.** The prior comment predicted that persisting these fields would touch off a refusal storm: every line already on the append-only file carries none of them, so comparing them naively would report a difference on every rung of every re-import, forever, until a migration rewrote the file. Compare-when-present dissolves that without any migration — a field is only compared when *both* the file's line and the export's row carry it, so a pre-widening line simply has nothing to compare against and reads back unchanged.

**No-migration property, proven directly.** `apps/tui/src/import-orders.test.ts` seeds a placement line in the pre-widening shape (ten keys, no descriptors), imports a descriptor-carrying export against it, and asserts the outcome is `imported`/`alreadyKnown` with the sidecar byte-identical to what was there before — not merely "no crash."

**The serializer-whitelist hazard.** `KEY_ORDER.orderPlaced` in `records.ts` is the literal list of keys `serializeOrderRecord` copies; a field added to the record type and forgotten there is silently dropped at write with a green typecheck and no failing test. `bitget-ingest.test.ts` guards this by asserting a real build → serialize → parse round trip rather than the in-memory record's own properties, so a missing whitelist entry fails there.

**Its own refusal, not the amendment's.** A descriptor difference gets a new `descriptor-changed` rejection class in the TUI import boundary instead of being folded into the amendment refusal. The amendment refusal's remedy is cancel-the-rung-at-the-venue, justified by a funding hazard: the encumbrance is `price × quantity`, and none of the three descriptors is in that product, so a differing `time_in_force` carries no such hazard. Handing an operator that remedy over a discrepancy that moves no money would destroy a live rung for nothing.

## Commits

1. `feat(engine): persist the placement descriptors on the order-placed record` — the record fields, `KEY_ORDER` whitelist entries, reader validation, the shared write/read gates, and the writer in `buildOrderPlacedRecords`. Written and read back; nothing compares them yet.
2. `feat(engine,tui): compare the placement descriptors when present, and refuse with their own remedy` — the `ClaimDifference` discriminated union and its predicates, `detectChangedClaims`'s compare-when-present logic, and the TUI's `descriptor-changed` rejection class with its own refusal wording.

## Test plan

- [x] `pnpm typecheck` clean
- [x] `pnpm test` — 1241 passed / 19 skipped (baseline 1222/19)
- [x] Each commit verified independently green

Closes #205