### PR TITLE
refactor(tui): extract the append-filter seam and changed-claim classifier

### DIFF
--- a/apps/tui/src/import-orders-append-filter.test.ts
+++ b/apps/tui/src/import-orders-append-filter.test.ts
@@ -1,0 +1,136 @@
+/**
+ * THE APPEND FILTER'S RULE, ASSERTED DIRECTLY — the reason the key and its set-builder
+ * left `import-orders.ts` together.
+ *
+ * Every fact below was reachable before only through a whole import: an export file, a
+ * sidecar, an injected clock, a prompt answered, a funding guard satisfied. The rule is a
+ * pure function of the records on file, so it is tested as one — no stub, no IO bag, no
+ * temp dir.
+ *
+ * NOTHING HERE ASSERTS THE KEY'S STRING FORMAT, and that is deliberate: the format is an
+ * implementation detail the module is free to change, while the PROPERTIES — which lines
+ * collide and which do not — are the rule. Every assertion is phrased as membership in
+ * the set the filter actually consults.
+ *
+ * The observation lines are built through `buildOrderFillObserved` rather than by object
+ * literal, because that is the only way to obtain one: the record type carries a
+ * compile-time brand precisely so an unvalidated figure cannot be passed off as observed.
+ */
+import {
+  buildOrderFillObserved,
+  type OrderFillObservedRecord,
+  type OrderPlacedRecord,
+} from "@numisma/engine";
+import { describe, expect, it } from "vitest";
+import { appendKey, currentClaimKeys } from "./import-orders-append-filter.js";
+
+function placed(id: string, observedAt = "2026-08-07T10:00:00"): OrderPlacedRecord {
+  return {
+    id,
+    observedAt,
+    kind: "orderPlaced",
+    currency: "USD",
+    symbol: "BTCUSDT",
+    side: "buy",
+    price: 100,
+    quantity: 10,
+    fundingReserveId: "cash-core",
+  };
+}
+
+function observedLine(
+  id: string,
+  observedFilledQuantity: number,
+  observedAt = "2026-08-07T12:00:00",
+): OrderFillObservedRecord {
+  const built = buildOrderFillObserved({
+    id,
+    observedAt,
+    currency: "USD",
+    observedFilledQuantity,
+  });
+  if (built.status !== "ok") {
+    throw new Error(`fixture is not buildable: ${built.message}`);
+  }
+  return built.record;
+}
+
+describe("currentClaimKeys — is this line already what the rung currently claims?", () => {
+  it("DEDUPES TWO OBSERVATIONS OF THE SAME CUMULATIVE FIGURE, whatever the stamps", () => {
+    // The same fact stated twice. The two stamps differ on purpose: the key is what the
+    // line ASSERTS, so a repeat of 8 is a repeat whether it was looked at a minute later
+    // or — the case `observedAt` cannot separate at all — inside the same second.
+    const keys = currentClaimKeys([placed("rung-1"), observedLine("rung-1", 8)]);
+    expect(keys.has(appendKey(observedLine("rung-1", 8, "2026-08-07T12:00:01")))).toBe(true);
+    expect(keys.has(appendKey(observedLine("rung-1", 8, "2026-08-07T12:00:00")))).toBe(true);
+  });
+
+  it("LETS 8 THEN 9 BOTH LAND — genuine movement is not a repeat", () => {
+    const keys = currentClaimKeys([placed("rung-1"), observedLine("rung-1", 8)]);
+    expect(keys.has(appendKey(observedLine("rung-1", 9)))).toBe(false);
+  });
+
+  it("KEEPS `kind` LOAD-BEARING: the FIRST observation of a known rung is not its placement", () => {
+    // An observation shares its rung's id, so an id-only key would read this line as a
+    // repeat of the placement already on file and drop it — the whole feature, filtered
+    // out by its own dedupe. Asserted as the PROPERTY (the two lines do not collide),
+    // never as the key's spelling.
+    const placement = placed("rung-1");
+    const firstObservation = observedLine("rung-1", 3);
+    expect(appendKey(firstObservation)).not.toBe(appendKey(placement));
+    expect(currentClaimKeys([placement]).has(appendKey(firstObservation))).toBe(false);
+  });
+
+  it("still dedupes a REPEAT PLACEMENT — the id-only reading, unchanged", () => {
+    // `synthesizeOrderId` already includes `observedAt`, so keying a placement on
+    // `(kind, id, observedAt)` is exactly equivalent to keying on the id alone. This is
+    // what makes re-importing an unchanged export append zero lines.
+    const keys = currentClaimKeys([placed("rung-1")]);
+    expect(keys.has(appendKey(placed("rung-1")))).toBe(true);
+  });
+
+  it("HOLDS ONLY THE LATEST OBSERVATION PER RUNG, so a SUPERSEDED figure can be re-asserted", () => {
+    // #212's rule, and the defect it fixed. Observe 8, then record a backwards restatement
+    // of 5: the venue's next export of 8 is a legitimate RE-ASSERTION, and a whole-history
+    // set would drop it as a repeat — nothing lands, and the operator is told
+    // `0 observation(s) recorded` about a line this flow had just decided to record.
+    const keys = currentClaimKeys([
+      placed("rung-1"),
+      observedLine("rung-1", 8, "2026-08-07T12:00:00"),
+      observedLine("rung-1", 5, "2026-08-07T13:00:00"),
+    ]);
+    expect(keys.has(appendKey(observedLine("rung-1", 5)))).toBe(true);
+    expect(keys.has(appendKey(observedLine("rung-1", 8)))).toBe(false);
+  });
+
+  it("BREAKS AN EQUAL-STAMP TIE LAST-WINS (`>=`), in step with `detectChangedClaims`", () => {
+    // One export is one look, so a whole batch shares one second-granular stamp and equal
+    // stamps are ORDINARY here, not a corner. `detectChangedClaims` scans with `>=` — the
+    // last line in file order wins — and that is what decides an observation is worth
+    // building at all. Were this to use `>`, one layer would build a line the other
+    // refused to write.
+    const stamp = "2026-08-07T12:00:00";
+    const keys = currentClaimKeys([
+      placed("rung-1"),
+      observedLine("rung-1", 8, stamp),
+      observedLine("rung-1", 5, stamp),
+    ]);
+    expect(keys.has(appendKey(observedLine("rung-1", 5)))).toBe(true);
+    expect(keys.has(appendKey(observedLine("rung-1", 8)))).toBe(false);
+  });
+
+  it("scopes the latest-observation rule PER RUNG, not across the file", () => {
+    const keys = currentClaimKeys([
+      placed("rung-1"),
+      placed("rung-2"),
+      observedLine("rung-1", 8, "2026-08-07T12:00:00"),
+      observedLine("rung-2", 3, "2026-08-07T13:00:00"),
+    ]);
+    expect(keys.has(appendKey(observedLine("rung-1", 8)))).toBe(true);
+    expect(keys.has(appendKey(observedLine("rung-2", 3)))).toBe(true);
+  });
+
+  it("reads an EMPTY file as claiming nothing", () => {
+    expect(currentClaimKeys([]).size).toBe(0);
+  });
+});

--- a/apps/tui/src/import-orders-append-filter.test.ts
+++ b/apps/tui/src/import-orders-append-filter.test.ts
@@ -18,6 +18,7 @@
  */
 import {
   buildOrderFillObserved,
+  type OrderCancelledRecord,
   type OrderFillObservedRecord,
   type OrderPlacedRecord,
 } from "@numisma/engine";
@@ -36,6 +37,16 @@ function placed(id: string, observedAt = "2026-08-07T10:00:00"): OrderPlacedReco
     quantity: 10,
     fundingReserveId: "cash-core",
   };
+}
+
+/**
+ * A cancellation of the same rung — the SECOND non-observed kind, and the only fixture in
+ * this file that can put two records through {@link appendKey}'s `(kind, id, observedAt)`
+ * branch at once. It carries nothing beyond the base, because a cancellation asserts
+ * nothing beyond "this rung left the book".
+ */
+function cancelled(id: string, observedAt = "2026-08-07T10:00:00"): OrderCancelledRecord {
+  return { id, observedAt, kind: "orderCancelled", currency: "USD" };
 }
 
 function observedLine(
@@ -70,15 +81,41 @@ describe("currentClaimKeys — is this line already what the rung currently clai
     expect(keys.has(appendKey(observedLine("rung-1", 9)))).toBe(false);
   });
 
-  it("KEEPS `kind` LOAD-BEARING: the FIRST observation of a known rung is not its placement", () => {
+  it("LETS THE FIRST OBSERVATION OF A KNOWN RUNG LAND — it is not a repeat of its placement", () => {
     // An observation shares its rung's id, so an id-only key would read this line as a
     // repeat of the placement already on file and drop it — the whole feature, filtered
     // out by its own dedupe. Asserted as the PROPERTY (the two lines do not collide),
     // never as the key's spelling.
+    //
+    // THIS TEST DOES NOT HOLD `kind` (PR #218 review), and its title used to claim it did.
+    // The two records go down DIFFERENT branches of `appendKey`, whose third components are
+    // a fill figure and a `YYYY-MM-DDTHH:MM:SS` stamp — shapes that cannot collide whatever
+    // the first component is. The property below is still worth holding; the rule `kind`
+    // actually guards is the next test's.
     const placement = placed("rung-1");
     const firstObservation = observedLine("rung-1", 3);
     expect(appendKey(firstObservation)).not.toBe(appendKey(placement));
     expect(currentClaimKeys([placement]).has(appendKey(firstObservation))).toBe(false);
+  });
+
+  it("KEEPS `kind` LOAD-BEARING: two DIFFERENT non-observed kinds at the same stamp are two claims", () => {
+    // THE RULE `kind` ACTUALLY GUARDS, and the only case that can hold it. Every record
+    // that is not an observation keys on `(kind, id, observedAt)`, so `kind` is the ONLY
+    // component separating a placement from a cancellation of the same rung at the same
+    // second — which is not a corner: one export is one look, so a whole batch shares one
+    // second-granular stamp, and a rung placed and pulled inside that second renders both
+    // lines at it.
+    //
+    // Drop `kind` and the two key identically: `currentClaimKeys` holds ONE key where the
+    // file states TWO facts, so a genuinely fresh placement is filtered out of `fresh` in
+    // `import-orders.ts` as a supposed repeat — while `reportOrdersImport` counts from
+    // `written` and tells the operator the line was already known. Silent loss reported as
+    // success, which is the failure mode this whole module is shaped to refuse.
+    const placement = placed("rung-1");
+    const cancellation = cancelled("rung-1");
+    expect(placement.observedAt).toBe(cancellation.observedAt);
+    expect(appendKey(cancellation)).not.toBe(appendKey(placement));
+    expect(currentClaimKeys([placement, cancellation]).size).toBe(2);
   });
 
   it("still dedupes a REPEAT PLACEMENT — the id-only reading, unchanged", () => {

--- a/apps/tui/src/import-orders-append-filter.ts
+++ b/apps/tui/src/import-orders-append-filter.ts
@@ -1,0 +1,115 @@
+/**
+ * THE APPEND FILTER'S RULE — what makes a line a REPEAT of one already on file, in the
+ * two halves the question actually has (#181, #212).
+ *
+ * BOTH HALVES LEFT `import-orders.ts` TOGETHER, and that is a decision worth recording
+ * rather than an accident of what was easy to cut. #213 named {@link appendKey} alone,
+ * while observing that the key-set built beside it is "arguably the same seam", and it
+ * was deliberately sequenced AFTER #212 because #212 would settle which side of that
+ * seam the interesting rule lived on. #212 settled it against the key: the rule went
+ * into WHAT THE SET IS BUILT FROM — the latest observation per rung rather than the
+ * whole history — and the key was left exactly as it was. So the half carrying the rule
+ * is {@link currentClaimKeys}, and extracting the key on its own would have moved the
+ * assertable half out and left the interesting half behind an end-to-end import with an
+ * injected IO bag. That is the whole point of the extraction, so the pair moves.
+ *
+ * TWO QUESTIONS, ONE PER EXPORT, and the split between them is the module's shape:
+ *
+ *   - {@link appendKey} answers *"is this figure already recorded?"* — everything a pure
+ *     function of ONE record can answer, since nothing in a record says what came after
+ *     it.
+ *   - {@link currentClaimKeys} answers *"is this figure still the rung's CURRENT
+ *     claim?"* — which needs the whole stream, and so is the only place it can be asked.
+ *
+ * THE CALLER STILL OWNS THE FILTER. `importBitgetOpenOrders` builds the set once and
+ * runs `[...records, ...observations].filter(...)` itself, for the reason its own
+ * comment gives: one set over both arrays in a single pass, so re-keying per record
+ * buys nothing and costs a quadratic pass.
+ */
+import type { OrderFillObservedRecord, OrderRecord } from "@numisma/engine";
+
+/**
+ * THE APPEND FILTER'S KEY — what makes a line a REPEAT of one already on file (#181).
+ *
+ * KEYED ON WHAT THE LINE ASSERTS, not on when it was looked at, and the two kinds assert
+ * different things:
+ *
+ *   - `orderFillObserved` → `(kind, id, observedFilledQuantity)`. Two observations of the
+ *     same cumulative figure are the SAME FACT stated twice and dedupe; 8 then 9 are
+ *     genuine movement and both land.
+ *   - everything else → `(kind, id, observedAt)`. For a placement this is exactly
+ *     equivalent to keying on the id alone, since `synthesizeOrderId` already includes
+ *     `observedAt`, so repeat-placement dedupe is unchanged.
+ *
+ * WHY NOT `observedAt` FOR AN OBSERVATION, which is what an id-and-stamp key would give.
+ * One export is one look, so a whole batch shares one second-granular stamp — and two
+ * imports inside the SAME second would then key identically, so the second import's
+ * observation was silently dropped while the operator was told it was RECORDED and a
+ * successful status came back. Honesty and information loss rather than money loss, and
+ * ordinary to reach: two exports back to back, or any scripted loop.
+ *
+ * MILLISECOND PRECISION WAS REJECTED as the fix, not overlooked. `isObservedAtStamp`
+ * validates `YYYY-MM-DDTHH:MM:SS`, the stamp is string-compared across the whole repo and
+ * is a component of a durable event id — and milliseconds only SHRINK the collision
+ * window rather than closing it, while keying on the figure closes it.
+ *
+ * THE EQUAL STAMPS ARE FINE DOWNSTREAM. `pickRestingOrdersAsOf` sorts stably, so file
+ * order breaks the tie and replays 8 then 9 — the batch stamp's own argument working as
+ * written.
+ *
+ * WHY `kind` IS IN THE KEY AT ALL: an observation shares its rung's id, so an id-only key
+ * would read the first observation of a known rung as a repeat of its placement line and
+ * drop it — the whole feature, filtered out by its own dedupe.
+ *
+ * ONE OF TWO QUESTIONS, AND THE CALL SITE ANSWERS THE OTHER. This key answers *"is this
+ * figure already recorded?"* — all a pure function of ONE record can answer, since nothing
+ * in a record says what came after it. *"Is this figure still the rung's CURRENT claim?"*
+ * is answered where it can be: the filter builds its set from the LATEST observation per
+ * rung rather than from every existing record, so a superseded figure no longer filters a
+ * legitimate re-assertion of it. Keep the scoping there; widening this key to reach for
+ * history would only move the second question somewhere it still cannot be answered.
+ */
+export function appendKey(record: OrderRecord): string {
+  return record.kind === "orderFillObserved"
+    ? `${record.kind} ${record.id} ${record.observedFilledQuantity}`
+    : `${record.kind} ${record.id} ${record.observedAt}`;
+}
+
+/**
+ * THE SET IS THE RUNG'S CURRENT CLAIM, NOT ITS WHOLE HISTORY (#212). `appendKey` is a
+ * pure function of ONE record and structurally cannot see what came after it, so it can
+ * only answer *"is this figure already recorded?"*; what the filter must answer is *"is
+ * this figure still the rung's CURRENT claim?"*. The scoping therefore lives HERE, in
+ * what the set is built from, and the key is left alone.
+ *
+ * The two questions part company the moment one observation supersedes another: observe
+ * 8, record a backwards restatement of 5, and the venue's next export of 8 is a
+ * legitimate RE-ASSERTION that a whole-history set drops as a repeat. Nothing lands —
+ * and the report describes the lines that were WRITTEN, so the operator is told
+ * `0 observation(s) recorded` about an observation this flow had just decided to record.
+ *
+ * ONLY THE LATEST OBSERVATION PER RUNG goes in, by the SAME last-wins-by-stamp rule
+ * `detectChangedClaims` uses — `>=`, so the last line in file order wins an equal-stamp
+ * tie. That function is what decides an observation is worth building; were the two to
+ * disagree about which figure is current, one layer would build a line the other refused
+ * to write. Every other kind goes in whole, which for a placement is equivalent to
+ * keying on the id alone, since `synthesizeOrderId` already includes `observedAt`.
+ */
+export function currentClaimKeys(existingRecords: readonly OrderRecord[]): ReadonlySet<string> {
+  const latestObserved = new Map<string, OrderFillObservedRecord>();
+  const currentOnFile = new Set<string>();
+  for (const record of existingRecords) {
+    if (record.kind !== "orderFillObserved") {
+      currentOnFile.add(appendKey(record));
+      continue;
+    }
+    const seen = latestObserved.get(record.id);
+    if (seen === undefined || record.observedAt >= seen.observedAt) {
+      latestObserved.set(record.id, record);
+    }
+  }
+  for (const record of latestObserved.values()) {
+    currentOnFile.add(appendKey(record));
+  }
+  return currentOnFile;
+}

--- a/apps/tui/src/import-orders-changed-claims.test.ts
+++ b/apps/tui/src/import-orders-changed-claims.test.ts
@@ -1,0 +1,218 @@
+/**
+ * THE CHANGED-CLAIM CLASSIFIER, ASSERTED DIRECTLY — the reason it left `import-orders.ts`.
+ *
+ * Every case below was reachable before only by driving a whole import: an export file, a
+ * sidecar, an injected clock, a prompt answered, a funding guard satisfied. The
+ * classifier is a pure function of three arrays, so it is tested as one.
+ *
+ * THE FIRST TEST IS THE POINT OF THE EXTRACTION. `amended` and `backwards` are NOT
+ * disjoint predicates — PR #211's review found the docstring's disjointness proof false on
+ * exactly that — and until now the only thing holding the branch ordering in place was a
+ * comment saying so. A comment does not fail. That test does.
+ */
+import type { BitgetOpenOrder, ChangedClaim, RestingOrder } from "@numisma/engine";
+import { describe, expect, it } from "vitest";
+import {
+  partitionChangedClaims,
+  weighRemainders,
+} from "./import-orders-changed-claims.js";
+
+const PLACED_QUANTITY = 10;
+
+/** A row of the export, carrying only what the classifier reads off it. */
+function row(id: string, filledQuantity: number, quantity = PLACED_QUANTITY): BitgetOpenOrder {
+  return {
+    id,
+    observedAt: "2026-08-07T10:00:00",
+    currency: "USD",
+    symbol: "BTCUSDT",
+    side: "buy",
+    price: 100,
+    quantity,
+    filledQuantity,
+    totalQuantity: quantity,
+    timeInForce: "GTC",
+    orderType: "limit",
+    triggerPrice: null,
+  };
+}
+
+/**
+ * What the FILE still counts as resting for this rung — `quantity − consumed`, folded by
+ * `pickRestingOrdersAsOf` over the whole stream. Passed as the remainder directly, because
+ * that is the one figure the classifier reads.
+ */
+function resting(id: string, remainingQuantity: number, quantity = PLACED_QUANTITY): RestingOrder {
+  return {
+    placed: {
+      id,
+      observedAt: "2026-08-07T10:00:00",
+      kind: "orderPlaced",
+      currency: "USD",
+      symbol: "BTCUSDT",
+      side: "buy",
+      price: 100,
+      quantity,
+      fundingReserveId: "cash-core",
+    },
+    remainingQuantity,
+  };
+}
+
+/** A restatement difference: what the file last OBSERVED against what the export shows. */
+function filledDifference(known: number, observed: number): ChangedClaim["differences"][number] {
+  return { field: "observedFilledQuantity", known, observed };
+}
+
+function claim(id: string, ...differences: ChangedClaim["differences"]): ChangedClaim {
+  return { id, differences };
+}
+
+describe("partitionChangedClaims — the branch ordering", () => {
+  it("ROUTES AN OVERLAPPING CLAIM TO `backwards` — REORDERING THE BRANCHES BREAKS THIS", () => {
+    // THE CASE THE DOCSTRING'S OLD DISJOINTNESS PROOF GOT WRONG (PR #211 review), and the
+    // one test in this file whose failure means a live rung can be destroyed.
+    //
+    // Placed 10, the file's latest observation 6, the export showing 4. BOTH predicates
+    // are true here:
+    //
+    //   - `backwards` fires on `export figure < latest observation` — 4 < 6;
+    //   - `amended`'s remainder test reduces to `export figure < consumed` — the file
+    //     counts 4 resting against the venue's 6, so `onFile < atVenue` holds too.
+    //
+    // `[0, consumed)` CONTAINS `[0, latestObserved)`, so the predicates are a superset
+    // relation and not a partition. Only the `continue` after the `backwards` push
+    // separates them. Move the fill test below the remainder test and this claim lands in
+    // `amended`, where the operator is told to CANCEL THE RUNG AT THE VENUE over what is
+    // almost always the wrong CSV — the exact harm #208's split exists to remove.
+    const result = partitionChangedClaims(
+      [claim("rung-1", filledDifference(6, 4))],
+      [resting("rung-1", 4)],
+      [row("rung-1", 4)],
+    );
+
+    const remainders = weighRemainders("rung-1", [resting("rung-1", 4)], [row("rung-1", 4)]);
+    // The overlap, stated as an assertion rather than as a claim in a comment: the
+    // `amended` branch's own test is satisfied by this very claim.
+    expect(remainders).toEqual({ onFile: 4, atVenue: 6 });
+    expect(remainders!.onFile < remainders!.atVenue).toBe(true);
+
+    expect(result.backwards).toEqual([{ id: "rung-1", known: 6, observed: 4 }]);
+    expect(result.amended).toEqual([]);
+  });
+});
+
+describe("partitionChangedClaims — the four-way split", () => {
+  it("`amended` — a `quantity` difference, the one figure nothing may go stale on", () => {
+    const amendment = claim("rung-1", { field: "quantity", known: 10, observed: 12 });
+    const result = partitionChangedClaims([amendment], [resting("rung-1", 10)], [row("rung-1", 0, 12)]);
+    expect(result.amended).toEqual([amendment]);
+    expect(result.backwards).toEqual([]);
+    expect(result.descriptors).toEqual([]);
+    expect(result.restated).toEqual([]);
+  });
+
+  it("`backwards` — the export's filled column below what the file last observed", () => {
+    const result = partitionChangedClaims(
+      [claim("rung-1", filledDifference(6, 2))],
+      [resting("rung-1", 4)],
+      [row("rung-1", 2)],
+    );
+    expect(result.backwards).toEqual([{ id: "rung-1", known: 6, observed: 2 }]);
+    expect(result.amended).toEqual([]);
+  });
+
+  it("`descriptors` — HOW the rung was placed differs, and no money moved", () => {
+    const descriptor = claim("rung-1", { field: "timeInForce", known: "GTC", observed: "IOC" });
+    const result = partitionChangedClaims([descriptor], [resting("rung-1", 4)], [row("rung-1", 6)]);
+    expect(result.descriptors).toEqual([descriptor]);
+    expect(result.amended).toEqual([]);
+    expect(result.restated).toEqual([]);
+  });
+
+  it("`restated` — the fill moved UP and the file still claims NO LESS than the venue holds", () => {
+    // Placed 10, observed 6 on file, the export showing 8. The venue still holds 2; the
+    // file counts 4 resting, which is no less — so the restatement is safe to RECORD
+    // rather than refuse.
+    const result = partitionChangedClaims(
+      [claim("rung-1", filledDifference(6, 8))],
+      [resting("rung-1", 4)],
+      [row("rung-1", 8)],
+    );
+    expect(result.restated).toEqual([{ id: "rung-1", known: 6, observed: 8 }]);
+    expect(result.amended).toEqual([]);
+    expect(result.backwards).toEqual([]);
+  });
+
+  it("`amended` — the fill moved UP but the fund's OWN bookings overtook it (#199)", () => {
+    // The traced case the `resting` parameter exists for: the file holds placed 10 /
+    // filled 6, the operator ran the fill flow and accepted the default remainder of 4,
+    // retiring the rung — the file now counts ZERO resting — and the venue's export shows
+    // filled 8, i.e. 2 units still resting. Calling that already known would leave the
+    // file claiming LESS than the venue holds, which is #174's own hazard.
+    const overtaken = claim("rung-1", filledDifference(6, 8));
+    const result = partitionChangedClaims([overtaken], [], [row("rung-1", 8)]);
+    expect(result.amended).toEqual([overtaken]);
+    expect(result.restated).toEqual([]);
+  });
+});
+
+describe("partitionChangedClaims — #205's routing, by hazard", () => {
+  it("A `quantity` DIFFERENCE WINS over a descriptor on the same rung", () => {
+    // A funding hazard outranks everything, so the rung is refused with today's token and
+    // today's message whatever else the export also got wrong about it.
+    const mixed = claim(
+      "rung-1",
+      { field: "quantity", known: 10, observed: 12 },
+      { field: "orderType", known: "limit", observed: "market" },
+    );
+    const result = partitionChangedClaims([mixed], [resting("rung-1", 10)], [row("rung-1", 0, 12)]);
+    expect(result.amended).toEqual([mixed]);
+    expect(result.descriptors).toEqual([]);
+  });
+
+  it("A DESCRIPTOR DIFFERENCE WINS over a fill difference riding along on the same claim", () => {
+    // Two things follow from taking it here. The wording the operator gets is accurate for
+    // this claim, where `amended`'s cancel-the-rung remedy is not — no descriptor is in
+    // `price × quantity`, so no funding hazard can exist. And the mixed claim cannot reach
+    // the permissive per-rung skip: it must not be RECORDED beside a safe fill.
+    const mixed = claim(
+      "rung-1",
+      filledDifference(6, 8),
+      { field: "triggerPrice", known: 90, observed: 95 },
+    );
+    const result = partitionChangedClaims([mixed], [resting("rung-1", 4)], [row("rung-1", 8)]);
+    expect(result.descriptors).toEqual([mixed]);
+    expect(result.restated).toEqual([]);
+    expect(result.amended).toEqual([]);
+  });
+});
+
+describe("weighRemainders", () => {
+  it("reads the venue's remainder off the row — `quantity − filledQuantity`", () => {
+    expect(weighRemainders("rung-1", [resting("rung-1", 4)], [row("rung-1", 8)])).toEqual({
+      onFile: 4,
+      atVenue: 2,
+    });
+  });
+
+  it("READS AN ID ABSENT FROM `resting` AS `0` — the stream already retired the claim", () => {
+    // Not a missing case: absent means the rung's fills exhausted it or a cancellation
+    // took it, and zero is the honest statement of what the file now counts against it.
+    expect(weighRemainders("rung-1", [], [row("rung-1", 8)])).toEqual({ onFile: 0, atVenue: 2 });
+  });
+
+  it("returns `undefined` on a missing observed row rather than inventing a `0`", () => {
+    // Unreachable for a `ChangedClaim` — every one of them is raised FROM an observed row
+    // — and reported rather than defaulted, so a future caller that does not hold that
+    // invariant cannot get a silently invented figure out of it.
+    expect(weighRemainders("rung-1", [resting("rung-1", 4)], [])).toBeUndefined();
+  });
+
+  it("reads a row nothing has filled as claiming its whole size at the venue", () => {
+    expect(weighRemainders("rung-1", [resting("rung-1", 10)], [row("rung-1", 0)])).toEqual({
+      onFile: 10,
+      atVenue: 10,
+    });
+  });
+});

--- a/apps/tui/src/import-orders-changed-claims.test.ts
+++ b/apps/tui/src/import-orders-changed-claims.test.ts
@@ -93,9 +93,15 @@ describe("partitionChangedClaims — the branch ordering", () => {
 
     const remainders = weighRemainders("rung-1", [resting("rung-1", 4)], [row("rung-1", 4)]);
     // The overlap, stated as an assertion rather than as a claim in a comment: the
-    // `amended` branch's own test is satisfied by this very claim.
+    // `amended` branch's own test is satisfied by this very claim. The narrowing carries
+    // its own type evidence rather than two `!`s — `weighRemainders` returns `undefined`
+    // on a missing row, and a test that asserted the overlap through an assertion operator
+    // would be suppressing exactly the possibility it needs ruled out.
+    if (remainders === undefined) {
+      throw new Error("fixture is wrong: weighRemainders saw no observed row for `rung-1`");
+    }
     expect(remainders).toEqual({ onFile: 4, atVenue: 6 });
-    expect(remainders!.onFile < remainders!.atVenue).toBe(true);
+    expect(remainders.onFile < remainders.atVenue).toBe(true);
 
     expect(result.backwards).toEqual([{ id: "rung-1", known: 6, observed: 4 }]);
     expect(result.amended).toEqual([]);
@@ -185,6 +191,46 @@ describe("partitionChangedClaims — #205's routing, by hazard", () => {
     expect(result.descriptors).toEqual([mixed]);
     expect(result.restated).toEqual([]);
     expect(result.amended).toEqual([]);
+  });
+});
+
+describe("partitionChangedClaims — the skip class refuses what it does not recognise", () => {
+  it("REFUSES A SAFE FILL CARRYING AN UNRECOGNISED DIFFERENCE, rather than skipping the rung", () => {
+    // THE `claim.differences.length !== 1` GUARD, which nothing else in this file holds
+    // (PR #218 review): the descriptor test above reads like coverage for it but passes via
+    // the `isDescriptorDifference` branch, one test earlier, and never reaches this line.
+    //
+    // The guard is written for a SIXTH `ClaimDifference` field — one that is neither
+    // `quantity` nor a descriptor. Today no such field exists, so the branch is
+    // unreachable-by-construction and this test is the ONLY thing that can hold it against
+    // the future it was written for. Without it, that field rides into the per-rung SKIP
+    // class alongside a safe fill: the batch is admitted, the observation is recorded, and
+    // the unknown disagreement is never shown to anyone — silently, and in the permissive
+    // direction, which is the one direction an admission guard must never default to.
+    //
+    // The fill half is deliberately the `restated` fixture — placed 10, observed 6, export
+    // showing 8, file counting 4 resting against the venue's 2 — so the ONLY thing keeping
+    // this claim out of `restated` is the length guard itself.
+    //
+    // THE CAST IS THE POINT AND IS AS NARROW AS IT CAN BE. `ClaimDifference` is a
+    // discriminated union over a closed `field` list, so the type system cannot express a
+    // field that does not exist yet — expressing it honestly would mean widening the
+    // engine's union, which would put the sixth field into production types purely to make
+    // a test compile. The cast is confined to this one fixture line and asserts nothing
+    // about behaviour; the assertions below do that.
+    const unrecognised = {
+      field: "postOnly",
+      known: 0,
+      observed: 1,
+    } as unknown as ChangedClaim["differences"][number];
+    const mixed = claim("rung-1", filledDifference(6, 8), unrecognised);
+
+    const result = partitionChangedClaims([mixed], [resting("rung-1", 4)], [row("rung-1", 8)]);
+
+    expect(result.amended).toEqual([mixed]);
+    expect(result.restated).toEqual([]);
+    expect(result.backwards).toEqual([]);
+    expect(result.descriptors).toEqual([]);
   });
 });
 

--- a/apps/tui/src/import-orders-changed-claims.ts
+++ b/apps/tui/src/import-orders-changed-claims.ts
@@ -1,0 +1,253 @@
+/**
+ * THE CHANGED-CLAIM CLASSIFIER — which of the four classes a row that DISAGREES with the
+ * file falls into, and the remainder arithmetic the decision is made on.
+ *
+ * ONE COHESIVE RULE, and the cohesion is why {@link weighRemainders} came across with
+ * {@link partitionChangedClaims} rather than staying behind: the partition decides the
+ * class off `onFile < atVenue`, and the refusal message in `import-orders.ts` prints the
+ * SAME pair, so the figures the operator is shown must be the ones the decision was made
+ * on. That is a property of one function used twice, not of two derivations that agree.
+ *
+ * PURE, AND THAT IS THE DELIVERABLE. Every fact below was reachable before only through a
+ * whole import — an export file, a sidecar, an injected clock, a prompt answered, a
+ * funding guard satisfied — while the thing most worth asserting is a BRANCH ORDERING
+ * that a comment was the only thing holding in place. See
+ * `import-orders-changed-claims.test.ts`.
+ *
+ * THE WORDS STAY IN THE SHELL. Nothing here renders an operator line; each class is
+ * returned and `importBitgetOpenOrders` owns the refusal it raises over it, in the order
+ * hazard demands.
+ */
+import {
+  isDescriptorDifference,
+  isFilledDifference,
+  type BitgetOpenOrder,
+  type ChangedClaim,
+  type RestingOrder,
+} from "@numisma/engine";
+import type { RecordedObservation } from "./import-orders-report.js";
+
+/**
+ * A rung the export shows LESS filled than the file's latest observation of it (#181) —
+ * the refusal `backwards-claim` is raised over.
+ *
+ * SPELLED SEPARATELY FROM {@link RecordedObservation} even though the two carry the same
+ * three fields, because they are opposite outcomes of the same comparison: one names a
+ * line this import WROTE, the other a line it REFUSED to write. Collapsing them into one
+ * type would let a refusal be handed to the reporter that describes what was recorded.
+ */
+export interface BackwardsClaim {
+  id: string;
+  /** The file's latest observation — see {@link RecordedObservation.known} for the basis. */
+  known: number;
+  /** The SMALLER partial the export shows. */
+  observed: number;
+}
+
+/** The four classes a disagreeing row can fall into — three refusals and one recording. */
+export interface ChangedClaimPartition {
+  amended: ChangedClaim[];
+  backwards: BackwardsClaim[];
+  descriptors: ChangedClaim[];
+  restated: RecordedObservation[];
+}
+
+/**
+ * Split the claims that disagree with the file into the ones that refuse the batch and
+ * the ones that cost their own rung — THE POLICY DECISION of #199, and the reason it
+ * lives here rather than in `import-orders-cli.ts`.
+ *
+ * Deciding which class a difference falls in is admission policy, and the wiring says so
+ * in its own words after #172 bit it for exactly this: "Admission is the engine's policy,
+ * not this wiring's." A CLI that filtered these out would be re-deciding, from the shell,
+ * something the flow is supposed to own.
+ *
+ * THE SKIP CLASS IS DECIDED BY THE REMAINDER THE GUARD ACTUALLY WEIGHS, which is why
+ * `resting` is a parameter rather than something this could work out from `changed`
+ * (#200 review). A difference is a statement about the venue's column; the guard weighs
+ * `pickRestingOrdersAsOf`, which replays `orderFilled` and `orderCancelled` too, so a fill
+ * already recorded against the rung can shrink the file's remainder BELOW the venue's
+ * while the partials still read as "moved up". The traced case: file holds placed 10 /
+ * filled 6, the operator runs the fill flow and accepts the default remainder of 4,
+ * retiring the rung — the file now counts ZERO resting — and the venue's next export shows
+ * filled 8, i.e. 2 units still resting. Skipping that would make `available` read HIGH,
+ * which is #174's own hazard.
+ *
+ * Three things must hold for a per-rung skip, and anything else refuses the batch:
+ *
+ *  1. NO `quantity` DIFFERENCE — unchanged policy, and not merely because of today's
+ *     encumbrance. `placed.quantity` is the ORIGINAL size a cumulative venue reading is
+ *     compared against (#176), so a stale one corrupts every future comparison of this
+ *     rung, not just this guard's sum. It is the one figure nothing may go stale on. It
+ *     refuses the WHOLE BATCH, and it refuses it whichever way the partial points.
+ *  2. EVERY REMAINING difference is `observedFilledQuantity`. The third, fourth and fifth
+ *     fields ARRIVED (#205) — the placement descriptors — and they are taken by their own
+ *     branch above this one rather than by this guard. The guard stays exactly as it was,
+ *     for the sixth: an unknown difference must land in a REFUSAL class by default instead
+ *     of silently riding in beside a safe fill as a per-rung skip.
+ *  3. `fileRemaining >= venueRemaining`. The `<=` on the left is where later fill lines
+ *     live; they only make it stricter.
+ *
+ * THE REFUSAL SPLITS TWO WAYS, AND THE TWO CANNOT OVERLAP (#181). One refusal used to
+ * serve two conditions that are not the same animal, and the wrong one is actively
+ * harmful: an operator who imports YESTERDAY's export against a file holding an observed 6
+ * was refused correctly and then told to cancel the rung at the venue or re-place it —
+ * advice that destroys a live rung in response to someone picking the wrong CSV.
+ *
+ *   - `backwards` — the export figure is BELOW the latest observation. A fill does not
+ *     un-fill, so the column went backwards and the likeliest cause is the file, not the
+ *     book: an older export, or not the export the operator meant. It gets its own wording
+ *     and NEVER tells anyone to touch the rung at the venue.
+ *   - `amended` — `latest observation <= export figure < consumed`. The fund has BOOKED
+ *     beyond what the venue shows, so calling the row already known would leave the file
+ *     claiming LESS than the venue still holds. Today's wording, today's exit.
+ *
+ * THE ORDER OF THE TWO TESTS IS LOAD-BEARING, NOT PRESENTATIONAL, and the two outcome
+ * classes are disjoint only BECAUSE `backwards` is taken first. `consumed >= latest
+ * observation` ALWAYS holds — the fold SETs `consumed` to the latest observation and
+ * `orderFilled` only ever ADDS to it, so `consumed` is that observation plus a non-negative
+ * sum of bookings made since — and that is exactly what makes the two PREDICATES a superset
+ * relation rather than a partition. `backwards` fires on `export figure < latest
+ * observation`. `amended`'s remainder test reduces to `export figure < consumed`, because
+ * the `quantity` branch further down has already taken every claim whose placed size
+ * differs, so `quantity` is equal on both sides and cancels out of
+ * `onFile < atVenue`. `[0, consumed)` therefore CONTAINS `[0, latestObserved)`: THE
+ * PREDICATES OVERLAP, and only the `continue` after the `backwards` push separates them.
+ * Placed 10, the file's latest observation 6, the export showing 4: both tests are true,
+ * and the order alone decides which one the operator is told.
+ *
+ * The intervals the two OUTCOMES occupy — `[0, latestObserved)` and
+ * `[latestObserved, consumed)`, adjacent and disjoint — describe the classes AFTER that
+ * ordering; they are not a property of the predicates and must not be read as one.
+ * Reordering the tests is therefore not a rearrangement of the same answer: every backwards
+ * claim would fall into `amended` and be handed the cancel-the-rung-at-the-venue advice
+ * #208 exists to keep it away from — the exact harm the split above was made to remove.
+ *
+ * THE CLOSED END OF THE SECOND INTERVAL IS NOT REACHED FROM HERE, and that is unchanged by
+ * the split rather than a hole it opens. An export exactly AT the latest observation is not
+ * a DIFFERENCE, so no `ChangedClaim` is raised for it and this function never sees it —
+ * whatever the fund booked afterwards. That is the same reading a re-import of an unchanged
+ * export has always had, and widening this to every observed row would turn an ordinary
+ * re-import into a batch refusal.
+ *
+ * AN EXPORT FIGURE ABOVE THE PLACED QUANTITY GETS NO CHECK, AND THAT IS THE DECISION. It
+ * is unreachable, by two gates upstream of this line:
+ *
+ *   - the VENUE's own export cannot render `filled_quantity > quantity` on the same row —
+ *     the two columns come from one order and a venue that filled more than it placed
+ *     would be contradicting itself, not reporting; and
+ *   - `parseBitgetOpenOrdersCsv`'s own admission gate drops any row whose remainder is not
+ *     POSITIVE — `quantity − filled_quantity <= 0` is a `not-resting` SKIP — so a
+ *     hand-edited CSV never reaches this partition as a claim at all. `mergeCollidingClaims`
+ *     preserves that, summing both columns of a collision and so both sides of the same
+ *     inequality.
+ *
+ * If such a line ever did reach the file anyway, the fold degrades correctly rather than
+ * lying: `remaining = quantity − consumed` goes negative, `pickRestingOrdersAsOf` drops
+ * the rung (`remaining > 0` is its resting test), and the fill-admission ceiling
+ * `min(remainingQuantity, quantity − bookedFills(id))` cannot authorize anything. Adding a
+ * runtime check here would put a third opinion about the same impossibility in the one
+ * place least able to explain it; RECORDING WHY IT CANNOT ARRIVE is the deliverable.
+ *
+ * An id ABSENT from `resting` reads as `0`, not as a missing case: absent means the
+ * stream already retired the claim — its fills exhausted it, or a cancellation took it —
+ * and zero is the honest statement of what the file now counts against that rung.
+ *
+ * A FOURTH CLASS, AND THE ROUTING IS BY HAZARD (#205). The placement descriptors —
+ * `orderType`, `timeInForce`, `triggerPrice` — are compared now, and a difference in one
+ * must not be handed `amended`'s cancel-the-rung remedy, which is justified by a funding
+ * hazard that cannot arise from a field the encumbrance does not contain. The three tests
+ * run in this order and the order is the argument:
+ *
+ *  1. ANY `quantity` DIFFERENCE → `amended`, exactly as before. A funding hazard outranks
+ *     everything, so a rung whose size changed is refused with today's token and today's
+ *     message whatever else it also disagrees about.
+ *  2. OTHERWISE ANY DESCRIPTOR DIFFERENCE → `descriptors`, EVEN IF a fill difference rides
+ *     along on the same claim. Two things follow from taking it here. The wording the
+ *     operator gets is accurate for that claim, where `amended`'s is not; and a mixed
+ *     claim still cannot reach the permissive per-rung skip below, which is what the
+ *     length guard in test 2 of the skip rule exists to protect.
+ *  3. OTHERWISE the fill logic, untouched.
+ */
+export function partitionChangedClaims(
+  changed: readonly ChangedClaim[],
+  resting: readonly RestingOrder[],
+  observed: readonly BitgetOpenOrder[],
+): ChangedClaimPartition {
+  const amended: ChangedClaim[] = [];
+  const backwards: BackwardsClaim[] = [];
+  const descriptors: ChangedClaim[] = [];
+  const restated: RecordedObservation[] = [];
+
+  for (const claim of changed) {
+    if (claim.differences.some((difference) => difference.field === "quantity")) {
+      amended.push(claim);
+      continue;
+    }
+    // The predicate is the ENGINE's, beside the field union it reads, so this boundary
+    // cannot fall out of step with the list of fields a descriptor difference can name.
+    if (claim.differences.some(isDescriptorDifference)) {
+      descriptors.push(claim);
+      continue;
+    }
+    const fill = claim.differences.find(isFilledDifference);
+    const remainders = weighRemainders(claim.id, resting, observed);
+    // The restatement must be the ONLY difference left, not merely one of them. The
+    // `quantity` branch above already took the field that exists today, so this length
+    // test is about the THIRD field a later `ClaimDifference` may carry: without it, an
+    // unknown difference would ride into the skip class alongside a safe fill — silently,
+    // and in the permissive direction — which is the whole point of guarding here.
+    if (fill === undefined || claim.differences.length !== 1 || remainders === undefined) {
+      amended.push(claim);
+      continue;
+    }
+    // `fill.known` IS the latest observation (see `ClaimDifference`), so this is the
+    // backwards test exactly as the argument above states it — and the difference exists
+    // at all only because the two figures are further apart than `QUANTITY_EPSILON`.
+    if (fill.observed < fill.known) {
+      backwards.push({ id: claim.id, known: fill.known, observed: fill.observed });
+      continue;
+    }
+    if (remainders.onFile < remainders.atVenue) {
+      amended.push(claim);
+      continue;
+    }
+    // THE REMAINDERS ARE WEIGHED AND NOT CARRIED (#181). They still DECIDE the class —
+    // `remainders.onFile < remainders.atVenue` is the test directly above — but they were
+    // carried onto the outcome to let an operator audit a SKIP's safety claim, and this
+    // build writes the observation instead of skipping. Once the line lands, the file's
+    // remainder IS the venue's, so the pair would print two equal numbers and invite an
+    // audit of nothing.
+    restated.push({ id: claim.id, known: fill.known, observed: fill.observed });
+  }
+
+  return { amended, backwards, descriptors, restated };
+}
+
+/**
+ * What one id still claims on each side — the file's remainder and the venue's.
+ *
+ * ONE function for both the partition and the refusal message, so the figures the
+ * operator is shown are the same ones the decision was made on rather than a second
+ * derivation that can drift from it.
+ *
+ * `undefined` only when the observed row is missing, which cannot happen for a
+ * `ChangedClaim` (every one of them is raised FROM an observed row) — reported rather
+ * than defaulted, so a future caller that does not hold that invariant cannot get a
+ * silently invented `0` out of it.
+ */
+export function weighRemainders(
+  id: string,
+  resting: readonly RestingOrder[],
+  observed: readonly BitgetOpenOrder[],
+): { onFile: number; atVenue: number } | undefined {
+  const row = observed.find((order) => order.id === id);
+  if (row === undefined) {
+    return undefined;
+  }
+  const open = resting.find((order) => order.placed.id === id);
+  return {
+    onFile: open?.remainingQuantity ?? 0,
+    atVenue: row.quantity - (row.filledQuantity ?? 0),
+  };
+}

--- a/apps/tui/src/import-orders-changed-claims.ts
+++ b/apps/tui/src/import-orders-changed-claims.ts
@@ -231,6 +231,12 @@ export function partitionChangedClaims(
  * operator is shown are the same ones the decision was made on rather than a second
  * derivation that can drift from it.
  *
+ * THE VENUE'S CUMULATIVE COLUMN IS READ WITHOUT A FALLBACK, deliberately (PR #218 review).
+ * `BitgetOpenOrder.filledQuantity` is a required, non-nullable `number`, so a `?? 0` here
+ * could never fire — and it would say, in the one place this module's arithmetic most needs
+ * certainty, that the column might be absent. An honest absence would be a parse problem
+ * and belongs to the parser, not to a defaulted subtraction here.
+ *
  * `undefined` only when the observed row is missing, which cannot happen for a
  * `ChangedClaim` (every one of them is raised FROM an observed row) — reported rather
  * than defaulted, so a future caller that does not hold that invariant cannot get a
@@ -248,6 +254,6 @@ export function weighRemainders(
   const open = resting.find((order) => order.placed.id === id);
   return {
     onFile: open?.remainingQuantity ?? 0,
-    atVenue: row.quantity - (row.filledQuantity ?? 0),
+    atVenue: row.quantity - row.filledQuantity,
   };
 }

--- a/apps/tui/src/import-orders.ts
+++ b/apps/tui/src/import-orders.ts
@@ -22,25 +22,22 @@ import {
   checkFundingCoverage,
   detectChangedClaims,
   formatObservedAt,
-  isDescriptorDifference,
-  isFilledDifference,
   leavesRungUnweighed,
   mergeCollidingClaims,
   parseBitgetOpenOrdersCsv,
   pickRestingOrdersAsOf,
   type BitgetOpenOrder,
   type BitgetRowSkip,
-  type ChangedClaim,
   type MergedOrderClaim,
   type OrderFillObservedRecord,
   type OrderPlacedRecord,
   type OrderRecord,
   type FundReviewData,
-  type RestingOrder,
   type UnmatchedRung,
 } from "@numisma/engine";
 import type { OrdersLoad } from "@numisma/preferences";
 import { appendKey, currentClaimKeys } from "./import-orders-append-filter.js";
+import { partitionChangedClaims, weighRemainders } from "./import-orders-changed-claims.js";
 import {
   reportOrdersImport,
   type OrdersImportRecorded,
@@ -223,23 +220,6 @@ export type OrdersImportRejection =
    * contract is the honest report — not a bare stack out of the CLI's outer catch.
    */
   | "write-failed";
-
-/**
- * A rung the export shows LESS filled than the file's latest observation of it (#181) —
- * the refusal `backwards-claim` is raised over.
- *
- * SPELLED SEPARATELY FROM {@link RecordedObservation} even though the two carry the same
- * three fields, because they are opposite outcomes of the same comparison: one names a
- * line this import WROTE, the other a line it REFUSED to write. Collapsing them into one
- * type would let a refusal be handed to the reporter that describes what was recorded.
- */
-interface BackwardsClaim {
-  id: string;
-  /** The file's latest observation — see {@link RecordedObservation.known} for the basis. */
-  known: number;
-  /** The SMALLER partial the export shows. */
-  observed: number;
-}
 
 /**
  * WHAT AN IMPORT REPORTS — the two recorded shapes, plus the refusal.
@@ -464,211 +444,6 @@ function describe(order: BitgetOpenOrder): string {
 function isAffirmative(answer: string): boolean {
   const normalized = answer.trim().toLowerCase();
   return normalized === "y" || normalized === "yes";
-}
-
-/**
- * Split the claims that disagree with the file into the ones that refuse the batch and
- * the ones that cost their own rung — THE POLICY DECISION of #199, and the reason it
- * lives here rather than in `import-orders-cli.ts`.
- *
- * Deciding which class a difference falls in is admission policy, and the wiring says so
- * in its own words after #172 bit it for exactly this: "Admission is the engine's policy,
- * not this wiring's." A CLI that filtered these out would be re-deciding, from the shell,
- * something the flow is supposed to own.
- *
- * THE SKIP CLASS IS DECIDED BY THE REMAINDER THE GUARD ACTUALLY WEIGHS, which is why
- * `resting` is a parameter rather than something this could work out from `changed`
- * (#200 review). A difference is a statement about the venue's column; the guard weighs
- * `pickRestingOrdersAsOf`, which replays `orderFilled` and `orderCancelled` too, so a fill
- * already recorded against the rung can shrink the file's remainder BELOW the venue's
- * while the partials still read as "moved up". The traced case: file holds placed 10 /
- * filled 6, the operator runs the fill flow and accepts the default remainder of 4,
- * retiring the rung — the file now counts ZERO resting — and the venue's next export shows
- * filled 8, i.e. 2 units still resting. Skipping that would make `available` read HIGH,
- * which is #174's own hazard.
- *
- * Three things must hold for a per-rung skip, and anything else refuses the batch:
- *
- *  1. NO `quantity` DIFFERENCE — unchanged policy, and not merely because of today's
- *     encumbrance. `placed.quantity` is the ORIGINAL size a cumulative venue reading is
- *     compared against (#176), so a stale one corrupts every future comparison of this
- *     rung, not just this guard's sum. It is the one figure nothing may go stale on. It
- *     refuses the WHOLE BATCH, and it refuses it whichever way the partial points.
- *  2. EVERY REMAINING difference is `observedFilledQuantity`. The third, fourth and fifth
- *     fields ARRIVED (#205) — the placement descriptors — and they are taken by their own
- *     branch above this one rather than by this guard. The guard stays exactly as it was,
- *     for the sixth: an unknown difference must land in a REFUSAL class by default instead
- *     of silently riding in beside a safe fill as a per-rung skip.
- *  3. `fileRemaining >= venueRemaining`. The `<=` on the left is where later fill lines
- *     live; they only make it stricter.
- *
- * THE REFUSAL SPLITS TWO WAYS, AND THE TWO CANNOT OVERLAP (#181). One refusal used to
- * serve two conditions that are not the same animal, and the wrong one is actively
- * harmful: an operator who imports YESTERDAY's export against a file holding an observed 6
- * was refused correctly and then told to cancel the rung at the venue or re-place it —
- * advice that destroys a live rung in response to someone picking the wrong CSV.
- *
- *   - `backwards` — the export figure is BELOW the latest observation. A fill does not
- *     un-fill, so the column went backwards and the likeliest cause is the file, not the
- *     book: an older export, or not the export the operator meant. It gets its own wording
- *     and NEVER tells anyone to touch the rung at the venue.
- *   - `amended` — `latest observation <= export figure < consumed`. The fund has BOOKED
- *     beyond what the venue shows, so calling the row already known would leave the file
- *     claiming LESS than the venue still holds. Today's wording, today's exit.
- *
- * THE ORDER OF THE TWO TESTS IS LOAD-BEARING, NOT PRESENTATIONAL, and the two outcome
- * classes are disjoint only BECAUSE `backwards` is taken first. `consumed >= latest
- * observation` ALWAYS holds — the fold SETs `consumed` to the latest observation and
- * `orderFilled` only ever ADDS to it, so `consumed` is that observation plus a non-negative
- * sum of bookings made since — and that is exactly what makes the two PREDICATES a superset
- * relation rather than a partition. `backwards` fires on `export figure < latest
- * observation`. `amended`'s remainder test reduces to `export figure < consumed`, because
- * the `quantity` branch further down has already taken every claim whose placed size
- * differs, so `quantity` is equal on both sides and cancels out of
- * `onFile < atVenue`. `[0, consumed)` therefore CONTAINS `[0, latestObserved)`: THE
- * PREDICATES OVERLAP, and only the `continue` after the `backwards` push separates them.
- * Placed 10, the file's latest observation 6, the export showing 4: both tests are true,
- * and the order alone decides which one the operator is told.
- *
- * The intervals the two OUTCOMES occupy — `[0, latestObserved)` and
- * `[latestObserved, consumed)`, adjacent and disjoint — describe the classes AFTER that
- * ordering; they are not a property of the predicates and must not be read as one.
- * Reordering the tests is therefore not a rearrangement of the same answer: every backwards
- * claim would fall into `amended` and be handed the cancel-the-rung-at-the-venue advice
- * #208 exists to keep it away from — the exact harm the split above was made to remove.
- *
- * THE CLOSED END OF THE SECOND INTERVAL IS NOT REACHED FROM HERE, and that is unchanged by
- * the split rather than a hole it opens. An export exactly AT the latest observation is not
- * a DIFFERENCE, so no `ChangedClaim` is raised for it and this function never sees it —
- * whatever the fund booked afterwards. That is the same reading a re-import of an unchanged
- * export has always had, and widening this to every observed row would turn an ordinary
- * re-import into a batch refusal.
- *
- * AN EXPORT FIGURE ABOVE THE PLACED QUANTITY GETS NO CHECK, AND THAT IS THE DECISION. It
- * is unreachable, by two gates upstream of this line:
- *
- *   - the VENUE's own export cannot render `filled_quantity > quantity` on the same row —
- *     the two columns come from one order and a venue that filled more than it placed
- *     would be contradicting itself, not reporting; and
- *   - `parseBitgetOpenOrdersCsv`'s own admission gate drops any row whose remainder is not
- *     POSITIVE — `quantity − filled_quantity <= 0` is a `not-resting` SKIP — so a
- *     hand-edited CSV never reaches this partition as a claim at all. `mergeCollidingClaims`
- *     preserves that, summing both columns of a collision and so both sides of the same
- *     inequality.
- *
- * If such a line ever did reach the file anyway, the fold degrades correctly rather than
- * lying: `remaining = quantity − consumed` goes negative, `pickRestingOrdersAsOf` drops
- * the rung (`remaining > 0` is its resting test), and the fill-admission ceiling
- * `min(remainingQuantity, quantity − bookedFills(id))` cannot authorize anything. Adding a
- * runtime check here would put a third opinion about the same impossibility in the one
- * place least able to explain it; RECORDING WHY IT CANNOT ARRIVE is the deliverable.
- *
- * An id ABSENT from `resting` reads as `0`, not as a missing case: absent means the
- * stream already retired the claim — its fills exhausted it, or a cancellation took it —
- * and zero is the honest statement of what the file now counts against that rung.
- *
- * A FOURTH CLASS, AND THE ROUTING IS BY HAZARD (#205). The placement descriptors —
- * `orderType`, `timeInForce`, `triggerPrice` — are compared now, and a difference in one
- * must not be handed `amended`'s cancel-the-rung remedy, which is justified by a funding
- * hazard that cannot arise from a field the encumbrance does not contain. The three tests
- * run in this order and the order is the argument:
- *
- *  1. ANY `quantity` DIFFERENCE → `amended`, exactly as before. A funding hazard outranks
- *     everything, so a rung whose size changed is refused with today's token and today's
- *     message whatever else it also disagrees about.
- *  2. OTHERWISE ANY DESCRIPTOR DIFFERENCE → `descriptors`, EVEN IF a fill difference rides
- *     along on the same claim. Two things follow from taking it here. The wording the
- *     operator gets is accurate for that claim, where `amended`'s is not; and a mixed
- *     claim still cannot reach the permissive per-rung skip below, which is what the
- *     length guard in test 2 of the skip rule exists to protect.
- *  3. OTHERWISE the fill logic, untouched.
- */
-function partitionChangedClaims(
-  changed: readonly ChangedClaim[],
-  resting: readonly RestingOrder[],
-  observed: readonly BitgetOpenOrder[],
-): {
-  amended: ChangedClaim[];
-  backwards: BackwardsClaim[];
-  descriptors: ChangedClaim[];
-  restated: RecordedObservation[];
-} {
-  const amended: ChangedClaim[] = [];
-  const backwards: BackwardsClaim[] = [];
-  const descriptors: ChangedClaim[] = [];
-  const restated: RecordedObservation[] = [];
-
-  for (const claim of changed) {
-    if (claim.differences.some((difference) => difference.field === "quantity")) {
-      amended.push(claim);
-      continue;
-    }
-    // The predicate is the ENGINE's, beside the field union it reads, so this boundary
-    // cannot fall out of step with the list of fields a descriptor difference can name.
-    if (claim.differences.some(isDescriptorDifference)) {
-      descriptors.push(claim);
-      continue;
-    }
-    const fill = claim.differences.find(isFilledDifference);
-    const remainders = weighRemainders(claim.id, resting, observed);
-    // The restatement must be the ONLY difference left, not merely one of them. The
-    // `quantity` branch above already took the field that exists today, so this length
-    // test is about the THIRD field a later `ClaimDifference` may carry: without it, an
-    // unknown difference would ride into the skip class alongside a safe fill — silently,
-    // and in the permissive direction — which is the whole point of guarding here.
-    if (fill === undefined || claim.differences.length !== 1 || remainders === undefined) {
-      amended.push(claim);
-      continue;
-    }
-    // `fill.known` IS the latest observation (see `ClaimDifference`), so this is the
-    // backwards test exactly as the argument above states it — and the difference exists
-    // at all only because the two figures are further apart than `QUANTITY_EPSILON`.
-    if (fill.observed < fill.known) {
-      backwards.push({ id: claim.id, known: fill.known, observed: fill.observed });
-      continue;
-    }
-    if (remainders.onFile < remainders.atVenue) {
-      amended.push(claim);
-      continue;
-    }
-    // THE REMAINDERS ARE WEIGHED AND NOT CARRIED (#181). They still DECIDE the class —
-    // `remainders.onFile < remainders.atVenue` is the test directly above — but they were
-    // carried onto the outcome to let an operator audit a SKIP's safety claim, and this
-    // build writes the observation instead of skipping. Once the line lands, the file's
-    // remainder IS the venue's, so the pair would print two equal numbers and invite an
-    // audit of nothing.
-    restated.push({ id: claim.id, known: fill.known, observed: fill.observed });
-  }
-
-  return { amended, backwards, descriptors, restated };
-}
-
-/**
- * What one id still claims on each side — the file's remainder and the venue's.
- *
- * ONE function for both the partition and the refusal message, so the figures the
- * operator is shown are the same ones the decision was made on rather than a second
- * derivation that can drift from it.
- *
- * `undefined` only when the observed row is missing, which cannot happen for a
- * `ChangedClaim` (every one of them is raised FROM an observed row) — reported rather
- * than defaulted, so a future caller that does not hold that invariant cannot get a
- * silently invented `0` out of it.
- */
-function weighRemainders(
-  id: string,
-  resting: readonly RestingOrder[],
-  observed: readonly BitgetOpenOrder[],
-): { onFile: number; atVenue: number } | undefined {
-  const row = observed.find((order) => order.id === id);
-  if (row === undefined) {
-    return undefined;
-  }
-  const open = resting.find((order) => order.placed.id === id);
-  return {
-    onFile: open?.remainingQuantity ?? 0,
-    atVenue: row.quantity - (row.filledQuantity ?? 0),
-  };
 }
 
 /**

--- a/apps/tui/src/import-orders.ts
+++ b/apps/tui/src/import-orders.ts
@@ -40,6 +40,7 @@ import {
   type UnmatchedRung,
 } from "@numisma/engine";
 import type { OrdersLoad } from "@numisma/preferences";
+import { appendKey, currentClaimKeys } from "./import-orders-append-filter.js";
 import {
   reportOrdersImport,
   type OrdersImportRecorded,
@@ -63,8 +64,8 @@ export interface OrdersImportIo {
    * ONE EXPORT IS ONE LOOK, so every observation of a batch shares one stamp, and the
    * stamp is second-granular because {@link isObservedAtStamp} is the shape the whole
    * repo string-compares. Two imports inside one second therefore carry the SAME stamp,
-   * and nothing downstream may depend on the stamp to tell them apart — see the append
-   * key at {@link appendKey}, which keys an observation on what it ASSERTS.
+   * and nothing downstream may depend on the stamp to tell them apart — see `appendKey` in
+   * `./import-orders-append-filter.js`, which keys an observation on what it ASSERTS.
    */
   now: () => Date;
   /** The sidecar's resolved path — resolved by the caller, never by this flow. */
@@ -1004,39 +1005,10 @@ export async function importBitgetOpenOrders(
   // ONE `appendOrders` CALL for both kinds: one lock, one temp write, one `rename`. There
   // is no ordering reason to split them — the selector sorts by `observedAt` at READ time,
   // so the file's byte order cannot change what it means.
-  // THE SET IS THE RUNG'S CURRENT CLAIM, NOT ITS WHOLE HISTORY (#212). `appendKey` is a
-  // pure function of ONE record and structurally cannot see what came after it, so it can
-  // only answer *"is this figure already recorded?"*; what the filter must answer is *"is
-  // this figure still the rung's CURRENT claim?"*. The scoping therefore lives HERE, in
-  // what the set is built from, and the key is left alone.
-  //
-  // The two questions part company the moment one observation supersedes another: observe
-  // 8, record a backwards restatement of 5, and the venue's next export of 8 is a
-  // legitimate RE-ASSERTION that a whole-history set drops as a repeat. Nothing lands —
-  // and the report describes the lines that were WRITTEN, so the operator is told
-  // `0 observation(s) recorded` about an observation this flow had just decided to record.
-  //
-  // ONLY THE LATEST OBSERVATION PER RUNG goes in, by the SAME last-wins-by-stamp rule
-  // `detectChangedClaims` uses — `>=`, so the last line in file order wins an equal-stamp
-  // tie. That function is what decides an observation is worth building; were the two to
-  // disagree about which figure is current, one layer would build a line the other refused
-  // to write. Every other kind goes in whole, which for a placement is equivalent to
-  // keying on the id alone, since `synthesizeOrderId` already includes `observedAt`.
-  const latestObserved = new Map<string, OrderFillObservedRecord>();
-  const currentOnFile = new Set<string>();
-  for (const record of existingRecords) {
-    if (record.kind !== "orderFillObserved") {
-      currentOnFile.add(appendKey(record));
-      continue;
-    }
-    const seen = latestObserved.get(record.id);
-    if (seen === undefined || record.observedAt >= seen.observedAt) {
-      latestObserved.set(record.id, record);
-    }
-  }
-  for (const record of latestObserved.values()) {
-    currentOnFile.add(appendKey(record));
-  }
+  // WHAT THE FILE CURRENTLY CLAIMS, AS KEYS — the rung's CURRENT claim rather than its
+  // whole history (#212), built by `currentClaimKeys` in `./import-orders-append-filter.js`
+  // where the argument for that scoping is recorded beside the key it scopes.
+  const currentOnFile = currentClaimKeys(existingRecords);
   // ONE SET, BUILT ONCE, over both arrays in a single pass — so a second line for the same
   // rung inside ONE batch would not see the first. It cannot arise: `mergeCollidingClaims`
   // has already summed id collisions, so `orders` holds at most one row per id, and
@@ -1068,51 +1040,4 @@ export async function importBitgetOpenOrders(
   });
   io.out(message);
   return outcome;
-}
-
-/**
- * THE APPEND FILTER'S KEY — what makes a line a REPEAT of one already on file (#181).
- *
- * KEYED ON WHAT THE LINE ASSERTS, not on when it was looked at, and the two kinds assert
- * different things:
- *
- *   - `orderFillObserved` → `(kind, id, observedFilledQuantity)`. Two observations of the
- *     same cumulative figure are the SAME FACT stated twice and dedupe; 8 then 9 are
- *     genuine movement and both land.
- *   - everything else → `(kind, id, observedAt)`. For a placement this is exactly
- *     equivalent to keying on the id alone, since `synthesizeOrderId` already includes
- *     `observedAt`, so repeat-placement dedupe is unchanged.
- *
- * WHY NOT `observedAt` FOR AN OBSERVATION, which is what an id-and-stamp key would give.
- * One export is one look, so a whole batch shares one second-granular stamp — and two
- * imports inside the SAME second would then key identically, so the second import's
- * observation was silently dropped while the operator was told it was RECORDED and a
- * successful status came back. Honesty and information loss rather than money loss, and
- * ordinary to reach: two exports back to back, or any scripted loop.
- *
- * MILLISECOND PRECISION WAS REJECTED as the fix, not overlooked. `isObservedAtStamp`
- * validates `YYYY-MM-DDTHH:MM:SS`, the stamp is string-compared across the whole repo and
- * is a component of a durable event id — and milliseconds only SHRINK the collision
- * window rather than closing it, while keying on the figure closes it.
- *
- * THE EQUAL STAMPS ARE FINE DOWNSTREAM. `pickRestingOrdersAsOf` sorts stably, so file
- * order breaks the tie and replays 8 then 9 — the batch stamp's own argument working as
- * written.
- *
- * WHY `kind` IS IN THE KEY AT ALL: an observation shares its rung's id, so an id-only key
- * would read the first observation of a known rung as a repeat of its placement line and
- * drop it — the whole feature, filtered out by its own dedupe.
- *
- * ONE OF TWO QUESTIONS, AND THE CALL SITE ANSWERS THE OTHER. This key answers *"is this
- * figure already recorded?"* — all a pure function of ONE record can answer, since nothing
- * in a record says what came after it. *"Is this figure still the rung's CURRENT claim?"*
- * is answered where it can be: the filter builds its set from the LATEST observation per
- * rung rather than from every existing record, so a superseded figure no longer filters a
- * legitimate re-assertion of it. Keep the scoping there; widening this key to reach for
- * history would only move the second question somewhere it still cannot be answered.
- */
-function appendKey(record: OrderRecord): string {
-  return record.kind === "orderFillObserved"
-    ? `${record.kind} ${record.id} ${record.observedFilledQuantity}`
-    : `${record.kind} ${record.id} ${record.observedAt}`;
 }

--- a/packages/engine/src/orders/ingest.ts
+++ b/packages/engine/src/orders/ingest.ts
@@ -351,8 +351,8 @@ export interface ChangedClaim {
  * stale on is the drift the batch refusal exists to prevent).
  *
  * AN EXPORT FIGURE ABOVE THE PLACED QUANTITY GETS NO CHECK HERE, AND THAT IS THE DECISION
- * — see the partition rule in `apps/tui/src/import-orders.ts`, which states why it cannot
- * arrive and names both gates that make it so.
+ * — see the partition rule in `apps/tui/src/import-orders-changed-claims.ts`, which
+ * states why it cannot arrive and names both gates that make it so.
  *
  * TIES ON EQUAL STAMPS RESOLVE TO THE LAST LINE IN FILE ORDER — `>=` on the scan below,
  * over the records in the order the caller holds them. That is exactly the tie-break the
@@ -395,8 +395,9 @@ export interface ChangedClaim {
  * Accepted for the same reason the gap was acceptable before: no descriptor moves the
  * encumbrance, which is `price * quantity`, so the funding guard stays correct across
  * such a change. That is also why a descriptor difference does NOT refuse as an
- * amendment — see `partitionChangedClaims` in `apps/tui/src/import-orders.ts`, which
- * routes it to its own class with its own wording.
+ * amendment — see `partitionChangedClaims` in
+ * `apps/tui/src/import-orders-changed-claims.ts`, which routes it to its own class with
+ * its own wording.
  */
 export function detectChangedClaims(
   known: readonly OrderRecord[],


### PR DESCRIPTION
## Summary

Two pure rules move out of `import-orders.ts` so their correctness is assertable without driving a whole end-to-end import. The deliverable here is the **tests**, not the file-length reduction — a pure refactor with zero behavior change.

- **The changed-claim classifier** → `import-orders-changed-claims.ts`: `partitionChangedClaims`, `weighRemainders`, `BackwardsClaim`, and `ChangedClaimPartition` (the previously-inline return object, now a named export — the one type-visibility allowance; no behavior moved with it). 12 tests.

  The headline test pins the classifier's branch ordering: placed 10, the file's latest observation 6, the export showing 4 — **both** predicates are true (`amended`'s remainder test reduces to `export figure < consumed`, a strict superset of `backwards`'s `export figure < latest observation`), and only the branch ordering separates the outcome classes. PR #211's review found the old docstring's disjointness proof **false** on exactly this point, and until now a comment was the only thing holding the ordering in place. **@bit mutation-checked it** — swapping the two branches makes that test fail. That is the evidence the test is real, not just a restatement of the code. (Background on the refusal split itself: #181, #199, #205, #207, #208.)

- **The append-filter seam** → `import-orders-append-filter.ts`: `appendKey` plus `currentClaimKeys`. #213 named only the key, but #212 settled that the rule lives in **what the set is built from**, not just how one record is keyed — so the key alone would have left the untestable half behind. 8 tests.

## Zero behavior change

- Operator-facing strings moved byte-identical.
- No existing test or snapshot was modified.
- `module-graph.test.ts` passes unmodified.
- `import-orders.ts`: 1118 → 818 lines.
- Suite: 1241 → 1261 passing (1249 after the first extraction alone, confirmed green before the second commit).

## Left alone, on purpose

A third candidate was spotted during this pass and deliberately not touched: `renderUnattributedRefusal` (~120 lines, already pure, its multi-section layout rules asserted nowhere directly). It gets its own future slice rather than riding along here.

## Test plan

- [x] `pnpm typecheck` clean
- [x] `pnpm test` — commit 1 alone green (1249 passed / 19 skipped), full branch green (1261 passed / 19 skipped)
- [x] `module-graph.test.ts` unmodified and passing

## Review round — two mutations escaped the new suite, and no longer do

The point of this PR is the tests, so the review mutation-tested them. Two mutations **escaped**, plus two cleanups. All four are fixed.

- **`appendKey` did not hold `kind`.** Dropping `${record.kind} ` from *both* branches left all 8 append-filter tests green — including the one titled "KEEPS `kind` LOAD-BEARING", which compares a placement to an observation. Those go down different branches, whose third components are a fill figure and a `YYYY-MM-DDTHH:MM:SS` stamp; they cannot collide whatever the first component is. That test is retitled to what it really pins. The rule `kind` *does* guard needs two records on the **same** branch — a placement and a cancellation of the same rung at the same second, which one export makes ordinary rather than exotic — and now has its own test. Without `kind` those key identically, a fresh placement is filtered out as a supposed repeat, and `reportOrdersImport` reports it as already-known: silent loss reported as success.
- **The `claim.differences.length !== 1` guard was unpinned.** Removing it left all 12 classifier tests green — the descriptor test reads like cover for it but exits one branch earlier and never reaches the line. The guard is written for a sixth `ClaimDifference` field, which does not exist yet, so a test is the only thing that can hold it against the future it was written for. New test carries a safe fill plus an unrecognised `postOnly` difference and asserts `amended`, not `restated`; its one cast is confined to the fixture line, since widening the engine's closed union to make a test compile would be the worse trade.
- **Cleanup — the overlap assertion's two `!`s** are replaced by a narrowing that carries its own type evidence. A test must not suppress the possibility it exists to rule out.
- **Cleanup — the dead `?? 0`** is gone from `atVenue: row.quantity - row.filledQuantity`. `BitgetOpenOrder.filledQuantity` is required and non-nullable, so it could never fire, and it implied doubt exactly where this module's arithmetic needs certainty. A real absence is a parse problem. Recorded in the docstring.

**Both new tests are mutation-confirmed independently:** dropping `kind` from `appendKey` fails the new `kind` test (1 failed / 8 passed); removing the length guard fails the new unrecognised-difference test (1 failed / 12 passed). Both mutations reverted — the branch holds no mutation.

- [x] `pnpm typecheck` clean across all six packages
- [x] `pnpm test` — **1261 → 1263 passing** / 19 skipped (100 files passed / 3 skipped)

Closes #213

