### PR TITLE
Extract renderUnattributedRefusal so its multi-section layout rules are assertable

### DIFF
--- a/apps/tui/src/import-orders-unattributed-refusal.test.ts
+++ b/apps/tui/src/import-orders-unattributed-refusal.test.ts
@@ -267,6 +267,25 @@ describe("SECTION ORDER — nothing compared positions before this file", () => 
     expect(mismatchAt).toBeGreaterThanOrEqual(0);
     expect(unfundableAt).toBeLessThan(mismatchAt);
   });
+
+  it("puts a fallback section LAST, after both classes the renderer knows", () => {
+    // The known classes lead because their advice is actionable; the fallback admits the
+    // renderer has no section for the reason and must not displace either.
+    const unmatched = [
+      unknownReason(orderId("1000"), "reserve-paper", "dangling-account"),
+      mismatched(orderId("1100"), "reserve-mxn"),
+      unfundable(orderId("1200"), "reserve-paper"),
+    ];
+
+    const refusal = renderUnattributedRefusal(unmatched, allOf(unmatched));
+
+    expect(refusal.indexOf("  unfundable reserve —")).toBeLessThan(
+      refusal.indexOf("  currency mismatch —"),
+    );
+    expect(refusal.indexOf("  currency mismatch —")).toBeLessThan(
+      refusal.indexOf("  dangling-account —"),
+    );
+  });
 });
 
 describe("LABEL → ADVICE → RUNGS inside a section — a comment was the only thing holding it", () => {
@@ -312,5 +331,108 @@ describe("LABEL → ADVICE → RUNGS inside a section — a comment was the only
     expect(refusal.indexOf("    Cross-currency funding is not supported")).toBeLessThan(
       refusal.indexOf(`      ${orderId("1000")}`),
     );
+  });
+});
+
+/**
+ * A rung carrying a reason the renderer has no section for — the THIRD
+ * `UnmatchedReason` that does not exist yet.
+ *
+ * THE CAST IS THE POINT AND IS AS NARROW AS IT CAN BE. `UnmatchedReason` is a closed
+ * union of two members, so the type system cannot express a third — expressing it
+ * honestly would mean widening the engine's union, putting a member into production types
+ * purely to make a test compile. The cast is confined to this one fixture helper and
+ * asserts nothing about behaviour; the assertions below do that.
+ *
+ * The premise is live rather than theoretical: splitting `unfundable-reserve` into its
+ * three causes — paper mode, unsupported currency, dangling account — is a change
+ * `UnmatchedReason` needs no new shape for.
+ */
+function unknownReason(id: string, fundingReserveId: string, token: string): UnmatchedRung {
+  return { rung: rung(id, fundingReserveId), reason: token } as unknown as UnmatchedRung;
+}
+
+describe("the `default: never` fallback — unreachable by types, so nothing reached it", () => {
+  it("NAMES THE UNKNOWN REASON UNDER ITS RAW TOKEN and lists its rungs", () => {
+    // Degrading honestly is the fallback's whole job. It does NOT throw, unlike
+    // `foldEvents`'s latch: the message IS the deliverable here, and `import-orders-cli.ts`
+    // would collapse a throw into one bare error line — losing every rung the operator was
+    // owed, to protect them from a rendering gap. Degrade the section, never the refusal.
+    const known = orderId("1000");
+    const unknown = orderId("1100");
+    const unmatched = [
+      unfundable(known, "reserve-paper"),
+      unknownReason(unknown, "reserve-ghost", "dangling-account"),
+    ];
+
+    const refusal = renderUnattributedRefusal(unmatched, allOf(unmatched));
+
+    expect(refusal).toContain(
+      "  dangling-account — 1 rung\n" +
+        "    This refusal has no section for that reason; it is named as the engine\n" +
+        "    gave it, so no rung counted above goes unlisted.\n" +
+        `      ${unknown}`,
+    );
+    // The known rung still renders its own section: one unknown reason does not cost the
+    // operator the classes the renderer DOES know.
+    expect(refusal).toContain("  unfundable reserve — 1 reserve, 1 rung\n");
+    expect(refusal).toContain(`        ${known}`);
+  });
+
+  it("OFFERS NO ADVICE LINE — nothing here knows the remedy for a reason it does not know", () => {
+    const unmatched = [unknownReason(orderId("1000"), "reserve-ghost", "dangling-account")];
+
+    const refusal = renderUnattributedRefusal(unmatched, allOf(unmatched));
+
+    expect(refusal).not.toContain("The fold excluded");
+    expect(refusal).not.toContain("Cross-currency funding is not supported");
+  });
+
+  it("KEEPS THE HEADER COUNT AND THE LISTING IN AGREEMENT — every counted rung is named", () => {
+    // THE MASKING DEFECT THIS GUARDS, and the reason the partition is a SWITCH rather than
+    // two `.filter` calls: the header counts off `unmatched.length` while the body lists
+    // only what the partition matched, so under two filters a third reason was COUNTED AND
+    // NEVER NAMED. That is #179's own defect rebuilt at the render boundary.
+    const ids = [orderId("1000"), orderId("1100"), orderId("1200")];
+    const unmatched = [
+      unfundable(ids[0] as string, "reserve-paper"),
+      mismatched(ids[1] as string, "reserve-mxn"),
+      unknownReason(ids[2] as string, "reserve-ghost", "dangling-account"),
+    ];
+
+    const refusal = renderUnattributedRefusal(unmatched, allOf(unmatched));
+
+    expect(refusal).toContain("3 rungs cannot be placed against a fundable reserve.");
+    for (const id of ids) {
+      expect(refusal).toContain(id);
+    }
+  });
+
+  it("NAMES THE RUNGS OF A HOMOGENEOUS UNKNOWN BATCH — the exact case two filters emptied", () => {
+    // Under two `.filter` calls this book rendered `sections` EMPTY: a refusal claiming a
+    // rung could not be placed while naming zero rungs. The switch is what stops it, and
+    // this is the fixture that can tell the difference.
+    const ids = [orderId("1000"), orderId("1100")];
+    const unmatched = ids.map((id) => unknownReason(id, "reserve-ghost", "dangling-account"));
+
+    const refusal = renderUnattributedRefusal(unmatched, allOf(unmatched));
+
+    expect(refusal).toContain("2 rungs cannot be placed against a fundable reserve.");
+    expect(refusal).toContain("  dangling-account — 2 rungs\n");
+    expect(refusal).toContain(`      ${ids[0] as string}\n      ${ids[1] as string}`);
+  });
+
+  it("groups the rungs of DIFFERENT unknown reasons under their own tokens", () => {
+    // One bucket per raw token, so two unrelated future reasons are not fused into a
+    // section whose label is true of only half its rungs.
+    const unmatched = [
+      unknownReason(orderId("1000"), "reserve-ghost", "dangling-account"),
+      unknownReason(orderId("1100"), "reserve-ghost", "unsupported-currency"),
+    ];
+
+    const refusal = renderUnattributedRefusal(unmatched, allOf(unmatched));
+
+    expect(refusal).toContain("  dangling-account — 1 rung\n");
+    expect(refusal).toContain("  unsupported-currency — 1 rung\n");
   });
 });

--- a/apps/tui/src/import-orders-unattributed-refusal.test.ts
+++ b/apps/tui/src/import-orders-unattributed-refusal.test.ts
@@ -436,3 +436,57 @@ describe("the `default: never` fallback — unreachable by types, so nothing rea
     expect(refusal).toContain("  unsupported-currency — 1 rung\n");
   });
 });
+
+/**
+ * Every line of `refusal`, with its length, for the ones that do not fit `width`.
+ *
+ * Reported as `line N (M cols): <text>` rather than as a bare boolean, because a failure
+ * here is a re-wrapping job and the only useful thing to hand back is WHICH line and how
+ * far over it ran.
+ */
+function overWide(refusal: string, width = 80): string[] {
+  return refusal
+    .split("\n")
+    .map((line, index) => ({ line, index }))
+    .filter(({ line }) => line.length > width)
+    .map(({ line, index }) => `line ${index + 1} (${line.length} cols): ${line}`);
+}
+
+describe("80 COLUMNS — no test in this suite measured a line length before this one", () => {
+  it("keeps every line of the widest refusal it can render inside 80 columns", () => {
+    // The renderer's own prose is what is pinned here — the advice paragraphs, the "on
+    // file" legend, and the closing balances paragraph #202's review re-wrapped at 72/71/19
+    // because it was the one paragraph that wrapped on an 80-column terminal, which is the
+    // worst place to spend the reader's attention: it is the paragraph admitting what the
+    // operator has NOT been told.
+    //
+    // Both classes, both plural advice paragraphs, the legend, the markers and the
+    // fallback section all present at once, over REAL synthesized ids — the widest thing
+    // the renderer indents.
+    const unmatched = [
+      unfundable(orderId("1000"), "reserve-paper"),
+      unfundable(orderId("1100"), "reserve-odd"),
+      mismatched(orderId("1200"), "reserve-mxn"),
+      unknownReason(orderId("1300"), "reserve-ghost", "dangling-account"),
+    ];
+
+    expect(overWide(renderUnattributedRefusal(unmatched, NONE))).toEqual([]);
+  });
+
+  it("keeps the SINGULAR advice paragraph and the unmarked layout inside 80 columns too", () => {
+    // The singular paragraph is a different string, not the plural one with an `s` removed,
+    // so it needs its own measurement; and dropping the legend changes which lines are
+    // emitted at all.
+    const unmatched = [unfundable(orderId("1000"), "reserve-paper")];
+
+    expect(overWide(renderUnattributedRefusal(unmatched, allOf(unmatched)))).toEqual([]);
+  });
+
+  it("keeps the mismatch clause inside 80 columns — id, currency and reserve on two lines", () => {
+    // The one clause built from THREE variable-width pieces at once. Kept on two lines
+    // precisely so it fits; a future edit folding it back onto one would fail here.
+    const unmatched = [mismatched(orderId("1200"), "reserve-mxn")];
+
+    expect(overWide(renderUnattributedRefusal(unmatched, NONE))).toEqual([]);
+  });
+});

--- a/apps/tui/src/import-orders-unattributed-refusal.test.ts
+++ b/apps/tui/src/import-orders-unattributed-refusal.test.ts
@@ -1,0 +1,251 @@
+/**
+ * THE ATTRIBUTION REFUSAL'S LAYOUT, ASSERTED DIRECTLY — the reason the renderer left
+ * `import-orders.ts`.
+ *
+ * Every rule below was reachable before only by driving a whole import: a temp dir, a CSV
+ * written to disk, a seeded sidecar, a frozen clock, a scripted prompt and a synthetic
+ * fund review — and each assertion was a `toContain`, a substring found SOMEWHERE in a
+ * thirty-line string. The renderer takes two arrays and returns a string, so it is tested
+ * as one, and the rules are stated on their own terms.
+ *
+ * FOUR OF THEM NOTHING HELD AT ALL, and they are the reason this file exists rather than
+ * a nicety: the `default: never` fallback (unreachable by types, so no end-to-end fixture
+ * can reach it), the ORDER of the sections, the LABEL → ADVICE → RUNGS order inside one,
+ * and the 80-column wrap. No test in this suite measured a line length anywhere before
+ * this one.
+ *
+ * THE THREE END-TO-END TESTS IN `import-orders.test.ts` STAY. They hold that this
+ * renderer is what the `unattributed` branch actually calls and that its output reaches
+ * the operator through `reject()` — a wiring fact no unit test over a pure function can
+ * state. What moves here is the LAYOUT, which never needed the apparatus.
+ *
+ * FIXTURE IDS ARE REALISTIC ON PURPOSE. The renderer's own risk is width, and a real
+ * synthesized order id (`bitget:BTCUSDT:buy:1000:2020-01-01T10:00:00`) is the widest
+ * thing it indents. Ids invented shorter than the real ones would make the 80-column
+ * assertion pass by fixture rather than by the renderer's own wrapping.
+ */
+import type { CommittedRung, UnmatchedRung } from "@numisma/engine";
+import { describe, expect, it } from "vitest";
+import { renderUnattributedRefusal } from "./import-orders-unattributed-refusal.js";
+
+/** A real synthesized id, spelled the way `synthesizeOrderId` spells one. */
+function orderId(price: string, observedAt = "2020-01-01T10:00:00"): string {
+  return `bitget:BTCUSDT:buy:${price}:${observedAt}`;
+}
+
+function rung(id: string, fundingReserveId: string, currency: "USD" | "MXN" = "USD"): CommittedRung {
+  return {
+    orderId: id,
+    observedAt: "2020-01-01T10:00:00",
+    currency,
+    symbol: "BTCUSDT",
+    side: "buy",
+    price: 1000,
+    quantity: 0.1,
+    remainingQuantity: 0.1,
+    fundingReserveId,
+    committed: 100,
+  };
+}
+
+function unfundable(id: string, fundingReserveId: string): UnmatchedRung {
+  return { rung: rung(id, fundingReserveId), reason: "unfundable-reserve" };
+}
+
+function mismatched(id: string, fundingReserveId: string): UnmatchedRung {
+  return { rung: rung(id, fundingReserveId), reason: "currency-mismatch" };
+}
+
+/** Every listed rung is this batch's, so nothing is marked and no legend is owed. */
+function allOf(unmatched: readonly UnmatchedRung[]): ReadonlySet<string> {
+  return new Set(unmatched.map((entry) => entry.rung.orderId));
+}
+
+/** Nothing is this batch's — the whole book came off the sidecar. */
+const NONE: ReadonlySet<string> = new Set<string>();
+
+describe("the header — the count the whole refusal is measured against", () => {
+  it("counts every unplaceable rung, with the noun agreeing", () => {
+    const one = [unfundable(orderId("1000"), "reserve-paper")];
+    expect(renderUnattributedRefusal(one, allOf(one))).toContain(
+      "1 rung cannot be placed against a fundable reserve.\n",
+    );
+
+    const several = [
+      unfundable(orderId("1000"), "reserve-paper"),
+      unfundable(orderId("1100"), "reserve-paper"),
+      mismatched(orderId("1200"), "reserve-mxn"),
+    ];
+    expect(renderUnattributedRefusal(several, allOf(several))).toContain(
+      "3 rungs cannot be placed against a fundable reserve.\n",
+    );
+  });
+});
+
+describe("provenance — which listed rungs are this batch's to re-declare (#202)", () => {
+  it("MARKS A RUNG OFF THE SIDECAR AT END-OF-LINE, and prints the legend that explains it", () => {
+    // Coverage weighs the WHOLE resting book, so a listed rung need not appear in the
+    // export just read. Unmarked, the header count invites a reconciliation against that
+    // export which cannot come out even.
+    const id = orderId("1000");
+    const unmatched = [unfundable(id, "reserve-paper")];
+
+    const refusal = renderUnattributedRefusal(unmatched, NONE);
+
+    expect(refusal).toContain(`        ${id} — on file\n`);
+    expect(refusal).toContain(
+      'Coverage weighs the WHOLE resting book, so rungs marked "on file" below were\n' +
+        "already in the sidecar before this import, not in the export just read.\n",
+    );
+  });
+
+  it("OMITS BOTH THE MARKER AND THE LEGEND when every rung came out of the export just read", () => {
+    // A batch that owes no marker owes no legend for one either — the paragraph is
+    // conditional on there being something to explain, not printed unconditionally.
+    const id = orderId("1000");
+    const unmatched = [unfundable(id, "reserve-paper")];
+
+    const refusal = renderUnattributedRefusal(unmatched, allOf(unmatched));
+
+    expect(refusal).toContain(`        ${id}\n`);
+    expect(refusal).not.toContain("— on file");
+    expect(refusal).not.toContain("Coverage weighs the WHOLE resting book");
+  });
+
+  it("marks per rung, not per batch — a mixed book carries the marker only where it is true", () => {
+    const mine = orderId("1000");
+    const onFile = orderId("1100");
+    const unmatched = [unfundable(mine, "reserve-paper"), unfundable(onFile, "reserve-paper")];
+
+    const refusal = renderUnattributedRefusal(unmatched, new Set([mine]));
+
+    expect(refusal).toContain(`        ${mine}\n`);
+    expect(refusal).toContain(`        ${onFile} — on file\n`);
+  });
+});
+
+describe("the unfundable-reserve section — grouped by RESERVE, because the fix is per reserve", () => {
+  it("dedups to reserve ids and counts BOTH reserves and rungs, with agreeing nouns", () => {
+    const unmatched = [
+      unfundable(orderId("1000"), "reserve-paper"),
+      unfundable(orderId("1100"), "reserve-paper"),
+      unfundable(orderId("1200"), "reserve-odd"),
+    ];
+
+    const refusal = renderUnattributedRefusal(unmatched, allOf(unmatched));
+
+    expect(refusal).toContain("  unfundable reserve — 2 reserves, 3 rungs\n");
+  });
+
+  it("says `this reserve` in the singular and `these reserves` in the plural", () => {
+    // Two advice paragraphs rather than one with a conditional `s`, because the whole
+    // paragraph shifts: "It cannot fund" against "They cannot fund", and "place it"
+    // against "place them".
+    const one = [unfundable(orderId("1000"), "reserve-paper")];
+    expect(renderUnattributedRefusal(one, allOf(one))).toContain(
+      "    The fold excluded this reserve: paper execution mode, an unsupported\n" +
+        "    currency, or a dangling account reference. It cannot fund a live order,\n" +
+        "    and the available-capital report would not be able to place it either.\n",
+    );
+
+    const two = [
+      unfundable(orderId("1000"), "reserve-paper"),
+      unfundable(orderId("1100"), "reserve-odd"),
+    ];
+    expect(renderUnattributedRefusal(two, allOf(two))).toContain(
+      "    The fold excluded these reserves: paper execution mode, an unsupported\n" +
+        "    currency, or a dangling account reference. They cannot fund a live order,\n" +
+        "    and the available-capital report would not be able to place them either.\n",
+    );
+  });
+
+  it("lists each reserve in FIRST-APPEARANCE order, its rungs beneath it in the order given", () => {
+    // Nothing is sorted: the rungs' own order survives inside each reserve and across the
+    // reserves, so what the operator reads is the order the engine handed over. The
+    // interleaved fixture is the point — `reserve-odd` first appears BETWEEN two
+    // `reserve-paper` rungs, and grouping must not reorder either.
+    const first = orderId("1000");
+    const middle = orderId("1100");
+    const last = orderId("1200");
+    const unmatched = [
+      unfundable(first, "reserve-paper"),
+      unfundable(middle, "reserve-odd"),
+      unfundable(last, "reserve-paper"),
+    ];
+
+    const refusal = renderUnattributedRefusal(unmatched, allOf(unmatched));
+
+    expect(refusal).toContain(
+      `      reserve-paper\n        ${first}\n        ${last}\n` + `      reserve-odd\n        ${middle}`,
+    );
+  });
+});
+
+describe("the currency-mismatch section — PER RUNG, because the fix is per rung", () => {
+  it("counts rungs only, and never dedups to a reserve", () => {
+    const unmatched = [
+      mismatched(orderId("1000"), "reserve-mxn"),
+      mismatched(orderId("1100"), "reserve-mxn"),
+    ];
+
+    const refusal = renderUnattributedRefusal(unmatched, allOf(unmatched));
+
+    expect(refusal).toContain("  currency mismatch — 2 rungs\n");
+    expect(refusal).not.toContain("reserves,");
+  });
+
+  it("puts the id ALONE on its line and indents the mismatch beneath it", () => {
+    // Not a third layout: it is the shape the unfundable section already uses for a
+    // grouping and its rungs. It is also what keeps the "on file" marker at end-of-line —
+    // the id plus the clause plus the marker do not fit inside 80 columns on one line.
+    const id = orderId("1000");
+    const unmatched = [mismatched(id, "reserve-mxn")];
+
+    const refusal = renderUnattributedRefusal(unmatched, NONE);
+
+    expect(refusal).toContain(
+      "    Cross-currency funding is not supported; fix the declaration.\n" +
+        `      ${id} — on file\n` +
+        "        quoted in USD, declared against reserve-mxn",
+    );
+  });
+});
+
+describe("each section is absent when its class is", () => {
+  it("renders ONE section for a homogeneous book, and does not name the other class", () => {
+    const unmatched = [unfundable(orderId("1000"), "reserve-paper")];
+
+    const refusal = renderUnattributedRefusal(unmatched, allOf(unmatched));
+
+    expect(refusal).toContain("  unfundable reserve — 1 reserve, 1 rung\n");
+    expect(refusal).not.toContain("currency mismatch");
+  });
+
+  it("renders the mismatch section alone when nothing is unfundable", () => {
+    const unmatched = [mismatched(orderId("1000"), "reserve-mxn")];
+
+    const refusal = renderUnattributedRefusal(unmatched, allOf(unmatched));
+
+    expect(refusal).toContain("  currency mismatch — 1 rung\n");
+    expect(refusal).not.toContain("unfundable reserve");
+  });
+});
+
+describe("the closing paragraph — the honest cost of batching, and not droppable", () => {
+  it("says the balances were NOT weighed, and ends on a blank line", () => {
+    // Batching creates the expectation "I have now been told everything", and without this
+    // sentence that expectation is false: `over-committed` never ran, because an
+    // unplaceable rung has no balance to weigh. The trailing newline is the blank line
+    // before `reject()`'s "Nothing was written to …" tail — without it the tail reads as a
+    // continuation of this sentence.
+    const unmatched = [unfundable(orderId("1000"), "reserve-paper")];
+
+    const refusal = renderUnattributedRefusal(unmatched, allOf(unmatched));
+
+    expect(refusal.endsWith(
+      "Reserve balances were NOT weighed: an unplaceable rung has no balance to\n" +
+        "compare against, so a coverage refusal may still follow once every rung\n" +
+        "above is placeable.\n",
+    )).toBe(true);
+  });
+});

--- a/apps/tui/src/import-orders-unattributed-refusal.test.ts
+++ b/apps/tui/src/import-orders-unattributed-refusal.test.ts
@@ -249,3 +249,68 @@ describe("the closing paragraph — the honest cost of batching, and not droppab
     )).toBe(true);
   });
 });
+
+describe("SECTION ORDER — nothing compared positions before this file", () => {
+  it("puts the unfundable section BEFORE the currency-mismatch one", () => {
+    // Every end-to-end assertion is a `toContain`, so the two sections could swap places
+    // without a single test noticing. `indexOf`, not `toContain`, is the whole point here.
+    const unmatched = [
+      mismatched(orderId("1000"), "reserve-mxn"),
+      unfundable(orderId("1100"), "reserve-paper"),
+    ];
+
+    const refusal = renderUnattributedRefusal(unmatched, allOf(unmatched));
+
+    const unfundableAt = refusal.indexOf("  unfundable reserve —");
+    const mismatchAt = refusal.indexOf("  currency mismatch —");
+    expect(unfundableAt).toBeGreaterThanOrEqual(0);
+    expect(mismatchAt).toBeGreaterThanOrEqual(0);
+    expect(unfundableAt).toBeLessThan(mismatchAt);
+  });
+});
+
+describe("LABEL → ADVICE → RUNGS inside a section — a comment was the only thing holding it", () => {
+  it("puts the advice under the LABEL, never after the rungs, with TWO unfundable reserves", () => {
+    // THE CASE WHERE THE ORDERING ACTUALLY MATTERS, and the one a single-reserve fixture
+    // cannot expose: with two reserves, advice-last sits directly under the SECOND
+    // reserve's rungs and reads as advice about that reserve alone. That is what the
+    // prototype exposed and what the grill's one-reserve example could not. Advice under
+    // the label plainly governs everything beneath it.
+    const firstRung = orderId("1000");
+    const secondRung = orderId("1100");
+    const unmatched = [
+      unfundable(firstRung, "reserve-paper"),
+      unfundable(secondRung, "reserve-odd"),
+    ];
+
+    const refusal = renderUnattributedRefusal(unmatched, allOf(unmatched));
+
+    const labelAt = refusal.indexOf("  unfundable reserve — 2 reserves, 2 rungs");
+    const adviceAt = refusal.indexOf("    The fold excluded these reserves");
+    const firstReserveAt = refusal.indexOf("      reserve-paper");
+    const secondReserveAt = refusal.indexOf("      reserve-odd");
+    expect(labelAt).toBeGreaterThanOrEqual(0);
+    expect(adviceAt).toBeGreaterThanOrEqual(0);
+    expect(labelAt).toBeLessThan(adviceAt);
+    expect(adviceAt).toBeLessThan(firstReserveAt);
+    expect(firstReserveAt).toBeLessThan(secondReserveAt);
+    // And the advice is not repeated per reserve — it is one paragraph governing both.
+    expect(refusal.split("The fold excluded these reserves")).toHaveLength(2);
+  });
+
+  it("puts the mismatch advice under its label too, before the first id", () => {
+    const unmatched = [
+      mismatched(orderId("1000"), "reserve-mxn"),
+      mismatched(orderId("1100"), "reserve-mxn"),
+    ];
+
+    const refusal = renderUnattributedRefusal(unmatched, allOf(unmatched));
+
+    expect(refusal.indexOf("  currency mismatch — 2 rungs")).toBeLessThan(
+      refusal.indexOf("    Cross-currency funding is not supported"),
+    );
+    expect(refusal.indexOf("    Cross-currency funding is not supported")).toBeLessThan(
+      refusal.indexOf(`      ${orderId("1000")}`),
+    );
+  });
+});

--- a/apps/tui/src/import-orders-unattributed-refusal.ts
+++ b/apps/tui/src/import-orders-unattributed-refusal.ts
@@ -1,0 +1,188 @@
+/**
+ * THE ATTRIBUTION REFUSAL, RENDERED — every rung the engine could not place, in the one
+ * message the operator gets (#179, #202).
+ *
+ * IT LEFT `import-orders.ts` FOR THE REASON #211 AND #213 LEFT IT: not length, but that a
+ * correct rule could only be exercised through a WHOLE IMPORT. The three tests that
+ * stood behind this renderer bought their assertions with a temp dir, a CSV on disk, a
+ * seeded sidecar, a frozen clock, a scripted prompt and a synthetic fund review — and
+ * every one of them was a `toContain`, a substring found SOMEWHERE in a thirty-line
+ * string. The function takes two arrays and returns a string; none of that apparatus is
+ * what its rules are about.
+ *
+ * FOUR RULES NOTHING COULD HOLD THROUGH THAT APPARATUS, and they are what the extraction
+ * bought: the `default: never` fallback below (unreachable by types, so no end-to-end
+ * fixture can reach it), the ORDER of the sections, the LABEL → ADVICE → RUNGS order
+ * inside one, and the 80-column wrap the closing paragraph is wrapped for. All four are
+ * argued in the docstring below and now asserted in
+ * `import-orders-unattributed-refusal.test.ts`.
+ *
+ * THE THREE END-TO-END TESTS STAY WHERE THEY ARE. They hold the WIRING — that the
+ * `unattributed` branch calls this and that its output reaches the operator through
+ * `reject()` — which is a fact about `import-orders.ts`, not about this string.
+ */
+import type { UnmatchedRung } from "@numisma/engine";
+import { plural } from "./plural.js";
+
+/**
+ * THE WHOLE ATTRIBUTION REFUSAL, IN ONE PASS — every rung the engine could not place,
+ * grouped by the class whose remedy it shares (#179).
+ *
+ * Reading order inside a section is LABEL → ADVICE → RUNGS, and the ordering is load
+ * bearing rather than cosmetic. Advice last orphans it: with two unfundable reserves it
+ * sits directly under the second reserve's rungs and reads as advice about that reserve
+ * alone, which is what the prototype exposed and the grill's one-reserve example could
+ * not. Advice under the label plainly governs everything beneath it.
+ *
+ * GRANULARITY IS THE ENGINE'S, NOT A RENDERING TASTE, and the two classes differ because
+ * their remedies do. `unfundable-reserve` dedups to RESERVE IDS with its rungs listed
+ * beneath — one declaration fix clears every rung against that reserve. `currency-mismatch`
+ * stays PER RUNG — the fix is per rung. That is the same split the guard used to make in
+ * the engine, moved to where it belongs: the engine now forwards every rung of both
+ * classes and narrows nothing (see `FundingCoverage`).
+ *
+ * EACH SECTION IS ABSENT WHEN ITS CLASS IS, so a homogeneous batch renders one section.
+ * `over-committed` cannot join them, because an unplaceable rung has no balance to weigh —
+ * which is exactly what the closing line says, and why that line is not droppable.
+ * Batching creates the expectation *"I have now been told everything"*, and without that
+ * sentence the expectation is false.
+ *
+ * WHICH IS ALSO WHY THE PARTITION IS A SWITCH AND NOT TWO FILTERS. The header counts off
+ * `unmatched.length` while the body lists only what the partition matched, so under two
+ * `.filter` calls a third {@link UnmatchedReason} was COUNTED AND NEVER NAMED — and with a
+ * homogeneous batch of it, `sections` was empty and the refusal named ZERO rungs while
+ * claiming one could not be placed. That is #179's masking defect rebuilt at the render
+ * boundary, and splitting `unfundable-reserve` into its three causes — paper mode,
+ * unsupported currency, dangling account — is a change `UnmatchedReason` needs no new
+ * shape for, so the premise is a live one.
+ *
+ * TWO LAYERS NOW STOP IT, AND ONLY ONE OF THEM IS THE FIX. The `never` assignment makes a
+ * new member a `pnpm typecheck` failure AT THIS SITE — that is the fix, and it is the only
+ * thing that catches the omission before an operator does. The fallback section is what
+ * the output degrades to if one ever arrives here unhandled anyway: named under its raw
+ * token rather than swallowed, so the count and the listing still agree.
+ */
+export function renderUnattributedRefusal(
+  unmatched: readonly UnmatchedRung[],
+  batchIds: ReadonlySet<string>,
+): string {
+  const unfundable: UnmatchedRung[] = [];
+  const mismatched: UnmatchedRung[] = [];
+  // Raw reason token → the rungs carrying it. Empty in every reachable state.
+  const unclassified = new Map<string, string[]>();
+  for (const entry of unmatched) {
+    switch (entry.reason) {
+      case "unfundable-reserve":
+        unfundable.push(entry);
+        break;
+      case "currency-mismatch":
+        mismatched.push(entry);
+        break;
+      default: {
+        const _never: never = entry.reason;
+        // It does NOT throw, unlike `foldEvents`'s latch. The message IS the deliverable
+        // here, and `import-orders-cli.ts` would collapse a throw into one bare error
+        // line — losing every rung the operator was owed, to protect them from a
+        // rendering gap. Degrade the section, never the refusal.
+        const token: string = _never;
+        const existing = unclassified.get(token);
+        if (existing) existing.push(entry.rung.orderId);
+        else unclassified.set(token, [entry.rung.orderId]);
+      }
+    }
+  }
+
+  // PROVENANCE, PER RUNG (#202 review). `O1` weighs the WHOLE resting book — the sidecar's
+  // existing records plus this batch — so a listed rung need not appear anywhere in the
+  // export the operator just read. Unmarked, the count invited a reconciliation against
+  // that export which could not come out even. The marker is short because these lines
+  // already carry a synthesized id and would wrap; the header spells out what it means.
+  // It marks the LINE, not the id: a marker wedged between an id and the clause that
+  // follows it reads as part of that clause rather than as a note about the rung. Keeping
+  // the marker at end-of-line is why the currency-mismatch section puts the id alone on
+  // its line and indents the mismatch beneath it — end-of-line and inside 80 columns are
+  // both wanted, and the id plus the clause plus the marker do not fit one line.
+  const mark = (line: string, orderId: string): string =>
+    batchIds.has(orderId) ? line : `${line} — on file`;
+  const anyOnFile = unmatched.some((entry) => !batchIds.has(entry.rung.orderId));
+
+  const sections: string[] = [];
+
+  if (unfundable.length > 0) {
+    // First-appearance order, so the rungs' own order survives inside each reserve and
+    // across the reserves — the grouping is stable, and nothing is sorted.
+    const byReserve = new Map<string, string[]>();
+    for (const entry of unfundable) {
+      const existing = byReserve.get(entry.rung.fundingReserveId);
+      if (existing) existing.push(entry.rung.orderId);
+      else byReserve.set(entry.rung.fundingReserveId, [entry.rung.orderId]);
+    }
+    const many = byReserve.size !== 1;
+    const advice = many
+      ? `    The fold excluded these reserves: paper execution mode, an unsupported\n` +
+        `    currency, or a dangling account reference. They cannot fund a live order,\n` +
+        `    and the available-capital report would not be able to place them either.`
+      : `    The fold excluded this reserve: paper execution mode, an unsupported\n` +
+        `    currency, or a dangling account reference. It cannot fund a live order,\n` +
+        `    and the available-capital report would not be able to place it either.`;
+    const listing = [...byReserve].map(
+      ([reserveId, orderIds]) =>
+        `      ${reserveId}\n` +
+        `${orderIds.map((orderId) => mark(`        ${orderId}`, orderId)).join("\n")}`,
+    );
+    sections.push(
+      `  unfundable reserve — ${plural(byReserve.size, "reserve")}, ` +
+        `${plural(unfundable.length, "rung")}\n${advice}\n${listing.join("\n")}`,
+    );
+  }
+
+  if (mismatched.length > 0) {
+    // Id on its own line, its mismatch indented beneath — the shape the unfundable section
+    // already uses for a grouping and its rungs, rather than a third layout for this one.
+    const listing = mismatched.map(
+      (entry) =>
+        `${mark(`      ${entry.rung.orderId}`, entry.rung.orderId)}\n` +
+        `        quoted in ${entry.rung.currency}, declared against ` +
+        `${entry.rung.fundingReserveId}`,
+    );
+    sections.push(
+      `  currency mismatch — ${plural(mismatched.length, "rung")}\n` +
+        `    Cross-currency funding is not supported; fix the declaration.\n` +
+        `${listing.join("\n")}`,
+    );
+  }
+
+  for (const [token, orderIds] of unclassified) {
+    // No advice line: nothing here knows the remedy for a reason it does not know. The
+    // token and the rungs are what can be said honestly, and they are enough to report.
+    sections.push(
+      `  ${token} — ${plural(orderIds.length, "rung")}\n` +
+        `    This refusal has no section for that reason; it is named as the engine\n` +
+        `    gave it, so no rung counted above goes unlisted.\n` +
+        `${orderIds.map((orderId) => mark(`      ${orderId}`, orderId)).join("\n")}`,
+    );
+  }
+
+  return (
+    `${plural(unmatched.length, "rung")} cannot be placed against a fundable reserve.\n` +
+    // Only when there is something to explain: a batch whose every unplaceable rung came
+    // out of the export just read owes the operator no marker and no legend for one.
+    (anyOnFile
+      ? `Coverage weighs the WHOLE resting book, so rungs marked "on file" below were\n` +
+        `already in the sidecar before this import, not in the export just read.\n`
+      : ``) +
+    `\n` +
+    `${sections.join("\n\n")}\n\n` +
+    // Wrapped at 72/71/19 rather than 80/83 (#202 review). Every other line this renderer
+    // emits sits inside 76, and these two were the only ones that did not — so on an
+    // 80-column terminal the one paragraph that admits what the operator has NOT been told
+    // was also the one paragraph that wrapped, which is the worst place to spend the
+    // reader's attention.
+    `Reserve balances were NOT weighed: an unplaceable rung has no balance to\n` +
+    `compare against, so a coverage refusal may still follow once every rung\n` +
+    `above is placeable.\n`
+    // That trailing newline is the blank line before `reject()`'s "Nothing was written to
+    // …" tail. Without it the tail reads as a continuation of the balances sentence —
+    // invisible when the body was one paragraph, plainly wrong now that it is several.
+  );
+}

--- a/apps/tui/src/import-orders.ts
+++ b/apps/tui/src/import-orders.ts
@@ -33,7 +33,6 @@ import {
   type OrderPlacedRecord,
   type OrderRecord,
   type FundReviewData,
-  type UnmatchedRung,
 } from "@numisma/engine";
 import type { OrdersLoad } from "@numisma/preferences";
 import { appendKey, currentClaimKeys } from "./import-orders-append-filter.js";
@@ -43,6 +42,7 @@ import {
   type OrdersImportRecorded,
   type RecordedObservation,
 } from "./import-orders-report.js";
+import { renderUnattributedRefusal } from "./import-orders-unattributed-refusal.js";
 import { plural } from "./plural.js";
 import { renderSkipMessage } from "./skip-message.js";
 
@@ -253,169 +253,6 @@ function reject(
   // be able to mistake a refusal for a quiet no-op.
   io.err(`REFUSED — ${message}\nNothing was written to ${io.ordersPath}.`);
   return { status: "rejected", reason, message };
-}
-
-/**
- * THE WHOLE ATTRIBUTION REFUSAL, IN ONE PASS — every rung the engine could not place,
- * grouped by the class whose remedy it shares (#179).
- *
- * Reading order inside a section is LABEL → ADVICE → RUNGS, and the ordering is load
- * bearing rather than cosmetic. Advice last orphans it: with two unfundable reserves it
- * sits directly under the second reserve's rungs and reads as advice about that reserve
- * alone, which is what the prototype exposed and the grill's one-reserve example could
- * not. Advice under the label plainly governs everything beneath it.
- *
- * GRANULARITY IS THE ENGINE'S, NOT A RENDERING TASTE, and the two classes differ because
- * their remedies do. `unfundable-reserve` dedups to RESERVE IDS with its rungs listed
- * beneath — one declaration fix clears every rung against that reserve. `currency-mismatch`
- * stays PER RUNG — the fix is per rung. That is the same split the guard used to make in
- * the engine, moved to where it belongs: the engine now forwards every rung of both
- * classes and narrows nothing (see `FundingCoverage`).
- *
- * EACH SECTION IS ABSENT WHEN ITS CLASS IS, so a homogeneous batch renders one section.
- * `over-committed` cannot join them, because an unplaceable rung has no balance to weigh —
- * which is exactly what the closing line says, and why that line is not droppable.
- * Batching creates the expectation *"I have now been told everything"*, and without that
- * sentence the expectation is false.
- *
- * WHICH IS ALSO WHY THE PARTITION IS A SWITCH AND NOT TWO FILTERS. The header counts off
- * `unmatched.length` while the body lists only what the partition matched, so under two
- * `.filter` calls a third {@link UnmatchedReason} was COUNTED AND NEVER NAMED — and with a
- * homogeneous batch of it, `sections` was empty and the refusal named ZERO rungs while
- * claiming one could not be placed. That is #179's masking defect rebuilt at the render
- * boundary, and splitting `unfundable-reserve` into its three causes — paper mode,
- * unsupported currency, dangling account — is a change `UnmatchedReason` needs no new
- * shape for, so the premise is a live one.
- *
- * TWO LAYERS NOW STOP IT, AND ONLY ONE OF THEM IS THE FIX. The `never` assignment makes a
- * new member a `pnpm typecheck` failure AT THIS SITE — that is the fix, and it is the only
- * thing that catches the omission before an operator does. The fallback section is what
- * the output degrades to if one ever arrives here unhandled anyway: named under its raw
- * token rather than swallowed, so the count and the listing still agree.
- */
-function renderUnattributedRefusal(
-  unmatched: readonly UnmatchedRung[],
-  batchIds: ReadonlySet<string>,
-): string {
-  const unfundable: UnmatchedRung[] = [];
-  const mismatched: UnmatchedRung[] = [];
-  // Raw reason token → the rungs carrying it. Empty in every reachable state.
-  const unclassified = new Map<string, string[]>();
-  for (const entry of unmatched) {
-    switch (entry.reason) {
-      case "unfundable-reserve":
-        unfundable.push(entry);
-        break;
-      case "currency-mismatch":
-        mismatched.push(entry);
-        break;
-      default: {
-        const _never: never = entry.reason;
-        // It does NOT throw, unlike `foldEvents`'s latch. The message IS the deliverable
-        // here, and `import-orders-cli.ts` would collapse a throw into one bare error
-        // line — losing every rung the operator was owed, to protect them from a
-        // rendering gap. Degrade the section, never the refusal.
-        const token: string = _never;
-        const existing = unclassified.get(token);
-        if (existing) existing.push(entry.rung.orderId);
-        else unclassified.set(token, [entry.rung.orderId]);
-      }
-    }
-  }
-
-  // PROVENANCE, PER RUNG (#202 review). `O1` weighs the WHOLE resting book — the sidecar's
-  // existing records plus this batch — so a listed rung need not appear anywhere in the
-  // export the operator just read. Unmarked, the count invited a reconciliation against
-  // that export which could not come out even. The marker is short because these lines
-  // already carry a synthesized id and would wrap; the header spells out what it means.
-  // It marks the LINE, not the id: a marker wedged between an id and the clause that
-  // follows it reads as part of that clause rather than as a note about the rung. Keeping
-  // the marker at end-of-line is why the currency-mismatch section puts the id alone on
-  // its line and indents the mismatch beneath it — end-of-line and inside 80 columns are
-  // both wanted, and the id plus the clause plus the marker do not fit one line.
-  const mark = (line: string, orderId: string): string =>
-    batchIds.has(orderId) ? line : `${line} — on file`;
-  const anyOnFile = unmatched.some((entry) => !batchIds.has(entry.rung.orderId));
-
-  const sections: string[] = [];
-
-  if (unfundable.length > 0) {
-    // First-appearance order, so the rungs' own order survives inside each reserve and
-    // across the reserves — the grouping is stable, and nothing is sorted.
-    const byReserve = new Map<string, string[]>();
-    for (const entry of unfundable) {
-      const existing = byReserve.get(entry.rung.fundingReserveId);
-      if (existing) existing.push(entry.rung.orderId);
-      else byReserve.set(entry.rung.fundingReserveId, [entry.rung.orderId]);
-    }
-    const many = byReserve.size !== 1;
-    const advice = many
-      ? `    The fold excluded these reserves: paper execution mode, an unsupported\n` +
-        `    currency, or a dangling account reference. They cannot fund a live order,\n` +
-        `    and the available-capital report would not be able to place them either.`
-      : `    The fold excluded this reserve: paper execution mode, an unsupported\n` +
-        `    currency, or a dangling account reference. It cannot fund a live order,\n` +
-        `    and the available-capital report would not be able to place it either.`;
-    const listing = [...byReserve].map(
-      ([reserveId, orderIds]) =>
-        `      ${reserveId}\n` +
-        `${orderIds.map((orderId) => mark(`        ${orderId}`, orderId)).join("\n")}`,
-    );
-    sections.push(
-      `  unfundable reserve — ${plural(byReserve.size, "reserve")}, ` +
-        `${plural(unfundable.length, "rung")}\n${advice}\n${listing.join("\n")}`,
-    );
-  }
-
-  if (mismatched.length > 0) {
-    // Id on its own line, its mismatch indented beneath — the shape the unfundable section
-    // already uses for a grouping and its rungs, rather than a third layout for this one.
-    const listing = mismatched.map(
-      (entry) =>
-        `${mark(`      ${entry.rung.orderId}`, entry.rung.orderId)}\n` +
-        `        quoted in ${entry.rung.currency}, declared against ` +
-        `${entry.rung.fundingReserveId}`,
-    );
-    sections.push(
-      `  currency mismatch — ${plural(mismatched.length, "rung")}\n` +
-        `    Cross-currency funding is not supported; fix the declaration.\n` +
-        `${listing.join("\n")}`,
-    );
-  }
-
-  for (const [token, orderIds] of unclassified) {
-    // No advice line: nothing here knows the remedy for a reason it does not know. The
-    // token and the rungs are what can be said honestly, and they are enough to report.
-    sections.push(
-      `  ${token} — ${plural(orderIds.length, "rung")}\n` +
-        `    This refusal has no section for that reason; it is named as the engine\n` +
-        `    gave it, so no rung counted above goes unlisted.\n` +
-        `${orderIds.map((orderId) => mark(`      ${orderId}`, orderId)).join("\n")}`,
-    );
-  }
-
-  return (
-    `${plural(unmatched.length, "rung")} cannot be placed against a fundable reserve.\n` +
-    // Only when there is something to explain: a batch whose every unplaceable rung came
-    // out of the export just read owes the operator no marker and no legend for one.
-    (anyOnFile
-      ? `Coverage weighs the WHOLE resting book, so rungs marked "on file" below were\n` +
-        `already in the sidecar before this import, not in the export just read.\n`
-      : ``) +
-    `\n` +
-    `${sections.join("\n\n")}\n\n` +
-    // Wrapped at 72/71/19 rather than 80/83 (#202 review). Every other line this renderer
-    // emits sits inside 76, and these two were the only ones that did not — so on an
-    // 80-column terminal the one paragraph that admits what the operator has NOT been told
-    // was also the one paragraph that wrapped, which is the worst place to spend the
-    // reader's attention.
-    `Reserve balances were NOT weighed: an unplaceable rung has no balance to\n` +
-    `compare against, so a coverage refusal may still follow once every rung\n` +
-    `above is placeable.\n`
-    // That trailing newline is the blank line before `reject()`'s "Nothing was written to
-    // …" tail. Without it the tail reads as a continuation of the balances sentence —
-    // invisible when the body was one paragraph, plainly wrong now that it is several.
-  );
 }
 
 /**


### PR DESCRIPTION
Closes #219.

## What moved

`renderUnattributedRefusal` moves out of `apps/tui/src/import-orders.ts` into `apps/tui/src/import-orders-unattributed-refusal.ts`, byte-identical apart from `function` → `export function`. Its ~40-line docstring — the #179 batching argument, the #202 provenance-marker reasoning, the two-layers-only-one-is-the-fix note about the `never` assignment — carries whole, not summarized, plus a new module docstring. `import-orders.ts` drops the call site to an import and the now-unused `UnmatchedRung` type import.

**Byte-identity proof:** the moved region diffed against `git show aeafe40:apps/tui/src/import-orders.ts` differs on exactly one line — the added `export`.

## The deliverable — four rules nothing held before

Re-homing the three end-to-end tests' coverage is the floor; the point of the issue is what they could not reach:

1. **The `default: never` fallback** — unreachable by types, since `UnmatchedReason` is a closed two-member union. `unknownReason` casts one rung to a reason token, confined to a single fixture helper; the assertions prove the fallback names the reason honestly, orders it last, offers no advice, and — the direct rebuild of #179's masking defect at the render boundary — keeps the header count and the listing in agreement.
2. **Section ordering** — every prior assertion was `toContain`, which compares no positions. `indexOf` now pins the unfundable section before the currency-mismatch one, and a fallback section last.
3. **LABEL → ADVICE → RUNGS inside a section** — a comment was the only thing holding this. Tested with two reserves specifically, since a single-reserve fixture can't expose advice-last reading as advice about only the second reserve.
4. **The 80-column wrap** — no test in this suite measured a line length anywhere before this. `overWide` reports which line and how far over, run against the widest refusal the renderer can build: both classes, both plural advice paragraphs, the legend, the markers, and the fallback section all present at once, over real synthesized ids.

## Standing terms met

- **Zero behavior change.** Operator-facing strings moved byte-identical; no existing test or snapshot was touched.
- `git diff --stat` on `apps/tui/src/import-orders.test.ts` and `apps/tui/src/module-graph.test.ts` against `main` is empty — neither file was modified.
- The three end-to-end tests in `import-orders.test.ts` stay as-is: they hold that this renderer is what the `unattributed` branch actually calls and that its output reaches the operator through `reject()` — a wiring fact no unit test over a pure function can state.
- The existing docstring moved with the function rather than being summarized.

## Numbers

- Suite: 1263 passed / 19 skipped → **1287 passed / 19 skipped**, 101 test files.
- `apps/tui/src/import-orders.ts`: 818 → 656 lines.
- `pnpm typecheck` and `pnpm test` both clean at every one of the four commits in this PR, not just at the tip.

## Two honest notes

- **Residual risk, named not hidden:** the 80-column assertion is scoped to the renderer's own prose. A longer symbol — a 12-character pair instead of `BTCUSDT` — plus the 8-space indent and ` — on file` would cross 80. That's a property of the synthesized id, not of the renderer's wrapping, so it isn't guarded here.
- **A fourth extraction candidate was found and deliberately not folded in:** `describeMerge` (the merged-claim operator line, `apps/tui/src/import-orders.ts:258`) — pure, single call site, same shape. It gets its own issue, per #219's own "if a fourth candidate is found while doing this, it gets its own issue rather than riding along."
