### PR TITLE
feat(tui): widen the operator wrap budget to 100 columns and extract the merge notice

### DIFF
--- a/apps/tui/src/import-orders-merge-notice.test.ts
+++ b/apps/tui/src/import-orders-merge-notice.test.ts
@@ -1,0 +1,117 @@
+/**
+ * THE MERGE NOTICE, ASSERTED DIRECTLY — the one line that tells the operator two export
+ * rows were summed into a single claim (#174, #221).
+ *
+ * WHY THIS FILE EXISTS AT ALL: the notice had a test before this one, and most of it did
+ * not bite. `import-orders.test.ts`'s "REPORTS the merge to the operator, naming both
+ * quantities and the total" asserted `toContain("1")` and `toContain("2")` against a
+ * string containing the price `1000` and the stamp `2020-01-01T10:00:00` — so both were
+ * satisfied by digits that are not quantities at all. Proved by mutation, not reasoned
+ * about: deleting `(${quantities.join(" + ")})` from the renderer left that test green,
+ * and so did deleting the symbol and the side outright.
+ *
+ * THE BAR HERE IS MUTATION, NOT COVERAGE. Every assertion below was run against a
+ * renderer mutated to remove the thing that assertion names, and every one of them went
+ * red. Anything that survived its own mutation was rewritten until it did not.
+ *
+ * FIXTURE VALUES ARE CHOSEN TO BE UNCONFUSABLE. The digits of the price, the stamp and
+ * the quantities do not overlap by accident here, and the assertions are structural
+ * (`ONE claim of 18`, `(7 + 11)`) rather than bare substrings, so neither this file nor
+ * a later reader can mistake a coincidence for a claim.
+ *
+ * ASSERTIONS READ THE FLATTENED STRING. A phrase this file names may straddle a line
+ * break once the renderer's prose is wrapped, so `flat()` collapses whitespace runs and
+ * every assertion below states a CONTENT rule and nothing about where lines end.
+ *
+ * THE END-TO-END TEST STAYS. `import-orders.test.ts` keeps the WIRING claim — that a
+ * colliding batch produces a merge notice on the `out` channel — which is a fact about
+ * `import-orders.ts` and not about this string.
+ */
+import { describe, expect, it } from "vitest";
+import type { MergedOrderClaim } from "@numisma/engine";
+import { describeMerge } from "./import-orders-merge-notice.js";
+
+/** Two rows the venue rendered under one id. The shape every fixture in the suite had. */
+const TWO_ROWS: MergedOrderClaim = {
+  id: "ETHUSDT:sell:1234.5:2020-03-04T05:06:07.000Z",
+  price: 1234.5,
+  observedAt: "2020-03-04T05:06:07.000Z",
+  symbol: "ETHUSDT",
+  side: "sell",
+  quantities: [7, 11],
+  mergedQuantity: 18,
+};
+
+/**
+ * THREE rows — the case `mergeCollidingClaims` sums ("two or more", an unbounded array)
+ * and that no fixture in this repo exercised before #221. It renders a different listing
+ * AND a different count, which is exactly why it is here.
+ */
+const THREE_ROWS: MergedOrderClaim = {
+  id: "ETHUSDT:sell:1234.5:2020-03-04T05:06:07.000Z",
+  price: 1234.5,
+  observedAt: "2020-03-04T05:06:07.000Z",
+  symbol: "ETHUSDT",
+  side: "sell",
+  quantities: [1, 2, 4],
+  mergedQuantity: 7,
+};
+
+/** Whitespace runs collapsed, so a content assertion is not also a wrapping assertion. */
+function flat(notice: string): string {
+  return notice.replace(/\s+/g, " ");
+}
+
+describe("the arithmetic the operator is owed", () => {
+  it("renders BOTH quantities as the sum that was applied, not merely somewhere in the line", () => {
+    // The assertion the old e2e test's title claimed and did not make: `toContain("7")`
+    // would be satisfied by the stamp's `07`, so the listing is asserted as a listing.
+    expect(flat(describeMerge(TWO_ROWS))).toContain("(7 + 11)");
+  });
+
+  it("renders THREE quantities as one chain — the unbounded case nothing exercised", () => {
+    expect(flat(describeMerge(THREE_ROWS))).toContain("(1 + 2 + 4)");
+  });
+
+  it("names the merged total as the size of the single surviving claim", () => {
+    // Anchored on `ONE claim of` so a bare `18` elsewhere could not satisfy it.
+    expect(flat(describeMerge(TWO_ROWS))).toContain("ONE claim of 18");
+    expect(flat(describeMerge(THREE_ROWS))).toContain("ONE claim of 7");
+  });
+
+  it("counts the rows, and the count AGREES with the listing it counts", () => {
+    // Two fields, rendered a clause apart: `${quantities.length} rows` counts one thing
+    // and `(${quantities.join(" + ")})` lists another. Nothing held them together.
+    for (const merge of [TWO_ROWS, THREE_ROWS]) {
+      const match = /(\d+) rows sharing one id \(([^)]*)\)/.exec(flat(describeMerge(merge)));
+      expect(match).not.toBeNull();
+      const [, counted, listed] = match ?? [];
+      expect(Number(counted)).toBe(merge.quantities.length);
+      expect(listed?.split(" + ")).toHaveLength(merge.quantities.length);
+    }
+  });
+});
+
+describe("WHICH claim was merged — the rung has to be identifiable", () => {
+  it("names the symbol and the side, adjacent, in the header", () => {
+    // Deleting either from the renderer left the old e2e test green. Asserted here as
+    // the header they actually form, so neither can go missing unnoticed.
+    expect(flat(describeMerge(TWO_ROWS))).toContain("MERGED — ETHUSDT sell at");
+  });
+
+  it("names the price the two rows agreed on", () => {
+    expect(flat(describeMerge(TWO_ROWS))).toContain("sell at 1234.5,");
+  });
+
+  it("names the second the venue stamped, so the collision is locatable in the export", () => {
+    expect(flat(describeMerge(TWO_ROWS))).toContain("submitted 2020-03-04T05:06:07.000Z");
+  });
+});
+
+describe("the remedy, which is the operator's to apply and not ours", () => {
+  it("says how to keep two genuinely distinct rungs distinct next time", () => {
+    expect(flat(describeMerge(TWO_ROWS))).toContain(
+      "re-place one a tick apart so their prices differ",
+    );
+  });
+});

--- a/apps/tui/src/import-orders-merge-notice.test.ts
+++ b/apps/tui/src/import-orders-merge-notice.test.ts
@@ -1,6 +1,6 @@
 /**
- * THE MERGE NOTICE, ASSERTED DIRECTLY — the one line that tells the operator two export
- * rows were summed into a single claim (#174, #221).
+ * THE MERGE NOTICE, ASSERTED DIRECTLY — the operator's only word that two export rows
+ * sharing one id were summed into a single claim (#174, #221).
  *
  * WHY THIS FILE EXISTS AT ALL: the notice had a test before this one, and most of it did
  * not bite. `import-orders.test.ts`'s "REPORTS the merge to the operator, naming both
@@ -113,5 +113,54 @@ describe("the remedy, which is the operator's to apply and not ours", () => {
     expect(flat(describeMerge(TWO_ROWS))).toContain(
       "re-place one a tick apart so their prices differ",
     );
+  });
+});
+
+/**
+ * THE WRAP BUDGET (#221), the same 100 `import-orders-unattributed-refusal.test.ts`
+ * asserts. This notice used to be ONE unbroken ~450-character line, so every terminal
+ * soft-wrapped it at a column nothing chose; the prose is now hard-wrapped at 88.
+ */
+const BUDGET = 100;
+
+/** Every line that does not fit, named with its width — a failure here is a re-wrap job. */
+function overWide(notice: string, width = BUDGET): string[] {
+  return notice
+    .split("\n")
+    .map((line, index) => ({ line, index }))
+    .filter(({ line }) => line.length > width)
+    .map(({ line, index }) => `line ${index + 1} (${line.length} cols): ${line}`);
+}
+
+describe(`${BUDGET} COLUMNS — nothing measured this line's length before`, () => {
+  it(`keeps every line inside ${BUDGET} columns for a realistic collision`, () => {
+    expect(overWide(describeMerge(TWO_ROWS))).toEqual([]);
+    expect(overWide(describeMerge(THREE_ROWS))).toEqual([]);
+  });
+
+  it("keeps the FIXED PROSE inside the budget no matter how wide the claim is", () => {
+    // The prose is the part a budget can actually govern, so it is the part asserted.
+    // Lines 1-3 are built from the symbol, the stamp and an unbounded `quantities`; no
+    // wrap width can promise those fit, and the docstring says so rather than pretending.
+    const wide = describeMerge({
+      ...TWO_ROWS,
+      symbol: "SOMELONGSYMBOL",
+      price: 123456.789,
+      quantities: [0.1234, 0.2345, 0.3456, 0.4567, 0.5678, 0.6789],
+      mergedQuantity: 2.4069,
+    });
+    expect(overWide(wide.split("\n").slice(3).join("\n"))).toEqual([]);
+  });
+
+  it("keeps the TOTAL on its own line, so a wide listing never soft-wraps it away", () => {
+    // The reliability claim behind the split: `quantities` is unbounded and the total is
+    // not, so the total must not share a line with it. Six rows at four decimals is 113
+    // columns of listing — and the total still arrives intact on a line of its own.
+    const wide = describeMerge({
+      ...TWO_ROWS,
+      quantities: [0.1234, 0.2345, 0.3456, 0.4567, 0.5678, 0.6789],
+      mergedQuantity: 2.4069,
+    });
+    expect(wide.split("\n")).toContain("were summed into ONE claim of 2.4069.");
   });
 });

--- a/apps/tui/src/import-orders-merge-notice.ts
+++ b/apps/tui/src/import-orders-merge-notice.ts
@@ -26,19 +26,41 @@
 import type { MergedOrderClaim } from "@numisma/engine";
 
 /**
- * The operator-facing line for one merged claim — FIRST-CLASS output, not an aside.
+ * The operator-facing notice for one merged claim — FIRST-CLASS output, not an aside.
  *
  * Two rows the venue rendered under one id have been summed, and the operator is owed
  * the whole arithmetic: which rung, at what second, both sizes, the total that will be
  * written, and the remedy if the two were meant to stay distinct claims.
+ *
+ * WRAPPED, WHICH IT WAS NOT (#221). This emitted ONE unbroken ~450-character line, so
+ * every terminal soft-wrapped it at a column nothing here chose — mid-word, mid-number,
+ * and differently on every screen. The budget is 100 and the prose is hard-wrapped at
+ * 88, the same target `renderUnattributedRefusal` now uses, so the two renderers of this
+ * flow do not disagree about how wide the operator's terminal is.
+ *
+ * THE FIRST THREE LINES ARE THE VARIABLE ONES and the last three are fixed prose. The
+ * header carries the symbol, the side, the price and the stamp; the second carries the
+ * row count and EVERY quantity; the third carries the total.
+ *
+ * THE TOTAL IS ON ITS OWN LINE BECAUSE THE LISTING ABOVE IT IS UNBOUNDED. `quantities`
+ * has no ceiling — six rows at four decimals measures 113 columns, past any budget a
+ * terminal offers — so no wrap width can promise that line fits. What CAN be promised is
+ * which line pays for the overflow: with the listing and the total on one line, a wide
+ * collision soft-wraps away the single number the operator most needs; split, the worst
+ * case soft-wraps a list of sizes the operator can still read, and `ONE claim of N`
+ * arrives intact every time.
+ *
+ * THE REMEDY GETS ITS OWN LINE, because it is the one sentence here that asks the
+ * operator to DO something. Everything above it explains a decision already applied.
  */
 export function describeMerge(merge: MergedOrderClaim): string {
   return (
-    `MERGED — ${merge.symbol} ${merge.side} at ${merge.price}, submitted ${merge.observedAt}: ` +
-    `${merge.quantities.length} rows sharing one id (${merge.quantities.join(" + ")}) were ` +
-    `summed into ONE claim of ${merge.mergedQuantity}. The venue's export carries no order ` +
-    `id, and these rows agree on every field identity is built from, so the sum is the only ` +
-    `reading that neither invents a second claim nor frees committed capital. To keep two ` +
-    `rungs distinct, re-place one a tick apart so their prices differ.`
+    `MERGED — ${merge.symbol} ${merge.side} at ${merge.price}, submitted ${merge.observedAt}:\n` +
+    `${merge.quantities.length} rows sharing one id (${merge.quantities.join(" + ")})\n` +
+    `were summed into ONE claim of ${merge.mergedQuantity}.\n` +
+    `The venue's export carries no order id, and these rows agree on every field identity is\n` +
+    `built from, so the sum is the only reading that neither invents a second claim nor frees\n` +
+    `committed capital.\n` +
+    `To keep two rungs distinct, re-place one a tick apart so their prices differ.`
   );
 }

--- a/apps/tui/src/import-orders-merge-notice.ts
+++ b/apps/tui/src/import-orders-merge-notice.ts
@@ -1,0 +1,44 @@
+/**
+ * THE MERGE NOTICE — the operator's only word that two export rows sharing one
+ * synthesized id were summed into a single claim (#174, #221).
+ *
+ * IT LEFT `import-orders.ts` FOR THE REASON #211, #213 AND #219 LEFT IT, and for one
+ * sharper reason of its own. The others were rules that could only be exercised through
+ * a whole import; this one had a test whose assertions did not hold what its title
+ * claimed. `toContain("1")` and `toContain("2")`, named in that test as "both
+ * quantities", were satisfied by the price `1000` and by the `2020` in the stamp — and
+ * deleting the quantities, the symbol and the side from this string left it green. The
+ * function takes one plain record and returns a string; none of the temp dir, the CSV on
+ * disk, the seeded sidecar or the scripted prompt behind that test is what its rules are
+ * about.
+ *
+ * WHAT THE EXTRACTION BUYS, now asserted in `import-orders-merge-notice.test.ts`: both
+ * quantities rendered as the `a + b` arithmetic rather than merely present; the merged
+ * total; the symbol; the side; the price; the stamp; the remedy; the agreement between
+ * the row COUNT and the listing it counts — two different fields, rendered a clause
+ * apart, that nothing held together; and the three-or-more-row collision that
+ * `mergeCollidingClaims` sums but no fixture in this repo had ever built.
+ *
+ * THE END-TO-END TEST STAYS WHERE IT IS, narrowed to the WIRING — that the merge branch
+ * calls this and that its output reaches the operator on the `out` channel. That is a
+ * fact about `import-orders.ts`, and no unit test over a pure function can make it.
+ */
+import type { MergedOrderClaim } from "@numisma/engine";
+
+/**
+ * The operator-facing line for one merged claim — FIRST-CLASS output, not an aside.
+ *
+ * Two rows the venue rendered under one id have been summed, and the operator is owed
+ * the whole arithmetic: which rung, at what second, both sizes, the total that will be
+ * written, and the remedy if the two were meant to stay distinct claims.
+ */
+export function describeMerge(merge: MergedOrderClaim): string {
+  return (
+    `MERGED — ${merge.symbol} ${merge.side} at ${merge.price}, submitted ${merge.observedAt}: ` +
+    `${merge.quantities.length} rows sharing one id (${merge.quantities.join(" + ")}) were ` +
+    `summed into ONE claim of ${merge.mergedQuantity}. The venue's export carries no order ` +
+    `id, and these rows agree on every field identity is built from, so the sum is the only ` +
+    `reading that neither invents a second claim nor frees committed capital. To keep two ` +
+    `rungs distinct, re-place one a tick apart so their prices differ.`
+  );
+}

--- a/apps/tui/src/import-orders-unattributed-refusal.test.ts
+++ b/apps/tui/src/import-orders-unattributed-refusal.test.ts
@@ -11,7 +11,7 @@
  * FOUR OF THEM NOTHING HELD AT ALL, and they are the reason this file exists rather than
  * a nicety: the `default: never` fallback (unreachable by types, so no end-to-end fixture
  * can reach it), the ORDER of the sections, the LABEL → ADVICE → RUNGS order inside one,
- * and the 80-column wrap. No test in this suite measured a line length anywhere before
+ * and the wrap budget. No test in this suite measured a line length anywhere before
  * this one.
  *
  * THE THREE END-TO-END TESTS IN `import-orders.test.ts` STAY. They hold that this
@@ -21,7 +21,7 @@
  *
  * FIXTURE IDS ARE REALISTIC ON PURPOSE. The renderer's own risk is width, and a real
  * synthesized order id (`bitget:BTCUSDT:buy:1000:2020-01-01T10:00:00`) is the widest
- * thing it indents. Ids invented shorter than the real ones would make the 80-column
+ * thing it indents. Ids invented shorter than the real ones would make the width
  * assertion pass by fixture rather than by the renderer's own wrapping.
  */
 import type { CommittedRung, UnmatchedRung } from "@numisma/engine";
@@ -94,8 +94,8 @@ describe("provenance — which listed rungs are this batch's to re-declare (#202
 
     expect(refusal).toContain(`        ${id} — on file\n`);
     expect(refusal).toContain(
-      'Coverage weighs the WHOLE resting book, so rungs marked "on file" below were\n' +
-        "already in the sidecar before this import, not in the export just read.\n",
+      'Coverage weighs the WHOLE resting book, so rungs marked "on file" below were already in\n' +
+        "the sidecar before this import, not in the export just read.\n",
     );
   });
 
@@ -143,9 +143,9 @@ describe("the unfundable-reserve section — grouped by RESERVE, because the fix
     // against "place them".
     const one = [unfundable(orderId("1000"), "reserve-paper")];
     expect(renderUnattributedRefusal(one, allOf(one))).toContain(
-      "    The fold excluded this reserve: paper execution mode, an unsupported\n" +
-        "    currency, or a dangling account reference. It cannot fund a live order,\n" +
-        "    and the available-capital report would not be able to place it either.\n",
+      "    The fold excluded this reserve: paper execution mode, an unsupported currency, or a\n" +
+        "    dangling account reference. It cannot fund a live order, and the available-capital\n" +
+        "    report would not be able to place it either.\n",
     );
 
     const two = [
@@ -153,9 +153,9 @@ describe("the unfundable-reserve section — grouped by RESERVE, because the fix
       unfundable(orderId("1100"), "reserve-odd"),
     ];
     expect(renderUnattributedRefusal(two, allOf(two))).toContain(
-      "    The fold excluded these reserves: paper execution mode, an unsupported\n" +
-        "    currency, or a dangling account reference. They cannot fund a live order,\n" +
-        "    and the available-capital report would not be able to place them either.\n",
+      "    The fold excluded these reserves: paper execution mode, an unsupported currency, or\n" +
+        "    a dangling account reference. They cannot fund a live order, and the available-\n" +
+        "    capital report would not be able to place them either.\n",
     );
   });
 
@@ -243,9 +243,8 @@ describe("the closing paragraph — the honest cost of batching, and not droppab
     const refusal = renderUnattributedRefusal(unmatched, allOf(unmatched));
 
     expect(refusal.endsWith(
-      "Reserve balances were NOT weighed: an unplaceable rung has no balance to\n" +
-        "compare against, so a coverage refusal may still follow once every rung\n" +
-        "above is placeable.\n",
+      "Reserve balances were NOT weighed: an unplaceable rung has no balance to compare\n" +
+        "against, so a coverage refusal may still follow once every rung above is placeable.\n",
     )).toBe(true);
   });
 });
@@ -369,8 +368,8 @@ describe("the `default: never` fallback — unreachable by types, so nothing rea
 
     expect(refusal).toContain(
       "  dangling-account — 1 rung\n" +
-        "    This refusal has no section for that reason; it is named as the engine\n" +
-        "    gave it, so no rung counted above goes unlisted.\n" +
+        "    This refusal has no section for that reason; it is named as the engine gave it, so\n" +
+        "    no rung counted above goes unlisted.\n" +
         `      ${unknown}`,
     );
     // The known rung still renders its own section: one unknown reason does not cost the
@@ -438,13 +437,22 @@ describe("the `default: never` fallback — unreachable by types, so nothing rea
 });
 
 /**
+ * THE WRAP BUDGET (#221). It was 80 and is now 100 — not because the prose was failing
+ * at 80 (it was not; the widest line this renderer emitted measured 77), but because the
+ * lines it indents are built from synthesized order ids of unbounded width, and 80 had
+ * no room to absorb a symbol longer than `BTCUSDT`. The renderer's own prose is wrapped
+ * at 88, so what this asserts is that nothing — prose or id — reaches the budget.
+ */
+const BUDGET = 100;
+
+/**
  * Every line of `refusal`, with its length, for the ones that do not fit `width`.
  *
  * Reported as `line N (M cols): <text>` rather than as a bare boolean, because a failure
  * here is a re-wrapping job and the only useful thing to hand back is WHICH line and how
  * far over it ran.
  */
-function overWide(refusal: string, width = 80): string[] {
+function overWide(refusal: string, width = BUDGET): string[] {
   return refusal
     .split("\n")
     .map((line, index) => ({ line, index }))
@@ -452,13 +460,13 @@ function overWide(refusal: string, width = 80): string[] {
     .map(({ line, index }) => `line ${index + 1} (${line.length} cols): ${line}`);
 }
 
-describe("80 COLUMNS — no test in this suite measured a line length before this one", () => {
-  it("keeps every line of the widest refusal it can render inside 80 columns", () => {
+describe(`${BUDGET} COLUMNS — no test in this suite measured a line length before this one`, () => {
+  it(`keeps every line of the widest refusal it can render inside ${BUDGET} columns`, () => {
     // The renderer's own prose is what is pinned here — the advice paragraphs, the "on
-    // file" legend, and the closing balances paragraph #202's review re-wrapped at 72/71/19
-    // because it was the one paragraph that wrapped on an 80-column terminal, which is the
-    // worst place to spend the reader's attention: it is the paragraph admitting what the
-    // operator has NOT been told.
+    // file" legend, and the closing balances paragraph #202's review re-wrapped because it
+    // was the one paragraph the terminal soft-wrapped, which is the worst place to spend
+    // the reader's attention: it is the paragraph admitting what the operator has NOT been
+    // told. That argument is why the budget moved rather than why it stayed — see #221.
     //
     // Both classes, both plural advice paragraphs, the legend, the markers and the
     // fallback section all present at once, over REAL synthesized ids — the widest thing
@@ -473,7 +481,7 @@ describe("80 COLUMNS — no test in this suite measured a line length before thi
     expect(overWide(renderUnattributedRefusal(unmatched, NONE))).toEqual([]);
   });
 
-  it("keeps the SINGULAR advice paragraph and the unmarked layout inside 80 columns too", () => {
+  it(`keeps the SINGULAR advice paragraph and the unmarked layout inside ${BUDGET} columns too`, () => {
     // The singular paragraph is a different string, not the plural one with an `s` removed,
     // so it needs its own measurement; and dropping the legend changes which lines are
     // emitted at all.
@@ -482,7 +490,7 @@ describe("80 COLUMNS — no test in this suite measured a line length before thi
     expect(overWide(renderUnattributedRefusal(unmatched, allOf(unmatched)))).toEqual([]);
   });
 
-  it("keeps the mismatch clause inside 80 columns — id, currency and reserve on two lines", () => {
+  it(`keeps the mismatch clause inside ${BUDGET} columns — id, currency and reserve on two lines`, () => {
     // The one clause built from THREE variable-width pieces at once. Kept on two lines
     // precisely so it fits; a future edit folding it back onto one would fail here.
     const unmatched = [mismatched(orderId("1200"), "reserve-mxn")];

--- a/apps/tui/src/import-orders-unattributed-refusal.ts
+++ b/apps/tui/src/import-orders-unattributed-refusal.ts
@@ -13,7 +13,7 @@
  * FOUR RULES NOTHING COULD HOLD THROUGH THAT APPARATUS, and they are what the extraction
  * bought: the `default: never` fallback below (unreachable by types, so no end-to-end
  * fixture can reach it), the ORDER of the sections, the LABEL → ADVICE → RUNGS order
- * inside one, and the 80-column wrap the closing paragraph is wrapped for. All four are
+ * inside one, and the wrap budget the closing paragraph is wrapped for. All four are
  * argued in the docstring below and now asserted in
  * `import-orders-unattributed-refusal.test.ts`.
  *
@@ -100,8 +100,10 @@ export function renderUnattributedRefusal(
   // It marks the LINE, not the id: a marker wedged between an id and the clause that
   // follows it reads as part of that clause rather than as a note about the rung. Keeping
   // the marker at end-of-line is why the currency-mismatch section puts the id alone on
-  // its line and indents the mismatch beneath it — end-of-line and inside 80 columns are
-  // both wanted, and the id plus the clause plus the marker do not fit one line.
+  // its line and indents the mismatch beneath it — end-of-line and inside the budget are
+  // both wanted, and the id plus the clause plus the marker do not fit one line. That was
+  // true at 80 and is still true at 100: the pieces are three variable-width ids, and no
+  // budget a terminal offers makes their concatenation safe to assume.
   const mark = (line: string, orderId: string): string =>
     batchIds.has(orderId) ? line : `${line} — on file`;
   const anyOnFile = unmatched.some((entry) => !batchIds.has(entry.rung.orderId));
@@ -119,12 +121,12 @@ export function renderUnattributedRefusal(
     }
     const many = byReserve.size !== 1;
     const advice = many
-      ? `    The fold excluded these reserves: paper execution mode, an unsupported\n` +
-        `    currency, or a dangling account reference. They cannot fund a live order,\n` +
-        `    and the available-capital report would not be able to place them either.`
-      : `    The fold excluded this reserve: paper execution mode, an unsupported\n` +
-        `    currency, or a dangling account reference. It cannot fund a live order,\n` +
-        `    and the available-capital report would not be able to place it either.`;
+      ? `    The fold excluded these reserves: paper execution mode, an unsupported currency, or\n` +
+        `    a dangling account reference. They cannot fund a live order, and the available-\n` +
+        `    capital report would not be able to place them either.`
+      : `    The fold excluded this reserve: paper execution mode, an unsupported currency, or a\n` +
+        `    dangling account reference. It cannot fund a live order, and the available-capital\n` +
+        `    report would not be able to place it either.`;
     const listing = [...byReserve].map(
       ([reserveId, orderIds]) =>
         `      ${reserveId}\n` +
@@ -157,8 +159,8 @@ export function renderUnattributedRefusal(
     // token and the rungs are what can be said honestly, and they are enough to report.
     sections.push(
       `  ${token} — ${plural(orderIds.length, "rung")}\n` +
-        `    This refusal has no section for that reason; it is named as the engine\n` +
-        `    gave it, so no rung counted above goes unlisted.\n` +
+        `    This refusal has no section for that reason; it is named as the engine gave it, so\n` +
+        `    no rung counted above goes unlisted.\n` +
         `${orderIds.map((orderId) => mark(`      ${orderId}`, orderId)).join("\n")}`,
     );
   }
@@ -168,19 +170,20 @@ export function renderUnattributedRefusal(
     // Only when there is something to explain: a batch whose every unplaceable rung came
     // out of the export just read owes the operator no marker and no legend for one.
     (anyOnFile
-      ? `Coverage weighs the WHOLE resting book, so rungs marked "on file" below were\n` +
-        `already in the sidecar before this import, not in the export just read.\n`
+      ? `Coverage weighs the WHOLE resting book, so rungs marked "on file" below were already in\n` +
+        `the sidecar before this import, not in the export just read.\n`
       : ``) +
     `\n` +
     `${sections.join("\n\n")}\n\n` +
-    // Wrapped at 72/71/19 rather than 80/83 (#202 review). Every other line this renderer
-    // emits sits inside 76, and these two were the only ones that did not — so on an
-    // 80-column terminal the one paragraph that admits what the operator has NOT been told
-    // was also the one paragraph that wrapped, which is the worst place to spend the
-    // reader's attention.
-    `Reserve balances were NOT weighed: an unplaceable rung has no balance to\n` +
-    `compare against, so a coverage refusal may still follow once every rung\n` +
-    `above is placeable.\n`
+    // #202'S ARGUMENT, RE-APPLIED AT 100 RATHER THAN OVERWRITTEN (#221). It was never that
+    // 80 was the number. It was that the paragraph admitting what the operator has NOT been
+    // told must not be the one paragraph the terminal soft-wraps — the worst place in the
+    // whole refusal to spend the reader's attention. At 80 that meant 72/71/19 against
+    // prose sitting inside 76. The budget is now 100 and this renderer's prose is wrapped
+    // at 88, so the same rule gives 80/83: still the narrowest paragraph here, still short
+    // of every other line the renderer emits, and now with twelve columns of slack.
+    `Reserve balances were NOT weighed: an unplaceable rung has no balance to compare\n` +
+    `against, so a coverage refusal may still follow once every rung above is placeable.\n`
     // That trailing newline is the blank line before `reject()`'s "Nothing was written to
     // …" tail. Without it the tail reads as a continuation of the balances sentence —
     // invisible when the body was one paragraph, plainly wrong now that it is several.

--- a/apps/tui/src/import-orders.test.ts
+++ b/apps/tui/src/import-orders.test.ts
@@ -1699,9 +1699,8 @@ describe("`O1` — the over-commitment reject (testing decision 6)", () => {
     // The honest cost of batching, and not droppable: `over-committed` never ran, so the
     // operator has NOT been told everything, and one sentence says so.
     expect(refusal).toContain(
-      "Reserve balances were NOT weighed: an unplaceable rung has no balance to\n" +
-        "compare against, so a coverage refusal may still follow once every rung\n" +
-        "above is placeable.",
+      "Reserve balances were NOT weighed: an unplaceable rung has no balance to compare\n" +
+        "against, so a coverage refusal may still follow once every rung above is placeable.",
     );
     // A blank line before `reject()`'s tail, so it does not read as a continuation of the
     // balances sentence.

--- a/apps/tui/src/import-orders.test.ts
+++ b/apps/tui/src/import-orders.test.ts
@@ -15,6 +15,7 @@ import { appendOrders, loadOrders, resolveOrdersPath } from "@numisma/preference
 import {
   BITGET_OPEN_ORDERS_HEADER,
   buildOrderFillObserved,
+  mergeCollidingClaims,
   parseBitgetOpenOrdersCsv,
   parseFundReview,
   pickRestingOrdersAsOf,
@@ -22,6 +23,7 @@ import {
   type OrderRecord,
 } from "@numisma/engine";
 import { afterEach, describe, expect, it } from "vitest";
+import { describeMerge } from "./import-orders-merge-notice.js";
 import { importBitgetOpenOrders, type OrdersImportIo } from "./import-orders.js";
 
 const createdDirs: string[] = [];
@@ -346,23 +348,33 @@ describe("one id identifies exactly ONE claim (#174)", () => {
     expect(await remainingOnDisk(ordersPath)).toEqual([3]);
   });
 
-  it("REPORTS the merge to the operator, naming both quantities and the total", async () => {
+  it("REPORTS the merge to the operator on the NORMAL channel, not silently", async () => {
+    // THE WIRING, AND ONLY THE WIRING (#221). What the notice SAYS — both quantities as
+    // the `a + b` arithmetic, the total, the symbol, the side, the price, the stamp, the
+    // row count and the remedy — is asserted exactly in
+    // `import-orders-merge-notice.test.ts`, over a plain record and without this
+    // apparatus. What only THIS test can hold is that the merge branch calls the
+    // renderer at all and that its output reaches the operator: arithmetic applied on
+    // the `out` channel, never whispered and never routed to `err` as if it were a
+    // warning about something skipped.
     const { csvPath, io, outputs } = await harness({
       csv: COLLIDING_LADDER,
       reserves: [{ id: "reserve-a", amount: 5000 }],
     });
     await importBitgetOpenOrders({ csvPath, io });
 
-    const merge = outputs.find((message) => message.toLowerCase().includes("merged"));
-    expect(merge).toBeDefined();
-    const text = merge ?? "";
-    expect(text).toContain("1000"); // the price
-    expect(text).toContain("2020-01-01T10:00:00"); // the second
-    expect(text).toContain("1"); // the first quantity
-    expect(text).toContain("2"); // the second quantity
-    expect(text).toContain("3"); // the merged total
-    // And how to keep two genuinely separate rungs distinct next time.
-    expect(text).toContain("tick");
+    const notice = outputs.find((message) => message.includes("MERGED"));
+    expect(notice).toBeDefined();
+    // The one content check that stays here, and it is a wiring check: the message on
+    // `out` is THIS renderer applied to THE ENGINE'S OWN merge for this batch, not some
+    // other message that happens to carry the word. Derived rather than transcribed, so
+    // it duplicates none of the notice's content rules.
+    const parsed = parseBitgetOpenOrdersCsv(COLLIDING_LADDER);
+    expect(parsed.status).toBe("ok");
+    if (parsed.status !== "ok") return;
+    const { merges } = mergeCollidingClaims(parsed.orders);
+    expect(merges).toHaveLength(1);
+    expect(notice).toContain(describeMerge(merges[0]!));
   });
 
   it("puts the SUMMED claim in front of `O1`, so an over-committed batch is caught", async () => {

--- a/apps/tui/src/import-orders.ts
+++ b/apps/tui/src/import-orders.ts
@@ -28,7 +28,6 @@ import {
   pickRestingOrdersAsOf,
   type BitgetOpenOrder,
   type BitgetRowSkip,
-  type MergedOrderClaim,
   type OrderFillObservedRecord,
   type OrderPlacedRecord,
   type OrderRecord,
@@ -37,6 +36,7 @@ import {
 import type { OrdersLoad } from "@numisma/preferences";
 import { appendKey, currentClaimKeys } from "./import-orders-append-filter.js";
 import { partitionChangedClaims, weighRemainders } from "./import-orders-changed-claims.js";
+import { describeMerge } from "./import-orders-merge-notice.js";
 import {
   reportOrdersImport,
   type OrdersImportRecorded,
@@ -253,24 +253,6 @@ function reject(
   // be able to mistake a refusal for a quiet no-op.
   io.err(`REFUSED — ${message}\nNothing was written to ${io.ordersPath}.`);
   return { status: "rejected", reason, message };
-}
-
-/**
- * The operator-facing line for one merged claim — FIRST-CLASS output, not an aside.
- *
- * Two rows the venue rendered under one id have been summed, and the operator is owed
- * the whole arithmetic: which rung, at what second, both sizes, the total that will be
- * written, and the remedy if the two were meant to stay distinct claims.
- */
-function describeMerge(merge: MergedOrderClaim): string {
-  return (
-    `MERGED — ${merge.symbol} ${merge.side} at ${merge.price}, submitted ${merge.observedAt}: ` +
-    `${merge.quantities.length} rows sharing one id (${merge.quantities.join(" + ")}) were ` +
-    `summed into ONE claim of ${merge.mergedQuantity}. The venue's export carries no order ` +
-    `id, and these rows agree on every field identity is built from, so the sum is the only ` +
-    `reading that neither invents a second claim nor frees committed capital. To keep two ` +
-    `rungs distinct, re-place one a tick apart so their prices differ.`
-  );
 }
 
 /** How one rung is shown when the operator asks to override it. */


### PR DESCRIPTION
## Stacking

This is stacked on #220 (base: `feature/219-extract-unattributed-refusal-renderer`), which is itself stacked on #219. #220 is not yet merged — do not read #220's commits as part of this diff. GitHub will retarget this PR to `main` automatically once #220 merges.

Closes #221

## What

Two commits, in order:

1. **`refactor(tui): extract the merge notice so the arithmetic the operator is owed is assertable`** — `describeMerge` moved to `import-orders-merge-notice.ts` byte-identical (verified: diffs against `HEAD:import-orders.ts` by exactly one line, `function` → `export function`). `type MergedOrderClaim` dropped from `import-orders.ts` after checking it was unused there. The new test file holds what the old one only appeared to; the end-to-end test at `import-orders.test.ts:349` is narrowed to the WIRING claim rather than deleted.

   The old test was titled *"naming both quantities and the total"* and **passed with both quantities, the symbol and the side deleted from the output** — `toContain("1")` was satisfied by the price `1000`, `toContain("2")` by `2020` in the stamp. Eleven mutations now go red, each only on the assertion that names it.

2. **`feat(tui): widen the operator wrap budget to 100 columns and wrap both renderers to it`** — the one sanctioned behavior change. `describeMerge` emitted ONE unbroken ~450-character line and now hard-wraps; `renderUnattributedRefusal` re-wraps from its 80-column assumption to the same target so the two renderers do not disagree about the terminal's width. The width assertion moves from 80 to a single `BUDGET = 100`.

   This **breaks the standing "zero behavior change" term every prior issue in this series carried**, deliberately and by the ruling on #221 — which is exactly why it is a separate commit landing after a provably byte-identical move.

   Measured widths (verified independently of the implementer): merge notice widest prose **88**, refusal renderer **87**, closing balances paragraph **80** — still the narrowest line in the renderer, which is what preserves #202's argument that the paragraph admitting what the operator has NOT been told must not be the one that wraps.

Both commits leave the suite green individually (verified in isolation, not just at the tip).

## Numbers

- Suite: 1287 → **1298** (+11)
- `import-orders.ts`: 655 → 637 lines
- `module-graph.test.ts`: unmodified
- `pnpm typecheck`: exit 0
- `pnpm verify`: full pass (typecheck + test + smoke)

## Existing assertions that had to be edited, and why each was unavoidable

Five multi-line literals pin exact line breaks and had to move with the wrap change: the provenance legend, both advice paragraphs, the fallback advice, and the closing-balances `endsWith`. Plus `import-orders.test.ts:1702` (the "Reserve balances were NOT weighed" literal). Every prefix-style assertion survived untouched.

## One judgment call beyond the literal ruling, flagged not buried

The merged total was split onto its own line. `quantities` is unbounded — six rows at four decimals measures 113 columns, past any budget — so no wrap width can promise that line fits. Splitting decides *which* line pays: the worst case now soft-wraps a list of sizes the operator can still read, and `ONE claim of N` arrives intact. Held by a mutation.

This is slightly beyond "re-wrap to 100" and is one revert away if the reviewer disagrees.

## Residual risks, named

- The listing line remains unbounded and no test can assert a bound there.
- 88 is a chosen target, not enforced — the tests assert ≤ 100, so a future edit wrapping new prose at 95 would pass.
- All widths are `String.length`, so a wide glyph would measure differently on a real terminal, which was not checked.

## A fifth extraction candidate, named not extracted

`declareFunding` (`import-orders.ts:278`) — ~35 lines mixing the prompt string, the affirmative parse, and the per-order override loop, with `describe` and `isAffirmative` as collaborators that would travel with it. Left for its own issue.