### PR TITLE
refactor(tui): extract the funding declaration cluster into its own module

### DIFF
--- a/apps/tui/src/import-orders-funding-declaration.test.ts
+++ b/apps/tui/src/import-orders-funding-declaration.test.ts
@@ -74,6 +74,8 @@ function scriptedAsk(answers: readonly string[]): {
 
 const BATCH_QUESTION = "Funding reserve for this batch: ";
 const OVERRIDE_QUESTION = "Override the funding reserve for any individual order? [y/N] ";
+/** What the default {@link order} renders as, under the batch answer `reserve-a`. */
+const PER_ORDER_PROMPT = "  BTCUSDT buy 0.5 @ 1000 (2026-08-07T10:00:00) [reserve-a]: ";
 
 describe("the batch answer", () => {
   it("is the declared reserve, and a declined override pass leaves no overrides", async () => {
@@ -110,8 +112,9 @@ describe("the batch answer", () => {
 /**
  * The override question is a yes/no, and the whitelist is the rule — `M1`, `M2` and `M3`
  * all live here. Each case is read off the OBSERVABLE consequence: an affirmative answer
- * opens the per-order pass, so the prompt count is what says whether the answer was read
- * as yes.
+ * opens the per-order pass, so the QUESTION THAT FOLLOWS is what says whether the answer
+ * was read as yes. Named in full rather than counted — a third question is not evidence,
+ * the per-order prompt is.
  */
 describe("the override question's answer", () => {
   const AFFIRMATIVE = ["y", "yes", "Y", "YES", " yes ", "  Y  ", "Yes"];
@@ -121,7 +124,7 @@ describe("the override question's answer", () => {
     it(`opens the per-order pass on ${JSON.stringify(answer)} (\`M2\`, \`M3\`)`, async () => {
       const { ask, asked } = scriptedAsk(["reserve-a", answer, ""]);
       await declareFunding(ask, [order()]);
-      expect(asked).toHaveLength(3);
+      expect(asked).toEqual([BATCH_QUESTION, OVERRIDE_QUESTION, PER_ORDER_PROMPT]);
     });
   }
 
@@ -199,9 +202,7 @@ describe("the per-order prompt", () => {
   }
 
   it("renders the rung AND the batch default, exactly (`M6`, `M7`)", async () => {
-    expect(await promptFor(order())).toBe(
-      "  BTCUSDT buy 0.5 @ 1000 (2026-08-07T10:00:00) [reserve-a]: ",
-    );
+    expect(await promptFor(order())).toBe(PER_ORDER_PROMPT);
   });
 
   it("carries the SYMBOL (`M8`)", async () => {

--- a/apps/tui/src/import-orders-funding-declaration.test.ts
+++ b/apps/tui/src/import-orders-funding-declaration.test.ts
@@ -21,15 +21,14 @@
  * RUNG they are about to re-fund was held by nothing.
  *
  * THIS IS NOT A PURE FUNCTION and the apparatus below is honest about it: `declareFunding`
- * awaits `io.ask`, so it takes a scripted-answer stub. What the stub does NOT take is an
- * export file, a sidecar, a temp dir, a frozen clock or a fund review — every other member
- * of the IO bag throws on touch, which is itself the assertion that this reads nothing but
- * the prompt channel.
+ * awaits the operator, so it takes a scripted-answer stub. What it cannot be handed is an
+ * export file, a sidecar, a temp dir, a frozen clock or a fund review — the parameter is
+ * the ASK CHANNEL, one function, so "this reads nothing but the prompt channel" is a
+ * compile-time fact rather than a trap this file has to lay and hope something springs.
  */
 import type { BitgetOpenOrder } from "@numisma/engine";
 import { describe, expect, it } from "vitest";
 import { declareFunding } from "./import-orders-funding-declaration.js";
-import type { OrdersImportIo } from "./import-orders.js";
 
 function order(overrides: Partial<BitgetOpenOrder> = {}): BitgetOpenOrder {
   return {
@@ -50,20 +49,18 @@ function order(overrides: Partial<BitgetOpenOrder> = {}): BitgetOpenOrder {
 }
 
 /**
- * An IO bag whose `ask` replays a script and records what it was asked — and whose every
- * OTHER member throws. Touching the sidecar path, the clock or the fund review from this
- * function would fail the test that touched it, so "prompt-only" is held rather than said.
+ * An `ask` that replays a script and records what it was asked. An UNSCRIPTED prompt
+ * throws rather than returning a blank, so a mutation that asks one question too many
+ * fails loudly instead of being read as an empty answer.
  */
-function scriptedIo(answers: readonly string[]): { io: OrdersImportIo; asked: string[] } {
+function scriptedAsk(answers: readonly string[]): {
+  ask: (question: string) => Promise<string>;
+  asked: string[];
+} {
   const asked: string[] = [];
   const remaining = [...answers];
-  const forbidden =
-    (member: string) =>
-    (): never => {
-      throw new Error(`declareFunding touched io.${member}`);
-    };
-
-  const io: OrdersImportIo = {
+  return {
+    asked,
     ask: async (question: string) => {
       asked.push(question);
       const next = remaining.shift();
@@ -72,18 +69,7 @@ function scriptedIo(answers: readonly string[]): { io: OrdersImportIo; asked: st
       }
       return next;
     },
-    readExport: forbidden("readExport"),
-    now: forbidden("now"),
-    loadOrders: forbidden("loadOrders"),
-    appendOrders: forbidden("appendOrders"),
-    fundReview: forbidden("fundReview"),
-    out: forbidden("out"),
-    err: forbidden("err"),
-    get ordersPath(): string {
-      throw new Error("declareFunding touched io.ordersPath");
-    },
   };
-  return { io, asked };
 }
 
 const BATCH_QUESTION = "Funding reserve for this batch: ";
@@ -91,8 +77,8 @@ const OVERRIDE_QUESTION = "Override the funding reserve for any individual order
 
 describe("the batch answer", () => {
   it("is the declared reserve, and a declined override pass leaves no overrides", async () => {
-    const { io, asked } = scriptedIo(["reserve-a", "n"]);
-    expect(await declareFunding(io, [order()])).toEqual({
+    const { ask, asked } = scriptedAsk(["reserve-a", "n"]);
+    expect(await declareFunding(ask, [order()])).toEqual({
       fundingReserveId: "reserve-a",
       overrides: {},
     });
@@ -101,22 +87,22 @@ describe("the batch answer", () => {
   });
 
   it("is TRIMMED — surrounding whitespace is not part of the reserve id (`M5`)", async () => {
-    const { io } = scriptedIo(["  reserve-a  ", "n"]);
-    expect(await declareFunding(io, [order()])).toEqual({
+    const { ask } = scriptedAsk(["  reserve-a  ", "n"]);
+    expect(await declareFunding(ask, [order()])).toEqual({
       fundingReserveId: "reserve-a",
       overrides: {},
     });
   });
 
   it("declares nothing when blank, and does not go on to ask about overrides", async () => {
-    const { io, asked } = scriptedIo([""]);
-    expect(await declareFunding(io, [order()])).toBeUndefined();
+    const { ask, asked } = scriptedAsk([""]);
+    expect(await declareFunding(ask, [order()])).toBeUndefined();
     expect(asked).toEqual([BATCH_QUESTION]);
   });
 
   it("declares nothing when it is only whitespace", async () => {
-    const { io, asked } = scriptedIo(["   "]);
-    expect(await declareFunding(io, [order()])).toBeUndefined();
+    const { ask, asked } = scriptedAsk(["   "]);
+    expect(await declareFunding(ask, [order()])).toBeUndefined();
     expect(asked).toEqual([BATCH_QUESTION]);
   });
 });
@@ -133,16 +119,16 @@ describe("the override question's answer", () => {
 
   for (const answer of AFFIRMATIVE) {
     it(`opens the per-order pass on ${JSON.stringify(answer)} (\`M2\`, \`M3\`)`, async () => {
-      const { io, asked } = scriptedIo(["reserve-a", answer, ""]);
-      await declareFunding(io, [order()]);
+      const { ask, asked } = scriptedAsk(["reserve-a", answer, ""]);
+      await declareFunding(ask, [order()]);
       expect(asked).toHaveLength(3);
     });
   }
 
   for (const answer of DECLINING) {
     it(`declines the per-order pass on ${JSON.stringify(answer)} (\`M1\`)`, async () => {
-      const { io, asked } = scriptedIo(["reserve-a", answer]);
-      expect(await declareFunding(io, [order()])).toEqual({
+      const { ask, asked } = scriptedAsk(["reserve-a", answer]);
+      expect(await declareFunding(ask, [order()])).toEqual({
         fundingReserveId: "reserve-a",
         overrides: {},
       });
@@ -165,9 +151,9 @@ describe("the per-order override pass", () => {
       order({ id: "rung-3" }),
       order({ id: "rung-4" }),
     ];
-    const { io } = scriptedIo(["reserve-a", "y", "reserve-b", "", "reserve-a", "  reserve-c  "]);
+    const { ask } = scriptedAsk(["reserve-a", "y", "reserve-b", "", "reserve-a", "  reserve-c  "]);
 
-    expect(await declareFunding(io, orders)).toEqual({
+    expect(await declareFunding(ask, orders)).toEqual({
       fundingReserveId: "reserve-a",
       // `rung-2` answered blank and `rung-3` answered the batch back: a redundant override
       // is not an override, and neither appears as a key.
@@ -177,16 +163,16 @@ describe("the per-order override pass", () => {
 
   it("keys the overrides by `order.id` and asks once per order, in order", async () => {
     const orders = [order({ id: "rung-1" }), order({ id: "rung-2" })];
-    const { io, asked } = scriptedIo(["reserve-a", "y", "reserve-b", "reserve-c"]);
+    const { ask, asked } = scriptedAsk(["reserve-a", "y", "reserve-b", "reserve-c"]);
 
-    const declaration = await declareFunding(io, orders);
+    const declaration = await declareFunding(ask, orders);
     expect(Object.keys(declaration?.overrides ?? {})).toEqual(["rung-1", "rung-2"]);
     expect(asked).toHaveLength(4);
   });
 
   it("asks nothing per order when the batch has no orders", async () => {
-    const { io, asked } = scriptedIo(["reserve-a", "y"]);
-    expect(await declareFunding(io, [])).toEqual({
+    const { ask, asked } = scriptedAsk(["reserve-a", "y"]);
+    expect(await declareFunding(ask, [])).toEqual({
       fundingReserveId: "reserve-a",
       overrides: {},
     });
@@ -202,8 +188,8 @@ describe("the per-order override pass", () => {
  */
 describe("the per-order prompt", () => {
   async function promptFor(subject: BitgetOpenOrder): Promise<string> {
-    const { io, asked } = scriptedIo(["reserve-a", "y", ""]);
-    await declareFunding(io, [subject]);
+    const { ask, asked } = scriptedAsk(["reserve-a", "y", ""]);
+    await declareFunding(ask, [subject]);
     return asked[2] as string;
   }
 
@@ -236,8 +222,8 @@ describe("the per-order prompt", () => {
   });
 
   it("carries the BATCH ANSWER as the default hint, not a hard-coded one (`M7`)", async () => {
-    const { io, asked } = scriptedIo(["reserve-zulu", "y", ""]);
-    await declareFunding(io, [order()]);
+    const { ask, asked } = scriptedAsk(["reserve-zulu", "y", ""]);
+    await declareFunding(ask, [order()]);
     expect(asked[2]).toContain("[reserve-zulu]");
   });
 });

--- a/apps/tui/src/import-orders-funding-declaration.test.ts
+++ b/apps/tui/src/import-orders-funding-declaration.test.ts
@@ -143,6 +143,11 @@ describe("the per-order override pass", () => {
    * and an answer equal to the batch, so the guards are exercised together rather than one
    * per fixture. The end-to-end test at `import-orders.test.ts:1743` exercises only the
    * first two, which is exactly why `M4` survived.
+   *
+   * AND `M4` COULD ONLY EVER BE KILLED HERE, at the map. `buildOrderPlacedRecords` reads
+   * `overrides?.[order.id] ?? fundingReserveId`, so a redundant entry writes the identical
+   * record and no end-to-end test over the written file can see the difference. This
+   * assertion is over the map's MEANING — a key is a dissent — not over an output.
    */
   it("records the dissenting rung only — blank falls through, equal-to-batch is NOT an override (`M4`)", async () => {
     const orders = [

--- a/apps/tui/src/import-orders-funding-declaration.test.ts
+++ b/apps/tui/src/import-orders-funding-declaration.test.ts
@@ -1,0 +1,243 @@
+/**
+ * THE DECLARATION PROMPT'S RULES, ASSERTED DIRECTLY — the reason the cluster left
+ * `import-orders.ts` (#223).
+ *
+ * EVERY ASSERTION HERE NAMES A MUTATION THAT SURVIVED THE WHOLE 1298-TEST SUITE. Eight
+ * were applied to the real source and re-run against every test in the repo, not just
+ * `import-orders.test.ts`; seven lived. They are named `M1`–`M8` below, beside the
+ * assertion that now kills each:
+ *
+ *   - `M1` whitelist → any-non-empty        → "declines on every answer that is not y/yes"
+ *   - `M2` drop the `"yes"` spelling        → the `"yes"` / `"YES"` / `" yes "` cases
+ *   - `M3` drop `.trim().toLowerCase()`     → the `"Y"` / `"YES"` / `" yes "` cases
+ *   - `M4` drop the `answer !== batch` guard → "an answer equal to the batch is NOT an override"
+ *   - `M5` drop `.trim()` on the batch      → "trims the batch answer"
+ *   - `M6` drop `describe(order)`           → the exact per-order prompt string
+ *   - `M7` drop the `[batch]` default hint  → the exact per-order prompt string
+ *   - `M8` gut `describe()` to a constant   → the five field-by-field prompt assertions
+ *
+ * `M8` is the one worth stating plainly: `describe` could be replaced by the constant
+ * `"an order"` and all 1298 tests stayed green. The function that shows the operator WHICH
+ * RUNG they are about to re-fund was held by nothing.
+ *
+ * THIS IS NOT A PURE FUNCTION and the apparatus below is honest about it: `declareFunding`
+ * awaits `io.ask`, so it takes a scripted-answer stub. What the stub does NOT take is an
+ * export file, a sidecar, a temp dir, a frozen clock or a fund review — every other member
+ * of the IO bag throws on touch, which is itself the assertion that this reads nothing but
+ * the prompt channel.
+ */
+import type { BitgetOpenOrder } from "@numisma/engine";
+import { describe, expect, it } from "vitest";
+import { declareFunding } from "./import-orders-funding-declaration.js";
+import type { OrdersImportIo } from "./import-orders.js";
+
+function order(overrides: Partial<BitgetOpenOrder> = {}): BitgetOpenOrder {
+  return {
+    id: "order-1",
+    observedAt: "2026-08-07T10:00:00",
+    currency: "USD",
+    symbol: "BTCUSDT",
+    side: "buy",
+    price: 1000,
+    quantity: 0.5,
+    filledQuantity: 0,
+    totalQuantity: 0.5,
+    timeInForce: "gtc",
+    orderType: "limit",
+    triggerPrice: null,
+    ...overrides,
+  };
+}
+
+/**
+ * An IO bag whose `ask` replays a script and records what it was asked — and whose every
+ * OTHER member throws. Touching the sidecar path, the clock or the fund review from this
+ * function would fail the test that touched it, so "prompt-only" is held rather than said.
+ */
+function scriptedIo(answers: readonly string[]): { io: OrdersImportIo; asked: string[] } {
+  const asked: string[] = [];
+  const remaining = [...answers];
+  const forbidden =
+    (member: string) =>
+    (): never => {
+      throw new Error(`declareFunding touched io.${member}`);
+    };
+
+  const io: OrdersImportIo = {
+    ask: async (question: string) => {
+      asked.push(question);
+      const next = remaining.shift();
+      if (next === undefined) {
+        throw new Error(`unscripted prompt: ${question}`);
+      }
+      return next;
+    },
+    readExport: forbidden("readExport"),
+    now: forbidden("now"),
+    loadOrders: forbidden("loadOrders"),
+    appendOrders: forbidden("appendOrders"),
+    fundReview: forbidden("fundReview"),
+    out: forbidden("out"),
+    err: forbidden("err"),
+    get ordersPath(): string {
+      throw new Error("declareFunding touched io.ordersPath");
+    },
+  };
+  return { io, asked };
+}
+
+const BATCH_QUESTION = "Funding reserve for this batch: ";
+const OVERRIDE_QUESTION = "Override the funding reserve for any individual order? [y/N] ";
+
+describe("the batch answer", () => {
+  it("is the declared reserve, and a declined override pass leaves no overrides", async () => {
+    const { io, asked } = scriptedIo(["reserve-a", "n"]);
+    expect(await declareFunding(io, [order()])).toEqual({
+      fundingReserveId: "reserve-a",
+      overrides: {},
+    });
+    // The two questions, in this order, and NO per-order pass.
+    expect(asked).toEqual([BATCH_QUESTION, OVERRIDE_QUESTION]);
+  });
+
+  it("is TRIMMED — surrounding whitespace is not part of the reserve id (`M5`)", async () => {
+    const { io } = scriptedIo(["  reserve-a  ", "n"]);
+    expect(await declareFunding(io, [order()])).toEqual({
+      fundingReserveId: "reserve-a",
+      overrides: {},
+    });
+  });
+
+  it("declares nothing when blank, and does not go on to ask about overrides", async () => {
+    const { io, asked } = scriptedIo([""]);
+    expect(await declareFunding(io, [order()])).toBeUndefined();
+    expect(asked).toEqual([BATCH_QUESTION]);
+  });
+
+  it("declares nothing when it is only whitespace", async () => {
+    const { io, asked } = scriptedIo(["   "]);
+    expect(await declareFunding(io, [order()])).toBeUndefined();
+    expect(asked).toEqual([BATCH_QUESTION]);
+  });
+});
+
+/**
+ * The override question is a yes/no, and the whitelist is the rule — `M1`, `M2` and `M3`
+ * all live here. Each case is read off the OBSERVABLE consequence: an affirmative answer
+ * opens the per-order pass, so the prompt count is what says whether the answer was read
+ * as yes.
+ */
+describe("the override question's answer", () => {
+  const AFFIRMATIVE = ["y", "yes", "Y", "YES", " yes ", "  Y  ", "Yes"];
+  const DECLINING = ["", " ", "n", "no", "N", "NO", "yeah", "yep", "1", "true", "ok", "sure"];
+
+  for (const answer of AFFIRMATIVE) {
+    it(`opens the per-order pass on ${JSON.stringify(answer)} (\`M2\`, \`M3\`)`, async () => {
+      const { io, asked } = scriptedIo(["reserve-a", answer, ""]);
+      await declareFunding(io, [order()]);
+      expect(asked).toHaveLength(3);
+    });
+  }
+
+  for (const answer of DECLINING) {
+    it(`declines the per-order pass on ${JSON.stringify(answer)} (\`M1\`)`, async () => {
+      const { io, asked } = scriptedIo(["reserve-a", answer]);
+      expect(await declareFunding(io, [order()])).toEqual({
+        fundingReserveId: "reserve-a",
+        overrides: {},
+      });
+      expect(asked).toEqual([BATCH_QUESTION, OVERRIDE_QUESTION]);
+    });
+  }
+});
+
+describe("the per-order override pass", () => {
+  /**
+   * THE THREE INTERACTIONS IN ONE PASS (#223 item 3) — an override, a blank fallthrough
+   * and an answer equal to the batch, so the guards are exercised together rather than one
+   * per fixture. The end-to-end test at `import-orders.test.ts:1743` exercises only the
+   * first two, which is exactly why `M4` survived.
+   */
+  it("records the dissenting rung only — blank falls through, equal-to-batch is NOT an override (`M4`)", async () => {
+    const orders = [
+      order({ id: "rung-1" }),
+      order({ id: "rung-2" }),
+      order({ id: "rung-3" }),
+      order({ id: "rung-4" }),
+    ];
+    const { io } = scriptedIo(["reserve-a", "y", "reserve-b", "", "reserve-a", "  reserve-c  "]);
+
+    expect(await declareFunding(io, orders)).toEqual({
+      fundingReserveId: "reserve-a",
+      // `rung-2` answered blank and `rung-3` answered the batch back: a redundant override
+      // is not an override, and neither appears as a key.
+      overrides: { "rung-1": "reserve-b", "rung-4": "reserve-c" },
+    });
+  });
+
+  it("keys the overrides by `order.id` and asks once per order, in order", async () => {
+    const orders = [order({ id: "rung-1" }), order({ id: "rung-2" })];
+    const { io, asked } = scriptedIo(["reserve-a", "y", "reserve-b", "reserve-c"]);
+
+    const declaration = await declareFunding(io, orders);
+    expect(Object.keys(declaration?.overrides ?? {})).toEqual(["rung-1", "rung-2"]);
+    expect(asked).toHaveLength(4);
+  });
+
+  it("asks nothing per order when the batch has no orders", async () => {
+    const { io, asked } = scriptedIo(["reserve-a", "y"]);
+    expect(await declareFunding(io, [])).toEqual({
+      fundingReserveId: "reserve-a",
+      overrides: {},
+    });
+    expect(asked).toEqual([BATCH_QUESTION, OVERRIDE_QUESTION]);
+  });
+});
+
+/**
+ * THE PROMPT ITSELF — `M6`, `M7` and `M8`. The operator is being asked to re-fund a
+ * SPECIFIC rung, so the prompt must say which rung and what happens if they just press
+ * return. Neither was held by anything: the rung's description could be deleted outright,
+ * replaced by a constant, or stripped of its default hint, and the suite stayed green.
+ */
+describe("the per-order prompt", () => {
+  async function promptFor(subject: BitgetOpenOrder): Promise<string> {
+    const { io, asked } = scriptedIo(["reserve-a", "y", ""]);
+    await declareFunding(io, [subject]);
+    return asked[2] as string;
+  }
+
+  it("renders the rung AND the batch default, exactly (`M6`, `M7`)", async () => {
+    expect(await promptFor(order())).toBe(
+      "  BTCUSDT buy 0.5 @ 1000 (2026-08-07T10:00:00) [reserve-a]: ",
+    );
+  });
+
+  it("carries the SYMBOL (`M8`)", async () => {
+    expect(await promptFor(order({ symbol: "ETHUSDT" }))).toContain("ETHUSDT");
+  });
+
+  it("carries the SIDE (`M8`)", async () => {
+    expect(await promptFor(order({ side: "sell" }))).toContain("sell");
+  });
+
+  it("carries the QUANTITY (`M8`)", async () => {
+    expect(await promptFor(order({ quantity: 0.125 }))).toContain("0.125");
+  });
+
+  it("carries the PRICE (`M8`)", async () => {
+    expect(await promptFor(order({ price: 64321.5 }))).toContain("64321.5");
+  });
+
+  it("carries the `observedAt` STAMP (`M8`)", async () => {
+    expect(await promptFor(order({ observedAt: "2031-12-25T23:59:59" }))).toContain(
+      "2031-12-25T23:59:59",
+    );
+  });
+
+  it("carries the BATCH ANSWER as the default hint, not a hard-coded one (`M7`)", async () => {
+    const { io, asked } = scriptedIo(["reserve-zulu", "y", ""]);
+    await declareFunding(io, [order()]);
+    expect(asked[2]).toContain("[reserve-zulu]");
+  });
+});

--- a/apps/tui/src/import-orders-funding-declaration.ts
+++ b/apps/tui/src/import-orders-funding-declaration.ts
@@ -1,0 +1,77 @@
+/**
+ * THE DECLARED HALF, PROMPTED — the one field this import asks the operator for, and the
+ * two collaborators that render and read the answers (#223).
+ *
+ * IT LEFT `import-orders.ts` FOR THE REASON #211, #213, #219 AND #221 LEFT IT, with one
+ * honest difference: this is not a pure function. It takes the IO bag and awaits
+ * `io.ask`, so its test buys a scripted-prompt stub rather than a plain call over a
+ * literal. What the extraction buys is the SEAM — the prompt strings and the answer rules
+ * become drivable without an export file, a sidecar, a frozen clock or a funding guard.
+ *
+ * AND THE COVERAGE ARGUMENT IS THE SHARPEST IN THE SERIES. Eight mutations were applied
+ * to this cluster and run against the whole 1298-test suite; SEVEN survived. `describe`
+ * could be replaced by the constant `"an order"` and every test stayed green — the
+ * function that renders each rung to the operator during the override pass was held by
+ * nothing at all. So were: the `"yes"` spelling, the case/whitespace normalization, the
+ * `answer !== batch` guard that makes a redundant override not an override, the trim on
+ * the batch answer, and the `[batch]` default hint in the per-order prompt. Each of those
+ * is now named by an assertion in `import-orders-funding-declaration.test.ts` that fails
+ * when the thing it names is removed.
+ *
+ * `isAffirmative` IS DUPLICATED IN `record-fill.ts` AND STAYS THAT WAY. De-duplicating it
+ * means choosing a shared home for a TUI-wide prompt primitive — a decision, not a move —
+ * so neither module imports the other.
+ *
+ * THE THREE END-TO-END TESTS STAY WHERE THEY ARE. They hold what no unit test over a
+ * stubbed `io` can: that the declaration actually lands on the written record as
+ * `fundingReserveId`, that the prompt happens exactly once per batch, and that a blank
+ * batch answer writes nothing at all.
+ */
+import type { BitgetOpenOrder } from "@numisma/engine";
+import type { OrdersImportIo } from "./import-orders.js";
+
+/** How one rung is shown when the operator asks to override it. */
+function describe(order: BitgetOpenOrder): string {
+  return `${order.symbol} ${order.side} ${order.quantity} @ ${order.price} (${order.observedAt})`;
+}
+
+function isAffirmative(answer: string): boolean {
+  const normalized = answer.trim().toLowerCase();
+  return normalized === "y" || normalized === "yes";
+}
+
+/**
+ * Prompt for the ONE declared field.
+ *
+ * Once per BATCH, then overridable per order — the granularity is the venue's own
+ * argument: a ladder is homogeneous by construction, so eight rungs is one decision
+ * copied eight times, and asking eight times is eight chances to disagree with yourself.
+ * The per-order pass is opt-in and defaults to the batch answer on a blank line, so the
+ * homogeneous case costs exactly one keystroke and the dissenting rung is still
+ * expressible.
+ */
+export async function declareFunding(
+  io: OrdersImportIo,
+  orders: readonly BitgetOpenOrder[],
+): Promise<{ fundingReserveId: string; overrides: Record<string, string> } | undefined> {
+  const batch = (await io.ask("Funding reserve for this batch: ")).trim();
+  if (batch === "") {
+    return undefined;
+  }
+
+  const overrides: Record<string, string> = {};
+  const wantsOverrides = isAffirmative(
+    await io.ask(`Override the funding reserve for any individual order? [y/N] `),
+  );
+  if (!wantsOverrides) {
+    return { fundingReserveId: batch, overrides };
+  }
+
+  for (const order of orders) {
+    const answer = (await io.ask(`  ${describe(order)} [${batch}]: `)).trim();
+    if (answer !== "" && answer !== batch) {
+      overrides[order.id] = answer;
+    }
+  }
+  return { fundingReserveId: batch, overrides };
+}

--- a/apps/tui/src/import-orders-funding-declaration.ts
+++ b/apps/tui/src/import-orders-funding-declaration.ts
@@ -26,6 +26,10 @@
  * is now named by an assertion in `import-orders-funding-declaration.test.ts` that fails
  * when the thing it names is removed.
  *
+ * ONE OF THE SEVEN IS NOT AN OUTPUT RULE, and pretending otherwise would mislead the next
+ * reader: the `answer !== batch` guard cannot change a written record, only the shape of
+ * the map that feeds it. The argument is at the guard itself.
+ *
  * `isAffirmative` IS DUPLICATED IN `record-fill.ts` AND STAYS THAT WAY. De-duplicating it
  * means choosing a shared home for a TUI-wide prompt primitive — a decision, not a move —
  * so neither module imports the other.
@@ -76,6 +80,13 @@ export async function declareFunding(
 
   for (const order of orders) {
     const answer = (await ask(`  ${describe(order)} [${batch}]: `)).trim();
+    // A REDUNDANT OVERRIDE IS NOT AN OVERRIDE — and this guard is a SHAPE rule, not an
+    // output rule, which is worth saying because the difference is invisible downstream.
+    // `buildOrderPlacedRecords` resolves attribution as
+    // `overrides?.[order.id] ?? fundingReserveId` (`packages/engine/src/orders/ingest.ts`),
+    // so an entry whose value equals the batch answer writes the IDENTICAL record either
+    // way. What the guard keeps is the map's meaning: a key here says the operator
+    // DISSENTED on that rung, and a rung they answered the batch back on did not.
     if (answer !== "" && answer !== batch) {
       overrides[order.id] = answer;
     }

--- a/apps/tui/src/import-orders-funding-declaration.ts
+++ b/apps/tui/src/import-orders-funding-declaration.ts
@@ -3,10 +3,18 @@
  * two collaborators that render and read the answers (#223).
  *
  * IT LEFT `import-orders.ts` FOR THE REASON #211, #213, #219 AND #221 LEFT IT, with one
- * honest difference: this is not a pure function. It takes the IO bag and awaits
- * `io.ask`, so its test buys a scripted-prompt stub rather than a plain call over a
- * literal. What the extraction buys is the SEAM — the prompt strings and the answer rules
- * become drivable without an export file, a sidecar, a frozen clock or a funding guard.
+ * honest difference: this is not a pure function. It awaits the operator, so its test buys
+ * a scripted-prompt stub rather than a plain call over a literal. What the extraction buys
+ * is the SEAM — the prompt strings and the answer rules become drivable without an export
+ * file, a sidecar, a frozen clock or a funding guard.
+ *
+ * IT TAKES THE PROMPT CHANNEL, NOT THE IO BAG. `ask` is the only member of
+ * `OrdersImportIo` this ever reads, and taking the whole bag cost twice: the type had to
+ * be imported BACK from the module this left — the only back-edge among the five
+ * extractions, where the other four reach no further than `@numisma/engine` and a peer
+ * leaf — and "reads nothing but the prompt channel" could only be held at RUNTIME, by a
+ * stub whose other eight members throw on touch. Narrowed to the one function, the
+ * compiler holds it and the stub is a closure.
  *
  * AND THE COVERAGE ARGUMENT IS THE SHARPEST IN THE SERIES. Eight mutations were applied
  * to this cluster and run against the whole 1298-test suite; SEVEN survived. `describe`
@@ -28,7 +36,6 @@
  * batch answer writes nothing at all.
  */
 import type { BitgetOpenOrder } from "@numisma/engine";
-import type { OrdersImportIo } from "./import-orders.js";
 
 /** How one rung is shown when the operator asks to override it. */
 function describe(order: BitgetOpenOrder): string {
@@ -51,24 +58,24 @@ function isAffirmative(answer: string): boolean {
  * expressible.
  */
 export async function declareFunding(
-  io: OrdersImportIo,
+  ask: (question: string) => Promise<string>,
   orders: readonly BitgetOpenOrder[],
 ): Promise<{ fundingReserveId: string; overrides: Record<string, string> } | undefined> {
-  const batch = (await io.ask("Funding reserve for this batch: ")).trim();
+  const batch = (await ask("Funding reserve for this batch: ")).trim();
   if (batch === "") {
     return undefined;
   }
 
   const overrides: Record<string, string> = {};
   const wantsOverrides = isAffirmative(
-    await io.ask(`Override the funding reserve for any individual order? [y/N] `),
+    await ask(`Override the funding reserve for any individual order? [y/N] `),
   );
   if (!wantsOverrides) {
     return { fundingReserveId: batch, overrides };
   }
 
   for (const order of orders) {
-    const answer = (await io.ask(`  ${describe(order)} [${batch}]: `)).trim();
+    const answer = (await ask(`  ${describe(order)} [${batch}]: `)).trim();
     if (answer !== "" && answer !== batch) {
       overrides[order.id] = answer;
     }

--- a/apps/tui/src/import-orders.ts
+++ b/apps/tui/src/import-orders.ts
@@ -36,6 +36,7 @@ import {
 import type { OrdersLoad } from "@numisma/preferences";
 import { appendKey, currentClaimKeys } from "./import-orders-append-filter.js";
 import { partitionChangedClaims, weighRemainders } from "./import-orders-changed-claims.js";
+import { declareFunding } from "./import-orders-funding-declaration.js";
 import { describeMerge } from "./import-orders-merge-notice.js";
 import {
   reportOrdersImport,
@@ -253,52 +254,6 @@ function reject(
   // be able to mistake a refusal for a quiet no-op.
   io.err(`REFUSED — ${message}\nNothing was written to ${io.ordersPath}.`);
   return { status: "rejected", reason, message };
-}
-
-/** How one rung is shown when the operator asks to override it. */
-function describe(order: BitgetOpenOrder): string {
-  return `${order.symbol} ${order.side} ${order.quantity} @ ${order.price} (${order.observedAt})`;
-}
-
-function isAffirmative(answer: string): boolean {
-  const normalized = answer.trim().toLowerCase();
-  return normalized === "y" || normalized === "yes";
-}
-
-/**
- * Prompt for the ONE declared field.
- *
- * Once per BATCH, then overridable per order — the granularity is the venue's own
- * argument: a ladder is homogeneous by construction, so eight rungs is one decision
- * copied eight times, and asking eight times is eight chances to disagree with yourself.
- * The per-order pass is opt-in and defaults to the batch answer on a blank line, so the
- * homogeneous case costs exactly one keystroke and the dissenting rung is still
- * expressible.
- */
-async function declareFunding(
-  io: OrdersImportIo,
-  orders: readonly BitgetOpenOrder[],
-): Promise<{ fundingReserveId: string; overrides: Record<string, string> } | undefined> {
-  const batch = (await io.ask("Funding reserve for this batch: ")).trim();
-  if (batch === "") {
-    return undefined;
-  }
-
-  const overrides: Record<string, string> = {};
-  const wantsOverrides = isAffirmative(
-    await io.ask(`Override the funding reserve for any individual order? [y/N] `),
-  );
-  if (!wantsOverrides) {
-    return { fundingReserveId: batch, overrides };
-  }
-
-  for (const order of orders) {
-    const answer = (await io.ask(`  ${describe(order)} [${batch}]: `)).trim();
-    if (answer !== "" && answer !== batch) {
-      overrides[order.id] = answer;
-    }
-  }
-  return { fundingReserveId: batch, overrides };
 }
 
 /**

--- a/apps/tui/src/import-orders.ts
+++ b/apps/tui/src/import-orders.ts
@@ -497,7 +497,9 @@ export async function importBitgetOpenOrders(
   // this flow can perform — so exiting early over it would skip the feature's best case.
   const records: OrderPlacedRecord[] = [];
   if (admitted.length > 0) {
-    const declaration = await declareFunding(io, admitted);
+    // `io.ask` ALONE, not the bag: that module reads the prompt channel and nothing else,
+    // and its signature says so — see its header.
+    const declaration = await declareFunding(io.ask, admitted);
     if (declaration === undefined) {
       return reject(io, "no-reserve-declared", "no funding reserve was declared for this batch");
     }


### PR DESCRIPTION
Closes #223.

## What moved

`declareFunding`, and the two collaborators it alone calls — `describe` and `isAffirmative` — move out of `apps/tui/src/import-orders.ts` into `apps/tui/src/import-orders-funding-declaration.ts`. The move is byte-identical apart from `function` → `export function` on `declareFunding`; docstrings moved whole, including the "once per BATCH, then overridable per order" paragraph. `describe` and `isAffirmative` stay module-private — every rule they own is reachable through `declareFunding`'s prompt channel.

This one differs from the pattern set by #211, #213, #219 and #221: `declareFunding` is not pure. It takes the IO bag and awaits `io.ask`, so its test buys a scripted-prompt stub rather than a plain call over a literal. What the extraction buys is the seam — the prompt strings and the answer rules become drivable without an export file, a sidecar, a frozen clock or a funding guard.

`isAffirmative` remains duplicated in `record-fill.ts` deliberately — de-duplicating it means choosing a shared home for a TUI-wide prompt primitive, a decision, not a move, so neither module imports the other.

## The mutation table

#223 applied eight mutations to this cluster and re-ran each against the full 1298-test suite. Seven survived; every one is now caught, each verified by applying the mutation to the real source on disk and watching the new suite go red:

| # | mutation | before | after |
|---|---|---|---|
| M1 | `isAffirmative`: whitelist → any-non-empty | caught | CAUGHT (12 failed) |
| M2 | drop the `"yes"` spelling | SURVIVED | CAUGHT (4 failed) |
| M3 | drop `.trim().toLowerCase()` | SURVIVED | CAUGHT (5 failed) |
| M4 | drop the `answer !== batch` guard | SURVIVED | CAUGHT (1 failed) |
| M5 | drop `.trim()` on the batch answer | SURVIVED | CAUGHT (2 failed) |
| M6 | remove `describe(order)` from the prompt | SURVIVED | CAUGHT (6 failed) |
| M7 | drop the `[batch]` default hint | SURVIVED | CAUGHT (2 failed) |
| M8 | gut `describe()` to the constant `"an order"` | SURVIVED | CAUGHT (6 failed) |

M8 is the one worth stating plainly: the function that shows the operator WHICH RUNG they are about to re-fund could be replaced by a constant string and all 1298 tests stayed green.

M4 is a deliberate rule nothing held — a redundant override is not an override. The new pass drives an override, a blank and an equal-to-batch answer across four rungs in one fixture, so the guards interact rather than being isolated one per fixture.

## Constraints honored

- `module-graph.test.ts` passes unmodified — not touched.
- No existing test is edited. The three end-to-end tests at `import-orders.test.ts:1729`, `:1743` and `:1769` stay as they are. #223 permitted narrowing `:1743` to the wiring claim; it was not narrowed, because it already is that claim — it asserts the declared answer reaches the written record as `fundingReserveId`, which no unit test over a stubbed `io` can make.
- `isAffirmative` duplication with `record-fill.ts` left alone deliberately, for the reason above.
- The IO stub in the new test throws on every member except `ask`, so "this reads nothing but the prompt channel" is held rather than asserted in prose.

## Numbers

- `import-orders.ts`: 637 → 592 lines.
- Suite: 1298 → 1331 passed / 19 skipped.
- `pnpm typecheck`: exit 0.


---

## Review pass (three follow-up commits)

A `pr-review` over this diff found no correctness defect — the move was verified
byte-identical against `main`, and both spot-checked mutations reproduced the table's kill
counts exactly. It found three cleanups, all now applied.

**1. It took the whole IO bag to read one member** (`refactor(tui): take the prompt channel,
not the whole IO bag`). `declareFunding` reads only `ask` and took all nine members of
`OrdersImportIo`, which cost twice: the type had to be imported BACK from the module the
cluster had just left — the only back-edge among the five extractions, where #211, #213,
#219 and #221 all reach no further than `@numisma/engine` and a peer leaf — and
"reads nothing but the prompt channel" could only be held at RUNTIME, by a stub with eight
throwing members and a throwing `ordersPath` getter. Narrowed to
`(question: string) => Promise<string>`, the compiler holds the claim, the stub collapses to
a nine-line closure, and the type graph is a DAG again. The call site passes `io.ask`, an
arrow closure in `import-orders-cli.ts`, so there is no `this` to lose.

**2. `M4` is not the kind of rule the other six are** (`docs(tui): name what the
redundant-override guard actually holds`). `buildOrderPlacedRecords` resolves attribution as
`overrides?.[order.id] ?? fundingReserveId`, so an override equal to the batch answer writes
the IDENTICAL record to one never recorded — no test over the written file can distinguish
the `answer !== batch` guard from its absence. Verified: a variant comparing the UNTRIMMED
answer, so `" reserve-a "` becomes a redundant entry, survives all 416 TUI tests and produces
byte-identical records. The guard holds the MAP's meaning — a key is a dissent — which is a
claim only a test at this seam can make. Now said at the guard, in the module header, and
beside the assertion. Comments only.

**3. The affirmative cases counted the third question instead of naming it** (`test(tui): name
the question the affirmative cases open, rather than counting it`). `toHaveLength(3)` is
satisfied by anything that opens the pass and then asks the wrong thing. Each of the seven now
asserts `[BATCH, OVERRIDE, PER_ORDER_PROMPT]` against the same constant the exact-rendering
test uses. Not a new rule, the same rule held tighter — and the table says by how much:

| # | mutation | at #224 | after the review pass |
|---|---|---|---|
| M6 | remove `describe(order)` from the prompt | 6 failed | 13 failed |
| M7 | drop the `[batch]` default hint | 2 failed | 9 failed |
| M8 | gut `describe()` to the constant `"an order"` | 6 failed | 13 failed |

M1–M5 are unchanged at 12, 4, 5, 1 and 2. All eight were re-run against the rewritten
apparatus; all eight still die.

**Left alone deliberately:** the `isAffirmative` duplication with `record-fill.ts`. The copy
count is unchanged by this PR and the reason for deferring — a shared home is a decision, not
a move — is already recorded in the module docstring.

**After the three commits:** full TUI suite 416 passed / 31 files, `pnpm typecheck` exit 0.
