### PR TITLE
fix(ops): fire the fetch hourly 18:00-23:00, because idempotency never recovered a missed run

### DIFF
--- a/apps/price-feed/src/schedule-window.test.ts
+++ b/apps/price-feed/src/schedule-window.test.ts
@@ -1,5 +1,6 @@
 import { describe, expect, it } from "vitest";
 import { execFileSync } from "node:child_process";
+import { readFileSync } from "node:fs";
 import { fileURLToPath } from "node:url";
 import { instrumentsForSource } from "@numisma/engine";
 import { DEFAULT_CONFIG } from "./config.js";
@@ -9,86 +10,168 @@ import { DEFAULT_CONFIG } from "./config.js";
  * asserted about it would only restate its own bytes ("the file says Hour 18, so
  * assert Hour 18") and would fail for no reason other than someone editing it on
  * purpose. This file deliberately asserts only the properties that have an
- * ORACLE SOMEWHERE ELSE — the ones a future edit to the plist, to
- * `DEFAULT_CONFIG`, or to the instrument registry could silently falsify:
+ * ORACLE SOMEWHERE ELSE — the ones a future edit to the plist, to `DEFAULT_CONFIG`,
+ * to the wrapper, or to the instrument registry could silently falsify.
  *
- *  1. It parses as a plist at all (oracle: Apple's own parser). A malformed edit
- *     is the one failure launchd gives no feedback for — it just never runs.
- *  2. No fire is scheduled before the mark time (oracle: `DEFAULT_CONFIG.markTime`
- *     in config.ts). Marks are gated on being at/after the mark instant, so a fire
- *     before it stores quotes and emits ZERO marks — a scheduled no-op that looks
- *     like a run.
- *  3. No fire is scheduled past the CDMX day (hour ≤ 23). `asOf` is the calendar
- *     date, so an interval that lands after midnight fetches under the NEXT day's
- *     `asOf` and can never recover the day it was meant to recover.
- *  4. More than one fire per day — the whole recovery property of #185 S2. One
- *     interval is precisely the shape that lost 2026-06-27 and friends.
- *  5. The day's worst-case Twelve Data spend fits the free tier's DAILY credit cap
- *     (oracle: the instrument registry's row count). This is the gate that parked
- *     this slice, and it moves whenever an equity is added to the registry OR an
- *     interval is added here — neither edit is near this file.
- *
- * `RunAtLoad` is deliberately NOT asserted: it is a true belt-and-braces half with
- * no second source of truth, so a test for it would only echo the file.
+ * `RunAtLoad` is deliberately NOT asserted: it is a belt-and-braces half with no
+ * second source of truth, so a test for it would only echo the file. Its real
+ * consequences are tested where they land — in the heartbeat reader
+ * (`packages/event-store/src/heartbeat.test.ts`), because a run at an arbitrary
+ * hour is a thing the READER has to get right.
  */
 
+const REPO_ROOT = new URL("../../../", import.meta.url);
 const PLIST_PATH = fileURLToPath(
-  new URL("../../../ops/price-feed/com.numisma.pricefeed.daily.plist", import.meta.url),
+  new URL("ops/price-feed/com.numisma.pricefeed.daily.plist", REPO_ROOT),
 );
+const WRAPPER_PATH = fileURLToPath(new URL("ops/price-feed/run-daily-fetch.sh", REPO_ROOT));
 
 /** Twelve Data Basic (free): 8 credits/minute, 800/day. A batched `time_series` costs 1 credit per symbol. */
 const TWELVE_DATA_DAILY_CREDIT_CAP = 800;
 
-/** `plutil` is macOS-only — and so is launchd, so there is nothing to guard elsewhere. */
+/** `plutil` is macOS-only. Only the lint needs it — everything else reads the XML directly. */
 const onMac = process.platform === "darwin";
 
+/**
+ * ONE `StartCalendarInterval` ENTRY — AND THE WILDCARD THAT MAKES COUNTING THEM
+ * DANGEROUS. From `man 5 launchd.plist`: *"Missing arguments are considered to be
+ * wildcard."* So a dict carrying `Hour` and no `Minute` does not fire once an hour,
+ * it fires SIXTY times — and deleting one `<key>Minute</key>` line is a plausible
+ * edit that turns 6 fires/day into 360.
+ */
 interface CalendarInterval {
   Hour?: number;
   Minute?: number;
 }
 
-/** Parse the template through Apple's own parser, so "is it valid?" is not our opinion. */
-function readPlist(): { StartCalendarInterval: CalendarInterval | CalendarInterval[] } {
-  const json = execFileSync("plutil", ["-convert", "json", "-o", "-", PLIST_PATH], {
-    encoding: "utf8",
+/**
+ * A deliberately small plist reader, because the useful assertions must run on CI
+ * (ubuntu) where `plutil` does not exist.
+ *
+ * It understands exactly the shape this ONE template uses — integer-valued keys in
+ * a dict, or an array of such dicts — and THROWS rather than returning empty if it
+ * cannot find what it is looking for. Failing closed matters: a silent `[]` would
+ * make the interval-count and credit assertions vacuously pass on a file this
+ * parser could not read. General plist well-formedness is `plutil -lint`'s job
+ * below; on macOS the two are cross-checked against each other.
+ */
+function parseIntervals(): CalendarInterval[] {
+  // Comments first: the header discusses hours in prose, and none of that is data.
+  const xml = readFileSync(PLIST_PATH, "utf8").replace(/<!--[\s\S]*?-->/g, "");
+  const keyIndex = xml.indexOf("<key>StartCalendarInterval</key>");
+  if (keyIndex === -1) {
+    throw new Error("no StartCalendarInterval in the plist — the job has no schedule at all");
+  }
+  const rest = xml.slice(keyIndex + "<key>StartCalendarInterval</key>".length);
+  const openArray = rest.indexOf("<array>");
+  const openDict = rest.indexOf("<dict>");
+  if (openDict === -1 && openArray === -1) {
+    throw new Error("StartCalendarInterval has neither a <dict> nor an <array> value");
+  }
+  // An array of dicts, or a single bare dict — launchd accepts both.
+  const isArray = openArray !== -1 && (openDict === -1 || openArray < openDict);
+  const body = isArray ? rest.slice(openArray, rest.indexOf("</array>")) : rest.slice(openDict);
+  const blocks = isArray
+    ? [...body.matchAll(/<dict>([\s\S]*?)<\/dict>/g)].map((m) => m[1] ?? "")
+    : [body.slice(0, body.indexOf("</dict>"))];
+  if (blocks.length === 0) {
+    throw new Error("StartCalendarInterval is an empty array — the job has no schedule at all");
+  }
+  return blocks.map((block) => {
+    const interval: CalendarInterval = {};
+    for (const [, key, value] of block.matchAll(
+      /<key>(\w+)<\/key>\s*<integer>(-?\d+)<\/integer>/g,
+    )) {
+      if (key === "Hour" || key === "Minute") {
+        interval[key] = Number(value);
+      }
+    }
+    return interval;
   });
-  return JSON.parse(json);
 }
 
-/** launchd accepts either ONE dict or an ARRAY of them; normalize so the assertions read the same. */
-function fireHours(): number[] {
-  const interval = readPlist().StartCalendarInterval;
-  const dicts = Array.isArray(interval) ? interval : [interval];
-  return dicts.map((d) => d.Hour ?? 0);
+/**
+ * How many times the job actually fires per day — wildcards EXPANDED, not counted
+ * as one. This is the number the credit budget has to be measured against; counting
+ * dicts instead is what let a missing `Minute` slip past an assertion whose whole
+ * purpose is to catch a quota breach.
+ */
+function firesPerDay(intervals: CalendarInterval[]): number {
+  return intervals.reduce((total, { Hour, Minute }) => {
+    const hours = Hour === undefined ? 24 : 1;
+    const minutes = Minute === undefined ? 60 : 1;
+    return total + hours * minutes;
+  }, 0);
 }
 
-describe.skipIf(!onMac)("the launchd fetch window", () => {
-  it("is a plist launchd can actually load", () => {
+describe("the launchd fetch window", () => {
+  it.skipIf(!onMac)("is a plist launchd can actually load", () => {
     // A malformed plist is silently ignored by launchd — no error, just no job.
     expect(() => execFileSync("plutil", ["-lint", PLIST_PATH], { encoding: "utf8" })).not.toThrow();
   });
 
+  it.skipIf(!onMac)("is read by this file's own parser the same way Apple reads it", () => {
+    // Keeps the hand parser above honest wherever the real one is available, so the
+    // assertions that run on CI are not testing a private misreading of the file.
+    const viaPlutil = JSON.parse(
+      execFileSync("plutil", ["-convert", "json", "-o", "-", PLIST_PATH], { encoding: "utf8" }),
+    ).StartCalendarInterval;
+    expect(parseIntervals()).toEqual(Array.isArray(viaPlutil) ? viaPlutil : [viaPlutil]);
+  });
+
+  it("pins every interval to an explicit hour AND minute, since a missing one is a wildcard", () => {
+    // `man 5 launchd.plist`: "Missing arguments are considered to be wildcard."
+    // Dropping a <key>Minute</key> line therefore schedules 60 fires an hour, and
+    // it looks like a tidy-up. Fail on the shape, not only on the consequence.
+    for (const interval of parseIntervals()) {
+      expect(interval.Hour).toBeTypeOf("number");
+      expect(interval.Minute).toBeTypeOf("number");
+    }
+  });
+
   it("schedules no fire before the mark time, when a run can emit no marks at all", () => {
+    // Not a fatal edit — a `RunAtLoad` run lands out of window routinely and is
+    // handled (the heartbeat records it as non-marking). But a SCHEDULED pre-mark
+    // fire is pure waste: it spends the same 9 credits and can never mark.
     const markHour = Number(DEFAULT_CONFIG.markTime.split(":")[0]);
-    for (const hour of fireHours()) {
-      expect(hour).toBeGreaterThanOrEqual(markHour);
+    for (const { Hour } of parseIntervals()) {
+      expect(Hour).toBeGreaterThanOrEqual(markHour);
     }
   });
 
   it("schedules no fire past the CDMX day, whose rollover makes the miss permanent", () => {
-    for (const hour of fireHours()) {
-      expect(hour).toBeLessThanOrEqual(23);
+    for (const { Hour } of parseIntervals()) {
+      expect(Hour).toBeLessThanOrEqual(23);
     }
   });
 
   it("fires more than once, which is the only thing that recovers a missed evening", () => {
-    // launchd DROPS a missed calendar interval rather than backfilling it, so a
-    // single daily interval means an asleep machine loses the day outright.
-    expect(fireHours().length).toBeGreaterThan(1);
+    // launchd DOES run a slept-through interval at the next wake, coalescing several
+    // into one — but that catch-up run lands under a NEW `asOf`, and `isFreshBar`
+    // refuses yesterday's bar, so it recovers nothing. Only another fire INSIDE the
+    // same CDMX day can. A single interval leaves none.
+    expect(parseIntervals().length).toBeGreaterThan(1);
   });
 
   it("cannot exceed the Twelve Data daily credit cap even if every fire marks", () => {
+    // A FLOOR ON THE SPEND, NOT A TOTAL: `RunAtLoad` adds an unbudgeted 9 credits per
+    // boot, login and `launchctl load`. That is what leaves headroom for — roughly 82
+    // extra loads a day before this bound is reached, so the schedule is what needs
+    // bounding and the loads do not.
     const twelveDataSymbols = instrumentsForSource("twelvedata").length;
-    expect(fireHours().length * twelveDataSymbols).toBeLessThanOrEqual(TWELVE_DATA_DAILY_CREDIT_CAP);
+    expect(firesPerDay(parseIntervals()) * twelveDataSymbols).toBeLessThanOrEqual(
+      TWELVE_DATA_DAILY_CREDIT_CAP,
+    );
+  });
+
+  it("keeps the wrapper's own mark hour equal to the contract's", () => {
+    // The wrapper duplicates the mark hour in bash to decide whether a run could
+    // mark at all (the heartbeat's `markWindow`). It cannot import `DEFAULT_CONFIG`,
+    // so this is the join: change the contract and a test fails rather than the
+    // breadcrumb quietly mis-classifying every run.
+    const markHour = Number(DEFAULT_CONFIG.markTime.split(":")[0]);
+    const declared = /^MARK_HOUR=(\d+)$/m.exec(readFileSync(WRAPPER_PATH, "utf8"));
+    expect(declared?.[1]).toBeDefined();
+    expect(Number(declared?.[1])).toBe(markHour);
   });
 });

--- a/apps/price-feed/src/schedule-window.test.ts
+++ b/apps/price-feed/src/schedule-window.test.ts
@@ -164,14 +164,48 @@ describe("the launchd fetch window", () => {
     );
   });
 
-  it("keeps the wrapper's own mark hour equal to the contract's", () => {
+  it("keeps the wrapper's own mark hour equal to the contract's, with no leading zero", () => {
     // The wrapper duplicates the mark hour in bash to decide whether a run could
     // mark at all (the heartbeat's `markWindow`). It cannot import `DEFAULT_CONFIG`,
     // so this is the join: change the contract and a test fails rather than the
     // breadcrumb quietly mis-classifying every run.
+    //
+    // THE REGEX REFUSES A LEADING ZERO ON PURPOSE. `[[ x -ge $MARK_HOUR ]]`
+    // arithmetic-evaluates its right operand, and `08`/`09` are invalid octal. That
+    // does not abort — it is an `if` condition, so `set -e` never fires — it silently
+    // classifies EVERY run as out-of-window. `Number("08") === 8` would let a guard
+    // written the obvious way sail straight past it, so the SHAPE is asserted, not
+    // just the value. (The wrapper also wraps both operands in `10#`; this is the
+    // second lock on the same door, because either alone is enough to be forgotten.)
     const markHour = Number(DEFAULT_CONFIG.markTime.split(":")[0]);
-    const declared = /^MARK_HOUR=(\d+)$/m.exec(readFileSync(WRAPPER_PATH, "utf8"));
+    const declared = /^MARK_HOUR=([1-9]?[0-9])$/m.exec(readFileSync(WRAPPER_PATH, "utf8"));
     expect(declared?.[1]).toBeDefined();
     expect(Number(declared?.[1])).toBe(markHour);
+  });
+
+  it("keeps the wrapper's own mark timezone equal to the contract's", () => {
+    // The hour is meaningless without the zone. The real gate resolves the mark
+    // instant through Intl in CDMX explicitly, so a wrapper reading the bare local
+    // hour would agree only by coincidence of the OS setting — and the install docs
+    // offer the divergent setup (CDMX-equivalent plist hours on a non-CDMX box) as
+    // supported. Under that config every scheduled fire would classify itself
+    // out-of-window, nothing would ever stamp, and the staleness trigger would be
+    // permanently and silently dead while the runs themselves marked correctly.
+    const declared = /^MARK_TZ="([^"]+)"$/m.exec(readFileSync(WRAPPER_PATH, "utf8"));
+    expect(declared?.[1]).toBe(DEFAULT_CONFIG.timeZone);
+  });
+
+  it("lists exactly the wrapper steps that follow the one appending marks", () => {
+    // The heartbeat stamps a run as having marked the day only if it got past
+    // `spine`, which is the step that appends. That predicate is a hardcoded list of
+    // step names, and its oracle is the ORDER OF THE `LAST_STEP` ASSIGNMENTS in the
+    // same file — so renaming a step, or inserting a new one after `spine` without
+    // adding it, fails here instead of quietly narrowing what counts as a marked day.
+    const wrapper = readFileSync(WRAPPER_PATH, "utf8");
+    const steps = [...wrapper.matchAll(/^LAST_STEP="([^"]+)"$/gm)].map((m) => m[1]);
+    const afterSpine = steps.slice(steps.indexOf("spine") + 1);
+    expect(steps).toContain("spine");
+    const declared = /^MARKS_LANDED_STEPS="([^"]+)"$/m.exec(wrapper)?.[1]?.split(" ");
+    expect(declared).toEqual(afterSpine);
   });
 });

--- a/apps/price-feed/src/schedule-window.test.ts
+++ b/apps/price-feed/src/schedule-window.test.ts
@@ -1,0 +1,94 @@
+import { describe, expect, it } from "vitest";
+import { execFileSync } from "node:child_process";
+import { fileURLToPath } from "node:url";
+import { instrumentsForSource } from "@numisma/engine";
+import { DEFAULT_CONFIG } from "./config.js";
+
+/**
+ * The launchd schedule template is CONFIG, not code, so most of what could be
+ * asserted about it would only restate its own bytes ("the file says Hour 18, so
+ * assert Hour 18") and would fail for no reason other than someone editing it on
+ * purpose. This file deliberately asserts only the properties that have an
+ * ORACLE SOMEWHERE ELSE — the ones a future edit to the plist, to
+ * `DEFAULT_CONFIG`, or to the instrument registry could silently falsify:
+ *
+ *  1. It parses as a plist at all (oracle: Apple's own parser). A malformed edit
+ *     is the one failure launchd gives no feedback for — it just never runs.
+ *  2. No fire is scheduled before the mark time (oracle: `DEFAULT_CONFIG.markTime`
+ *     in config.ts). Marks are gated on being at/after the mark instant, so a fire
+ *     before it stores quotes and emits ZERO marks — a scheduled no-op that looks
+ *     like a run.
+ *  3. No fire is scheduled past the CDMX day (hour ≤ 23). `asOf` is the calendar
+ *     date, so an interval that lands after midnight fetches under the NEXT day's
+ *     `asOf` and can never recover the day it was meant to recover.
+ *  4. More than one fire per day — the whole recovery property of #185 S2. One
+ *     interval is precisely the shape that lost 2026-06-27 and friends.
+ *  5. The day's worst-case Twelve Data spend fits the free tier's DAILY credit cap
+ *     (oracle: the instrument registry's row count). This is the gate that parked
+ *     this slice, and it moves whenever an equity is added to the registry OR an
+ *     interval is added here — neither edit is near this file.
+ *
+ * `RunAtLoad` is deliberately NOT asserted: it is a true belt-and-braces half with
+ * no second source of truth, so a test for it would only echo the file.
+ */
+
+const PLIST_PATH = fileURLToPath(
+  new URL("../../../ops/price-feed/com.numisma.pricefeed.daily.plist", import.meta.url),
+);
+
+/** Twelve Data Basic (free): 8 credits/minute, 800/day. A batched `time_series` costs 1 credit per symbol. */
+const TWELVE_DATA_DAILY_CREDIT_CAP = 800;
+
+/** `plutil` is macOS-only — and so is launchd, so there is nothing to guard elsewhere. */
+const onMac = process.platform === "darwin";
+
+interface CalendarInterval {
+  Hour?: number;
+  Minute?: number;
+}
+
+/** Parse the template through Apple's own parser, so "is it valid?" is not our opinion. */
+function readPlist(): { StartCalendarInterval: CalendarInterval | CalendarInterval[] } {
+  const json = execFileSync("plutil", ["-convert", "json", "-o", "-", PLIST_PATH], {
+    encoding: "utf8",
+  });
+  return JSON.parse(json);
+}
+
+/** launchd accepts either ONE dict or an ARRAY of them; normalize so the assertions read the same. */
+function fireHours(): number[] {
+  const interval = readPlist().StartCalendarInterval;
+  const dicts = Array.isArray(interval) ? interval : [interval];
+  return dicts.map((d) => d.Hour ?? 0);
+}
+
+describe.skipIf(!onMac)("the launchd fetch window", () => {
+  it("is a plist launchd can actually load", () => {
+    // A malformed plist is silently ignored by launchd — no error, just no job.
+    expect(() => execFileSync("plutil", ["-lint", PLIST_PATH], { encoding: "utf8" })).not.toThrow();
+  });
+
+  it("schedules no fire before the mark time, when a run can emit no marks at all", () => {
+    const markHour = Number(DEFAULT_CONFIG.markTime.split(":")[0]);
+    for (const hour of fireHours()) {
+      expect(hour).toBeGreaterThanOrEqual(markHour);
+    }
+  });
+
+  it("schedules no fire past the CDMX day, whose rollover makes the miss permanent", () => {
+    for (const hour of fireHours()) {
+      expect(hour).toBeLessThanOrEqual(23);
+    }
+  });
+
+  it("fires more than once, which is the only thing that recovers a missed evening", () => {
+    // launchd DROPS a missed calendar interval rather than backfilling it, so a
+    // single daily interval means an asleep machine loses the day outright.
+    expect(fireHours().length).toBeGreaterThan(1);
+  });
+
+  it("cannot exceed the Twelve Data daily credit cap even if every fire marks", () => {
+    const twelveDataSymbols = instrumentsForSource("twelvedata").length;
+    expect(fireHours().length * twelveDataSymbols).toBeLessThanOrEqual(TWELVE_DATA_DAILY_CREDIT_CAP);
+  });
+});

--- a/docs/price-feed-ops.md
+++ b/docs/price-feed-ops.md
@@ -15,7 +15,7 @@ Everything here is machine-local. Nothing secret or trade-derived enters the rep
 | File | Role |
 | --- | --- |
 | `ops/price-feed/run-daily-fetch.sh` | Wrapper the scheduler calls. Sets a PATH that can find `pnpm`, sources tokens, runs `pnpm prices:fetch`; on a clean fetch: (2) `pnpm spine` then (3) an auto-commit of any new data-repo changes scoped to `$NUMISMA_DATA_DIR` — idempotent if no new marks, never pushes — then (4) a post-check that **fails the job** if the durable event log is still uncommitted (lenient warn for the `head-digest.json` breadcrumb). Only once the log is verified does it touch anything derived, local before networked: (5) `pnpm gap-report -- --write` to rewrite `gap-report.json` beside the log and (6) `pnpm backfill` to refresh the hosted projection. Preserves the non-zero exit code so the scheduler notices a failure or rejection. |
-| `ops/price-feed/com.numisma.pricefeed.daily.plist` | launchd definition firing the wrapper **hourly from 18:00 to 23:00 local** (six intervals; 18:00 is the default mark time), **every day** — plus `RunAtLoad` true. The first fire with the machine awake marks the day; the rest are 0-mark no-ops. See "Why the window is hourly, not a single 18:00 fire" and "Why the schedule fires 7 days/week" below. |
+| `ops/price-feed/com.numisma.pricefeed.daily.plist` | launchd definition firing the wrapper **hourly from 18:00 to 23:00 local** (six intervals; 18:00 is the default mark time), **every day** — plus `RunAtLoad` true. The first fire on an awake machine marks the day; later fires add 0 new marks (though they still spend credits and time). See "Why the window is hourly, not a single 18:00 fire" and "Why the schedule fires 7 days/week" below. |
 
 Both files are templates: replace `__REPO_DIR__` / `__HOME__` before installing.
 
@@ -103,7 +103,7 @@ from the log — not to touch the source of truth, and not to move money. That i
 real step up from "reads public prices," and still short of the trigger below.
 
 Against that threat, a `chmod 600` file outside the repo is proportionate, and it
-keeps the hands-off 18:00 launchd run dead-simple: no interactive keychain/vault
+keeps the hands-off evening launchd run dead-simple: no interactive keychain/vault
 unlock that could block a scheduled, non-login job.
 
 **Your real defense is fast revocation, not encryption-at-rest.** If a key ever
@@ -119,7 +119,7 @@ leaks (committed by mistake, copied into a shared backup, pasted somewhere):
   role's password at the database and update **both** copies
   (`~/.config/numisma/price-feed.env` and `apps/web/.env.push.local`). Two copies
   is the price of the single `source` line; a rotation that updates only one
-  leaves either the hand-run push or the 18:00 job failing.
+  leaves either the hand-run push or the scheduled evening job failing.
 
 After rotating, re-run the manual dry run to confirm the new credential works.
 
@@ -185,7 +185,7 @@ threat model does not need.
 launchd and cron start the job with a **bare, non-login PATH**
 (`/usr/bin:/bin:/usr/sbin:/sbin`), which does **not** include the directory holding
 `pnpm` (typically `~/Library/pnpm` or a Homebrew prefix like `/opt/homebrew/bin`).
-Without a fix the 18:00 run dies immediately with `pnpm: command not found` (exit
+Without a fix every scheduled run dies immediately with `pnpm: command not found` (exit
 127), even though a manual dry run in your interactive shell passes (it inherits
 your login PATH).
 
@@ -236,10 +236,29 @@ without a signal (issue #185):
 
 - The deterministic mark id `pm-<id>-<asOf>` makes a **repeated** run harmless — it
   appends 0 new marks.
-- It does nothing at all for a run that **never happened**. launchd *drops* a
-  calendar interval the machine slept through rather than backfilling it at wake,
-  and `asOf` is the CDMX **calendar date**, so once midnight passes `isFreshBar`
-  refuses yesterday's bar permanently. The day is then unrecoverable by any rerun.
+- It does nothing at all for a run that **never happened**, and `asOf` is the CDMX
+  **calendar date** — so once midnight passes `isFreshBar` refuses yesterday's bar
+  permanently. The day is then unrecoverable by any rerun.
+
+**What launchd actually does with a slept-through interval**, since the intuitive
+answer is wrong and #185 was filed on the wrong one. From `man 5 launchd.plist`:
+
+> Unlike cron which skips job invocations when the computer is asleep, launchd will
+> start the job the next time the computer wakes up. If multiple intervals transpire
+> before the computer is woken, those events will be coalesced into one event upon
+> wake from sleep.
+
+So launchd does **not** drop the interval — it runs one catch-up at wake. That
+changes the mechanism but not the conclusion: the catch-up executes under a **new**
+`asOf`, so it marks *today* and cannot reach the day that was missed. Two things
+follow that are easy to get backwards:
+
+- **Six intervals coalesce into ONE event on wake, not six.** They are six chances
+  at a machine that is *awake* during the evening, not six retries against a
+  sleeping one.
+- **The distinction that matters is asleep vs. powered-off/logged-out.** Asleep →
+  a coalesced catch-up fires, uselessly. Powered off or logged out → the LaunchAgent
+  was never loaded, so there is nothing to coalesce across the boot.
 
 So recovery has to come from the schedule, and it does, in two halves:
 
@@ -247,11 +266,19 @@ So recovery has to come from the schedule, and it does, in two halves:
   at 18:00 but open at any hour through 23:00 still marks the day, inside the same
   CDMX date. Every fire is at/after the 18:00 mark time on purpose: an earlier one
   would store quotes and emit **zero** marks.
-- **`RunAtLoad` true is the belt-and-braces half.** A machine booted (or the job
-  reloaded) inside the window runs at once instead of waiting for the next hour.
+- **`RunAtLoad` true is the belt-and-braces half**, and the boot/login case above is
+  precisely what it covers — the one case where no coalesced catch-up exists.
 
-Neither recovers a day the machine was off for all six hours. Nothing can — that
+Neither recovers a day the machine was off for the whole window. Nothing can — that
 loss is permanent, and naming it after the fact is the gap report's job (#186).
+
+**`RunAtLoad` has a cost on the reading side, and it is paid explicitly.** A load can
+happen at any hour, and a pre-18:00 run stores quotes, emits **zero** marks and exits
+`0`. That is indistinguishable from a healthy evening unless someone records the
+difference — and read naively it *silenced* the heartbeat's staleness warning on
+exactly the morning after a lost day. So the heartbeat now carries `markWindow`
+(schema version 2) plus the last in-window finish, and staleness is judged against
+the latter. See `packages/event-store/src/heartbeat.ts`.
 
 **Why six fires fit the free tier.** Twelve Data Basic allows 8 credits/minute and
 **800/day**; the registry holds **9** Twelve Data symbols at 1 credit each. Six
@@ -263,9 +290,21 @@ fallback was not needed. Adding intervals here, or equities to the registry, spe
 against that 800; `apps/price-feed/src/schedule-window.test.ts` fails if the product
 ever exceeds it.
 
-**Repeat fires are cheap by construction**, which is what makes six affordable: the
-second run of an evening appends 0 new marks, step 3 commits nothing, step 4 passes,
-and step 6 `pnpm backfill` upserts under `ON CONFLICT … DO UPDATE`.
+**Read 54 as a floor, not a total.** It is the *scheduled* spend. `RunAtLoad` adds an
+unbudgeted 9 credits per boot, login and `launchctl load`, and none of that is
+knowable in advance — so the guard bounds the schedule, which is the part that can be
+bounded. The headroom is large (roughly 82 extra loads in one day before 800), so
+this is a thing to state rather than a thing to fix. One practical note: the install
+sequence below is itself a live run followed by a `start` dry run, i.e. two runs
+inside a minute against the 8/min cap — the second's Twelve Data calls may pace or
+fail, which is expected and self-heals on the next hour.
+
+**Repeat fires are cheap, but not free**, which is worth stating precisely because a
+`RunAtLoad` run can land at any hour: a second run of an evening appends 0 new marks,
+commits nothing at step 3, passes step 4, and re-upserts at step 6 under
+`ON CONFLICT … DO UPDATE`. What it still spends is 9 Twelve Data credits and about
+two minutes of wall time (the 60 s pacing sleep runs regardless). "No new marks" and
+"no cost" are different claims.
 
 ## Why the schedule fires 7 days/week (crypto vs. equities)
 
@@ -287,11 +326,21 @@ failure. The run stays clean (exit 0), the crypto marks still ingest, and the
 `*-mxn` derived marks naturally skip too (their USD leg is stale). A weekday-only
 schedule was rejected: it would starve crypto AND still misfire on weekday holidays.
 
-## Manual dry run (the schedule's only verification)
+## Manual dry run (the schedule's main verification)
 
-The wrapper and the launchd/cron definition are verified by a MANUAL dry run, not
-by unit tests (there is nothing meaningful to unit-test in a plist). Run it after
-install and record the result below.
+The wrapper and the launchd/cron definition are verified mainly by a MANUAL dry run.
+Run it after install and record the result below.
+
+Two narrow automated guards exist alongside it, and they are worth knowing the limits
+of. `apps/price-feed/src/schedule-window.test.ts` checks only the properties of the
+plist that have an oracle elsewhere — that it lints, that no fire precedes the mark
+time or leaves the CDMX day, that every interval pins both `Hour` and `Minute` (a
+missing field is a launchd wildcard), that the credit budget fits, and that the
+wrapper's `MARK_HOUR` still matches `DEFAULT_CONFIG.markTime`. The last describe in
+`packages/event-store/src/heartbeat.test.ts` runs the wrapper and feeds its heartbeat
+to the real parser. **Neither tells you the installed job works** — they read the
+repo's templates, and the installed LaunchAgent is a separately-resolved copy. That
+is still what the dry run is for.
 
 ```sh
 # Exercise the wrapper exactly as the scheduler will (does not wait for the window):

--- a/docs/price-feed-ops.md
+++ b/docs/price-feed-ops.md
@@ -15,7 +15,7 @@ Everything here is machine-local. Nothing secret or trade-derived enters the rep
 | File | Role |
 | --- | --- |
 | `ops/price-feed/run-daily-fetch.sh` | Wrapper the scheduler calls. Sets a PATH that can find `pnpm`, sources tokens, runs `pnpm prices:fetch`; on a clean fetch: (2) `pnpm spine` then (3) an auto-commit of any new data-repo changes scoped to `$NUMISMA_DATA_DIR` — idempotent if no new marks, never pushes — then (4) a post-check that **fails the job** if the durable event log is still uncommitted (lenient warn for the `head-digest.json` breadcrumb). Only once the log is verified does it touch anything derived, local before networked: (5) `pnpm gap-report -- --write` to rewrite `gap-report.json` beside the log and (6) `pnpm backfill` to refresh the hosted projection. Preserves the non-zero exit code so the scheduler notices a failure or rejection. |
-| `ops/price-feed/com.numisma.pricefeed.daily.plist` | launchd definition firing the wrapper at 18:00 local (the default mark time), **every day** (see "Why the schedule fires 7 days/week" below). |
+| `ops/price-feed/com.numisma.pricefeed.daily.plist` | launchd definition firing the wrapper **hourly from 18:00 to 23:00 local** (six intervals; 18:00 is the default mark time), **every day** — plus `RunAtLoad` true. The first fire with the machine awake marks the day; the rest are 0-mark no-ops. See "Why the window is hourly, not a single 18:00 fire" and "Why the schedule fires 7 days/week" below. |
 
 Both files are templates: replace `__REPO_DIR__` / `__HOME__` before installing.
 
@@ -137,8 +137,9 @@ threat model does not need.
 
 ## Install the daily schedule (macOS launchd)
 
-1. Set the Mac's timezone to America/Mexico_City (or adjust the plist `Hour`/`Minute`
-   to the local clock equal to 18:00 CDMX).
+1. Set the Mac's timezone to America/Mexico_City (or shift **all six** of the plist's
+   `Hour` entries to the local clock equal to 18:00–23:00 CDMX — they must stay
+   at/after the mark time and inside the same CDMX day).
 2. Edit both placeholders in `run-daily-fetch.sh` (`REPO_DIR`) and the plist
    (`__REPO_DIR__`, `__HOME__`).
 3. Set the durable-data home in the plist. The wrapper forwards `NUMISMA_DATA_DIR`
@@ -160,6 +161,24 @@ threat model does not need.
       ~/Library/LaunchAgents/com.numisma.pricefeed.daily.plist
    launchctl load ~/Library/LaunchAgents/com.numisma.pricefeed.daily.plist
    ```
+
+   **The installed copy is a RESOLVED COPY, so a change to the template in this repo
+   does nothing until you reinstall by hand.** `cp` expands nothing — you edit
+   `__REPO_DIR__` / `__HOME__` in the installed file, so the two files diverge by
+   design and no automation reconciles them. After pulling a change to the plist
+   (e.g. the hourly window), redo the copy, re-edit the placeholders, then:
+
+   ```sh
+   launchctl unload ~/Library/LaunchAgents/com.numisma.pricefeed.daily.plist
+   launchctl load   ~/Library/LaunchAgents/com.numisma.pricefeed.daily.plist
+   # verify the six intervals are what launchd now holds, not what the repo holds:
+   launchctl print gui/$(id -u)/com.numisma.pricefeed.daily | grep -A20 'start interval\|periodic'
+   ```
+
+   **`RunAtLoad` is true, so that `load` runs the job immediately** — intended (it is
+   the belt-and-braces half of the recovery), safe at any hour, but it means the
+   reinstall is itself a live run. Watch `~/Library/Logs/numisma/price-feed-*.log`
+   rather than assuming it waited for the next hour.
 
 ### PATH: the scheduler must be able to find `pnpm` **and** `node`
 
@@ -201,9 +220,52 @@ If `pnpm` or `node` is still unresolvable the wrapper fails LOUD with a named er
 If you prefer cron over launchd (again assuming the box is on CDMX time):
 
 ```cron
-# m h  dom mon dow  command
-  0 18  *   *   *   /bin/bash /ABSOLUTE/PATH/numisma/ops/price-feed/run-daily-fetch.sh
+# m h     dom mon dow  command
+  0 18-23  *   *   *   /bin/bash /ABSOLUTE/PATH/numisma/ops/price-feed/run-daily-fetch.sh
 ```
+
+The `18-23` hour range is the same window as the plist, and for the same reason
+(below). cron has no `RunAtLoad` equivalent, so a cron install gets the working
+half of the recovery but not the belt-and-braces half.
+
+## Why the window is hourly, not a single 18:00 fire
+
+**A missed fire is not recovered by idempotency.** These are two different
+properties, and conflating them is what let 2026-06-27 and its siblings disappear
+without a signal (issue #185):
+
+- The deterministic mark id `pm-<id>-<asOf>` makes a **repeated** run harmless — it
+  appends 0 new marks.
+- It does nothing at all for a run that **never happened**. launchd *drops* a
+  calendar interval the machine slept through rather than backfilling it at wake,
+  and `asOf` is the CDMX **calendar date**, so once midnight passes `isFreshBar`
+  refuses yesterday's bar permanently. The day is then unrecoverable by any rerun.
+
+So recovery has to come from the schedule, and it does, in two halves:
+
+- **The hourly 18:00–23:00 window is the half that does the work.** A laptop shut
+  at 18:00 but open at any hour through 23:00 still marks the day, inside the same
+  CDMX date. Every fire is at/after the 18:00 mark time on purpose: an earlier one
+  would store quotes and emit **zero** marks.
+- **`RunAtLoad` true is the belt-and-braces half.** A machine booted (or the job
+  reloaded) inside the window runs at once instead of waiting for the next hour.
+
+Neither recovers a day the machine was off for all six hours. Nothing can — that
+loss is permanent, and naming it after the fact is the gap report's job (#186).
+
+**Why six fires fit the free tier.** Twelve Data Basic allows 8 credits/minute and
+**800/day**; the registry holds **9** Twelve Data symbols at 1 credit each. Six
+fires × 9 = **54 credits/day against 800** (6.75%), so the daily cap was never the
+constraint it looked like — the *per-minute* cap is, and that is already handled in
+code by `twelveDataMaxSymbolsPerMinute: 8` plus a 60 s pause, which costs each fire
+about one extra minute and nothing else. This is why the 18/20/22 three-fire
+fallback was not needed. Adding intervals here, or equities to the registry, spends
+against that 800; `apps/price-feed/src/schedule-window.test.ts` fails if the product
+ever exceeds it.
+
+**Repeat fires are cheap by construction**, which is what makes six affordable: the
+second run of an evening appends 0 new marks, step 3 commits nothing, step 4 passes,
+and step 6 `pnpm backfill` upserts under `ON CONFLICT … DO UPDATE`.
 
 ## Why the schedule fires 7 days/week (crypto vs. equities)
 
@@ -232,7 +294,7 @@ by unit tests (there is nothing meaningful to unit-test in a plist). Run it afte
 install and record the result below.
 
 ```sh
-# Exercise the wrapper exactly as the scheduler will (does not wait for 18:00):
+# Exercise the wrapper exactly as the scheduler will (does not wait for the window):
 /bin/bash ops/price-feed/run-daily-fetch.sh ; echo "wrapper exit: $?"
 
 # Or drive it through launchd itself:
@@ -246,6 +308,8 @@ Confirm, in order:
    `N new PriceMarked candidate(s)`.
 2. Running it **again the same day** logs `0 new ... already pending — skipped`
    and `pnpm spine` reports `0 new` (idempotency — the deterministic id, #106).
+   This is no longer an edge case to check once: with the hourly window it is what
+   the 19:00–23:00 fires do on every normal evening.
 3. The wrapper exit code is `0` on a clean run, non-zero if any symbol failed or a
    mark was rejected.
 4. **On a weekend/holiday**, the equity lines read
@@ -341,8 +405,12 @@ bad day never appends a bad mark. The console/log distinguishes the two cases �
 
 - The provider returned an error, a malformed payload, or timed out. Partial
   progress is kept (other symbols still stored/queued) and the run exits non-zero.
-- **Action:** usually none. A missed or partial fetch is harmless under the
-  idempotent id — the next daily run (or a manual `pnpm prices:fetch`) catches up.
+- **Action:** usually none *if there is still an hour left in the CDMX day* — one
+  of the remaining fires in the 18:00–23:00 window re-fetches the symbol, and the
+  idempotent id means the retry costs nothing (the marks that already landed are
+  not duplicated). A manual `pnpm prices:fetch` does the same thing sooner.
+  **After midnight it is not "caught up" by anything**: `asOf` is the calendar
+  date, so the missed day stays missed and only the gap report will name it.
   Investigate only if a symbol fails repeatedly (registry/symbol drift, provider
   outage). The failing symbol is named in the message.
 

--- a/docs/price-feed-ops.md
+++ b/docs/price-feed-ops.md
@@ -280,6 +280,22 @@ exactly the morning after a lost day. So the heartbeat now carries `markWindow`
 (schema version 2) plus the last in-window finish, and staleness is judged against
 the latter. See `packages/event-store/src/heartbeat.ts`.
 
+Two refinements of that rule are worth knowing, because both are the difference
+between a warning that fires and one that does not:
+
+- **Being in the window is not evidence of marking.** A run only stamps itself as
+  the last in-window run if it got past `pnpm spine`, the step that appends. A
+  provider outage kills every fire at `prices-fetch` — six in-window runs, zero
+  marks — and stamping those would record the outage as proof the day was covered.
+  The predicate is deliberately *not* "exit 0": a failure at `gap-report` or
+  `backfill` (steps 5–6) comes **after** the day was marked and committed, so
+  gating on the exit code would under-stamp and cry wolf about a day the log holds.
+- **The window is judged in CDMX, not in the machine's local time.** The wrapper
+  reads `TZ="$MARK_TZ" date +%H`, matching the mark-instant contract. This is what
+  makes the "shift the plist hours instead of the OS timezone" option above safe:
+  on a UTC box with plist hours 00–05, a bare local-hour test would classify every
+  scheduled fire as out-of-window and silently disable the staleness trigger.
+
 **Why six fires fit the free tier.** Twelve Data Basic allows 8 credits/minute and
 **800/day**; the registry holds **9** Twelve Data symbols at 1 credit each. Six
 fires × 9 = **54 credits/day against 800** (6.75%), so the daily cap was never the

--- a/ops/price-feed/com.numisma.pricefeed.daily.plist
+++ b/ops/price-feed/com.numisma.pricefeed.daily.plist
@@ -2,13 +2,43 @@
 <!--
   launchd definition for the hands-off daily price run (slice #108).
 
-  Fires the wrapper (run-daily-fetch.sh) at 18:00 in the MACHINE's local timezone.
-  The mark-instant contract's default mark time is 18:00 America/Mexico_City
-  (ADR-005 / config.ts), so this assumes the Mac's System Settings timezone is
-  CDMX. If the machine runs another timezone, set Hour/Minute to the local clock
-  that equals 18:00 CDMX, or keep the OS on CDMX. Missed fires (laptop asleep at
-  18:00) are harmless: launchd runs the job at the next wake, and the deterministic
-  id makes the catch-up run add no duplicate marks.
+  Fires the wrapper (run-daily-fetch.sh) EVERY HOUR from 18:00 through 23:00 in the
+  MACHINE's local timezone. The mark-instant contract's default mark time is 18:00
+  America/Mexico_City (ADR-005 / config.ts), so this assumes the Mac's System
+  Settings timezone is CDMX. If the machine runs another timezone, shift all six
+  Hours to the local clock equal to 18:00–23:00 CDMX, or keep the OS on CDMX.
+
+  WHY SIX FIRES AND NOT ONE (#185 S2). A MISSED FIRE IS NOT RECOVERED BY
+  IDEMPOTENCY. Those are two different properties and the old note here conflated
+  them: the deterministic id `pm-<id>-<asOf>` makes a REPEATED run harmless, which
+  is not the same as making a MISSED run recoverable. launchd DROPS a calendar
+  interval the machine slept through — it does not backfill it at wake — and `asOf`
+  is the CDMX CALENDAR DATE, so once midnight passes, `isFreshBar` refuses
+  yesterday's bar permanently and the day is gone. That is how 2026-06-27 and
+  friends were lost with no signal.
+
+  So recovery is the SCHEDULE's job, and it has two halves:
+    - The hourly 18:00–23:00 window (this array) is the half that does the work. A
+      laptop shut at 18:00 but open by 23:00 still marks the day, within the same
+      CDMX date. Six retries, all at/after the 18:00 mark time — an earlier fire
+      would store quotes and emit ZERO marks.
+    - RunAtLoad true (below) is the belt-and-braces half: a machine booted inside
+      the window runs immediately rather than waiting for the next hour.
+  Neither recovers a day the machine was off for all six hours. Nothing can; only
+  the gap report names it after the fact.
+
+  THE COST FITS THE FREE TIER, which is what unparked this slice. Twelve Data Basic
+  is 8 credits/minute and 800/day; the registry has 9 TD symbols at 1 credit each.
+  Six fires x 9 = 54 credits/day against 800 — 6.75%. The per-minute cap is already
+  handled in code (twelveDataMaxSymbolsPerMinute: 8 + a 60s pause,
+  apps/price-feed/src/config.ts), so each fire just takes ~1 extra minute. Adding
+  intervals here, or equities to the registry, spends against that 800 — the guard
+  is apps/price-feed/src/schedule-window.test.ts.
+
+  Repeat fires are harmless, which is what makes a six-fire window affordable at
+  all: the second run of an evening appends 0 new marks (deterministic id), step 3
+  commits nothing, step 4 passes, and step 6 `pnpm backfill` upserts under
+  `ON CONFLICT ... DO UPDATE`.
 
   The schedule fires EVERY day (7 days/week) ON PURPOSE. Crypto (Binance) trades
   24/7 and SHOULD mark every day, weekends included. Equities do NOT trade
@@ -29,7 +59,10 @@
     cp ops/price-feed/com.numisma.pricefeed.daily.plist \
        ~/Library/LaunchAgents/com.numisma.pricefeed.daily.plist
     launchctl load  ~/Library/LaunchAgents/com.numisma.pricefeed.daily.plist
-  Trigger a manual dry run (does not wait for 18:00):
+  NOTE: with RunAtLoad true, that `load` RUNS THE JOB IMMEDIATELY. That is intended
+  (it is the belt-and-braces half), and it is safe at any hour — but it means the
+  reinstall itself is a live run, so watch its log rather than assuming it waited.
+  Trigger a manual dry run (does not wait for the next hour):
     launchctl start com.numisma.pricefeed.daily
   Remove:
     launchctl unload ~/Library/LaunchAgents/com.numisma.pricefeed.daily.plist
@@ -64,18 +97,57 @@
     <string>/Users/amet/Dev/accumulus/data</string>
   </dict>
 
-  <!-- 18:00 local, EVERY day (7-day schedule; see the header note on why). -->
+  <!-- Hourly 18:00-23:00 local, EVERY day (7-day schedule; see the header note on
+       why 7 days, and on why six fires rather than one). An ARRAY of dicts, which
+       is how launchd expresses several calendar intervals for one job. The first
+       fire that lands with the machine awake marks the day; the rest are cheap
+       no-ops (0 new marks). No interval past 23:00: `asOf` rolls at midnight. -->
   <key>StartCalendarInterval</key>
-  <dict>
-    <key>Hour</key>
-    <integer>18</integer>
-    <key>Minute</key>
-    <integer>0</integer>
-  </dict>
+  <array>
+    <dict>
+      <key>Hour</key>
+      <integer>18</integer>
+      <key>Minute</key>
+      <integer>0</integer>
+    </dict>
+    <dict>
+      <key>Hour</key>
+      <integer>19</integer>
+      <key>Minute</key>
+      <integer>0</integer>
+    </dict>
+    <dict>
+      <key>Hour</key>
+      <integer>20</integer>
+      <key>Minute</key>
+      <integer>0</integer>
+    </dict>
+    <dict>
+      <key>Hour</key>
+      <integer>21</integer>
+      <key>Minute</key>
+      <integer>0</integer>
+    </dict>
+    <dict>
+      <key>Hour</key>
+      <integer>22</integer>
+      <key>Minute</key>
+      <integer>0</integer>
+    </dict>
+    <dict>
+      <key>Hour</key>
+      <integer>23</integer>
+      <key>Minute</key>
+      <integer>0</integer>
+    </dict>
+  </array>
 
-  <!-- Do not run at load; only on the calendar interval (and manual `start`). -->
+  <!-- Run at load: the belt-and-braces half of the recovery (see header). A machine
+       booted or a job reloaded INSIDE the window runs at once instead of waiting for
+       the next hour; outside the window the run is a cheap no-op (pre-18:00 stores
+       quotes and emits no marks; post-midnight is the next day's asOf). -->
   <key>RunAtLoad</key>
-  <false/>
+  <true/>
 
   <!-- launchd's own capture of the wrapper's stdout/stderr (outside the repo). -->
   <key>StandardOutPath</key>

--- a/ops/price-feed/com.numisma.pricefeed.daily.plist
+++ b/ops/price-feed/com.numisma.pricefeed.daily.plist
@@ -11,21 +11,36 @@
   WHY SIX FIRES AND NOT ONE (#185 S2). A MISSED FIRE IS NOT RECOVERED BY
   IDEMPOTENCY. Those are two different properties and the old note here conflated
   them: the deterministic id `pm-<id>-<asOf>` makes a REPEATED run harmless, which
-  is not the same as making a MISSED run recoverable. launchd DROPS a calendar
-  interval the machine slept through — it does not backfill it at wake — and `asOf`
-  is the CDMX CALENDAR DATE, so once midnight passes, `isFreshBar` refuses
-  yesterday's bar permanently and the day is gone. That is how 2026-06-27 and
-  friends were lost with no signal.
+  is not the same as making a MISSED run recoverable.
+
+  BE PRECISE ABOUT WHAT LAUNCHD DOES, because the obvious story is wrong in both
+  directions. `man 5 launchd.plist`: "Unlike cron which skips job invocations when
+  the computer is asleep, launchd will start the job the next time the computer
+  wakes up. If multiple intervals transpire before the computer is woken, those
+  events will be coalesced into one event upon wake from sleep." So launchd does
+  NOT drop a slept-through interval — it runs a single catch-up. What it cannot do
+  is make that catch-up useful: it lands under a NEW `asOf` (the CDMX CALENDAR
+  DATE), and `isFreshBar` refuses yesterday's bar, so the previous day is gone
+  regardless. That is how 2026-06-27 and friends were lost with no signal.
+
+  Two consequences worth stating, because both were got wrong here before:
+    - The six intervals COALESCE INTO ONE EVENT on wake, not six. They are not six
+      independent chances at a sleeping machine; they are six chances at a machine
+      that is awake at some point during the evening.
+    - The real split is ASLEEP vs. POWERED-OFF/LOGGED-OUT. Asleep: launchd fires a
+      coalesced catch-up, useless once the date rolled. Powered off or logged out:
+      the LaunchAgent was never loaded, so there is nothing to coalesce across the
+      boot — and THAT is the case RunAtLoad actually covers.
 
   So recovery is the SCHEDULE's job, and it has two halves:
     - The hourly 18:00–23:00 window (this array) is the half that does the work. A
       laptop shut at 18:00 but open by 23:00 still marks the day, within the same
-      CDMX date. Six retries, all at/after the 18:00 mark time — an earlier fire
-      would store quotes and emit ZERO marks.
-    - RunAtLoad true (below) is the belt-and-braces half: a machine booted inside
-      the window runs immediately rather than waiting for the next hour.
-  Neither recovers a day the machine was off for all six hours. Nothing can; only
-  the gap report names it after the fact.
+      CDMX date. All six are at/after the 18:00 mark time — an earlier fire would
+      store quotes and emit ZERO marks.
+    - RunAtLoad true (below) is the belt-and-braces half, and it earns its place on
+      the boot/login path specifically, where no coalesced catch-up exists.
+  Neither recovers a day the machine was off for the whole window. Nothing can;
+  only the gap report names it after the fact.
 
   THE COST FITS THE FREE TIER, which is what unparked this slice. Twelve Data Basic
   is 8 credits/minute and 800/day; the registry has 9 TD symbols at 1 credit each.
@@ -100,8 +115,12 @@
   <!-- Hourly 18:00-23:00 local, EVERY day (7-day schedule; see the header note on
        why 7 days, and on why six fires rather than one). An ARRAY of dicts, which
        is how launchd expresses several calendar intervals for one job. The first
-       fire that lands with the machine awake marks the day; the rest are cheap
-       no-ops (0 new marks). No interval past 23:00: `asOf` rolls at midnight. -->
+       fire on an AWAKE machine marks the day and the rest add 0 new marks. Note
+       these are six chances at an awake machine, NOT six retries against a sleeping
+       one — intervals slept through coalesce into a single catch-up (see header).
+       Every dict pins BOTH Hour and Minute: a missing field is a launchd WILDCARD,
+       so dropping a Minute line would schedule 60 fires an hour rather than one.
+       No interval past 23:00: `asOf` rolls at midnight. -->
   <key>StartCalendarInterval</key>
   <array>
     <dict>
@@ -142,10 +161,27 @@
     </dict>
   </array>
 
-  <!-- Run at load: the belt-and-braces half of the recovery (see header). A machine
-       booted or a job reloaded INSIDE the window runs at once instead of waiting for
-       the next hour; outside the window the run is a cheap no-op (pre-18:00 stores
-       quotes and emits no marks; post-midnight is the next day's asOf). -->
+  <!-- Run at load: the belt-and-braces half of the recovery (see header). It covers
+       the BOOT/LOGIN path, where no coalesced catch-up exists because the agent was
+       never loaded — a machine started inside the window marks the day at once
+       instead of waiting for the next hour.
+
+       AN OUT-OF-WINDOW LOAD IS NOT FREE, and calling it a "no-op" (as this comment
+       once did) is wrong in two ways. It costs 9 Twelve Data credits, about two
+       minutes of wall time (the 60s pacing sleep runs regardless), a commit attempt
+       in accumulus and a full `pnpm backfill`. It emits no MARKS, which is a
+       different claim — and one the heartbeat now records explicitly (`markWindow`,
+       #185 S2), because a 0-mark run exiting 0 otherwise looked exactly like a
+       healthy evening and silenced the staleness warning.
+
+       `man 5 launchd.plist` says of this key: "This key should be avoided, as
+       speculative job launches have an adverse effect on system-boot and user-login
+       scenarios." That is blanket advice and it is worth weighing rather than
+       waving away: this job is a ~2-minute network fetch on the login path. It is
+       accepted here because the login cost is bounded and off the critical path
+       (launchd does not wait on it), and because the alternative is the failure
+       this whole slice exists to end. If login latency ever becomes a complaint,
+       drop this key: the hourly window is the half that does the work. -->
   <key>RunAtLoad</key>
   <true/>
 

--- a/ops/price-feed/run-daily-fetch.sh
+++ b/ops/price-feed/run-daily-fetch.sh
@@ -8,8 +8,17 @@
 # a doomed mark is never appended and never silently lost.
 #
 # Idempotency is free (ADR-005 / #106): the deterministic id `pm-<id>-<asOf>` means
-# a missed run catches up on the next fire and a doubled run adds 0 new marks — so
-# this wrapper needs no locking of its own.
+# a doubled run adds 0 new marks — so this wrapper needs no locking of its own, and
+# the schedule can fire this script repeatedly without thought.
+#
+# IT DOES NOT MEAN A MISSED RUN CATCHES UP (an earlier version of this comment said
+# it did). Idempotency makes a REPEATED run harmless; it does nothing for a run that
+# never happened. `asOf` is the CDMX calendar date, so once midnight passes,
+# `isFreshBar` refuses yesterday's bar permanently — the day is unrecoverable, and
+# launchd drops a slept-through interval rather than backfilling it. What actually
+# recovers a missed evening is the SCHEDULE: the plist fires this script hourly from
+# 18:00 to 23:00 (#185 S2), so any hour the machine is awake within the CDMX day
+# still marks it. Past midnight, only the gap report can name the loss (#186).
 #
 # Edit the two placeholders below (or export them from the launchd plist), install
 # per docs/price-feed-ops.md, then verify with the documented manual dry run.

--- a/ops/price-feed/run-daily-fetch.sh
+++ b/ops/price-feed/run-daily-fetch.sh
@@ -80,19 +80,45 @@ HEARTBEAT_FILE="$DATA_DIR/job-heartbeat.json"
 # identical to a healthy evening, which SILENCED the staleness warning on exactly
 # the morning after a lost day. So record the distinction instead of guessing at it.
 #
-# `10#` forces base 10: bare `08`/`09` from `date +%H` are invalid OCTAL and would
-# abort the arithmetic — a boundary that only breaks during two hours of the morning.
+# THE ZONE IS PART OF THE CONTRACT, NOT THE MACHINE'S BUSINESS. The real gate is
+# `isAtOrAfterMarkTime(instant, { timeZone: "America/Mexico_City" })`, which resolves
+# through Intl in CDMX explicitly. Reading the bare local hour would agree with it
+# only by coincidence of the OS setting — and docs/price-feed-ops.md offers the
+# divergent setup as SUPPORTED ("or shift all six of the plist's Hour entries to the
+# local clock equal to 18:00-23:00 CDMX"). Take that option on a UTC box and every
+# scheduled fire computes out-of-window, so nothing ever stamps and the staleness
+# trigger is permanently, silently dead — while the runs themselves mark fine.
 #
-# Duplicating the mark hour into bash is deliberate and guarded: the plist hardcodes
-# it too, and apps/price-feed/src/schedule-window.test.ts pins BOTH against
-# DEFAULT_CONFIG.markTime so a change to the contract fails a test rather than
-# rotting here silently.
+# `10#` forces base 10 ON BOTH OPERANDS: bare `08`/`09` are invalid OCTAL, and `[[ ]]`
+# arithmetic-evaluates the right-hand side too. Unguarded, a mark hour in the 08/09
+# band would not abort — it is an `if` condition, so `set -e` never fires — it would
+# silently classify EVERY run as out-of-window. Moot at 18, latent the moment the
+# contract moves, which is precisely what the guard below exists to survive.
+#
+# Duplicating the hour AND the zone into bash is deliberate and guarded:
+# apps/price-feed/src/schedule-window.test.ts pins both against DEFAULT_CONFIG, so a
+# change to the contract fails a test rather than rotting here silently.
 MARK_HOUR=18
-if [[ $((10#$(date +%H))) -ge $MARK_HOUR ]]; then
+MARK_TZ="America/Mexico_City"
+if [[ $((10#$(TZ="$MARK_TZ" date +%H))) -ge $((10#$MARK_HOUR)) ]]; then
   MARK_WINDOW=true
 else
   MARK_WINDOW=false
 fi
+
+# WHICH STEPS MEAN THE DAY'S MARKS ARE ACTUALLY IN THE LOG. `pnpm spine` (step 2) is
+# what appends them, so every step AFTER it implies they landed. Being in the window
+# is not enough on its own: a run that dies at `prices-fetch` is in-window and marked
+# NOTHING, and stamping it would record the failure as evidence the day was covered.
+#
+# DELIBERATELY NOT "exit 0". The exit code covers the whole pipeline, but the marks
+# land at step 2. A run that fails at `gap-report` or `backfill` (steps 5-6) has
+# already appended and committed the day — gating on exit 0 would leave that evening
+# unstamped, so the next morning would claim "nothing recorded" for a day the log
+# plainly holds, and contradict the gap report standing next to it. Cry-wolf is the
+# failure this channel was designed around; under-stamping trades one false negative
+# for a false positive rather than fixing anything.
+MARKS_LANDED_STEPS="commit post-check gap-report backfill complete"
 
 # The heartbeat has ONE slot, so an out-of-window run OVERWRITES the evening run's
 # breadcrumb. Carrying the last in-window finish forward is what stops that erasing
@@ -100,8 +126,17 @@ fi
 # login (the bug) and crying wolf after every healthy evening. Read BEFORE the trap
 # can overwrite the file, and never inside the trap — pure bash, but `sed` is still
 # more work than an EXIT path in the middle of a failure should be doing.
+#
+# READ UNCONDITIONALLY, not only when out of window: an IN-window run that dies
+# before `spine` must also fall back to what it carried, so this value has to exist
+# on every path. (`|| VAR=""` on the pipelines below READS as a safety net and is
+# not one: under `pipefail`, if `head -n1` exits before `sed` finishes, `sed` takes
+# SIGPIPE, the pipeline reports failure, and the `||` blanks a value that was read
+# correctly. A heartbeat has one match, so this needs thousands of matching lines to
+# reach — and it fails CLOSED, to an unset carry. Left as is, named rather than
+# papered over.)
 CARRIED_MARK_WINDOW_AT=""
-if [[ "$MARK_WINDOW" == "false" && -f "$HEARTBEAT_FILE" ]]; then
+if [[ -f "$HEARTBEAT_FILE" ]]; then
   CARRIED_MARK_WINDOW_AT="$(sed -n \
     's/.*"lastMarkWindowFinishedAt"[[:space:]]*:[[:space:]]*"\([^"]*\)".*/\1/p' \
     "$HEARTBEAT_FILE" 2>/dev/null | head -n1)" || CARRIED_MARK_WINDOW_AT=""
@@ -112,6 +147,17 @@ if [[ "$MARK_WINDOW" == "false" && -f "$HEARTBEAT_FILE" ]]; then
     CARRIED_MARK_WINDOW_AT="$(sed -n \
       's/.*"finishedAt"[[:space:]]*:[[:space:]]*"\([^"]*\)".*/\1/p' \
       "$HEARTBEAT_FILE" 2>/dev/null | head -n1)" || CARRIED_MARK_WINDOW_AT=""
+  fi
+  # VALIDATE BEFORE RE-EMITTING. This value is copied verbatim into the next file, so
+  # a corrupt one (a torn write, a hand-edit, an embedded quote or backslash) does not
+  # merely travel — it can make the JSON unparseable, and the reader condemns the
+  # WHOLE record on a bad field, losing the exit code and step name with it. Worse, it
+  # is self-sustaining: every later out-of-window run re-reads and re-emits it, so only
+  # an in-window run would ever heal it. Dropping an unreadable carry costs one
+  # staleness date; keeping it costs the entire breadcrumb. Same ISO-instant shape the
+  # reader enforces, so anything accepted here is accepted there.
+  if [[ ! "$CARRIED_MARK_WINDOW_AT" =~ ^[0-9]{4}-[0-9]{2}-[0-9]{2}T[0-9]{2}:[0-9]{2}:[0-9]{2}(\.[0-9]+)?(Z|[+-][0-9]{2}:[0-9]{2})$ ]]; then
+    CARRIED_MARK_WINDOW_AT=""
   fi
 fi
 # ----------------------------------------------------------------------------
@@ -140,14 +186,28 @@ write_heartbeat() {
   HEARTBEAT_STATUS=$?
   [[ -d "$DATA_DIR" ]] || return 0
   HEARTBEAT_FINISHED_AT="$(date -u +%Y-%m-%dT%H:%M:%SZ 2>/dev/null)" || HEARTBEAT_FINISHED_AT="$STARTED_AT"
-  # An in-window run IS its own last in-window run; an out-of-window one re-emits
-  # whatever it carried. The field is OMITTED rather than written empty when there is
-  # nothing to carry: the reader validates it as an ISO instant and treats a bad one
-  # as an unreadable FILE, so `""` here would blind the whole breadcrumb.
+  # A run stamps itself as the last in-window run only if it was in the window AND
+  # actually landed the day's marks. IN-WINDOW ALONE IS NOT ENOUGH, and the gap is
+  # not hypothetical: a provider outage makes all six fires die at `prices-fetch`,
+  # each one in-window with zero marks. Stamping those records the outage as proof
+  # the day was covered — and the next morning's successful login run then carries
+  # that stamp forward while overwriting the red exit code with 0, so the failure
+  # disappears from every trigger at once. That is the same shape as the bug this
+  # field was added to fix, just entered from the other side.
+  #
+  # Anything else re-emits what it carried, so a genuine earlier evening survives an
+  # arbitrary number of later failures. The field is OMITTED rather than written
+  # empty when there is nothing to carry: the reader validates it as an ISO instant
+  # and treats a bad one as an unreadable FILE, so `""` here would blind the whole
+  # breadcrumb.
+  HEARTBEAT_MARK_WINDOW_AT="$CARRIED_MARK_WINDOW_AT"
   if [[ "$MARK_WINDOW" == "true" ]]; then
-    HEARTBEAT_MARK_WINDOW_AT="$HEARTBEAT_FINISHED_AT"
-  else
-    HEARTBEAT_MARK_WINDOW_AT="$CARRIED_MARK_WINDOW_AT"
+    for landed_step in $MARKS_LANDED_STEPS; do
+      if [[ "$LAST_STEP" == "$landed_step" ]]; then
+        HEARTBEAT_MARK_WINDOW_AT="$HEARTBEAT_FINISHED_AT"
+        break
+      fi
+    done
   fi
   if [[ -n "$HEARTBEAT_MARK_WINDOW_AT" ]]; then
     printf '{\n  "schemaVersion": 2,\n  "startedAt": "%s",\n  "finishedAt": "%s",\n  "exitCode": %d,\n  "lastStep": "%s",\n  "markWindow": %s,\n  "lastMarkWindowFinishedAt": "%s"\n}\n' \

--- a/ops/price-feed/run-daily-fetch.sh
+++ b/ops/price-feed/run-daily-fetch.sh
@@ -8,17 +8,26 @@
 # a doomed mark is never appended and never silently lost.
 #
 # Idempotency is free (ADR-005 / #106): the deterministic id `pm-<id>-<asOf>` means
-# a doubled run adds 0 new marks — so this wrapper needs no locking of its own, and
-# the schedule can fire this script repeatedly without thought.
+# a doubled run adds 0 new marks, so the schedule can fire this script repeatedly.
 #
 # IT DOES NOT MEAN A MISSED RUN CATCHES UP (an earlier version of this comment said
 # it did). Idempotency makes a REPEATED run harmless; it does nothing for a run that
 # never happened. `asOf` is the CDMX calendar date, so once midnight passes,
-# `isFreshBar` refuses yesterday's bar permanently — the day is unrecoverable, and
-# launchd drops a slept-through interval rather than backfilling it. What actually
-# recovers a missed evening is the SCHEDULE: the plist fires this script hourly from
-# 18:00 to 23:00 (#185 S2), so any hour the machine is awake within the CDMX day
-# still marks it. Past midnight, only the gap report can name the loss (#186).
+# `isFreshBar` refuses yesterday's bar permanently and the day is unrecoverable.
+# launchd DOES start a slept-through job at the next wake (coalescing several
+# intervals into one), but that catch-up lands under the new date and so recovers
+# nothing. What actually recovers a missed evening is the SCHEDULE: the plist fires
+# this script hourly from 18:00 to 23:00 (#185 S2), so any hour the machine is awake
+# within the CDMX day still marks it. Past midnight, only the gap report (#186) can
+# name the loss.
+#
+# WHY THERE IS NO LOCK, stated accurately — the mark id is NOT the reason. It covers
+# marks only, and says nothing about `atomicWrite`'s fixed `${filePath}.tmp` or the
+# accumulus git `index.lock`, both of which two concurrent runs would collide over.
+# What actually makes the repeated schedule safe is launchd's PER-LABEL SINGLETON:
+# it will not start a second instance of a job already running. That leaves only
+# schedule-vs-human collisions (a manual run during a scheduled one), which fail
+# loud under `set -e` and self-heal on the next hour — cheaper than a lock.
 #
 # Edit the two placeholders below (or export them from the launchd plist), install
 # per docs/price-feed-ops.md, then verify with the documented manual dry run.
@@ -64,6 +73,49 @@ STARTED_AT="$(date -u +%Y-%m-%dT%H:%M:%SZ)"
 LAST_STEP="startup"
 HEARTBEAT_FILE="$DATA_DIR/job-heartbeat.json"
 
+# --- was this run even CAPABLE of marking? (#185 S2) -------------------------
+# `RunAtLoad true` means this script now fires at ANY hour — a 09:00 login is an
+# ordinary trigger. Such a run stores quotes and emits ZERO marks (the mark-instant
+# contract gates on 18:00 CDMX), then exits 0. To the heartbeat reader that looked
+# identical to a healthy evening, which SILENCED the staleness warning on exactly
+# the morning after a lost day. So record the distinction instead of guessing at it.
+#
+# `10#` forces base 10: bare `08`/`09` from `date +%H` are invalid OCTAL and would
+# abort the arithmetic — a boundary that only breaks during two hours of the morning.
+#
+# Duplicating the mark hour into bash is deliberate and guarded: the plist hardcodes
+# it too, and apps/price-feed/src/schedule-window.test.ts pins BOTH against
+# DEFAULT_CONFIG.markTime so a change to the contract fails a test rather than
+# rotting here silently.
+MARK_HOUR=18
+if [[ $((10#$(date +%H))) -ge $MARK_HOUR ]]; then
+  MARK_WINDOW=true
+else
+  MARK_WINDOW=false
+fi
+
+# The heartbeat has ONE slot, so an out-of-window run OVERWRITES the evening run's
+# breadcrumb. Carrying the last in-window finish forward is what stops that erasing
+# the evidence: without it the reader must choose between going silent after every
+# login (the bug) and crying wolf after every healthy evening. Read BEFORE the trap
+# can overwrite the file, and never inside the trap — pure bash, but `sed` is still
+# more work than an EXIT path in the middle of a failure should be doing.
+CARRIED_MARK_WINDOW_AT=""
+if [[ "$MARK_WINDOW" == "false" && -f "$HEARTBEAT_FILE" ]]; then
+  CARRIED_MARK_WINDOW_AT="$(sed -n \
+    's/.*"lastMarkWindowFinishedAt"[[:space:]]*:[[:space:]]*"\([^"]*\)".*/\1/p' \
+    "$HEARTBEAT_FILE" 2>/dev/null | head -n1)" || CARRIED_MARK_WINDOW_AT=""
+  # A schemaVersion-1 file predates this field, and every v1 run was treated as
+  # in-window — so its `finishedAt` IS the last in-window finish. Only fall back
+  # when the previous run did not explicitly declare itself out-of-window.
+  if [[ -z "$CARRIED_MARK_WINDOW_AT" ]] && ! grep -q '"markWindow"[[:space:]]*:[[:space:]]*false' "$HEARTBEAT_FILE" 2>/dev/null; then
+    CARRIED_MARK_WINDOW_AT="$(sed -n \
+      's/.*"finishedAt"[[:space:]]*:[[:space:]]*"\([^"]*\)".*/\1/p' \
+      "$HEARTBEAT_FILE" 2>/dev/null | head -n1)" || CARRIED_MARK_WINDOW_AT=""
+  fi
+fi
+# ----------------------------------------------------------------------------
+
 # --- the heartbeat (#191) ---------------------------------------------------
 # THE ONE FACT THE DURABLE LOG CANNOT CONTAIN IS WHETHER THIS JOB RAN. The gap
 # report is a pure function of the log, deliberately — and the price of that purity
@@ -88,9 +140,25 @@ write_heartbeat() {
   HEARTBEAT_STATUS=$?
   [[ -d "$DATA_DIR" ]] || return 0
   HEARTBEAT_FINISHED_AT="$(date -u +%Y-%m-%dT%H:%M:%SZ 2>/dev/null)" || HEARTBEAT_FINISHED_AT="$STARTED_AT"
-  printf '{\n  "schemaVersion": 1,\n  "startedAt": "%s",\n  "finishedAt": "%s",\n  "exitCode": %d,\n  "lastStep": "%s"\n}\n' \
-    "$STARTED_AT" "$HEARTBEAT_FINISHED_AT" "$HEARTBEAT_STATUS" "$LAST_STEP" \
-    > "$HEARTBEAT_FILE" 2>/dev/null || true
+  # An in-window run IS its own last in-window run; an out-of-window one re-emits
+  # whatever it carried. The field is OMITTED rather than written empty when there is
+  # nothing to carry: the reader validates it as an ISO instant and treats a bad one
+  # as an unreadable FILE, so `""` here would blind the whole breadcrumb.
+  if [[ "$MARK_WINDOW" == "true" ]]; then
+    HEARTBEAT_MARK_WINDOW_AT="$HEARTBEAT_FINISHED_AT"
+  else
+    HEARTBEAT_MARK_WINDOW_AT="$CARRIED_MARK_WINDOW_AT"
+  fi
+  if [[ -n "$HEARTBEAT_MARK_WINDOW_AT" ]]; then
+    printf '{\n  "schemaVersion": 2,\n  "startedAt": "%s",\n  "finishedAt": "%s",\n  "exitCode": %d,\n  "lastStep": "%s",\n  "markWindow": %s,\n  "lastMarkWindowFinishedAt": "%s"\n}\n' \
+      "$STARTED_AT" "$HEARTBEAT_FINISHED_AT" "$HEARTBEAT_STATUS" "$LAST_STEP" \
+      "$MARK_WINDOW" "$HEARTBEAT_MARK_WINDOW_AT" \
+      > "$HEARTBEAT_FILE" 2>/dev/null || true
+  else
+    printf '{\n  "schemaVersion": 2,\n  "startedAt": "%s",\n  "finishedAt": "%s",\n  "exitCode": %d,\n  "lastStep": "%s",\n  "markWindow": %s\n}\n' \
+      "$STARTED_AT" "$HEARTBEAT_FINISHED_AT" "$HEARTBEAT_STATUS" "$LAST_STEP" "$MARK_WINDOW" \
+      > "$HEARTBEAT_FILE" 2>/dev/null || true
+  fi
   return 0
 }
 # Installed BEFORE the log dir is even made, so every exit path below is covered —

--- a/packages/event-store/src/heartbeat.test.ts
+++ b/packages/event-store/src/heartbeat.test.ts
@@ -1,17 +1,23 @@
 /**
- * The job heartbeat's reader — the half of #191 that CAN be tested.
+ * The job heartbeat's reader, and — since #185 S2 — the writer it must agree with.
  *
- * The writer is five lines of bash in `ops/price-feed/run-daily-fetch.sh` and the
- * repo has no shell-test infrastructure; this slice deliberately does not invent
- * one. The mitigation is to keep the bash to a trap and a `printf` and to test
- * everything downstream of it exhaustively — so these fixtures are written in the
- * EXACT byte shape that `printf` emits, not in a shape convenient for the parser.
- * If the two ever disagree, that is the bug this file exists to catch.
+ * The writer is a trap and a `printf` in `ops/price-feed/run-daily-fetch.sh`. #191
+ * could only approach it indirectly: the fixtures below are written in the EXACT
+ * byte shape that `printf` emits rather than a shape convenient for the parser, so
+ * that a drift between the two would show up here.
+ *
+ * That is no longer the only defence. Adding `markWindow` (#185 S2) meant editing
+ * BOTH halves at once, which is precisely when they drift — so the last describe in
+ * this file now RUNS the wrapper and feeds its real output to `parseHeartbeat`. The
+ * fixtures still earn their place: they reach the dates and exit codes a live run
+ * cannot be made to produce on demand.
  *
  * Dates, step names and exit codes only. No figures of any kind — the same privacy
  * property `gap-report.json` carries, for the same reason.
  */
-import { mkdtemp, rm, writeFile } from "node:fs/promises";
+import { mkdtemp, readFile, rm, writeFile } from "node:fs/promises";
+import { execFileSync } from "node:child_process";
+import { fileURLToPath } from "node:url";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { addDays, tradingDayAsOf } from "@numisma/engine";
@@ -43,6 +49,9 @@ function heartbeatFileBody(fields: {
   exitCode: number;
   lastStep: string;
   schemaVersion?: number;
+  /** Omitted ⇒ the v1 shape, which the reader must go on treating as in-window. */
+  markWindow?: boolean;
+  lastMarkWindowFinishedAt?: string;
 }): string {
   return (
     `{\n` +
@@ -50,8 +59,12 @@ function heartbeatFileBody(fields: {
     `  "startedAt": "${fields.startedAt}",\n` +
     `  "finishedAt": "${fields.finishedAt}",\n` +
     `  "exitCode": ${fields.exitCode},\n` +
-    `  "lastStep": "${fields.lastStep}"\n` +
-    `}\n`
+    `  "lastStep": "${fields.lastStep}"` +
+    (fields.markWindow === undefined ? `` : `,\n  "markWindow": ${fields.markWindow}`) +
+    (fields.lastMarkWindowFinishedAt === undefined
+      ? ``
+      : `,\n  "lastMarkWindowFinishedAt": "${fields.lastMarkWindowFinishedAt}"`) +
+    `\n}\n`
   );
 }
 
@@ -218,16 +231,172 @@ describe("formatHeartbeatWarning — the six cases", () => {
   it("ignores a schemaVersion it does not understand rather than misreading it", () => {
     // #189's convention: the version is bumped only when the shape changes in a way
     // that breaks a reader. Refusing an unknown one is what makes that promise safe.
-    expect(HEARTBEAT_SCHEMA_VERSION).toBe(1);
+    expect(HEARTBEAT_SCHEMA_VERSION).toBe(2);
     const future = heartbeatFileBody({
       startedAt: "2026-08-01T00:00:00Z",
       finishedAt: "2026-08-01T00:05:00Z",
       exitCode: 1,
       lastStep: "spine",
-      schemaVersion: 2,
+      schemaVersion: 3,
     });
     expect(parseHeartbeat(future)).toBeUndefined();
     expect(formatHeartbeatWarning(parseHeartbeat(future), NOW)).toEqual([]);
+  });
+});
+
+/**
+ * `RunAtLoad` (#185 S2) lets the job fire at ANY hour, and a pre-mark-time run emits
+ * zero marks while exiting 0. Read naively, that healthy-looking breadcrumb silences
+ * the one trigger that reports a lost day.
+ */
+describe("a run outside the mark window is not evidence that the day was marked", () => {
+  /** A `RunAtLoad` run at 09:00 CDMX on `day` — before the 18:00 mark time. */
+  function loginRunOn(
+    day: string,
+    options: { exitCode?: number; lastStep?: string; carried?: string } = {},
+  ): string {
+    return heartbeatFileBody({
+      schemaVersion: 2,
+      startedAt: `${day}T15:00:00Z`, // 09:00 CDMX on `day`
+      finishedAt: `${day}T15:02:00Z`, // 09:02 CDMX on `day`
+      exitCode: options.exitCode ?? 0,
+      lastStep: options.lastStep ?? "complete",
+      markWindow: false,
+      ...(options.carried === undefined ? {} : { lastMarkWindowFinishedAt: options.carried }),
+    });
+  }
+
+  it("STILL REPORTS THE LOST DAY after a clean login run — the #185 S2 regression", () => {
+    // Machine off through the evening of 2026-08-04 (the ceiling), opened 09:00 the
+    // next morning: the LaunchAgent loads, RunAtLoad fires, 0 marks, exit 0. Before
+    // this fix that run's own date satisfied the staleness check and 08-04 vanished
+    // from this channel entirely. The carried date is the last real evening, 08-03.
+    const lines = formatHeartbeatWarning(
+      parseHeartbeat(loginRunOn("2026-08-05", { carried: "2026-08-04T00:05:00Z" })),
+      NOW,
+    );
+    expect(lines).toHaveLength(1);
+    expect(lines[0]).toContain("has not completed since 2026-08-03");
+    expect(lines[0]).toContain(`nothing recorded for ${CEILING}`);
+  });
+
+  it("stays silent when the evening before it DID mark — no cry-wolf on a healthy morning", () => {
+    // Same login run, but 2026-08-04 was marked at 18:05 CDMX (stamped 08-05T00:05Z).
+    // The out-of-window run must not manufacture a warning either.
+    expect(
+      formatHeartbeatWarning(
+        parseHeartbeat(loginRunOn("2026-08-05", { carried: "2026-08-05T00:05:00Z" })),
+        NOW,
+      ),
+    ).toEqual([]);
+  });
+
+  it("still surfaces a FAILED login run — the exit code is about this run, not the window", () => {
+    // Out-of-window only disqualifies a run as evidence of MARKING. A run that died
+    // at exit 127 with no node still has to reach the operator.
+    const lines = formatHeartbeatWarning(
+      parseHeartbeat(
+        loginRunOn("2026-08-05", {
+          exitCode: 127,
+          lastStep: "resolve-tools",
+          carried: "2026-08-05T00:05:00Z",
+        }),
+      ),
+      NOW,
+    );
+    expect(lines).toHaveLength(1);
+    expect(lines[0]).toContain("FAILED");
+    expect(lines[0]).toContain("exit 127");
+    expect(lines[0]).toContain("resolve-tools");
+  });
+
+  it("says nothing about staleness when no in-window run is on record at all", () => {
+    // First ever load on a fresh machine: no evening has happened yet, so there is
+    // no date to be stale against. Silence, exactly as for an absent file — the gap
+    // report is the backstop.
+    const parsed = parseHeartbeat(loginRunOn("2026-08-05"));
+    expect(parsed?.lastMarkWindowFinishedAt).toBeUndefined();
+    expect(formatHeartbeatWarning(parsed, NOW)).toEqual([]);
+  });
+
+  it("reads a v1 file exactly as it did before, so an un-reinstalled wrapper is not broken", () => {
+    // The installed LaunchAgent/wrapper is a hand-resolved copy, so this reader will
+    // ship ahead of it. A v1 breadcrumb must keep behaving, not start crying.
+    expect(formatHeartbeatWarning(parseHeartbeat(ranOn(CEILING)), NOW)).toEqual([]);
+    expect(formatHeartbeatWarning(parseHeartbeat(ranOn("2026-08-03")), NOW)).toHaveLength(1);
+  });
+
+  it("refuses a markWindow that is not a boolean rather than coercing it", () => {
+    expect(
+      parseHeartbeat(
+        '{"schemaVersion":2,"startedAt":"2026-08-04T00:00:00Z","finishedAt":"2026-08-04T00:01:00Z",' +
+          '"exitCode":0,"lastStep":"complete","markWindow":"yes"}',
+      ),
+    ).toBeUndefined();
+  });
+});
+
+/**
+ * THE ONE SEAM THE FIXTURES ABOVE CANNOT COVER. Every other test in this file feeds
+ * the reader bytes a TEST wrote in the shape the wrapper is BELIEVED to emit. The
+ * failure mode that costs a real day is the two drifting apart — a `printf` edited
+ * without the parser, or the reverse — and a hand-written fixture agrees with
+ * whichever side wrote it.
+ *
+ * So run the actual script. It is pointed at a nonexistent repo so it dies at the
+ * `cd` in well under a second, which is enough: the heartbeat is written from an
+ * EXIT trap installed before anything else, and a failing run is the case the
+ * breadcrumb exists for.
+ */
+describe("the wrapper's own bytes, read by the reader that must consume them", () => {
+  const wrapper = fileURLToPath(
+    new URL("../../../ops/price-feed/run-daily-fetch.sh", import.meta.url),
+  );
+
+  /** Run the wrapper against a throwaway data dir and return the breadcrumb it left. */
+  async function runWrapper(): Promise<string> {
+    const dataDir = await mkdtemp(join(tmpdir(), "numisma-heartbeat-wrapper-"));
+    created.push(dataDir);
+    try {
+      execFileSync("/bin/bash", [wrapper], {
+        env: {
+          ...process.env,
+          NUMISMA_DATA_DIR: dataDir,
+          NUMISMA_REPO_DIR: join(dataDir, "no-such-repo"),
+          NUMISMA_PRICEFEED_ENV: join(dataDir, "no-such-env"),
+          NUMISMA_PRICEFEED_LOG_DIR: join(dataDir, "logs"),
+        },
+        stdio: "ignore",
+      });
+    } catch {
+      // EXPECTED: there is no repo to `cd` into, so the run dies early and non-zero.
+      // That is the case the breadcrumb exists for, and the trap still fires.
+    }
+    return readFile(join(dataDir, "job-heartbeat.json"), "utf8");
+  }
+
+  it("writes a heartbeat parseHeartbeat accepts, at the version this reader expects", async () => {
+    const parsed = parseHeartbeat(await runWrapper());
+    // Unparseable here means the printf and the parser have drifted — the exact
+    // break that would silently blind this channel in production.
+    expect(parsed).toBeDefined();
+    expect(parsed?.schemaVersion).toBe(HEARTBEAT_SCHEMA_VERSION);
+    expect(parsed?.lastStep).toBe("startup");
+    expect(parsed?.exitCode).not.toBe(0);
+    // Asserted as a TYPE, not a value: which branch it takes depends on the wall
+    // clock, and pinning that would make this test pass or fail by time of day.
+    expect(typeof parsed?.markWindow).toBe("boolean");
+  });
+
+  it("emits no lastMarkWindowFinishedAt at all when there is none to carry", async () => {
+    // Written EMPTY it would fail the ISO-instant check and take the whole file
+    // down as unreadable — losing the exit code too, on a first-ever failing run.
+    const raw = await runWrapper();
+    const parsed = parseHeartbeat(raw);
+    expect(parsed).toBeDefined();
+    if (!raw.includes("lastMarkWindowFinishedAt")) {
+      expect(parsed?.lastMarkWindowFinishedAt).toBeUndefined();
+    }
   });
 });
 
@@ -247,6 +416,10 @@ describe("parseHeartbeat — over the writer's exact bytes", () => {
       finishedAt: "2026-08-04T23:00:41Z",
       exitCode: 0,
       lastStep: "complete",
+      // A v1 file predates the mark window, so it is read the way it always was:
+      // the run counts as in-window and is its own last in-window run.
+      markWindow: true,
+      lastMarkWindowFinishedAt: "2026-08-04T23:00:41Z",
     });
   });
 
@@ -305,7 +478,9 @@ describe("parseHeartbeat — over the writer's exact bytes", () => {
     expect(Object.keys(parsed ?? {}).sort()).toEqual([
       "exitCode",
       "finishedAt",
+      "lastMarkWindowFinishedAt",
       "lastStep",
+      "markWindow",
       "schemaVersion",
       "startedAt",
     ]);

--- a/packages/event-store/src/heartbeat.test.ts
+++ b/packages/event-store/src/heartbeat.test.ts
@@ -326,6 +326,40 @@ describe("a run outside the mark window is not evidence that the day was marked"
     expect(formatHeartbeatWarning(parseHeartbeat(ranOn("2026-08-03")), NOW)).toHaveLength(1);
   });
 
+  it("REPORTS A DAY LOST TO A PROVIDER OUTAGE, even after a clean login run next morning", () => {
+    // The full scenario, end to end. Provider outage on 2026-08-04 (the ceiling):
+    // all six fires die at `prices-fetch`, in-window, zero marks — so none of them
+    // stamps, and the last in-window finish stays 08-03's evening. Next morning the
+    // provider is back and a 09:00 login run exits 0, overwriting the red exit code.
+    // The failure is gone from the exitCode trigger, so staleness is the only thing
+    // left holding the lost day — and it must not be fooled by the carried date
+    // belonging to a run that is now two days old.
+    const lines = formatHeartbeatWarning(
+      parseHeartbeat(loginRunOn("2026-08-05", { carried: "2026-08-04T00:05:00Z" })),
+      NOW,
+    );
+    expect(lines).toHaveLength(1);
+    expect(lines[0]).toContain("has not completed since 2026-08-03");
+  });
+
+  it("does not credit an in-window run that never stamped itself", () => {
+    // The reader half of the same bug. A v2 breadcrumb that is in-window but carries
+    // NO stamp is a run that did not reach the marks — deriving the date from its own
+    // `finishedAt` would re-create the failure the writer just took care to avoid.
+    const failedEvening = heartbeatFileBody({
+      schemaVersion: 2,
+      startedAt: "2026-08-05T00:00:00Z",
+      finishedAt: "2026-08-05T00:05:00Z", // 18:05 CDMX on the ceiling day
+      exitCode: 1,
+      lastStep: "prices-fetch",
+      markWindow: true,
+    });
+    const parsed = parseHeartbeat(failedEvening);
+    expect(parsed?.lastMarkWindowFinishedAt).toBeUndefined();
+    // It still says the run FAILED; it just refuses to call it a marked day.
+    expect(formatHeartbeatWarning(parsed, NOW).join(" ")).toContain("FAILED");
+  });
+
   it("refuses a markWindow that is not a boolean rather than coercing it", () => {
     expect(
       parseHeartbeat(
@@ -347,18 +381,47 @@ describe("a run outside the mark window is not evidence that the day was marked"
  * `cd` in well under a second, which is enough: the heartbeat is written from an
  * EXIT trap installed before anything else, and a failing run is the case the
  * breadcrumb exists for.
+ *
+ * TWO THINGS ARE CONTROLLED SO NOTHING HERE DEPENDS ON THE WALL CLOCK. The window
+ * branch is forced by rewriting the script's own `MARK_HOUR` constant in a copy — 0
+ * is always in-window, 99 never is — because the wrapper reads the CDMX hour itself
+ * and no ambient `TZ` can move it. And the data dir is SEEDED, because a fresh
+ * `mkdtemp` per run means no previous breadcrumb exists and the entire carry-forward
+ * path goes unreached. An earlier version of this describe did both the other way
+ * and its assertions were vacuous for part of every day.
  */
 describe("the wrapper's own bytes, read by the reader that must consume them", () => {
   const wrapper = fileURLToPath(
     new URL("../../../ops/price-feed/run-daily-fetch.sh", import.meta.url),
   );
 
-  /** Run the wrapper against a throwaway data dir and return the breadcrumb it left. */
-  async function runWrapper(): Promise<string> {
+  /**
+   * Run the wrapper and return the breadcrumb it left.
+   *
+   * `window` rewrites ONE constant — the mark hour — so the in/out-of-window branch
+   * becomes an input rather than a function of the time of day. Everything else is
+   * the real script, including the `sed` carry-forward read and the printf.
+   */
+  async function runWrapper(
+    options: { window?: "in" | "out"; seed?: string } = {},
+  ): Promise<string> {
     const dataDir = await mkdtemp(join(tmpdir(), "numisma-heartbeat-wrapper-"));
     created.push(dataDir);
+    if (options.seed !== undefined) {
+      await writeFile(join(dataDir, "job-heartbeat.json"), options.seed, "utf8");
+    }
+    let script = wrapper;
+    if (options.window !== undefined) {
+      const forced = options.window === "in" ? "0" : "99";
+      const source = await readFile(wrapper, "utf8");
+      const rewritten = source.replace(/^MARK_HOUR=18$/m, `MARK_HOUR=${forced}`);
+      // Fail loudly rather than silently testing the unmodified script.
+      expect(rewritten).not.toBe(source);
+      script = join(dataDir, "run-daily-fetch.sh");
+      await writeFile(script, rewritten, "utf8");
+    }
     try {
-      execFileSync("/bin/bash", [wrapper], {
+      execFileSync("/bin/bash", [script], {
         env: {
           ...process.env,
           NUMISMA_DATA_DIR: dataDir,
@@ -375,6 +438,17 @@ describe("the wrapper's own bytes, read by the reader that must consume them", (
     return readFile(join(dataDir, "job-heartbeat.json"), "utf8");
   }
 
+  /** A healthy evening on 2026-08-04 (18:05 CDMX = 2026-08-05T00:05Z), as v2. */
+  const HEALTHY_EVENING = heartbeatFileBody({
+    schemaVersion: 2,
+    startedAt: "2026-08-05T00:00:00Z",
+    finishedAt: "2026-08-05T00:05:00Z",
+    exitCode: 0,
+    lastStep: "complete",
+    markWindow: true,
+    lastMarkWindowFinishedAt: "2026-08-05T00:05:00Z",
+  });
+
   it("writes a heartbeat parseHeartbeat accepts, at the version this reader expects", async () => {
     const parsed = parseHeartbeat(await runWrapper());
     // Unparseable here means the printf and the parser have drifted — the exact
@@ -383,20 +457,82 @@ describe("the wrapper's own bytes, read by the reader that must consume them", (
     expect(parsed?.schemaVersion).toBe(HEARTBEAT_SCHEMA_VERSION);
     expect(parsed?.lastStep).toBe("startup");
     expect(parsed?.exitCode).not.toBe(0);
-    // Asserted as a TYPE, not a value: which branch it takes depends on the wall
-    // clock, and pinning that would make this test pass or fail by time of day.
-    expect(typeof parsed?.markWindow).toBe("boolean");
+  });
+
+  it("DOES NOT STAMP AN IN-WINDOW RUN THAT DIED BEFORE THE MARKS LANDED", async () => {
+    // The regression this pins: being in the window is not evidence of marking. A
+    // provider outage kills every fire at `prices-fetch`, all six in-window with zero
+    // marks — stamping them records the outage as proof the day was covered.
+    const parsed = parseHeartbeat(await runWrapper({ window: "in" }));
+    expect(parsed?.markWindow).toBe(true);
+    expect(parsed?.lastStep).toBe("startup");
+    expect(parsed?.lastMarkWindowFinishedAt).toBeUndefined();
+  });
+
+  it("lets a real evening survive a later in-window failure, rather than clobbering it", async () => {
+    // Same run as above, but an evening IS on record. The failure must not overwrite
+    // it — otherwise the next successful login run carries the failure's own stamp
+    // forward while resetting the exit code, and the lost day leaves every trigger.
+    const parsed = parseHeartbeat(await runWrapper({ window: "in", seed: HEALTHY_EVENING }));
+    expect(parsed?.exitCode).not.toBe(0);
+    expect(parsed?.lastMarkWindowFinishedAt).toBe("2026-08-05T00:05:00Z");
+  });
+
+  it("carries the last in-window finish across an out-of-window run", async () => {
+    const parsed = parseHeartbeat(await runWrapper({ window: "out", seed: HEALTHY_EVENING }));
+    expect(parsed?.markWindow).toBe(false);
+    expect(parsed?.lastMarkWindowFinishedAt).toBe("2026-08-05T00:05:00Z");
+  });
+
+  it("adopts a v1 file's finishedAt, since every v1 run counted as in-window", async () => {
+    const v1 = heartbeatFileBody({
+      startedAt: "2026-08-05T00:00:00Z",
+      finishedAt: "2026-08-05T00:05:00Z",
+      exitCode: 0,
+      lastStep: "complete",
+    });
+    const parsed = parseHeartbeat(await runWrapper({ window: "out", seed: v1 }));
+    expect(parsed?.lastMarkWindowFinishedAt).toBe("2026-08-05T00:05:00Z");
+  });
+
+  it("does not adopt finishedAt from a previous OUT-of-window run", async () => {
+    // That run's finish is not evidence of marking either, so the v1 fallback must
+    // not fire for it — otherwise the carry-forward launders a non-marking run.
+    const priorLogin = heartbeatFileBody({
+      schemaVersion: 2,
+      startedAt: "2026-08-05T15:00:00Z",
+      finishedAt: "2026-08-05T15:02:00Z",
+      exitCode: 0,
+      lastStep: "complete",
+      markWindow: false,
+    });
+    const parsed = parseHeartbeat(await runWrapper({ window: "out", seed: priorLogin }));
+    expect(parsed?.lastMarkWindowFinishedAt).toBeUndefined();
   });
 
   it("emits no lastMarkWindowFinishedAt at all when there is none to carry", async () => {
-    // Written EMPTY it would fail the ISO-instant check and take the whole file
-    // down as unreadable — losing the exit code too, on a first-ever failing run.
-    const raw = await runWrapper();
-    const parsed = parseHeartbeat(raw);
-    expect(parsed).toBeDefined();
-    if (!raw.includes("lastMarkWindowFinishedAt")) {
-      expect(parsed?.lastMarkWindowFinishedAt).toBeUndefined();
-    }
+    // Written EMPTY it would fail the ISO-instant check and take the whole file down
+    // as unreadable — losing the exit code too, on a first-ever failing run. Forced
+    // out-of-window so this asserts something every hour of the day.
+    const raw = await runWrapper({ window: "out" });
+    expect(raw).not.toContain("lastMarkWindowFinishedAt");
+    expect(parseHeartbeat(raw)?.lastMarkWindowFinishedAt).toBeUndefined();
+  });
+
+  it("drops a CORRUPT carried value instead of re-emitting it into unparseable JSON", async () => {
+    // The carried value is copied verbatim into the next file, so a torn write or a
+    // hand-edit can break the whole record — and it is self-sustaining, since every
+    // later out-of-window run re-reads and re-emits it. Dropping it costs one
+    // staleness date; keeping it costs the exit code and the step name as well.
+    const corrupt = HEALTHY_EVENING.replace(
+      /"lastMarkWindowFinishedAt": "[^"]*"/,
+      String.raw`"lastMarkWindowFinishedAt": "2026-08-05T00:05:00\Z"`,
+    );
+    expect(corrupt).not.toBe(HEALTHY_EVENING);
+    const raw = await runWrapper({ window: "out", seed: corrupt });
+    expect(() => JSON.parse(raw)).not.toThrow();
+    expect(parseHeartbeat(raw)).toBeDefined();
+    expect(parseHeartbeat(raw)?.lastMarkWindowFinishedAt).toBeUndefined();
   });
 });
 

--- a/packages/event-store/src/heartbeat.ts
+++ b/packages/event-store/src/heartbeat.ts
@@ -17,8 +17,9 @@
  * converts an exit code shown to nobody into a line on a surface opened daily.
  *
  * ── THE VERDICT: THREE TRIGGERS, ONE CLOCK ────────────────────────────────────
- * It speaks when the last run exited NON-ZERO, when the last run PREDATES the gap
- * report's ceiling, or when the last run is dated AFTER TODAY.
+ * It speaks when the last run exited NON-ZERO, when the last run that could actually
+ * MARK (see the mark-window section below) predates the gap report's ceiling, or when
+ * the last run is dated AFTER TODAY.
  *
  * The staleness ceiling is `dueThrough`, imported — **not a second staleness
  * number.** One window rule for the whole increment: a second, independently-derived
@@ -48,6 +49,29 @@
  * It is safe because the gap report is the backstop: if the job has genuinely
  * stopped, the marks stop landing and the gap report speaks.
  *
+ * ── WHY STALENESS READS A DIFFERENT FIELD THAN THE OTHER TWO TRIGGERS ─────────
+ * `RunAtLoad` (#185 S2) made the job fire on load as well as on the schedule, and a
+ * load can happen at any hour — a 09:00 login is a perfectly ordinary one. Such a
+ * run is PRE-MARK-TIME: it stores quotes, emits ZERO marks, and exits 0. Its
+ * `finishedAt` is therefore evidence that the SCRIPT ran, and no evidence at all
+ * that the DAY was marked.
+ *
+ * Read against `finishedAt`, staleness went silent in exactly the case it exists
+ * for: machine off all evening (day lost), opened at 09:00 next morning, login run
+ * exits 0 dated today — `ranOn < ceiling` false, `exitCode` 0, nothing said. The
+ * lost day vanished from this channel.
+ *
+ * A boolean alone cannot fix that, and it is worth saying why, because the obvious
+ * patch is wrong: this file holds ONE slot, so the login run OVERWRITES the evening
+ * run's breadcrumb. Merely ignoring an out-of-window run for staleness leaves the
+ * reader with no date at all — silent again in the same case. Refusing to ignore it
+ * cries wolf every morning after a HEALTHY evening.
+ *
+ * So the writer carries the fact forward instead: `lastMarkWindowFinishedAt` is the
+ * finish of the most recent IN-WINDOW run, re-emitted unchanged by runs that land
+ * outside the window. Staleness reads that; `exitCode` and the future-date check
+ * still read THIS run, so an out-of-window run that FAILS is never hidden.
+ *
  * NOT FOLDED INTO `gap-report.json`. Two writers, two languages, two lifetimes —
  * one written by bash on every run, the other by a TypeScript CLI on demand. The
  * standup reads both files; that is cheaper than a shared format neither owner
@@ -69,7 +93,17 @@ export const HEARTBEAT_FILENAME = "job-heartbeat.json";
  * A version this reader does not recognise is treated as UNREADABLE rather than
  * guessed at — refusing an unknown shape is what makes the bump rule safe to rely on.
  */
-export const HEARTBEAT_SCHEMA_VERSION = 1;
+export const HEARTBEAT_SCHEMA_VERSION = 2;
+
+/**
+ * Versions this reader accepts. **A bump adds to this set rather than replacing it**,
+ * because the file on disk is written by a script the operator installs BY HAND (the
+ * LaunchAgent is a resolved copy — see docs/price-feed-ops.md), so a reader that only
+ * ever accepted the newest version would go blind on every machine between a `git
+ * pull` and a reinstall. Version 1 is the pre-#185 shape, before the mark window was
+ * recorded; it is read as `markWindow: true`, which is exactly its old behavior.
+ */
+const READABLE_SCHEMA_VERSIONS: ReadonlySet<number> = new Set([1, 2]);
 
 /** What the wrapper's `printf` records. Dates, a step name and an exit code. */
 export interface JobHeartbeat {
@@ -82,6 +116,18 @@ export interface JobHeartbeat {
   exitCode: number;
   /** How far the run got: `startup`, `resolve-tools`, `prices-fetch`, … */
   lastStep: string;
+  /**
+   * Whether THIS run landed at/after the mark time, i.e. whether it was even capable
+   * of emitting marks. False for a `RunAtLoad` login/boot run before 18:00 CDMX.
+   */
+  markWindow: boolean;
+  /**
+   * The `finishedAt` of the most recent IN-WINDOW run — this run's own when
+   * `markWindow`, otherwise carried forward unchanged from the previous breadcrumb.
+   * `undefined` means no in-window run is on record at all, which is treated exactly
+   * like an absent file: silence, with the gap report as the backstop.
+   */
+  lastMarkWindowFinishedAt?: string;
 }
 
 /**
@@ -126,10 +172,10 @@ export function parseHeartbeat(raw: string | undefined): JobHeartbeat | undefine
     return undefined;
   }
   const body = parsed as Record<string, unknown>;
-  if (body.schemaVersion !== HEARTBEAT_SCHEMA_VERSION) {
+  if (typeof body.schemaVersion !== "number" || !READABLE_SCHEMA_VERSIONS.has(body.schemaVersion)) {
     return undefined;
   }
-  const { startedAt, finishedAt, exitCode, lastStep } = body;
+  const { schemaVersion, startedAt, finishedAt, exitCode, lastStep } = body;
   if (
     !isIsoInstant(startedAt) ||
     !isIsoInstant(finishedAt) ||
@@ -140,9 +186,32 @@ export function parseHeartbeat(raw: string | undefined): JobHeartbeat | undefine
   ) {
     return undefined;
   }
+  // ABSENT means version 1 — the shape written before the mark window existed, whose
+  // every run was read as evidence of a marked day. Defaulting to `true` keeps that
+  // file behaving exactly as it does today rather than making an installed wrapper
+  // start warning the moment this reader ships ahead of it.
+  const markWindow = body.markWindow === undefined ? true : body.markWindow;
+  if (typeof markWindow !== "boolean") {
+    return undefined;
+  }
+  // An in-window run IS its own last in-window run, so the writer need not repeat
+  // itself and a v1 file needs no new field to stay correct.
+  const carried = body.lastMarkWindowFinishedAt;
+  if (carried !== undefined && !isIsoInstant(carried)) {
+    return undefined;
+  }
+  const lastMarkWindowFinishedAt = markWindow ? finishedAt : carried;
   // Rebuilt field by field, never spread: an unknown key is dropped here rather
   // than carried into a line the operator reads.
-  return { schemaVersion: HEARTBEAT_SCHEMA_VERSION, startedAt, finishedAt, exitCode, lastStep };
+  return {
+    schemaVersion,
+    startedAt,
+    finishedAt,
+    exitCode,
+    lastStep,
+    markWindow,
+    ...(lastMarkWindowFinishedAt === undefined ? {} : { lastMarkWindowFinishedAt }),
+  };
 }
 
 /**
@@ -185,11 +254,18 @@ export function formatHeartbeatWarning(
         `else this breadcrumb says can be trusted.`,
     );
   }
-  if (ranOn < ceiling) {
-    lines.push(
-      `Numisma: the daily price job has not completed since ${ranOn} — ` +
-        `nothing recorded for ${ceiling}.`,
-    );
+  // STALENESS READS THE LAST IN-WINDOW RUN, NOT THIS RUN. A pre-mark-time `RunAtLoad`
+  // run emits no marks, so crediting its date here would answer "has the job marked
+  // the day?" with the fact that a script executed. Undefined means no in-window run
+  // is on record — silence, same as an absent file, with the gap report as backstop.
+  if (heartbeat.lastMarkWindowFinishedAt !== undefined) {
+    const markedOn = tradingDayAsOf(new Date(heartbeat.lastMarkWindowFinishedAt), REPORT_TIME_ZONE);
+    if (markedOn < ceiling) {
+      lines.push(
+        `Numisma: the daily price job has not completed since ${markedOn} — ` +
+          `nothing recorded for ${ceiling}.`,
+      );
+    }
   }
   return lines;
 }

--- a/packages/event-store/src/heartbeat.ts
+++ b/packages/event-store/src/heartbeat.ts
@@ -194,13 +194,23 @@ export function parseHeartbeat(raw: string | undefined): JobHeartbeat | undefine
   if (typeof markWindow !== "boolean") {
     return undefined;
   }
-  // An in-window run IS its own last in-window run, so the writer need not repeat
-  // itself and a v1 file needs no new field to stay correct.
   const carried = body.lastMarkWindowFinishedAt;
   if (carried !== undefined && !isIsoInstant(carried)) {
     return undefined;
   }
-  const lastMarkWindowFinishedAt = markWindow ? finishedAt : carried;
+  // TAKEN AS WRITTEN FOR v2, NEVER SYNTHESIZED. An earlier version derived this from
+  // `finishedAt` whenever `markWindow` was true, on the reasoning that an in-window
+  // run is its own last in-window run. THAT IS FALSE: being inside the window says
+  // only that a run COULD have marked. A provider outage kills every fire at
+  // `prices-fetch` — in-window, zero marks — and synthesizing here would credit those
+  // failures as evidence the day was covered, re-creating the bug this field exists
+  // to close even though the writer is careful not to stamp them. The writer decides;
+  // the reader reports.
+  //
+  // A v1 file is the one exception, and it is a migration rather than a synthesis:
+  // that shape predates the distinction and every v1 run was read as marking, so its
+  // `finishedAt` keeps meaning what it always meant.
+  const lastMarkWindowFinishedAt = carried ?? (schemaVersion === 1 ? finishedAt : undefined);
   // Rebuilt field by field, never spread: an unknown key is dropped here rather
   // than carried into a line the operator reads.
   return {


### PR DESCRIPTION
Slice S2 of #185 — the fetch half. S1 (`pnpm backfill` as step 6 of the wrapper) already landed and ran green.

**Closes #185**

> **Updated after review.** Four findings were fixed on this branch (commit `45589fd`); the sections below have been corrected where the original body said things those fixes falsify — in particular the launchd mechanism, which the first version of this PR got backwards. See "What review changed" at the end.

## The claim that was false

`ops/price-feed/com.numisma.pricefeed.daily.plist` had **one** `StartCalendarInterval` and `RunAtLoad false`. Three separate comments — in the plist header, in `run-daily-fetch.sh`, and in `docs/price-feed-ops.md` — all defended that with the same sentence: a missed run "catches up on the next fire" under the deterministic mark id.

It does not. Idempotency makes a **repeated** run harmless; it does nothing for a run that **never happened**. `asOf` is the CDMX **calendar date**, so once midnight passes, `isFreshBar` (`apps/price-feed/src/fetch-prices.ts:393`) refuses yesterday's bar permanently — no later run of any kind can mark that day.

**What launchd actually does, stated correctly.** From `man 5 launchd.plist`:

> Unlike cron which skips job invocations when the computer is asleep, launchd will start the job the next time the computer wakes up. If multiple intervals transpire before the computer is woken, those events will be coalesced into one event upon wake from sleep.

So launchd does **not** drop a slept-through interval — it runs one coalesced catch-up. The conclusion is unchanged (that catch-up lands under a new `asOf` and cannot reach the missed day), but two things follow that the comments had wrong:

- **Six intervals coalesce into ONE event on wake**, not six. They are six chances at a machine that is *awake* during the evening, not six retries against a sleeping one.
- **The distinction that matters is asleep vs. powered-off/logged-out.** Asleep → a useless coalesced catch-up. Powered off or logged out → the agent was never loaded, so nothing is coalesced across the boot. **That second case is what `RunAtLoad` actually covers.**

All three original comments are rewritten rather than deleted — the error is worth naming where it was made.

## What ships

- `StartCalendarInterval` becomes an **array** of six dicts: Hour 18/19/20/21/22/23, Minute 0. This is the half that does the work — a laptop shut at 18:00 but open by 23:00 still marks the day, inside the same CDMX date. Every fire is at/after the 18:00 mark time on purpose; an earlier one would store quotes and emit **zero** marks.
- `RunAtLoad` → **true**, covering the boot/login path where no coalesced catch-up exists.
- **The heartbeat learns to tell a marking run from a non-marking one** (`schemaVersion: 2`). This is not incidental — see below.
- Neither half recovers a day the machine was off for the whole window. Nothing can — naming that loss after the fact is the gap report's job (#186).

## `RunAtLoad` had a behavioral cost, and it is paid explicitly

Firing on load means firing at **any** hour, and a pre-mark-time run stores quotes, emits **zero** marks and exits `0`. `formatHeartbeatWarning` judged staleness on the run's own `finishedAt`, so this sequence went silent:

- Machine off from 17:00 on day D through 09:00 on D+1. No run on D. **Day D is permanently lost.**
- 09:00 on D+1: login → agent loads → `RunAtLoad` fires → 0 marks, exit 0.
- TUI at 09:30: `exitCode` 0 → silent; not future-dated; `ranOn (D+1) < ceiling (D)` false. **All three triggers silent** — where `main` correctly says *"has not completed since D-1"*.

Two candidate fixes were rejected, both on evidence rather than taste:

- **Gating the heartbeat WRITE on marks emitted.** A run that dies at `prices-fetch` emits no marks either, so this suppresses the breadcrumb for precisely the failing runs it exists for — and it makes the writer depend on something node produced, destroying the pure-bash property the `exit 127` case rests on. It also false-alarms on a healthy second fire, which emits no *new* marks by design.
- **A boolean alone.** The file has ONE slot, so the login run *overwrites* the evening run's breadcrumb. Ignoring an out-of-window run for staleness leaves no date at all — silent again in the same case — while not ignoring it cries wolf every morning after a healthy evening.

So the writer **carries the fact forward**: `markWindow` plus `lastMarkWindowFinishedAt`, the finish of the most recent run that actually landed marks, re-emitted unchanged by runs that did not. Staleness reads that; `exitCode` and the future-date check still read *this* run. A `schemaVersion: 1` file reads as `markWindow: true` — today's exact behavior — because the installed wrapper is a hand-resolved copy and this reader ships ahead of it.

**The date is stamped by "did this run get past the step that appends", not by "exit 0", and the distinction cuts both ways.** An earlier revision of this PR branched on `markWindow` alone, and a second review pass showed that hid a lost day in the opposite direction: a provider outage kills all six in-window fires at `prices-fetch`, each stamps itself as evidence the day was covered, and the next morning's successful login run carries that stamp forward while overwriting the red exit code with 0 — every trigger silent, where `main` still says *"FAILED on D — exit 1 at step `prices-fetch`"*. So both directions must be stated:

- An out-of-window run that **fails** is never hidden — `exitCode` is always this run's.
- An out-of-window run that **succeeds** can no longer hide a preceding in-window failure — it has no stamp to carry, because a run that never reached `spine` never set one.

Gating on `exit 0` instead would have been wrong in the other direction: marks land at step 2, while the exit code covers all six steps, so a run failing at `gap-report` or `backfill` has **already** appended and committed the day. That evening would go unstamped and the next morning would claim *"nothing recorded"* for a day the log plainly holds — contradicting the gap report standing beside it, and trading a false negative for the cry-wolf this channel was designed around. The gate is therefore `LAST_STEP` being one of the steps after `spine`.

**The reader had the same bug independently, and the new tests are what surfaced it.** `parseHeartbeat` derived `lastMarkWindowFinishedAt` from `finishedAt` whenever `markWindow` was true, reasoning that an in-window run is its own last in-window run — false for exactly the failed runs above, so a correct writer would have been undone by the reader. `schemaVersion: 2` is now taken as written; only v1, which predates the distinction, still maps `finishedAt`, and that is a migration rather than a synthesis.

## Why the parked gate is answered

S2 was parked on the Twelve Data credit cap. Basic (free) is 8 credits/minute and **800/day**; the registry holds **9** TD symbols at 1 credit each.

**6 fires × 9 = 54 credits/day against 800 — 6.75%.**

The daily cap was never the constraint; the *per-minute* cap is, and it is already handled by `twelveDataMaxSymbolsPerMinute: 8` plus a 60 s pause (`apps/price-feed/src/config.ts:73`). The 18/20/22 three-fire fallback is not needed.

**Read 54 as a floor, not a total.** It is the *scheduled* spend; `RunAtLoad` adds an unbudgeted 9 credits per boot, login and `launchctl load`. The headroom is large (~82 extra loads before 800), so this is stated rather than fixed — but the guard bounds the schedule, which is the part that *can* be bounded.

Repeat fires are cheap **but not free**: a second run of an evening appends 0 new marks, commits nothing, and re-upserts under `ON CONFLICT … DO UPDATE` — while still spending 9 credits and ~2 minutes (the pacing sleep runs regardless). "No new marks" and "no cost" are different claims, and an earlier version of this branch conflated them.

## S3–S6 did not close #185; this slice does

The `2026-08-02…08-04` outage was a **push** miss, not a fetch miss — the marks were fetched and landed in the durable log, and only the hosted projection went stale. The gap report is a pure function of the log, so it is **correctly silent** about those three days. S1's move to `pnpm backfill` fixed the push half. This slice fixes the fetch half — the one that actually loses days — which is why it closes the issue.

## The test seam

A plist is config. A test asserting "the file says Hour 18, so Hour 18" has no oracle but the file itself. `apps/price-feed/src/schedule-window.test.ts` therefore asserts **only properties with a source of truth outside the plist**:

1. It lints through Apple's own `plutil` — a malformed plist is the one failure launchd gives no feedback for.
2. No fire precedes `DEFAULT_CONFIG.markTime`; none lands past hour 23.
3. **Every interval pins both `Hour` and `Minute`.** `man 5 launchd.plist`: *"Missing arguments are considered to be wildcard"* — a dict with `Hour` and no `Minute` fires **sixty** times.
4. More than one interval exists — the recovery property itself.
5. **Fires per day × the registry's TD symbol count ≤ 800**, with wildcards **expanded**, not counted as one.
6. The wrapper's `MARK_HOUR` equals `DEFAULT_CONFIG.markTime` — the bash constant cannot rot silently.

**The literal hours and `RunAtLoad` are deliberately NOT asserted**: those would be pure byte restatements. `RunAtLoad`'s real consequence is tested where it lands — in the heartbeat reader, because a run at an arbitrary hour is a thing the *reader* has to get right.

`packages/event-store/src/heartbeat.test.ts` now also **runs the wrapper** and feeds its real output to `parseHeartbeat`. That seam is where a `markWindow`-shaped edit drifts, and hand-written fixtures agree with whichever side wrote them.

**These guards do not tell you the installed job works.** They read the repo's templates; the installed LaunchAgent is a separately-resolved copy. The manual dry run is still what covers that.

## Operator action required after merge

**The installed LaunchAgent is not updated by this PR.** `~/Library/LaunchAgents/com.numisma.pricefeed.daily.plist` is a *resolved copy* with `__REPO_DIR__` / `__HOME__` expanded by hand, so the two files diverge by design. Nothing on this branch touched it, and no `launchctl` command was run.

The docs give the sequence (copy → re-edit placeholders → `unload` → `load` → `launchctl print` to verify six intervals), including that **`RunAtLoad true` makes that `load` a live run**.

**The wrapper must be reinstalled too, not just the plist** — it is the half that writes `schemaVersion: 2`. Until it is, the reader keeps reading v1 breadcrumbs with today's behavior (no regression, no benefit).

## What review changed

### First pass

| # | Finding | Fix |
| --- | --- | --- |
| 1 | `RunAtLoad true` silenced the heartbeat staleness warning (behavioral) | `schemaVersion: 2` with `markWindow` + carried `lastMarkWindowFinishedAt`; staleness reads the last run that landed marks |
| 2 | Credit guard counted dicts, not fires — the six-`Minute`-deletion mutation passed all five assertions while scheduling 3240 credits/day | Fires counted with wildcards expanded, plus an explicit under-specified-dict assertion. Verified: that mutation now fails both |
| 3 | "launchd drops a missed interval" is backwards, in four places | Corrected to the coalesced-catch-up mechanism; conclusion unchanged, consequences restated |
| 4 | The whole test file was macOS-gated, so CI never ran it | Only `plutil` is gated now; the rest parse the XML directly, fail closed, and are cross-checked against `plutil` on macOS |

Plus, from the same review: the "cheap no-op" claim corrected, `man`'s advice against `RunAtLoad` quoted and weighed, the no-locking rationale re-credited to launchd's per-label singleton (the mark id covers marks only — not `atomicWrite`'s fixed `.tmp`, not accumulus's `index.lock`), 54 credits labelled a floor, and the stale "18:00 job" phrasings swept.

### Second pass

A fresh review of the heartbeat work above found that fix 1 had moved the bug rather than closed it.

| # | Finding | Fix |
| --- | --- | --- |
| A | An in-window run that **failed** still stamped itself as the last in-window run, so the next morning's successful run carried it forward and hid a lost day — a regression against `main` | Stamp gated on `LAST_STEP` reaching a step after `spine`, not on `markWindow` alone and not on `exit 0`. **The reader had the same bug independently** and is fixed with it |
| B | `markWindow` read the machine's local hour while the gate it mirrors resolves through `Intl` in CDMX — on the documented shifted-hours install, nothing would ever stamp and staleness would be silently dead | `TZ="$MARK_TZ" date +%H`, with `MARK_TZ` pinned against `DEFAULT_CONFIG.timeZone` the way `MARK_HOUR` is pinned against `markTime` |
| C | The carry-forward had **no test** — `runWrapper()` minted a fresh temp dir per call, so every path added by the previous commit was unreached, and two assertions were vacuous for part of each day | Data dir seeded and the window forced through the script's own `MARK_HOUR` in a copy (`0` always in-window, `99` never). These tests are what caught the reader half of A |
| D | `10#` guarded only the left operand, so a mark hour of `08`/`09` would silently classify every run out-of-window — and the guard compared `Number("08")`, sailing past it | Both operands wrapped; the guard's regex refuses a leading zero |
| E | A corrupt carried value was copied verbatim into the next breadcrumb, and the reader condemns the whole record on a bad field — self-sustaining, since only an in-window run heals it | Validated in bash before re-emitting, against the same ISO shape the reader enforces |
| F | `\|\| VAR=""` after a `sed \| head` pipeline reads as a safety net and is not one — under `pipefail` a SIGPIPE'd `sed` blanks a correctly-read value | **Left as is, named rather than papered over.** Needs thousands of matching lines to reach, and fails closed |

Note C's fix does not use the `TZ`-forcing the review suggested: once B lands, the wrapper resolves the CDMX hour itself and no ambient `TZ` can move it.

## Verification

- `pnpm typecheck` — clean across all six packages.
- `pnpm test` — **1357 passed, 19 skipped**. The skips are the pre-existing DB-gated integration tests, unchanged by this branch.
- `plutil -lint` on the template — OK. `bash -n` on the wrapper — OK.
- The heartbeat carry-forward is exercised against the **real script**, with the previous breadcrumb seeded on disk so the read path is actually reached: in-window-and-landed sets the field; a run that did not reach `spine` does not; out-of-window carries it; a v1 file's `finishedAt` is adopted; nothing to carry omits the field rather than writing `""`, which would fail the ISO check and blind the whole breadcrumb.
- Every new guard was mutation-checked: a leading-zero hour, a drifted timezone, a renamed step, and a new step inserted after `spine` each fail exactly one test, and restoring the reader's synthesis fails three.
- The first pass's `Minute`-deletion mutation was re-run independently by the second reviewer: 6 fires on this branch, 360 on the mutant, which now fails two assertions.

