### PR TITLE
chore(release): 0.7.5

### DIFF
--- a/apps/price-feed/package.json
+++ b/apps/price-feed/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@numisma/price-feed",
-  "version": "0.7.4",
+  "version": "0.7.5",
   "private": true,
   "type": "module",
   "exports": {

--- a/apps/tui/package.json
+++ b/apps/tui/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@numisma/tui",
-  "version": "0.7.4",
+  "version": "0.7.5",
   "private": true,
   "type": "module",
   "dependencies": {

--- a/apps/web/README.md
+++ b/apps/web/README.md
@@ -4,7 +4,7 @@ The hosted read-projection dashboard — a phone-checkable view of fund
 composition, backed by a disposable Postgres projection of the local event
 log. Built on **TanStack Start** (Vite-based full-stack React), chosen over
 Next.js in ADR-009. Package name `@numisma/web`, version tracks the monorepo
-root (`0.7.4`). Deployed to Vercel as project `numisma-web`; see
+root (`0.7.5`). Deployed to Vercel as project `numisma-web`; see
 `docs/web-deploy-runbook.md` for the deploy mechanism.
 
 ## What this app owns

--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@numisma/web",
-  "version": "0.7.4",
+  "version": "0.7.5",
   "private": true,
   "type": "module",
   "scripts": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "numisma",
-  "version": "0.7.4",
+  "version": "0.7.5",
   "private": true,
   "type": "module",
   "packageManager": "pnpm@11.1.2",

--- a/packages/engine/package.json
+++ b/packages/engine/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@numisma/engine",
-  "version": "0.7.4",
+  "version": "0.7.5",
   "private": true,
   "type": "module",
   "exports": {

--- a/packages/event-store/package.json
+++ b/packages/event-store/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@numisma/event-store",
-  "version": "0.7.4",
+  "version": "0.7.5",
   "private": true,
   "type": "module",
   "exports": {

--- a/packages/preferences/package.json
+++ b/packages/preferences/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@numisma/preferences",
-  "version": "0.7.4",
+  "version": "0.7.5",
   "private": true,
   "type": "module",
   "exports": {


### PR DESCRIPTION
Bumps the workspace to **0.7.5** so it can be tagged and released.

## What moves

All seven manifests, together — the monorepo carries one version:

| | |
|---|---|
| root | \`package.json\` |
| packages | \`engine\`, \`event-store\`, \`preferences\` |
| apps | \`tui\`, \`web\`, \`price-feed\` |

Plus `apps/web/README.md:7`, which states in prose that the web package version tracks the root.

## What deliberately does not move

- **`pnpm-lock.yaml`** — every cross-package dependency is `workspace:*`, so no version is pinned in the lock. No reinstall, no lock churn.
- **The `0.7.3` strings in `context/adr/ADR-009` and `docs/web-deploy-runbook.md`** — verbatim quotes from the 2026-07-25 build log of deployment `dpl_BSahSvPJoEwRHfLuUBRFWDQzc7Nm`. They are evidence that the workspace resolves on a git-connected Vercel build; rewriting them would falsify the record.
- **`numisma-version: 0.7.2` in `packages/engine/src/durable-log.test.ts:219`** — a fixture argument to `formatIngestCommitMessage`, not a read of the real version.

## Blast radius

`readAppVersion()` reads the root `package.json` at runtime, so ingest commits will stamp `numisma-version: 0.7.5` from the next fold onward. Nothing else reads a version.

## Verification

`pnpm test` — **1359 passed, 19 skipped** (the skips are the Postgres push-integration tests, which need `NUMISMA_TEST_DATABASE_URL`).

Tag `v0.7.5` goes on the merge commit after this lands, matching how `v0.7.4` sits on `b4c90ec`.