### PR TITLE
engine: reject a second close of a closed position; strengthen shadow/fold agreement test

### DIFF
--- a/packages/engine/src/cash-settlement-scenarios.test.ts
+++ b/packages/engine/src/cash-settlement-scenarios.test.ts
@@ -312,7 +312,11 @@ describe("cash leg — the cross-ref shadow tracks the fold exactly (slice #87)"
         tier: "c1",
       },
       // Mixed-Tier close of a genesis position (proceeds split c1 25% / c2 75%).
-      { id: "close-alt", asOf: "2026-06-06", type: "PositionClosed", positionId: "alt-pos", settlement: { reserveId: "tiered", proceeds: 360 } },
+      // Proceeds sit at alt-pos' expected 800 (20 × last close 40): the batch now
+      // runs through the real cross-ref gate, and the old 360 was a 55% deviation
+      // the settlement-magnitude guard rejects. The Tier mix — the thing this leg
+      // exercises — is a property of the closed lots, not of the proceeds figure.
+      { id: "close-alt", asOf: "2026-06-06", type: "PositionClosed", positionId: "alt-pos", settlement: { reserveId: "tiered", proceeds: 800 } },
       // Untiered credit: moves `amount` only, mints no Tier — the null-tiers path.
       { id: "dep-untiered", asOf: "2026-06-07", type: "Deposit", reserveId: "untiered", amount: 100, tier: "c3" },
       // Close a position opened earlier in the SAME batch (both encodings must
@@ -321,18 +325,37 @@ describe("cash leg — the cross-ref shadow tracks the fold exactly (slice #87)"
     ];
   }
 
-  it("every folded reserve equals the shadow's running balance, per amount and per Tier", () => {
-    const events = batch();
-
-    // The fold's encoding: mutate a `ReserveRecord` (amount + lots array).
-    const folded = foldEvents(genesis(), events);
-
-    // The shadow's encoding: advance the cross-ref balances exactly as the
-    // sufficiency gate does across a batch (amount + Tier Map).
+  /**
+   * Drive a batch through the REAL ingest path — the cross-ref gate first, then both
+   * encodings over the ACCEPTED subset — and assert the shadow's running balances
+   * equal the folded reserves, per amount and per Tier. Returns the ids the gate
+   * rejected, so a caller can lock which events never reached either encoding.
+   *
+   * Routing through `crossReferenceEvent` is the load-bearing part (audit finding
+   * 32). Hand-feeding both encodings the same known-good batch could only ever catch
+   * arithmetic drift, never the sharper class: an event THE GATE LETS THROUGH that
+   * only one of the two encodings applies. The fold silently ignores a second close
+   * of a retired position while the shadow re-credits its proceeds, so an unguarded
+   * gate shows up here as a balance mismatch — no error text, no reference internals,
+   * nothing that a rewrite of how the gate remembers a closed id could invalidate.
+   */
+  function expectShadowAgreesWithFold(events: PortfolioEvent[]): string[] {
+    const rejected: string[] = [];
+    const accepted: PortfolioEvent[] = [];
     const reference = buildEventReference(genesis());
     for (const event of events) {
+      if (crossReferenceEvent(event, reference).kind !== "ok") {
+        rejected.push(event.id);
+        continue;
+      }
+      accepted.push(event);
+      // The shadow's encoding: advance the cross-ref balances exactly as the
+      // sufficiency gate does across a batch (amount + Tier Map).
       applyEventToReference(reference, event);
     }
+
+    // The fold's encoding: mutate a `ReserveRecord` (amount + lots array).
+    const folded = foldEvents(genesis(), accepted);
 
     // Sanity: the batch actually moved cash, so the guard is not vacuous.
     expect(reserveById(folded, "tiered").amount).not.toBe(1500);
@@ -359,5 +382,29 @@ describe("cash leg — the cross-ref shadow tracks the fold exactly (slice #87)"
 
     // The reverse: the shadow holds no reserve the fold dropped (same reserve set).
     expect(reference.reserveBalances.size).toBe(folded.reserves.length);
+    return rejected;
+  }
+
+  it("every folded reserve equals the shadow's running balance, per amount and per Tier", () => {
+    // The whole representative batch clears the gate — nothing is dropped before
+    // the comparison, so the agreement below is over all six verbs.
+    expect(expectShadowAgreesWithFold(batch())).toEqual([]);
+  });
+
+  it("a re-authored second close is gated out, so neither encoding sees it (audit 1/32)", () => {
+    const events = batch();
+    // Same position, same reserve, same proceeds as `close-alt` — only the event id
+    // is fresh, which is all the durable log's id-keyed dedup looks at. The gate is
+    // the only thing that can stop it, and if it does not, the shadow credits 360
+    // the fold never books and the agreement assertions above fail.
+    events.push({
+      id: "close-alt-reauthored",
+      asOf: "2026-06-09",
+      type: "PositionClosed",
+      positionId: "alt-pos",
+      settlement: { reserveId: "tiered", proceeds: 800 },
+    });
+
+    expect(expectShadowAgreesWithFold(events)).toEqual(["close-alt-reauthored"]);
   });
 });

--- a/packages/engine/src/event-ingest.test.ts
+++ b/packages/engine/src/event-ingest.test.ts
@@ -434,6 +434,50 @@ describe("crossReferenceEvent — InvalidationMarked reference + post-close gate
   });
 });
 
+// Audit 2026-08-07 MUST FIX 1. `PositionClosed` was the one position-targeting verb
+// whose gate never consulted the retired-id set — trim and add-to both reject a
+// post-close event, close did not. Ingest dedup keys on event id alone, so a
+// re-authored close carrying a FRESH id passed the gate a second time: the cross-ref
+// shadow credited the proceeds again while the fold silently dropped the event, and
+// NAV drifted with `warnings: []` — the silent-cash-leg class ADR-003's fail-loud
+// posture exists to eliminate.
+//
+// The closed world-state below is built by running a real close through
+// `applyEventToReference` and never by reaching into the reference's internals, so
+// these locks hold whatever encoding the gate later uses to remember a retired id.
+describe("crossReferenceEvent — PositionClosed post-close gate (audit MUST FIX 1)", () => {
+  it("accepts the first close of a known open position", () => {
+    expect(crossReferenceEvent(asEvent(closedInput()), buildEventReference(genesis())).kind).toBe(
+      "ok",
+    );
+  });
+
+  it("rejects a re-authored second close of an already-closed position", () => {
+    const reference = buildEventReference(genesis());
+    const first = asEvent(closedInput());
+    expect(crossReferenceEvent(first, reference).kind).toBe("ok");
+    applyEventToReference(reference, first); // retires aapl-core
+
+    // A fresh event id: the durable log's id-keyed dedup cannot see this as a
+    // duplicate, so the gate is the only thing standing between it and the fold.
+    const second = asEvent(closedInput({ id: "e-close-reauthored", asOf: "2026-06-11" }));
+    const error = expectRejected(crossReferenceEvent(second, reference));
+    expect(error.path).toBe("positionId");
+    expect(error.message).toMatch(/already closed/);
+  });
+
+  it("names a dangling close distinctly from a post-close one", () => {
+    const error = expectRejected(
+      crossReferenceEvent(
+        asEvent(closedInput({ positionId: "ghost" })),
+        buildEventReference(genesis()),
+      ),
+    );
+    expect(error.path).toBe("positionId");
+    expect(error.message).toMatch(/neither the genesis seed nor the log contains/);
+  });
+});
+
 /** Parse a fixture input and unwrap to a typed event (fixtures are valid). */
 function asEvent(input: Record<string, unknown>): PortfolioEvent {
   const result = parseEvent(input);

--- a/packages/engine/src/event-ingest.test.ts
+++ b/packages/engine/src/event-ingest.test.ts
@@ -466,16 +466,8 @@ describe("crossReferenceEvent — PositionClosed post-close gate (audit MUST FIX
     expect(error.message).toMatch(/already closed/);
   });
 
-  it("names a dangling close distinctly from a post-close one", () => {
-    const error = expectRejected(
-      crossReferenceEvent(
-        asEvent(closedInput({ positionId: "ghost" })),
-        buildEventReference(genesis()),
-      ),
-    );
-    expect(error.path).toBe("positionId");
-    expect(error.message).toMatch(/neither the genesis seed nor the log contains/);
-  });
+  // A dangling close (unknown id) staying distinct from a post-close rejection is
+  // already locked by the MF1 case above — not re-asserted here.
 });
 
 /** Parse a fixture input and unwrap to a typed event (fixtures are valid). */

--- a/packages/engine/src/events/crossref.ts
+++ b/packages/engine/src/events/crossref.ts
@@ -205,8 +205,9 @@ export function buildEventReference(
  * close for a mid-stream instrument), a mark advances the last close. Mutates in
  * place. A close leaves the id known — it existed, and the domain's close-and-
  * reopen rule mints a fresh id rather than reusing the retired one — but records
- * it in {@link EventReference.closedPositionIds} so the ingest gate can reject a
- * post-close `InvalidationMarked` on it.
+ * it in {@link EventReference.closedPositionIds} so the ingest gate can reject
+ * EVERY later verb targeting it: a second close, a trim, an add-to, or a
+ * post-close `InvalidationMarked`.
  */
 export function applyEventToReference(reference: EventReference, event: PortfolioEvent): void {
   switch (event.type) {
@@ -240,7 +241,8 @@ export function applyEventToReference(reference: EventReference, event: Portfoli
           reserveDeltasForClose(closed.lots, event.settlement.proceeds),
         );
       }
-      // Flag the id retired so a later post-close InvalidationMarked fails loud.
+      // Flag the id retired so every later verb targeting it fails loud — a second
+      // close, a trim, an add-to, or a post-close InvalidationMarked.
       reference.closedPositionIds.add(event.positionId);
       break;
     }
@@ -659,6 +661,15 @@ function checkDebit(
   return null;
 }
 
+/**
+ * Cross-reference a `PositionClosed`. The position id must be KNOWN (genesis seed
+ * or log) and not already RETIRED — a close retires the id, the fold silently
+ * drops any later close of it, and log dedup keys on event id alone, so this gate
+ * is the only thing standing between a re-authored second close and silent NAV
+ * drift. The settlement leg is then checked for a live reserve and by the
+ * settlement-magnitude gate (Σ quantity × last close). Pure: reads `reference`,
+ * never mutates it.
+ */
 function crossReferenceClose(
   event: PositionClosedEvent,
   reference: EventReference,

--- a/packages/engine/src/events/crossref.ts
+++ b/packages/engine/src/events/crossref.ts
@@ -109,10 +109,12 @@ export interface EventReference {
    * Position ids the log has retired via a `PositionClosed`. A closed id stays in
    * {@link positionIds} (it existed, and close-and-reopen mints a fresh id rather
    * than reusing the retired one), but is additionally flagged here so the ingest
-   * gate can reject a post-close `InvalidationMarked` — a level on a retired
-   * position can never fold (breach is derived per OPEN position), so accepting it
-   * would silently drop the mark at fold. See {@link crossReferenceInvalidation}
-   * and ADR-003 (fail-loud-at-ingest).
+   * gate can reject every verb that targets a retired position — a post-close
+   * `InvalidationMarked` (a level on a retired position can never fold, since breach
+   * is derived per OPEN position), a trim, an add-to, and a SECOND close. Each would
+   * be silently dropped at fold, which is exactly the drift this ledger eliminates.
+   * See {@link crossReferenceInvalidation} / {@link crossReferenceClose} and ADR-003
+   * (fail-loud-at-ingest).
    */
   closedPositionIds: Set<string>;
   /** Latest known close per instrument: the magnitude guard's comparison point. */
@@ -667,6 +669,17 @@ function crossReferenceClose(
       "positionId",
       `PositionClosed references position id '${event.positionId}', which neither ` +
         `the genesis seed nor the log contains.`,
+    );
+  }
+  // A close retires the id, so a SECOND close of it can never fold to anything: the
+  // fold drops it silently while this shadow re-credits the proceeds, drifting NAV
+  // with no warning. Log dedup keys on event id alone and cannot catch a re-authored
+  // close carrying a fresh id — the retired-id set is the only guard, the same one
+  // trim, add-to and the post-close mark consult.
+  if (reference.closedPositionIds.has(event.positionId)) {
+    return eventError(
+      "positionId",
+      `PositionClosed targets position id '${event.positionId}', which is already closed.`,
     );
   }
   const settlesInto = requireReserveBornBy(


### PR DESCRIPTION
Addresses audit finding 1 by making crossReferenceClose consult closedPositionIds in the same idiom as the sibling guards, so a second close event against an already-closed position is rejected instead of silently accepted, with regression cases covering the new guard. Addresses audit finding 32 by folding the shadow/fold agreement check through cross-ref via expectShadowAgreesWithFold, so the batch only asserts agreement on the gate-accepted subset of scenarios rather than the full unfiltered set. As part of that change, close-alt's proceeds fixture moves from 360 to 800, since the old 360 figure was never gate-legal — a 55% deviation from the expected 800 that the settlement-magnitude guard rejects.