### PR TITLE
tui: migrateLegacyLog writes via writeLogImage and numbers lines as the reader does

### DIFF
--- a/apps/tui/src/event-store.test.ts
+++ b/apps/tui/src/event-store.test.ts
@@ -615,13 +615,16 @@ describe("durable-log migration — legacy-shape events fail loud, then migrate 
     // (fsync before rename, a distinct temp name) must cover the one path that rewrites
     // the WHOLE durable log, so this body must delegate rather than hand-roll.
     const source = await readFile(resolve(dirname(fileURLToPath(import.meta.url)), "event-store.ts"), "utf8");
-    const body = source.slice(
-      source.indexOf("export async function migrateLegacyLog"),
-      source.indexOf("* Append events atomically"),
-    );
+    const startIdx = source.indexOf("export async function migrateLegacyLog");
+    expect(startIdx).toBeGreaterThan(-1);
+    // Bound by the function's own closing brace (first column-0 `}` after the
+    // start) so a docstring reword or a function reorder elsewhere in the file
+    // cannot silently widen or empty the slice.
+    const closingBraceIdx = source.indexOf("\n}", startIdx);
+    expect(closingBraceIdx).toBeGreaterThan(startIdx);
+    const body = source.slice(startIdx, closingBraceIdx + 2);
     expect(body).toContain("writeLogImage(");
-    expect(body).not.toMatch(/\brename\(/);
-    expect(body).not.toMatch(/\bwriteFile\(/);
+    expect(body).not.toMatch(/\b(?:rename|renameSync|writeFile|writeFileSync|appendFile|appendFileSync|createWriteStream)\s*\(/);
   });
 
   it("migrateLegacyLog fails loud (writes nothing) when a legacy record has no supplied leg", async () => {

--- a/apps/tui/src/event-store.test.ts
+++ b/apps/tui/src/event-store.test.ts
@@ -582,6 +582,22 @@ describe("durable-log migration — legacy-shape events fail loud, then migrate 
     expect(data.reserves.find((reserve) => reserve.id === "cash-core")?.amount).toBe(1290);
   });
 
+  it("numbers lines the way the reader does, so both halves name the SAME line", async () => {
+    // Blank lines are records to neither half — but the reader counts them toward the
+    // line number and the migration must too. When they disagree the operator hand-edits
+    // whichever line the second message named, corrupting a *good* line of the durable,
+    // append-only log. Two blanks before the legacy close: physical line 4.
+    const log = `${JSON.stringify(markAapl(160, "pre-mark"))}\n\n\n${JSON.stringify(legacyClose)}\n`;
+    const paths = await makeStore({ log });
+
+    // What the READ half calls it.
+    const { quarantined } = await loadEventLog(paths.log);
+    expect(quarantined[0]?.lineNumber).toBe(4);
+
+    // What the WRITE half calls it — the same number, or the operator edits the wrong line.
+    await expect(migrateLegacyLog(paths, new Map())).rejects.toThrow(/line 4: PositionClosed/);
+  });
+
   it("migrateLegacyLog fails loud (writes nothing) when a legacy record has no supplied leg", async () => {
     const log = `${JSON.stringify(legacyClose)}\n`;
     const paths = await makeStore({ log });

--- a/apps/tui/src/event-store.test.ts
+++ b/apps/tui/src/event-store.test.ts
@@ -8,6 +8,7 @@
 import { mkdir, mkdtemp, readdir, readFile, rm, stat, writeFile } from "node:fs/promises";
 import { dirname, resolve } from "node:path";
 import { tmpdir } from "node:os";
+import { fileURLToPath } from "node:url";
 import {
   loadEventLog,
   loadFoldedReview,
@@ -596,6 +597,31 @@ describe("durable-log migration — legacy-shape events fail loud, then migrate 
 
     // What the WRITE half calls it — the same number, or the operator edits the wrong line.
     await expect(migrateLegacyLog(paths, new Map())).rejects.toThrow(/line 4: PositionClosed/);
+  });
+
+  it("migrateLegacyLog writes through writeLogImage — no second temp+rename writer", async () => {
+    const paths = await makeStore({ log: `${JSON.stringify(legacyClose)}\n` });
+    const cashLegs = new Map<string, SuppliedCashLeg>([
+      ["legacy-close-aapl", { settlement: { reserveId: "cash-core", proceeds: 290 } }],
+    ]);
+
+    await migrateLegacyLog(paths, cashLegs);
+
+    // The temp image is renamed away, never left behind (the writeLogImage contract).
+    expect(await exists(`${paths.log}.tmp`)).toBe(false);
+
+    // And structurally: the migration holds no writer of its own. `writeLogImage` is
+    // documented as "the only way the log is written" — any hardening landed there
+    // (fsync before rename, a distinct temp name) must cover the one path that rewrites
+    // the WHOLE durable log, so this body must delegate rather than hand-roll.
+    const source = await readFile(resolve(dirname(fileURLToPath(import.meta.url)), "event-store.ts"), "utf8");
+    const body = source.slice(
+      source.indexOf("export async function migrateLegacyLog"),
+      source.indexOf("* Append events atomically"),
+    );
+    expect(body).toContain("writeLogImage(");
+    expect(body).not.toMatch(/\brename\(/);
+    expect(body).not.toMatch(/\bwriteFile\(/);
   });
 
   it("migrateLegacyLog fails loud (writes nothing) when a legacy record has no supplied leg", async () => {

--- a/apps/tui/src/event-store.ts
+++ b/apps/tui/src/event-store.ts
@@ -294,12 +294,17 @@ export async function migrateLegacyLog(
   const unresolved: string[] = [];
   let migratedCount = 0;
 
-  const lines = raw
-    .split("\n")
-    .map((line) => line.trim())
-    .filter((line) => line.length > 0);
-
-  for (const [index, line] of lines.entries()) {
+  // Number lines EXACTLY as the read half does (`loadEventLog`): a blank line is a
+  // record to neither half, but it still consumes a line number, so every number
+  // reported here is the physical line an editor shows. When the two halves disagree
+  // the operator hand-edits whichever line the second message named — and in an
+  // append-only durable log that corrupts a good line. Hence: skip blanks INSIDE the
+  // loop, never filter them out before enumerating.
+  for (const [index, rawLine] of raw.split("\n").entries()) {
+    const line = rawLine.trim();
+    if (line.length === 0) {
+      continue;
+    }
     const lineNumber = index + 1;
     let json: unknown;
     try {

--- a/apps/tui/src/event-store.ts
+++ b/apps/tui/src/event-store.ts
@@ -275,7 +275,9 @@ export interface MigrationReport {
  *     supplied leg that overdraws a Reserve or is a fat-finger magnitude fails loud
  *     BEFORE anything touches disk.
  *
- * The rewrite is atomic (temp + rename), like {@link appendEvents}. This is a
+ * The rewrite goes through {@link writeLogImage} — the one temp + rename writer — so
+ * the path that rewrites the WHOLE durable log is hardened by anything landed there,
+ * never left behind by a second hand-rolled copy. This is a
  * deliberate one-time reconstruction, NOT a runtime append path — append-only still
  * holds going forward. Idempotent: re-running a clean log migrates nothing.
  */
@@ -365,11 +367,7 @@ export async function migrateLegacyLog(
     );
   }
 
-  await mkdir(dirname(paths.log), { recursive: true });
-  const body = `${migrated.map((event) => serializeEvent(event)).join("\n")}\n`;
-  const tempPath = `${paths.log}.tmp`;
-  await writeFile(tempPath, body, "utf8");
-  await rename(tempPath, paths.log);
+  await writeLogImage(paths.log, `${migrated.map((event) => serializeEvent(event)).join("\n")}\n`);
 
   return { migratedCount, unchangedCount: migrated.length - migratedCount, outputPath: paths.log };
 }

--- a/packages/event-store/src/event-store.test.ts
+++ b/packages/event-store/src/event-store.test.ts
@@ -103,6 +103,20 @@ describe("loadEventLog — log-line quarantine", () => {
     expect(lane).toContain("this is not json");
   });
 
+  it("numbers a quarantined line by its PHYSICAL position, blank lines included", async () => {
+    // The number the operator hand-edits by. Blank lines are skipped as records but
+    // still consume a line number, so the reported number matches what an editor
+    // shows — and matches what the one-shot migration reports for the same bytes
+    // (apps/tui `migrateLegacyLog`). The two halves must never disagree.
+    const log = `${JSON.stringify(openBtc())}\n\n\nthis is not json\n`;
+    const paths = await makeStore({ log });
+
+    const { quarantined } = await loadEventLog(paths.log);
+
+    expect(quarantined).toHaveLength(1);
+    expect(quarantined[0]).toMatchObject({ lineNumber: 4, line: "this is not json" });
+  });
+
   it("fails loud on the fold path when any line is unloadable (never a partial fold)", async () => {
     // ADR-003 amendment (M1): the fold/ingest read no longer degrades gracefully —
     // a dropped line would silently skew NAV, so loadFoldedReview refuses to fold a


### PR DESCRIPTION
Fixes two gaps in migrateLegacyLog surfaced by the audit. It now numbers log lines exactly the way loadEventLog does — iterating the raw split and skipping blanks inside the loop rather than filtering them out first — so a "line N" it reports matches the reader's quarantined.lineNumber for the same bytes (audit finding 11). It also writes the migrated log image through writeLogImage instead of a hand-rolled mkdir + writeFile + rename, so any hardening landed in that one writer covers the migration path too, and updates the surrounding docstring accordingly (audit finding 10).