### PR TITLE
engine: add-arm refreshes the display Close beside the blended markPrice

### DIFF
--- a/packages/engine/src/events/fold.ts
+++ b/packages/engine/src/events/fold.ts
@@ -314,7 +314,24 @@ export function foldEvents(
           // print a fabricated unrealized P&L. A real mark — a genesis seed mark (never
           // in the fallback set) or any PriceMarked — is left untouched.
           if (entryWacFallback.has(adding.id) && !latestMark.has(adding.instrumentId)) {
-            adding.markPrice = weightedAverageCost(adding.lots);
+            const blended = weightedAverageCost(adding.lots);
+            adding.markPrice = blended;
+            // Move the display-only Close WITH the fallback mark. The open arm seeds
+            // the two together; omitting the refresh here left the stale pre-add
+            // anchor as the instrument's latest Close and fired a synthetic
+            // `markprice-close-mismatch` on a legitimate scale-in (ADR-003 claims that
+            // warning cannot fire on the event path). Same-day re-anchor is an
+            // in-place edit, not an append: `latestCloseByInstrument` breaks an
+            // equal-asOf tie by keeping the FIRST, so an appended twin would be ignored.
+            const sameDay = closes.find(
+              (close) => close.instrumentId === adding.instrumentId && close.asOf === event.asOf,
+            );
+            if (sameDay) {
+              sameDay.price = blended;
+            } else {
+              seededInstruments.add(adding.instrumentId);
+              closes.push({ instrumentId: adding.instrumentId, asOf: event.asOf, price: blended });
+            }
           }
           applyToReserve(
             reserves,

--- a/packages/engine/src/events/fold.ts
+++ b/packages/engine/src/events/fold.ts
@@ -167,22 +167,36 @@ export function foldEvents(
   // already yields a 2-point journey (the journey builder skips single anchors).
   // The anchor is the genesis `markPrice`, NOT cost: that keeps it coherent with
   // the authoritative valuation, so no synthetic `markprice-close-mismatch` fires.
-  // Genesis-provided closes win — we only fill instruments that have none.
+  // Genesis-provided closes win — we only fill instruments that have none, and
+  // `costAnchors` below records ONLY the anchors the fold itself minted, so a
+  // scale-in can re-price its own baseline and never recorded history.
   //
   // First-position-wins here: if two genesis positions ever shared an instrument
   // with different `markPrice`, this seeds the t0 anchor from the FIRST while the
   // magnitude guard's `buildEventReference`/`noteClose` keeps the LAST (equal-asOf
   // overwrite), so the fold anchor and the guard seed could diverge. Unreachable
   // today (one position per instrument); revisit this tie-break if that changes.
+  //
+  // The two anchors also diverge, legitimately, after any scale-in: the ingest
+  // magnitude gate reads `buildEventReference(genesis)` — the SEED's closes — and
+  // never the fold's output, so the fold re-pricing its own cost anchor below is
+  // invisible to that gate by construction. Nothing reconciles the two, and
+  // nothing needs to: the gate compares an incoming event against recorded
+  // history, while the fold anchor is a display baseline for the journey.
   const seededInstruments = new Set(closes.map((close) => close.instrumentId));
+  // The fold-minted cost baseline per instrument (a genesis `markPrice` seed or an
+  // entry VWAC), held by reference so a later scale-in can re-price it in place.
+  const costAnchors = new Map<string, Close>();
   for (const position of genesis.positions) {
     if (!seededInstruments.has(position.instrumentId)) {
       seededInstruments.add(position.instrumentId);
-      closes.push({
+      const anchor: Close = {
         instrumentId: position.instrumentId,
         asOf: genesis.review.asOf,
         price: position.markPrice,
-      });
+      };
+      closes.push(anchor);
+      costAnchors.set(position.instrumentId, anchor);
     }
   }
 
@@ -221,7 +235,13 @@ export function foldEvents(
         // instrument first held mid-stream also has a baseline for its journey.
         if (!seededInstruments.has(position.instrumentId)) {
           seededInstruments.add(position.instrumentId);
-          closes.push({ instrumentId: position.instrumentId, asOf: event.asOf, price: entryPrice });
+          const anchor: Close = {
+            instrumentId: position.instrumentId,
+            asOf: event.asOf,
+            price: entryPrice,
+          };
+          closes.push(anchor);
+          costAnchors.set(position.instrumentId, anchor);
         }
         // Cash leg: debit the funding reserve. Sufficiency was proven at ingest.
         applyToReserve(reserves, event.funding.reserveId, reserveDeltasForOpen(position.lots, event.funding.amount));
@@ -320,17 +340,25 @@ export function foldEvents(
             // the two together; omitting the refresh here left the stale pre-add
             // anchor as the instrument's latest Close and fired a synthetic
             // `markprice-close-mismatch` on a legitimate scale-in (ADR-003 claims that
-            // warning cannot fire on the event path). Same-day re-anchor is an
-            // in-place edit, not an append: `latestCloseByInstrument` breaks an
-            // equal-asOf tie by keeping the FIRST, so an appended twin would be ignored.
-            const sameDay = closes.find(
-              (close) => close.instrumentId === adding.instrumentId && close.asOf === event.asOf,
-            );
-            if (sameDay) {
-              sameDay.price = blended;
-            } else {
-              seededInstruments.add(adding.instrumentId);
-              closes.push({ instrumentId: adding.instrumentId, asOf: event.asOf, price: blended });
+            // warning cannot fire on the event path).
+            //
+            // RE-PRICE, never append. The blend is a COST, not a price observed on the
+            // add's date: appending it as a fresh dated point drew a spike the market
+            // never printed (open 100 → add 150 → mark 105 rendered a 100/150/105
+            // journey with a nonsense changeAbs). So the fold edits its OWN cost
+            // baseline in place, keeping that anchor's original date — the journey
+            // then carries one restated baseline plus the real marks.
+            //
+            // The anchor is looked up by identity, not by (instrument, date): only
+            // anchors this fold minted are in `costAnchors`, so a genesis-provided
+            // Close — which wins by rule, see the seeding block above — is never
+            // clobbered. No fold anchor (the instrument's baseline came from genesis)
+            // means there is nothing this arm may honestly rewrite, so it leaves the
+            // display alone; the mark stays authoritative and any resulting divergence
+            // is a real one worth warning about.
+            const anchor = costAnchors.get(adding.instrumentId);
+            if (anchor) {
+              anchor.price = blended;
             }
           }
           applyToReserve(
@@ -349,13 +377,31 @@ export function foldEvents(
           direction: event.direction,
         });
         break;
-      case "PriceMarked":
+      case "PriceMarked": {
         latestMark.set(event.instrumentId, event.price);
-        closes.push({ instrumentId: event.instrumentId, asOf: event.asOf, price: event.price });
+        // A MARK OWNS ITS DAY. `latestCloseByInstrument` breaks an equal-`asOf` tie by
+        // keeping the FIRST close it sees, so blind-pushing a twin let a stale same-day
+        // anchor — an entry/blend cost baseline, or a superseded earlier mark — outrank
+        // the mark that actually sets `markPrice`, firing a synthetic
+        // `markprice-close-mismatch`. Overwriting instead makes the display agree with
+        // valuation by construction, and makes two marks on one day keep the LAST
+        // (matching the latest-wins `markPrice`) rather than the first.
+        const sameDay = closes.find(
+          (close) => close.instrumentId === event.instrumentId && close.asOf === event.asOf,
+        );
+        if (sameDay) {
+          // The overwritten close may BE the fold's cost anchor for this instrument;
+          // it stays registered but is unreachable to a later scale-in, which refuses
+          // to blend once `latestMark` holds a real mark for the instrument.
+          sameDay.price = event.price;
+        } else {
+          closes.push({ instrumentId: event.instrumentId, asOf: event.asOf, price: event.price });
+        }
         if (event.usdMxn !== undefined) {
           usdMxn = event.usdMxn;
         }
         break;
+      }
       case "Deposit":
         applyToReserve(reserves, event.reserveId, [{ tier: event.tier, amount: event.amount }]);
         break;

--- a/packages/engine/src/fold.test.ts
+++ b/packages/engine/src/fold.test.ts
@@ -257,11 +257,11 @@ describe("foldEvents — PositionAddedTo refreshes the entry-VWAC fallback mark"
       },
     ]);
 
-    // The anchor and the mark move together: the open seeds 100 at 06-02, the add
-    // re-anchors the blended 150 at its own 06-03.
+    // The anchor and the mark move together, but the blend re-prices the fold's own
+    // cost anchor IN PLACE at its original date — it never appends a new dated point,
+    // because a blended cost is not a price observed on 06-03.
     expect((folded.closes ?? []).filter((close) => close.instrumentId === "btc-usd")).toEqual([
-      { instrumentId: "btc-usd", asOf: "2026-06-02", price: 100 },
-      { instrumentId: "btc-usd", asOf: "2026-06-03", price: 150 },
+      { instrumentId: "btc-usd", asOf: "2026-06-02", price: 150 },
     ]);
 
     // ADR-003's claim holds on the event path: no synthetic mismatch for a scale-in.
@@ -330,6 +330,170 @@ describe("foldEvents — PositionAddedTo refreshes the entry-VWAC fallback mark"
     expect((folded.closes ?? []).filter((close) => close.instrumentId === "btc-usd")).toEqual([
       { instrumentId: "btc-usd", asOf: "2026-06-02", price: 100 },
       { instrumentId: "btc-usd", asOf: "2026-06-03", price: 130 },
+    ]);
+  });
+
+  it("a mark landing the SAME day as a scale-in wins the display anchor (no synthetic mismatch)", () => {
+    // Events sort stable on (asOf, log order), so the add runs first with no mark yet
+    // and blends 150; the mark then lands on the same 06-03. The MARK is the price for
+    // that day — a cost blend must never outrank it.
+    const folded = foldEvents(emptyGenesis(), [
+      opened("open-6", "2026-06-02", {
+        id: "sameday-mark-core",
+        portfolioId: "tactical",
+        tempo: "Liquid",
+        executionMode: "live",
+        accountId: "binance-usd",
+        instrumentId: "btc-usd",
+        direction: "long",
+        currency: "USD",
+        lots: [{ quantity: 10, cost: 100, tier: "c1" }],
+      }),
+      {
+        id: "add-6",
+        asOf: "2026-06-03",
+        type: "PositionAddedTo",
+        positionId: "sameday-mark-core",
+        lot: { quantity: 10, cost: 200, tier: "c1" },
+        funding: { reserveId: "no-such-reserve", amount: 2000 },
+      },
+      marked("mk-3", "2026-06-03", "btc-usd", 130),
+    ]);
+
+    expect(positionById(folded, "sameday-mark-core")?.markPrice).toBe(130);
+    const latest = (folded.closes ?? [])
+      .filter((close) => close.instrumentId === "btc-usd")
+      .reduce((best, close) => (close.asOf >= best.asOf ? close : best));
+    expect(latest.price).toBe(130);
+
+    const report = buildCompositionReport(folded);
+    expect(report.warnings.filter((warning) => warning.code === "markprice-close-mismatch")).toEqual([]);
+  });
+
+  it("an open + add + mark all on ONE day still ends at the mark's price", () => {
+    const folded = foldEvents(emptyGenesis(), [
+      opened("open-7", "2026-06-02", {
+        id: "one-day-core",
+        portfolioId: "tactical",
+        tempo: "Liquid",
+        executionMode: "live",
+        accountId: "binance-usd",
+        instrumentId: "btc-usd",
+        direction: "long",
+        currency: "USD",
+        lots: [{ quantity: 10, cost: 100, tier: "c1" }],
+      }),
+      {
+        id: "add-7",
+        asOf: "2026-06-02",
+        type: "PositionAddedTo",
+        positionId: "one-day-core",
+        lot: { quantity: 10, cost: 200, tier: "c1" },
+        funding: { reserveId: "no-such-reserve", amount: 2000 },
+      },
+      marked("mk-4", "2026-06-02", "btc-usd", 130),
+    ]);
+
+    expect((folded.closes ?? []).filter((close) => close.instrumentId === "btc-usd")).toEqual([
+      { instrumentId: "btc-usd", asOf: "2026-06-02", price: 130 },
+    ]);
+    const report = buildCompositionReport(folded);
+    expect(report.warnings.filter((warning) => warning.code === "markprice-close-mismatch")).toEqual([]);
+  });
+
+  it("two marks on the same day keep the LAST one as that day's anchor", () => {
+    const folded = foldEvents(emptyGenesis(), [
+      opened("open-8", "2026-06-02", {
+        id: "twin-mark-core",
+        portfolioId: "tactical",
+        tempo: "Liquid",
+        executionMode: "live",
+        accountId: "binance-usd",
+        instrumentId: "btc-usd",
+        direction: "long",
+        currency: "USD",
+        lots: [{ quantity: 10, cost: 100, tier: "c1" }],
+      }),
+      marked("mk-5", "2026-06-03", "btc-usd", 120),
+      marked("mk-6", "2026-06-03", "btc-usd", 130),
+    ]);
+
+    // markPrice is latest-wins (130); the display anchor now agrees instead of
+    // stranding the superseded 120 as the day's Close.
+    expect(positionById(folded, "twin-mark-core")?.markPrice).toBe(130);
+    expect((folded.closes ?? []).filter((close) => close.instrumentId === "btc-usd")).toEqual([
+      { instrumentId: "btc-usd", asOf: "2026-06-02", price: 100 },
+      { instrumentId: "btc-usd", asOf: "2026-06-03", price: 130 },
+    ]);
+  });
+
+  it("the scale-in never fabricates a phantom spike in the price journey", () => {
+    const folded = foldEvents(emptyGenesis(), [
+      opened("open-9", "2026-06-02", {
+        id: "journey-core",
+        portfolioId: "tactical",
+        tempo: "Liquid",
+        executionMode: "live",
+        accountId: "binance-usd",
+        instrumentId: "btc-usd",
+        direction: "long",
+        currency: "USD",
+        lots: [{ quantity: 10, cost: 100, tier: "c1" }],
+      }),
+      {
+        id: "add-9",
+        asOf: "2026-06-03",
+        type: "PositionAddedTo",
+        positionId: "journey-core",
+        lot: { quantity: 10, cost: 200, tier: "c1" },
+        funding: { reserveId: "no-such-reserve", amount: 2000 },
+      },
+      marked("mk-7", "2026-06-04", "btc-usd", 105),
+    ]);
+
+    // Appending the blend as a dated point rendered 100 → 150 → 105: a spike the
+    // market never printed, with a nonsense changeAbs/changePct. The journey carries
+    // only the re-anchored cost baseline and the real mark.
+    const journey = buildCompositionReport(folded).priceJourneys.find(
+      (candidate) => candidate.instrumentId === "btc-usd",
+    );
+    expect(journey?.points).toEqual([
+      { asOf: "2026-06-02", price: 150 },
+      { asOf: "2026-06-04", price: 105 },
+    ]);
+    expect(journey?.changeAbs).toBe(-45);
+  });
+
+  it("a scale-in never overwrites a GENESIS-provided Close", () => {
+    // Genesis closes win (the fold only ever fills instruments that have none), so the
+    // add may re-price the fold's own cost anchor but never recorded history.
+    const genesis = emptyGenesis();
+    genesis.closes = [{ instrumentId: "btc-usd", asOf: GENESIS_AS_OF, price: 95 }];
+    const folded = foldEvents(genesis, [
+      opened("open-10", GENESIS_AS_OF, {
+        id: "genesis-close-core",
+        portfolioId: "tactical",
+        tempo: "Liquid",
+        executionMode: "live",
+        accountId: "binance-usd",
+        instrumentId: "btc-usd",
+        direction: "long",
+        currency: "USD",
+        lots: [{ quantity: 10, cost: 100, tier: "c1" }],
+      }),
+      {
+        id: "add-10",
+        asOf: GENESIS_AS_OF,
+        type: "PositionAddedTo",
+        positionId: "genesis-close-core",
+        lot: { quantity: 10, cost: 200, tier: "c1" },
+        funding: { reserveId: "no-such-reserve", amount: 2000 },
+      },
+    ]);
+
+    expect(positionById(folded, "genesis-close-core")?.markPrice).toBe(150);
+    expect((folded.closes ?? []).filter((close) => close.instrumentId === "btc-usd")).toEqual([
+      { instrumentId: "btc-usd", asOf: GENESIS_AS_OF, price: 95 },
     ]);
   });
 });

--- a/packages/engine/src/fold.test.ts
+++ b/packages/engine/src/fold.test.ts
@@ -233,6 +233,105 @@ describe("foldEvents — PositionAddedTo refreshes the entry-VWAC fallback mark"
     // A real PriceMarked (130) wins over any VWAC fallback — the add never blends it away.
     expect(positionById(folded, "marked-core")?.markPrice).toBe(130);
   });
+
+  it("refreshes the display Close alongside the blended fallback mark, so a legitimate scale-in fires no markprice-close-mismatch", () => {
+    const folded = foldEvents(emptyGenesis(), [
+      opened("open-3", "2026-06-02", {
+        id: "scale-core",
+        portfolioId: "tactical",
+        tempo: "Liquid",
+        executionMode: "live",
+        accountId: "binance-usd",
+        instrumentId: "btc-usd",
+        direction: "long",
+        currency: "USD",
+        lots: [{ quantity: 10, cost: 100, tier: "c1" }],
+      }),
+      {
+        id: "add-3",
+        asOf: "2026-06-03",
+        type: "PositionAddedTo",
+        positionId: "scale-core",
+        lot: { quantity: 10, cost: 200, tier: "c1" },
+        funding: { reserveId: "no-such-reserve", amount: 2000 },
+      },
+    ]);
+
+    // The anchor and the mark move together: the open seeds 100 at 06-02, the add
+    // re-anchors the blended 150 at its own 06-03.
+    expect((folded.closes ?? []).filter((close) => close.instrumentId === "btc-usd")).toEqual([
+      { instrumentId: "btc-usd", asOf: "2026-06-02", price: 100 },
+      { instrumentId: "btc-usd", asOf: "2026-06-03", price: 150 },
+    ]);
+
+    // ADR-003's claim holds on the event path: no synthetic mismatch for a scale-in.
+    const report = buildCompositionReport(folded);
+    expect(report.warnings.filter((warning) => warning.code === "markprice-close-mismatch")).toEqual([]);
+  });
+
+  it("re-anchors in place when the scale-in lands on the same day as the open", () => {
+    // Same-asOf matters because latestCloseByInstrument breaks ties by KEEPING the
+    // first: a naive append would leave the stale 100 as the latest Close.
+    const folded = foldEvents(emptyGenesis(), [
+      opened("open-4", "2026-06-02", {
+        id: "sameday-core",
+        portfolioId: "tactical",
+        tempo: "Liquid",
+        executionMode: "live",
+        accountId: "binance-usd",
+        instrumentId: "btc-usd",
+        direction: "long",
+        currency: "USD",
+        lots: [{ quantity: 10, cost: 100, tier: "c1" }],
+      }),
+      {
+        id: "add-4",
+        asOf: "2026-06-02",
+        type: "PositionAddedTo",
+        positionId: "sameday-core",
+        lot: { quantity: 10, cost: 200, tier: "c1" },
+        funding: { reserveId: "no-such-reserve", amount: 2000 },
+      },
+    ]);
+
+    expect((folded.closes ?? []).filter((close) => close.instrumentId === "btc-usd")).toEqual([
+      { instrumentId: "btc-usd", asOf: "2026-06-02", price: 150 },
+    ]);
+
+    const report = buildCompositionReport(folded);
+    expect(report.warnings.filter((warning) => warning.code === "markprice-close-mismatch")).toEqual([]);
+  });
+
+  it("leaves the display Close alone when the add does not refresh the mark", () => {
+    const folded = foldEvents(emptyGenesis(), [
+      opened("open-5", "2026-06-02", {
+        id: "marked-core",
+        portfolioId: "tactical",
+        tempo: "Liquid",
+        executionMode: "live",
+        accountId: "binance-usd",
+        instrumentId: "btc-usd",
+        direction: "long",
+        currency: "USD",
+        lots: [{ quantity: 10, cost: 100, tier: "c1" }],
+      }),
+      marked("mk-2", "2026-06-03", "btc-usd", 130),
+      {
+        id: "add-5",
+        asOf: "2026-06-04",
+        type: "PositionAddedTo",
+        positionId: "marked-core",
+        lot: { quantity: 10, cost: 200, tier: "c1" },
+        funding: { reserveId: "no-such-reserve", amount: 2000 },
+      },
+    ]);
+
+    // A real mark owns both sides; the add pushes no anchor of its own.
+    expect((folded.closes ?? []).filter((close) => close.instrumentId === "btc-usd")).toEqual([
+      { instrumentId: "btc-usd", asOf: "2026-06-02", price: 100 },
+      { instrumentId: "btc-usd", asOf: "2026-06-03", price: 130 },
+    ]);
+  });
 });
 
 describe("foldEvents — as-of windows", () => {


### PR DESCRIPTION
Audit finding 19 observed that add-arm events blend the position's markPrice but leave the adjacent display Close stale, so the two drift apart after a scale-in. This refreshes the Close whenever markPrice is recomputed on an add-arm.

One subtlety worth flagging for review: latestCloseByInstrument keeps the FIRST close on an equal-asOf tie, so a same-day scale-in re-anchors the existing Close in place rather than displacing it — only a genuinely new day appends a fresh entry.

Reworked after review: the same audit finding also covered a re-fired mismatch warning on same-day add-then-mark and phantom price-journey points from cost blends, now fixed by restricting blends to anchors the fold itself seeded and having PriceMarked overwrite a same-day close in place.