### PR TITLE
docs: reconcile the operational runbooks with the code

### DIFF
--- a/docs/accumulus-restore-runbook.md
+++ b/docs/accumulus-restore-runbook.md
@@ -93,6 +93,19 @@ ingest was not the tip, git may report a conflict on `events.jsonl` (an append a
 resolve by keeping every surviving line **except** the reverted one, then
 `git revert --continue`.
 
+**The daily wrapper's commit is per-run, not per-file.** `run-daily-fetch.sh` stages
+and commits every tracked sidecar that changed in the same commit as the price marks
+(`events.jsonl`, `genesis.json`, `preferences.jsonl`, `orders.jsonl`) — whatever
+changed that run rides in together. If an `orders:import` or a preferences change
+landed the same day as the bad mark, `git revert` on that commit undoes **all of
+it**, not just the price mark: the `OrderRecord`s and any preferences edits from that
+run disappear too, silently — no skip, no warning, nothing in `available-capital`
+naming what left. Before reverting, run `git show <bad-sha> --stat` and read the diff
+of every changed file, not just `events.jsonl`; if the commit also touched
+`orders.jsonl` or `preferences.jsonl`, either accept losing those changes or use the
+surgical `checkout` alternative below to keep them and hand-remove only the bad
+event line.
+
 (Surgical alternative for a mixed batch: `git checkout <good-sha> -- data/events.jsonl`,
 delete only the bad line in your editor, `git add data/events.jsonl`.)
 

--- a/docs/durable-log-ops.md
+++ b/docs/durable-log-ops.md
@@ -1,7 +1,8 @@
 # Durable-log operations (verify, test, reproduce)
 
-The durable ledger — `events.jsonl`, `genesis.json`, `preferences.jsonl`, and the
-derived `head-digest.json` breadcrumb — lives in the private sibling repo
+The durable ledger — `events.jsonl`, `genesis.json`, `preferences.jsonl`,
+`orders.jsonl`, and the derived `head-digest.json` breadcrumb — lives in the
+private sibling repo
 **`<fund>`** (`~/Dev/<fund>/data` by default, or wherever `NUMISMA_DATA_DIR`
 points). Every successful ingest commits the log + Head Digest under **your own git
 identity**, so a bad-but-honest NAV is **locatable** (`git log -p head-digest.json`)

--- a/docs/hosted-cutover-runbook.md
+++ b/docs/hosted-cutover-runbook.md
@@ -511,7 +511,7 @@ all expected rather than faults:
    schemaVersion=3 feedGap=<arrived>/<expected> reserveFloor=<pct|absent>
    suppressed=[<keys>]`; exactly one row for that `(fund_id, as_of)`; the
    `report` JSONB carries exactly `totals`, `dashboard`, and `glance`. Verify
-   all four at once — this asserts what *landed*, which is stronger than the
+   all three at once — this asserts what *landed*, which is stronger than the
    CI contract test's assertion about what the code *would produce*. Read
    `suppressed=[…]` on a first push: any key listed there is a number the
    projection is deliberately NOT rendering because its input was
@@ -619,7 +619,7 @@ these connection strings rely on. On that upgrade, change them to
 | Seeded account password rotated — old rejected, new accepted | manual | PASS — both halves verified at the deployed URL | 2026-07-25 |
 | Rate-limit attack against the deployed URL (`auth:verify-limit`) | manual | PASS — 150 attempts, `403=14 429=136`, first 429 at #15, exit 0 | 2026-07-25 |
 | Rate-limit counter is DB-backed (D5), not per-instance memory | manual | PASS — 1 row, `has_signin_bucket=t`, `max_count=11` | 2026-07-25 |
-| First real push, push-side signal | manual | PASS — `fundId=<fund>-fund asOf=2026-07-24 schemaVersion=2`; 1 row; keys `{dashboard,totals}` | 2026-07-25 |
+| First real push, push-side signal | manual | PASS — `fundId=<fund>-fund asOf=2026-07-24 schemaVersion=2` (v2 was current then; v3 today); 1 row; keys `{dashboard,totals}` | 2026-07-25 |
 | First real push, **gate-closing** signal (phone, away from desk) | manual | TODO | TODO |
 | Soak: one week spanning a weekend, four conditions hold | manual | TODO | TODO |
 

--- a/docs/hosted-cutover-runbook.md
+++ b/docs/hosted-cutover-runbook.md
@@ -507,11 +507,16 @@ all expected rather than faults:
 **Two success signals — do not report one for the other.**
 
 1. **Push-side (code half):** exit `0`, prints
-   `fundId=<slug> asOf=<log's last event date> schemaVersion=2`; exactly one
-   row for that `(fund_id, as_of)`; the `report` JSONB carries exactly
-   `totals` and `dashboard`. Verify all three at once — this asserts what
-   *landed*, which is stronger than the CI contract test's assertion about
-   what the code *would produce*:
+   `[push] pushed snapshot fundId=<slug> asOf=<log's last event date>
+   schemaVersion=3 feedGap=<arrived>/<expected> reserveFloor=<pct|absent>
+   suppressed=[<keys>]`; exactly one row for that `(fund_id, as_of)`; the
+   `report` JSONB carries exactly `totals`, `dashboard`, and `glance`. Verify
+   all four at once — this asserts what *landed*, which is stronger than the
+   CI contract test's assertion about what the code *would produce*. Read
+   `suppressed=[…]` on a first push: any key listed there is a number the
+   projection is deliberately NOT rendering because its input was
+   unexpectedly absent — an empty `[]` is the clean signal, a non-empty list
+   is worth explaining before you move on:
 
    ```sh
    psql "$PROJECTION_WRITE_DATABASE_URL" -c "SELECT fund_id, as_of, schema_version, pushed_at, (SELECT count(*) FROM composition_snapshot) AS total_rows, (SELECT array_agg(k ORDER BY k) FROM jsonb_object_keys(report) AS k) AS report_keys FROM composition_snapshot;"

--- a/docs/local-data.md
+++ b/docs/local-data.md
@@ -49,14 +49,19 @@ Under that root (`<dataDir>`, e.g. `~/Dev/<fund>/data`):
 | `<dataDir>/head-digest.json`           | Derived, versioned summary of the folded head (the Head Digest) — a breadcrumb that makes a bad-NAV search cheap; never a source of truth (nothing folds it back). | tracked |
 | `<dataDir>/preferences.jsonl`          | Append-only profit-split policy sidecar, validated on load.                           | tracked         |
 | `<dataDir>/orders.jsonl`               | Append-only Orders sidecar — resting claims on capital, joined to the fold at read time and never folded into NAV (ADR-013). | tracked |
+| `<dataDir>/orders.jsonl.lock`          | Transient exclusive-create lock guarding a concurrent `orders.jsonl` write.           | ignored         |
+| `<dataDir>/gap-report.json`            | Derived standup artifact — dates/counts of the fetch window, overwritten every run, no rotation or history. | ignored         |
+| `<dataDir>/job-heartbeat.json`         | Derived launchd-run outcome (one slot, overwritten every run) — where and how the last scheduled run ended. | ignored         |
 | `<dataDir>/inbox/transactions.json`    | Disposable write channel: drop an array of new events here to be ingested on startup. | ignored         |
 | `<dataDir>/ingested/<wall-clock>.json` | Archive of a consumed inbox — stamped, never clobbered.                               | ignored         |
 | `<dataDir>/prices/`                    | Disposable price-quote cache (upserted every fetch).                                  | ignored         |
 | `<dataDir>/events.jsonl.quarantine`    | The side lane for corrupt log lines, surfaced rather than aborting the load.          | ignored         |
 
 `<fund>`'s `.gitignore` is an **allowlist**: only the five durable files are
-tracked; `prices/`, `inbox/`, `ingested/`, `*.tmp`, and `*.quarantine` are
-structurally excluded, so the disposable cache can never enter history.
+tracked; `prices/`, `inbox/`, `ingested/`, `*.tmp`, `*.quarantine`, the
+`orders.jsonl.lock` lock file, and the derived `gap-report.json` /
+`job-heartbeat.json` sidecars are structurally excluded, so the disposable
+cache can never enter history.
 
 ## Reversibility
 

--- a/docs/price-feed-ops.md
+++ b/docs/price-feed-ops.md
@@ -20,7 +20,6 @@ any command below.
 | --- | --- |
 | `ops/price-feed/run-daily-fetch.sh` | Wrapper the scheduler calls. Sets a PATH that can find `pnpm`, sources tokens, runs `pnpm prices:fetch`; on a clean fetch: (2) `pnpm spine` then (3) an auto-commit of any new data-repo changes scoped to `$NUMISMA_DATA_DIR` — idempotent if no new marks, never pushes — then (4) a post-check that **fails the job** if the durable event log is still uncommitted (lenient warn for the `head-digest.json` breadcrumb). Only once the log is verified does it touch anything derived, local before networked: (5) `pnpm gap-report -- --write` to rewrite `gap-report.json` beside the log and (6) `pnpm backfill` to refresh the hosted projection. Preserves the non-zero exit code so the scheduler notices a failure or rejection. |
 | `ops/price-feed/com.numisma.pricefeed.daily.plist` | launchd definition firing the wrapper **hourly from 18:00 to 23:00 local** (six intervals; 18:00 is the default mark time), **every day** — plus `RunAtLoad` true. The first fire on an awake machine marks the day; later fires add 0 new marks (though they still spend credits and time). See "Why the window is hourly, not a single 18:00 fire" and "Why the schedule fires 7 days/week" below. |
-
 | `ops/price-feed/launchagent-reinstall.md` | Runbook for pushing a plist change into the job launchd actually runs. Not executed by anything — it exists because the wrapper installs via `git pull` (launchd runs it in place) while the plist is a resolved copy, so merging a plist change does nothing on its own. |
 
 Both `.plist` / `.sh` files are templates: replace `__REPO_DIR__` / `__HOME__`
@@ -354,13 +353,22 @@ The `dow` field is `*` — **every day** — on purpose, and it is safe:
   mark (a fresh deterministic id the dedup can't catch, 0% move so the magnitude
   guard passes) — it would silently pile up every weekend.
 
-The fetch prevents that with **per-provider bar-date validation**: an equity mark is
-emitted only when the provider bar's date equals the run's trading-day `asOf`. When
-it doesn't (weekend/holiday), that instrument is **skipped as INFO** — you'll see
-`equity mark skipped — no fresh close for <asOf>` in the fetch output — **not** a
-failure. The run stays clean (exit 0), the crypto marks still ingest, and the
-`*-mxn` derived marks naturally skip too (their USD leg is stale). A weekday-only
-schedule was rejected: it would starve crypto AND still misfire on weekday holidays.
+The fetch prevents that with **bar-date validation applied uniformly to every
+instrument** — one rule, no per-source special case (`fetch-prices.ts`): a mark
+is emitted only when the provider bar's date equals the run's trading-day
+`asOf`. When it doesn't, that instrument is **skipped as INFO** — you'll see
+`mark skipped — no fresh close for <asOf>: <instrumentId> <symbol> (latest bar
+<observationDate>)` in the fetch output — **not** a failure. The run stays
+clean (exit 0). A weekday-only schedule was rejected: it would starve crypto
+AND still misfire on weekday holidays.
+
+The uniform rule means the same skip fires for any instrument whose bar is
+stale, but its **meaning differs by source**: for equities (and the `*-mxn`
+derived legs), a skip on a weekend or market holiday is expected and requires
+no action. For **crypto (Binance, 24/7)**, there is no closed day — a crypto
+skip on any date, including a weekend, is not "market closed, ignore"; it
+signals a late-firing provider or a stuck symbol and is worth investigating
+the same day it appears, not deferred to the next morning's gap report.
 
 ## Manual dry run (the schedule's main verification)
 
@@ -398,10 +406,13 @@ Confirm, in order:
 3. The wrapper exit code is `0` on a clean run, non-zero if any symbol failed or a
    mark was rejected.
 4. **On a weekend/holiday**, the equity lines read
-   `equity mark skipped — no fresh close for <asOf>` (one per equity, incl. the
+   `mark skipped — no fresh close for <asOf>: …` (one per equity, incl. the
    `*-mxn` legs), the crypto marks still emit, and the wrapper exit stays `0` — a
-   market-closed skip is expected INFO, not a failure. If you install on a weekday,
-   the equity marks emit normally; re-check this on the first weekend run.
+   market-closed skip on an equity is expected INFO, not a failure. If you install
+   on a weekday, the equity marks emit normally; re-check this on the first weekend
+   run. The same skip line on a **crypto** symbol is never expected (see "Why the
+   schedule fires 7 days/week" above) and should be treated as a live problem, not
+   waited out.
 5. **Auto-commit (step 3):** after a run that appended new marks, the log reads
    `committed durable-log changes (not pushed)` and `git -C "$NUMISMA_DATA_DIR" log
    -1` (or the `~/Dev/<fund>/data` default when the var is unset) shows a commit
@@ -531,14 +542,21 @@ bad day never appends a bad mark. The console/log distinguishes the two cases �
      blocks the whole batch (including hand-authored events) until it is removed,
      replaced, or admitted via `--magnitude-threshold`.
 
-### `equity mark skipped — no fresh close for <asOf>` — NOT a failure
+### `mark skipped — no fresh close for <asOf>: …` — usually NOT a failure, source-dependent
 
-- Info, not an error. It means the market was closed (weekend/holiday) so the Twelve
-  Data provider had no fresh close dated `asOf`; that equity (and, if it is a `*-mxn`
-  leg, its derived MXN mark) is skipped for the day rather than re-marked stale.
-- **Action: none.** The run still exits `0`, crypto still marks, and the equity marks
-  resume on the next trading day. Only investigate if you see it on a **trading day**
-  (would suggest provider bar-date drift or a stuck symbol).
+- The bar-date check is uniform — one rule for every instrument, no per-source
+  special case — so this line can appear for an equity, its `*-mxn` derived leg,
+  or crypto alike.
+- **Equity (incl. `*-mxn`): Action: none** on a weekend or market holiday. The
+  Twelve Data provider had no fresh close dated `asOf`; that instrument is
+  skipped for the day rather than re-marked stale, the run still exits `0`, and
+  the mark resumes on the next trading day. Only investigate an equity skip on a
+  **trading day** (would suggest provider bar-date drift or a stuck symbol).
+- **Crypto: Action: investigate the same day.** Binance trades 24/7, so there is
+  no "market closed" excuse — a crypto skip on any date (weekday or weekend)
+  means the provider fired late or a symbol is stuck. Do not wait for the gap
+  report: it only backstops the *next* morning, and only if every instrument for
+  that day was skipped, not one.
 
 ### Where to look
 

--- a/docs/web-deploy-runbook.md
+++ b/docs/web-deploy-runbook.md
@@ -113,12 +113,15 @@ database **redirects** rather than serving, and sign-in cannot complete — logg
 in is itself what needs `AUTH_DATABASE_URL`. This is designed behavior, not an
 incident and not a regression.
 
-Measured against a live preview with empty env (2026-07-25):
+The app's actual route table (`apps/web/src/routeTree.gen.ts`) is `/`,
+`/login`, `/big-picture`, and the `/api/auth/$` splat — there is no
+`/dashboard` route (the dashboard renders at `/`) and no `/api/health` route.
+Measured against those real routes on a live preview with empty env:
 
 | Route | Result |
 | --- | --- |
-| `/`, `/login`, `/dashboard` | `200` — shell renders |
-| `/api/auth/get-session`, `/api/auth/session`, `/api/health` | `302` redirect |
+| `/`, `/login`, `/big-picture` | `200` — shell renders |
+| `/api/auth/get-session`, `/api/auth/session` (matched by `/api/auth/$`) | `302` redirect |
 
 **No 500s.** Unauthenticated traffic is redirected before anything touches the
 database, so there is no error to see — which is exactly why the green-looking

--- a/ops/price-feed/com.numisma.pricefeed.daily.plist
+++ b/ops/price-feed/com.numisma.pricefeed.daily.plist
@@ -58,10 +58,14 @@
   The schedule fires EVERY day (7 days/week) ON PURPOSE. Crypto (Binance) trades
   24/7 and SHOULD mark every day, weekends included. Equities do NOT trade
   weekends/holidays, so on a market-closed day the fetch self-skips each equity mark
-  via per-provider bar-date validation (the provider's latest bar is a prior trading
-  day → INFO "equity mark skipped", not a failure) instead of appending a misdated
-  stale mark. So a 7-day schedule is correct for crypto AND safe for equities — a
-  weekday-only schedule would wrongly starve crypto and still misfire on holidays.
+  via bar-date validation applied uniformly to every instrument (the provider's
+  latest bar is a prior trading day → INFO "mark skipped — no fresh close for
+  <asOf>", not a failure) instead of appending a misdated stale mark. So a 7-day
+  schedule is correct for crypto AND safe for equities — a weekday-only schedule
+  would wrongly starve crypto and still misfire on holidays. NOTE: because the skip
+  rule is uniform, the SAME line can print for a crypto symbol; unlike an equity
+  skip, a crypto skip is never expected (Binance never closes) and should be
+  investigated the same day (docs/price-feed-ops.md).
 
   PATH: launchd starts this job with a bare, non-login PATH, so the wrapper sets its
   own PATH to find pnpm AND the node pnpm shells out to (NUMISMA_PATH_PREPEND). With


### PR DESCRIPTION
This reconciles the operational runbooks with what the code actually does, per audit findings 21, 22, 23, 24 and 30. The hosted cutover runbook's step 8 now shows the real schemaVersion-3 three-key report shape rather than the outdated one. The accumulus restore runbook now warns that run-daily-fetch.sh commits orders and preferences alongside marks, so restoring from a snapshot discards same-day edits to those files as well as marks. The web deploy runbook's route table is brought in line with routeTree.gen.ts, and the price-feed ops doc's skip message and triage guidance now match the uniform per-instrument skip rule. Finally, local-data.md's on-disk layout table gains the lock, gap-report, and heartbeat rows it was missing.