### PR TITLE
preferences: un-export appendPreference; inline the seeder's append

### DIFF
--- a/packages/preferences/README.md
+++ b/packages/preferences/README.md
@@ -21,8 +21,7 @@ Enumerated explicitly in `src/index.ts`:
 | --- | --- | --- |
 | `resolvePreferencesPath` | function | Resolve `<dataDir>/preferences.jsonl` under the shared `resolveDataDir` root (never CWD-relative). |
 | `loadPreferences` | function | Read the append-only sidecar into ordered, validated `ProfitPolicyEntry[]`. A missing file is `[]`; a malformed/out-of-range line is quarantined (dropped), not thrown. |
-| `appendPreference` | function | Genuinely append-only: add one `ProfitPolicyEntry` line without touching prior entries. |
-| `seedDefaultPreferences` | function | Seed a **new** sidecar with the fund's locked default policy only if it holds no valid entry yet — not a read-gap fallback; never call it to paper over a missing/quarantined policy. |
+| `seedDefaultPreferences` | function | The **only** preferences writer: seed a **new** sidecar with the fund's locked default policy, only if it holds no valid entry yet — not a read-gap fallback; never call it to paper over a missing/quarantined policy. Its one-line append is inline; there is no general `appendPreference` entry point (see below). |
 | `resolveOrdersPath` | function | Resolve `<dataDir>/orders.jsonl` under the shared `resolveDataDir` root. |
 | `loadOrders` | function | Read the sidecar into a total `OrdersLoad` outcome: `{status: "loaded", records, skips}` \| `{status: "absent"}` \| `{status: "unreadable", message}`. Never throws. |
 | `appendOrders` | function | Genuinely append-only: build the full next image, write to a same-directory unique temp file, then `rename` over the sidecar (crash-atomic), serialized across processes by an exclusive-create lock file. |
@@ -35,6 +34,13 @@ Enumerated explicitly in `src/index.ts`:
   temp-file + `rename` for crash-atomicity (the stronger contract, chosen
   because a plain `appendFile` suffix-write on a torn last line has
   concretely lost records before — see `orders.ts`'s header).
+- **No general preferences write surface.** `preferences.jsonl` has exactly one
+  writer, `seedDefaultPreferences`, whose single-line append is inline. The
+  package used to export an `appendPreference` — documented and tested, with
+  zero callers, on the weaker `appendFile` contract above. It was deleted rather
+  than hardened, so a future `preferences:set` cannot inherit the rejected
+  shape: whoever needs to write a policy must add that entry point deliberately,
+  on `appendOrders`' lock + temp + rename contract.
 - **Cross-process write serialization for orders.** `appendOrders` takes an
   exclusive-create lock file (`<path>.lock`) before its read-modify-write,
   because two overlapping appends reading the same image would otherwise let

--- a/packages/preferences/README.md
+++ b/packages/preferences/README.md
@@ -37,7 +37,7 @@ Enumerated explicitly in `src/index.ts`:
 - **No general preferences write surface.** `preferences.jsonl` has exactly one
   writer, `seedDefaultPreferences`, whose single-line append is inline. The
   package used to export an `appendPreference` — documented and tested, with
-  zero callers, on the weaker `appendFile` contract above. It was deleted rather
+  no caller outside the seeder, on the weaker `appendFile` contract above. It was deleted rather
   than hardened, so a future `preferences:set` cannot inherit the rejected
   shape: whoever needs to write a policy must add that entry point deliberately,
   on `appendOrders`' lock + temp + rename contract.

--- a/packages/preferences/src/index.ts
+++ b/packages/preferences/src/index.ts
@@ -1,5 +1,4 @@
 export {
-  appendPreference,
   loadPreferences,
   resolvePreferencesPath,
   seedDefaultPreferences,

--- a/packages/preferences/src/preferences-reliable.test.ts
+++ b/packages/preferences/src/preferences-reliable.test.ts
@@ -1,4 +1,4 @@
-// The RELIABLE half of the hardened preferences sidecar IO. The package has NO public
+// The RELIABLE half of the hardened preferences sidecar IO. The package has no GENERAL
 // write surface: seeding is the only writer, and it must be genuinely append-only (no
 // whole-file overwrite — a seed onto a file of quarantined lines preserves them). The
 // validating loader QUARANTINES malformed/garbage lines (bad JSON/shape, invalid ratio,

--- a/packages/preferences/src/preferences-reliable.test.ts
+++ b/packages/preferences/src/preferences-reliable.test.ts
@@ -1,21 +1,16 @@
-// The RELIABLE half of the hardened preferences sidecar IO: the genuinely
-// append-only writer
-// preserves ALL prior entries; the validating loader QUARANTINES malformed/garbage
-// lines (bad JSON/shape, invalid ratio, bad splitBasis, unparseable effectiveAt)
-// instead of throwing through or corrupting as-of replay; blank lines are tolerated;
-// a non-monotonic file replays deterministically through `pickPolicyAsOf`; and seeding
-// goes through the append path (no whole-file overwrite). Prior art: #90/#93.
-import { mkdir, mkdtemp, readFile, rm, writeFile } from "node:fs/promises";
+// The RELIABLE half of the hardened preferences sidecar IO. The package has NO public
+// write surface: seeding is the only writer, and it must be genuinely append-only (no
+// whole-file overwrite — a seed onto a file of quarantined lines preserves them). The
+// validating loader QUARANTINES malformed/garbage lines (bad JSON/shape, invalid ratio,
+// bad splitBasis, unparseable effectiveAt) instead of throwing through or corrupting
+// as-of replay; blank lines are tolerated; a non-monotonic file replays deterministically
+// through `pickPolicyAsOf`. Prior art: #90/#93.
+import { appendFile, mkdir, mkdtemp, readFile, rm, writeFile } from "node:fs/promises";
 import { dirname, isAbsolute, join, resolve } from "node:path";
 import { homedir, tmpdir } from "node:os";
 import { pickPolicyAsOf, resolveDataDir, type ProfitPolicyEntry } from "@numisma/engine";
 import { afterEach, describe, expect, it } from "vitest";
-import {
-  appendPreference,
-  loadPreferences,
-  resolvePreferencesPath,
-  seedDefaultPreferences,
-} from "./preferences.js";
+import { loadPreferences, resolvePreferencesPath, seedDefaultPreferences } from "./preferences.js";
 
 const createdDirs: string[] = [];
 
@@ -45,30 +40,17 @@ function entry(
   };
 }
 
-describe("appendPreference — genuinely append-only", () => {
-  it("preserves ALL prior entries across successive appends", async () => {
-    const path = await tempPath();
-    await appendPreference(path, entry("2026-06-01", "highWaterMark"));
-    await appendPreference(path, entry("2026-06-10", "perClose"));
-    await appendPreference(path, entry("2026-06-20", "highWaterMark"));
+/**
+ * Test-local fixture writer. The package deliberately exposes NO append entry point
+ * (audit finding 34 — a plain-`appendFile` write surface with no lock and no torn-line
+ * handling was DELETED rather than hardened), so loader/ordering fixtures write their
+ * own lines here instead of reaching for a production writer that no longer exists.
+ */
+async function appendLine(path: string, value: ProfitPolicyEntry): Promise<void> {
+  await appendFile(path, `${JSON.stringify(value)}\n`, "utf8");
+}
 
-    const loaded = await loadPreferences(path);
-    expect(loaded.map((e) => e.effectiveAt)).toEqual(["2026-06-01", "2026-06-10", "2026-06-20"]);
-    expect(loaded.map((e) => e.splitBasis)).toEqual(["highWaterMark", "perClose", "highWaterMark"]);
-  });
-
-  it("does not truncate a pre-existing file when adding one line", async () => {
-    const path = await tempPath();
-    await appendPreference(path, entry("2026-06-01"));
-    const before = await readFile(path, "utf8");
-    await appendPreference(path, entry("2026-06-10", "perClose"));
-    const after = await readFile(path, "utf8");
-    expect(after.startsWith(before)).toBe(true); // history is a prefix of the new file
-    expect((await loadPreferences(path)).length).toBe(2);
-  });
-});
-
-describe("seedDefaultPreferences — seeds via the append path", () => {
+describe("seedDefaultPreferences — the only writer, and genuinely append-only", () => {
   it("writes exactly one default line when the sidecar is absent", async () => {
     const path = await tempPath();
     const seeded = await seedDefaultPreferences(path, "2026-06-01", "sink-usdt");
@@ -78,12 +60,30 @@ describe("seedDefaultPreferences — seeds via the append path", () => {
     expect(raw.trim().split("\n")).toHaveLength(1); // one appended line, not a rewrite
   });
 
+  it("seeding a file whose every line is QUARANTINED appends — it never truncates them", async () => {
+    // The only reachable path on which the writer meets a non-empty file: `loadPreferences`
+    // returns [] (all lines quarantined) so the seed proceeds. A whole-file overwrite here
+    // would destroy the very bytes an operator needs to repair the corrupt sidecar.
+    const path = await tempPath();
+    const garbage = `{ not valid json\n${JSON.stringify({ ...entry("2026-06-05"), splitBasis: "lifetime" })}\n`;
+    await writeFile(path, garbage, "utf8");
+
+    await seedDefaultPreferences(path, "2026-06-01", "sink-usdt");
+
+    const after = await readFile(path, "utf8");
+    expect(after.startsWith(garbage)).toBe(true); // the corrupt history is a PREFIX, not a casualty
+    const loaded = await loadPreferences(path);
+    expect(loaded.map((e) => e.effectiveAt)).toEqual(["2026-06-01"]);
+  });
+
   it("does not overwrite an existing valid policy", async () => {
     const path = await tempPath();
-    await appendPreference(path, entry("2026-06-01", "perClose"));
+    await appendLine(path, entry("2026-06-01", "perClose"));
+    const before = await readFile(path, "utf8");
     const result = await seedDefaultPreferences(path, "2026-07-01", "sink-usdt");
     expect(result).toHaveLength(1);
     expect(result[0]?.splitBasis).toBe("perClose"); // untouched, not re-seeded
+    expect(await readFile(path, "utf8")).toBe(before); // and not written at all
   });
 });
 
@@ -172,8 +172,8 @@ describe("non-monotonic file — deterministic as-of replay through the selector
   it("loads in append order; pickPolicyAsOf sorts to the correct as-of policy", async () => {
     const path = await tempPath();
     // Appended OUT of date order on purpose.
-    await appendPreference(path, entry("2026-06-10", "perClose"));
-    await appendPreference(path, entry("2026-06-01", "highWaterMark"));
+    await appendLine(path, entry("2026-06-10", "perClose"));
+    await appendLine(path, entry("2026-06-01", "highWaterMark"));
 
     const loaded = await loadPreferences(path);
     expect(loaded.map((e) => e.effectiveAt)).toEqual(["2026-06-10", "2026-06-01"]); // append order kept

--- a/packages/preferences/src/preferences.ts
+++ b/packages/preferences/src/preferences.ts
@@ -166,7 +166,7 @@ export async function loadPreferences(path: string): Promise<ProfitPolicyEntry[]
  * Seed a NEW sidecar with this fund's locked default policy if it holds no valid entry
  * yet. The one-line append is INLINE here on purpose: this package exposes no general
  * write surface (audit finding 34). A public `appendPreference` was exported, documented
- * and tested with zero callers, carrying a weaker durability contract than
+ * and tested with no caller outside this seeder, carrying a weaker durability contract than
  * `appendOrders` — a plain `appendFile` with no lock and no torn-line handling, the shape
  * that has concretely lost records before. Rather than harden a writer nothing used, the
  * write surface was DELETED. Any future caller that genuinely needs to write a policy

--- a/packages/preferences/src/preferences.ts
+++ b/packages/preferences/src/preferences.ts
@@ -12,8 +12,10 @@
  *   data/preferences.jsonl   append-only, one ProfitPolicyEntry JSON per line
  *
  * Durability contract (R4/M5):
- *   - Writes are genuinely APPEND-ONLY (`appendPreference`) — a new policy line never
- *     destroys prior history. There is no whole-file overwrite on the reliable path.
+ *   - There is NO public write surface: `seedDefaultPreferences` is the only writer, and
+ *     its one-line append is inline (audit finding 34 deleted the exported, caller-less
+ *     `appendPreference` rather than hardening it). The seed is genuinely APPEND-ONLY —
+ *     no whole-file overwrite, so prior bytes survive even when every line is quarantined.
  *   - The loader VALIDATES every line on read (`loadPreferences`): shape, a present &
  *     parseable `effectiveAt`, a split whose Reserve fraction lands in [0, 1], and a
  *     `splitBasis` in the enum. Malformed/garbage lines are QUARANTINED (dropped from
@@ -161,18 +163,18 @@ export async function loadPreferences(path: string): Promise<ProfitPolicyEntry[]
 }
 
 /**
- * Genuinely APPEND-ONLY writer: append exactly ONE `ProfitPolicyEntry` as a JSON line
- * without touching prior entries. This is the reliable write path — a new policy never
- * destroys history.
- */
-export async function appendPreference(path: string, entry: ProfitPolicyEntry): Promise<void> {
-  await mkdir(dirname(path), { recursive: true });
-  await appendFile(path, `${JSON.stringify(entry)}\n`, "utf8");
-}
-
-/**
  * Seed a NEW sidecar with this fund's locked default policy if it holds no valid entry
- * yet. Uses the append-only writer so seeding, like every write, preserves history.
+ * yet. The one-line append is INLINE here on purpose: this package exposes no general
+ * write surface (audit finding 34). A public `appendPreference` was exported, documented
+ * and tested with zero callers, carrying a weaker durability contract than
+ * `appendOrders` — a plain `appendFile` with no lock and no torn-line handling, the shape
+ * that has concretely lost records before. Rather than harden a writer nothing used, the
+ * write surface was DELETED. Any future caller that genuinely needs to write a policy
+ * (a `preferences:set` CLI) must add its entry point deliberately, on the
+ * lock + temp + rename contract of `orders.ts`, instead of inheriting the rejected shape.
+ *
+ * Seeding still preserves history: it appends rather than rewriting, so the one file it
+ * can meet non-empty — every line quarantined by the loader — keeps its bytes for repair.
  *
  * This is a SEED FOR A NEW SIDECAR, and it is NOT a read-gap fallback — the distinction
  * is load-bearing. It writes `defaultProfitPolicyEntry`, whose `reserveTargetPct` is
@@ -192,6 +194,7 @@ export async function seedDefaultPreferences(
     return existing;
   }
   const seeded = defaultProfitPolicyEntry(effectiveAt, routingReserveId);
-  await appendPreference(path, seeded);
+  await mkdir(dirname(path), { recursive: true });
+  await appendFile(path, `${JSON.stringify(seeded)}\n`, "utf8");
   return [seeded];
 }


### PR DESCRIPTION
Audit finding 34 flagged that the exported appendPreference writer had a single caller, seedDefaultPreferences, so exposing it as a public write surface added risk without a real use case. This change deletes the export and inlines the append logic directly into the seeder. The append-only guard that previously lived on the writer now lives on the seeder itself, where the only invocation occurs.