### PR TITLE
web: testable argv parsing for push/backfill; document AUTH_VERIFY_BASE_URL

### DIFF
--- a/apps/web/.env.example
+++ b/apps/web/.env.example
@@ -59,7 +59,8 @@ NUMISMA_SEED_NAME=Operator
 
 # --- Rate-limit verification target (ADR-011 D10) ---------------------------
 # The base URL `pnpm --filter @numisma/web auth:verify-limit` attacks. UNSET IT
-# DEFAULTS TO http://localhost:3000 AND STILL EXITS 0 — a pass that proves
+# DEFAULTS TO http://localhost:3000 (needs a local dev server running; without
+# one the run fails for the wrong reason) — and a localhost pass proves
 # nothing about the shared DB-backed counter, which is the one thing a deployed
 # multi-instance run exists to show, and the exact false pass the script's own
 # header warns about. Cutover step 7 is where it bites. `-- --url <target>`

--- a/apps/web/.env.example
+++ b/apps/web/.env.example
@@ -56,3 +56,16 @@ NUMISMA_SEED_EMAIL=operator@example.com
 NUMISMA_SEED_PASSWORD=change-me-a-strong-password
 # Optional display name; defaults to the email when unset.
 NUMISMA_SEED_NAME=Operator
+
+# --- Rate-limit verification target (ADR-011 D10) ---------------------------
+# The base URL `pnpm --filter @numisma/web auth:verify-limit` attacks. UNSET IT
+# DEFAULTS TO http://localhost:3000 AND STILL EXITS 0 — a pass that proves
+# nothing about the shared DB-backed counter, which is the one thing a deployed
+# multi-instance run exists to show, and the exact false pass the script's own
+# header warns about. Cutover step 7 is where it bites. `-- --url <target>`
+# overrides this; the deployed run wants the STABLE PRODUCTION ALIAS, never a
+# preview (previews hold no env vars at all).
+#
+# Leave it commented out for local dev: the localhost default is right there,
+# and a variable that is present-but-wrong is worse than one that is absent.
+# AUTH_VERIFY_BASE_URL=https://<stable-production-alias>

--- a/apps/web/README.md
+++ b/apps/web/README.md
@@ -148,6 +148,7 @@ See `apps/web/.env.example` for the authoritative, commented list. Summary:
 | `PROJECTION_ADMIN_DATABASE_URL` | `db:provision` | One-shot, local/operator only |
 | `PROJECTION_WRITER_ROLE` / `PROJECTION_READER_ROLE` | `db:provision` | Optional, default `numisma_push` / `numisma_web` |
 | `NUMISMA_SEED_EMAIL` / `NUMISMA_SEED_PASSWORD` / `NUMISMA_SEED_NAME` | `auth:seed` | Local/operator only |
+| `AUTH_VERIFY_BASE_URL` | `auth:verify-limit` | Local/operator only — **set it, or the run proves nothing** (defaults to `http://localhost:3000`) |
 | `NUMISMA_DATA_DIR` | `push`, `backfill` (via `@numisma/engine`) | Should stay **unset** in production use — defaults to `~/Dev/<fund>/data` |
 
 ## Tests

--- a/apps/web/src/push/backfill-core.test.ts
+++ b/apps/web/src/push/backfill-core.test.ts
@@ -112,7 +112,7 @@ describe("parseBackfillArgs", () => {
     });
   });
 
-  it("does NOT let --fixture alone trip the credential-free, DB-free path", () => {
+  it("--fixture alone does not set fixtureOnly", () => {
     expect(parseBackfillArgs(["--fixture"]).fixtureOnly).toBe(false);
   });
 

--- a/apps/web/src/push/backfill-core.test.ts
+++ b/apps/web/src/push/backfill-core.test.ts
@@ -25,6 +25,7 @@ import {
 import {
   enumerateAnchors,
   foldAnchor,
+  parseBackfillArgs,
   runBackfill,
   toSnapshotAnchors,
   writeAnchorFixture,
@@ -80,6 +81,55 @@ const THREE_ANCHORS =
   `${priceMarkedLine("m2", "2026-06-09", 175)}\n` +
   `${priceMarkedLine("m3", "2026-06-09", 176)}\n` +
   `${priceMarkedLine("m4", "2026-06-12", 180)}\n`;
+
+/**
+ * The half `backfill.ts` used to keep unreachable, for the same reason `push.ts`
+ * did: two `argv.includes` calls inside an unimportable `main()`. `--fixture-only`
+ * is the flag that decides whether a WRITE CREDENTIAL is required at all, so fusing
+ * it with `--fixture` would either demand production write access to regenerate a
+ * local fixture or, worse, write to the database on a run the operator asked to keep
+ * local. Pinned here, with no database and no credential.
+ */
+describe("parseBackfillArgs", () => {
+  it("defaults to replay-into-the-DB with no fixture rewrite", () => {
+    expect(parseBackfillArgs([])).toEqual({
+      writeFixture: false,
+      fixtureOnly: false,
+    });
+  });
+
+  it("--fixture replays into the DB AND rewrites the fixture", () => {
+    expect(parseBackfillArgs(["--fixture"])).toEqual({
+      writeFixture: true,
+      fixtureOnly: false,
+    });
+  });
+
+  it("--fixture-only implies writeFixture (the rewrite is its whole point)", () => {
+    expect(parseBackfillArgs(["--fixture-only"])).toEqual({
+      writeFixture: true,
+      fixtureOnly: true,
+    });
+  });
+
+  it("does NOT let --fixture alone trip the credential-free, DB-free path", () => {
+    expect(parseBackfillArgs(["--fixture"]).fixtureOnly).toBe(false);
+  });
+
+  it("ignores the `--` pnpm forwards for `pnpm backfill -- --fixture-only`", () => {
+    expect(parseBackfillArgs(["--", "--fixture-only"])).toEqual({
+      writeFixture: true,
+      fixtureOnly: true,
+    });
+  });
+
+  it("ignores tokens it does not know rather than failing the backfill", () => {
+    expect(parseBackfillArgs(["--verbose", "extra"])).toEqual({
+      writeFixture: false,
+      fixtureOnly: false,
+    });
+  });
+});
 
 describe("enumerateAnchors — the log's DISTINCT anchored dates (V3)", () => {
   it("returns each anchored date once, ascending, never a calendar day", async () => {

--- a/apps/web/src/push/backfill-core.ts
+++ b/apps/web/src/push/backfill-core.ts
@@ -84,6 +84,37 @@ import {
   type SnapshotDerivation,
 } from "./push-core.ts";
 
+/** What the backfill shell's two flags decide, once argv has been read. */
+export interface BackfillArgs {
+  /** Rewrite the replay fixture. Set by `--fixture` AND by `--fixture-only`. */
+  writeFixture: boolean;
+  /**
+   * Fold and write the fixture with NO database and NO credential. This is the flag
+   * that decides whether `PROJECTION_WRITE_DATABASE_URL` is required at all.
+   */
+  fixtureOnly: boolean;
+}
+
+/**
+ * Parse the backfill shell's argv. Lives here, not in `backfill.ts`, for the reason
+ * `parsePushArgs` lives in `push-core.ts`: the shell is a self-executing script, so
+ * an importable parser is the only way a test reaches this half.
+ *
+ * EXACT-MATCH, so `--fixture-only` never also trips `--fixture` by substring, and
+ * `--fixture` never trips `fixtureOnly`. The second direction is the one with teeth:
+ * `--fixture-only` is what makes regenerating the fixture work with no write
+ * credential, so fusing the two would either demand production write access for a
+ * local file rewrite, or send a run the operator asked to keep local to the database.
+ *
+ * Permissive about unknown tokens on the same grounds as `parsePushArgs` — both
+ * flags are booleans whose absence is the safe default, and it lets the literal `--`
+ * pnpm forwards for `pnpm backfill -- --fixture` fall through unremarked.
+ */
+export function parseBackfillArgs(argv: readonly string[]): BackfillArgs {
+  const fixtureOnly = argv.includes("--fixture-only");
+  return { writeFixture: fixtureOnly || argv.includes("--fixture"), fixtureOnly };
+}
+
 /**
  * V3 — THE LOG'S OWN DISTINCT ANCHORED DATES, ASCENDING. NOT calendar days.
  *

--- a/apps/web/src/push/backfill.ts
+++ b/apps/web/src/push/backfill.ts
@@ -24,12 +24,17 @@
  * DELETEd (the writer credential cannot).
  */
 import { Pool } from "pg";
-import { runBackfill, writeAnchorFixture } from "./backfill-core.ts";
+import {
+  parseBackfillArgs,
+  runBackfill,
+  writeAnchorFixture,
+} from "./backfill-core.ts";
 
 async function main(): Promise<void> {
-  // Exact-match argv, so `--fixture-only` never also trips `--fixture`.
-  const fixtureOnly = process.argv.includes("--fixture-only");
-  const writeFixture = fixtureOnly || process.argv.includes("--fixture");
+  // `argv.slice(2)` drops the node binary and this script's own path; the parser and
+  // the reasoning behind its exact-match flag pairing live in `backfill-core.ts`,
+  // where a test can reach them.
+  const { writeFixture, fixtureOnly } = parseBackfillArgs(process.argv.slice(2));
 
   // `--fixture-only` needs no credential at all: it folds local disk and writes a
   // local file. Requiring the write URL for it would make regenerating the fixture

--- a/apps/web/src/push/push-core.integration.test.ts
+++ b/apps/web/src/push/push-core.integration.test.ts
@@ -168,7 +168,7 @@ describe.skipIf(!runIntegration)(
  * `loadCurrentFold` — the exact source the `push` command now uses — and
  * asserts the two properties the fixture block never did:
  *
- *  - R4: the pushed `report` JSONB carries EXACTLY `totals` and `dashboard`. The
+ *  - R4: the pushed `report` JSONB carries EXACTLY `totals`, `dashboard` and `glance`. The
  *    payload's WIDTH, asserted on the stored row rather than on the derivation,
  *    so the narrowing is proven where it matters — in the cloud.
  *  - R3: a second push over the SAME unchanged log leaves exactly one row with an

--- a/apps/web/src/push/push-core.test.ts
+++ b/apps/web/src/push/push-core.test.ts
@@ -70,7 +70,7 @@ describe("parsePushArgs", () => {
     expect(parsePushArgs(["--init-only"])).toEqual({ init: true, initOnly: true });
   });
 
-  it("does NOT let --init-only be matched by --init's substring (the old fusion)", () => {
+  it("--init alone does not set initOnly", () => {
     // The regression that mattered ran the other way too: an exact-match on
     // `--init` must not be SATISFIED by `--init-only` alone deciding both, nor
     // `--init` alone ever setting initOnly. Only the second half is a real risk

--- a/apps/web/src/push/push-core.test.ts
+++ b/apps/web/src/push/push-core.test.ts
@@ -8,7 +8,7 @@ import { afterEach, describe, expect, it } from "vitest";
 import type { CompositionReport } from "@numisma/engine";
 import { quarantineLogPath } from "@numisma/event-store";
 import { COMPOSITION_SNAPSHOT_SCHEMA_VERSION } from "../projection/contract.ts";
-import { deriveSnapshot, loadCurrentFold } from "./push-core.ts";
+import { deriveSnapshot, loadCurrentFold, parsePushArgs } from "./push-core.ts";
 import {
   loadFixture,
   makeTempStore,
@@ -46,6 +46,50 @@ describe("deriveSnapshot (pure fixture → derivation)", () => {
   it("takes asOf verbatim from the summary (the conflict key's date half)", () => {
     const report = reportWith("Fund X", "2026-12-31");
     expect(deriveSnapshot(report, TEST_GLANCE).asOf).toBe("2026-12-31");
+  });
+});
+
+/**
+ * The half `push.ts` used to keep unreachable. `--init` and `--init-only` were once
+ * ONE flag, which made `pnpm db:init` fold the durable log before applying the DDL
+ * and so throw ENOENT on exactly the bootstrap and recovery paths the command is
+ * for (see the shell's header). The fix was two `argv.includes` calls inside an
+ * unimportable `main()`, so a re-regression was invisible until a Neon reset. These
+ * cases are the guard: the pairing is asserted here, on every machine, with no DB.
+ */
+describe("parsePushArgs", () => {
+  it("defaults to fold-and-upsert: no DDL, no early return", () => {
+    expect(parsePushArgs([])).toEqual({ init: false, initOnly: false });
+  });
+
+  it("--init applies the DDL and STILL folds and upserts", () => {
+    expect(parsePushArgs(["--init"])).toEqual({ init: true, initOnly: false });
+  });
+
+  it("--init-only implies init, so `db:init` applies the DDL it exists to apply", () => {
+    expect(parsePushArgs(["--init-only"])).toEqual({ init: true, initOnly: true });
+  });
+
+  it("does NOT let --init-only be matched by --init's substring (the old fusion)", () => {
+    // The regression that mattered ran the other way too: an exact-match on
+    // `--init` must not be SATISFIED by `--init-only` alone deciding both, nor
+    // `--init` alone ever setting initOnly. Only the second half is a real risk
+    // (`"--init-only".includes("--init")` is true for a substring scan), so pin it.
+    expect(parsePushArgs(["--init"]).initOnly).toBe(false);
+  });
+
+  it("ignores the `--` pnpm forwards for `pnpm push -- --init-only`", () => {
+    expect(parsePushArgs(["--", "--init-only"])).toEqual({
+      init: true,
+      initOnly: true,
+    });
+  });
+
+  it("ignores tokens it does not know rather than failing the push", () => {
+    expect(parsePushArgs(["--verbose", "extra"])).toEqual({
+      init: false,
+      initOnly: false,
+    });
   });
 });
 

--- a/apps/web/src/push/push-core.ts
+++ b/apps/web/src/push/push-core.ts
@@ -186,7 +186,7 @@ export interface SnapshotDerivation {
   /**
    * The NARROWED payload written to the `report` JSONB column — built key-by-key
    * by `toProjectionReport`, never the wide `CompositionReport` (D8). Everything
-   * outside `{ totals, dashboard }` stops here and never leaves the machine.
+   * outside `{ totals, dashboard, glance }` stops here and never leaves the machine.
    */
   report: ProjectionReport;
 }

--- a/apps/web/src/push/push-core.ts
+++ b/apps/web/src/push/push-core.ts
@@ -21,6 +21,39 @@ import {
 } from "../projection/contract.ts";
 import { buildGlanceBlock } from "./glance.ts";
 
+/** What the push shell's two flags decide, once argv has been read. */
+export interface PushArgs {
+  /** Apply the DDL before anything else. Set by `--init` AND by `--init-only`. */
+  init: boolean;
+  /** Apply the DDL and STOP — no fold, no upsert, no durable log required. */
+  initOnly: boolean;
+}
+
+/**
+ * Parse the push shell's argv. Lives here, not in `push.ts`, because `push.ts` is a
+ * self-executing script: importing it to test it would run the push. The flag
+ * PAIRING is the part worth a test — `--init` and `--init-only` were once fused,
+ * which made `pnpm db:init` fold the durable log first and throw ENOENT on exactly
+ * the bootstrap and recovery paths it exists for (the shell's header tells the
+ * story). That regression was invisible to the suite until a Neon reset; it is not
+ * anymore.
+ *
+ * EXACT-MATCH, so `--init-only` never also trips `--init` by substring. It sets
+ * `init` DELIBERATELY and separately: `--init-only` still applies the DDL, it just
+ * stops there.
+ *
+ * DELIBERATELY PERMISSIVE, unlike `parseGapReportArgs`, which rejects an unknown
+ * token. That parser takes VALUES (`--since <date>`), where a typo silently rescopes
+ * the answer; these two flags are booleans whose absence is the safe default, and
+ * the push runs from launchd nightly. Refusing to run on an unrecognized token would
+ * turn a harmless typo into a missed day. Ignoring one also lets the literal `--`
+ * that pnpm forwards for `pnpm push -- --init` fall through with no special case.
+ */
+export function parsePushArgs(argv: readonly string[]): PushArgs {
+  const initOnly = argv.includes("--init-only");
+  return { init: initOnly || argv.includes("--init"), initOnly };
+}
+
 /** The folded read model AND the report built from it, for one anchor. */
 export interface FoldedAnchor {
   /**

--- a/apps/web/src/push/push.ts
+++ b/apps/web/src/push/push.ts
@@ -5,10 +5,10 @@
  * and idempotently upserts it into the projection DB using the WRITE credential
  * (PROJECTION_WRITE_DATABASE_URL). There is no fixture path and no flag that
  * restores one: this command can only push real data. The
- * pure derivation and the actual upsert SQL live in `push-core.ts` (importable,
- * unit- and integration-tested); this file is just the argv + credential +
- * process-exit wiring around them, so importing `push-core.ts` never runs the
- * script.
+ * pure derivation, the actual upsert SQL and the argv parse all live in
+ * `push-core.ts` (importable, unit- and integration-tested); this file is just the
+ * credential + ordering + process-exit wiring around them, so importing
+ * `push-core.ts` never runs the script.
  *
  *   pnpm --filter @numisma/web push                 # fold the log, upsert the snapshot
  *   pnpm --filter @numisma/web push -- --init       # create table first, then upsert
@@ -31,6 +31,7 @@ import { readSchemaDdl } from "../projection/provision.ts";
 import {
   buildGlanceForAnchor,
   loadCurrentFold,
+  parsePushArgs,
   upsertSnapshot,
 } from "./push-core.ts";
 
@@ -46,9 +47,10 @@ async function initSchema(pool: Pool): Promise<void> {
 }
 
 async function main(): Promise<void> {
-  // Exact-match argv, so `--init-only` never also trips `--init`.
-  const initOnly = process.argv.includes("--init-only");
-  const doInit = initOnly || process.argv.includes("--init");
+  // `argv.slice(2)` drops the node binary and this script's own path; the parser and
+  // the reasoning behind its exact-match flag pairing live in `push-core.ts`, where a
+  // test can reach them.
+  const { init: doInit, initOnly } = parsePushArgs(process.argv.slice(2));
 
   const connectionString = process.env.PROJECTION_WRITE_DATABASE_URL;
   if (!connectionString) {


### PR DESCRIPTION
Audit finding 16 flagged that the push and backfill CLI entrypoints parsed argv inline, leaving the flag-handling logic without a seam a unit test could reach; push.ts and backfill.ts now scan argv.slice(2) and delegate to pure parsers in push-core.ts and backfill-core.ts, each covered by new tests. The parsers stay deliberately permissive on unknown tokens rather than rejecting them, because the nightly launchd push must never let a stray or misspelled flag abort the run and turn into a missed day. Separately, audit finding 40 noted that AUTH_VERIFY_BASE_URL controls the auth:verify-limit target but was undocumented; this adds it to apps/web/.env.example and the apps/web/README.md env table, including the caveat that an unset value defaults to localhost and still exits 0 without exercising the shared DB-backed counter.