### PR TITLE
engine: compute the remainder before the Bitget vocabulary gate refuses

### DIFF
--- a/packages/engine/src/orders/bitget-ingest.test.ts
+++ b/packages/engine/src/orders/bitget-ingest.test.ts
@@ -11,6 +11,7 @@
 import { describe, expect, it } from "vitest";
 import {
   BITGET_OPEN_ORDERS_HEADER,
+  leavesRungUnweighed,
   parseBitgetOpenOrdersCsv,
   type BitgetOpenOrder,
 } from "./bitget.js";
@@ -230,6 +231,95 @@ describe("#173 — the venue's filled_quantity is carried, and the REMAINDER dec
     if (!record) throw new Error("expected one record");
     expect(record).not.toHaveProperty("observedFilledQuantity");
     expect(serializeOrderRecord(record)).not.toContain("observedFilledQuantity");
+  });
+});
+
+// The remainder is computed BEFORE the vocabulary check, so the one ordinary event the
+// #184 apparatus exists for — a rung filling between the operator's export and their
+// import — is answered by the quantities rather than refused on a guessed word. The
+// vocabulary is NOT widened: no terminal status word was added to the known list, and a
+// row that still has a remainder open is still refused when its word is unknown.
+describe("the remainder is decided before the status vocabulary is consulted", () => {
+  it("reads a TERMINAL status word with nothing left as not-resting, not unknown-status", () => {
+    const parsed = parseBitgetOpenOrdersCsv(
+      csv(row({ status: "Filled", quantity: "10", filled_quantity: "10" })),
+    );
+    expect(parsed.status).toBe("ok");
+    if (parsed.status !== "ok") return;
+    expect(parsed.orders).toHaveLength(0);
+    expect(parsed.skips.map((entry) => entry.problem)).toEqual(["not-resting"]);
+  });
+
+  it("does not fire the money-direction alarm for that ordinary fill (#184)", () => {
+    const parsed = parseBitgetOpenOrdersCsv(
+      csv(row({ status: "Filled", quantity: "10", filled_quantity: "10" })),
+    );
+    expect(parsed.status).toBe("ok");
+    if (parsed.status !== "ok") return;
+    expect(parsed.skips.filter((entry) => leavesRungUnweighed(entry.problem))).toEqual([]);
+  });
+
+  it("answers ANY unknown word by the quantities when nothing is left claimed", () => {
+    for (const status of ["Cancelled", "Expired", "Fully Filled", "已成交"]) {
+      const parsed = parseBitgetOpenOrdersCsv(
+        csv(row({ status, quantity: "10", filled_quantity: "10" })),
+      );
+      expect(parsed.status).toBe("ok");
+      if (parsed.status !== "ok") return;
+      expect(parsed.skips.map((entry) => entry.problem)).toEqual(["not-resting"]);
+    }
+  });
+
+  it("also reads an OVER-filled row as not-resting rather than as an unknown word", () => {
+    const parsed = parseBitgetOpenOrdersCsv(
+      csv(row({ status: "Filled", quantity: "10", filled_quantity: "10.0001" })),
+    );
+    expect(parsed.status).toBe("ok");
+    if (parsed.status !== "ok") return;
+    expect(parsed.skips.map((entry) => entry.problem)).toEqual(["not-resting"]);
+  });
+
+  it("does NOT widen the vocabulary — an unknown word with a remainder OPEN is still refused", () => {
+    const parsed = parseBitgetOpenOrdersCsv(
+      csv(row({ status: "Filled", quantity: "10", filled_quantity: "6" })),
+    );
+    expect(parsed.status).toBe("ok");
+    if (parsed.status !== "ok") return;
+    expect(parsed.orders).toHaveLength(0);
+    expect(parsed.skips.map((entry) => entry.problem)).toEqual(["unknown-status"]);
+    // And it still counts as an unweighed rung: the row may be claiming capital.
+    expect(parsed.skips.every((entry) => leavesRungUnweighed(entry.problem))).toBe(true);
+  });
+
+  it("keeps a KNOWN resting word admitted on the same ordering", () => {
+    const parsed = parseBitgetOpenOrdersCsv(csv(row({ quantity: "10", filled_quantity: "6" })));
+    expect(parsed.status).toBe("ok");
+    if (parsed.status !== "ok") return;
+    expect(parsed.skips).toEqual([]);
+    expect(parsed.orders).toHaveLength(1);
+  });
+
+  // THE ONE ACCEPTED RECLASSIFICATION. The quantities are now read first, so a row that
+  // is unreadable in BOTH the quantity columns and the status word is reported as
+  // `malformed` rather than `unknown-status`. Both classes are unweighed, so the #184
+  // alarm is unchanged; only the operator-facing label moves, and `malformed` is the more
+  // actionable of the two — the quantity cell is what could not be read.
+  it("reports an unknown word with an unreadable quantity as malformed, not unknown-status", () => {
+    const parsed = parseBitgetOpenOrdersCsv(csv(row({ status: "Filled", quantity: "abc" })));
+    expect(parsed.status).toBe("ok");
+    if (parsed.status !== "ok") return;
+    expect(parsed.skips.map((entry) => entry.problem)).toEqual(["malformed"]);
+    // Still on the safe side of the alarm — nothing about this row is known.
+    expect(parsed.skips.every((entry) => leavesRungUnweighed(entry.problem))).toBe(true);
+  });
+
+  it("reports an unreadable filled_quantity as malformed whatever the word says", () => {
+    const parsed = parseBitgetOpenOrdersCsv(
+      csv(row({ status: "Filled", quantity: "10", filled_quantity: "-1" })),
+    );
+    expect(parsed.status).toBe("ok");
+    if (parsed.status !== "ok") return;
+    expect(parsed.skips.map((entry) => entry.problem)).toEqual(["malformed"]);
   });
 });
 

--- a/packages/engine/src/orders/bitget-ingest.test.ts
+++ b/packages/engine/src/orders/bitget-ingest.test.ts
@@ -234,11 +234,13 @@ describe("#173 — the venue's filled_quantity is carried, and the REMAINDER dec
   });
 });
 
-// The remainder is computed BEFORE the vocabulary check, so the one ordinary event the
-// #184 apparatus exists for — a rung filling between the operator's export and their
-// import — is answered by the quantities rather than refused on a guessed word. The
-// vocabulary is NOT widened: no terminal status word was added to the known list, and a
-// row that still has a remainder open is still refused when its word is unknown.
+// The remainder is computed BEFORE the vocabulary check — and AFTER the row's identity
+// columns — so the one ordinary event the #184 apparatus exists for (a rung filling
+// between the operator's export and their import) is answered by the quantities rather
+// than refused on a guessed word, while a row we cannot even identify still reaches the
+// alarm. The vocabulary is NOT widened: no terminal status word was added to the known
+// list, and a row that still has a remainder open is still refused when its word is
+// unknown.
 describe("the remainder is decided before the status vocabulary is consulted", () => {
   it("reads a TERMINAL status word with nothing left as not-resting, not unknown-status", () => {
     const parsed = parseBitgetOpenOrdersCsv(
@@ -264,9 +266,11 @@ describe("the remainder is decided before the status vocabulary is consulted", (
       const parsed = parseBitgetOpenOrdersCsv(
         csv(row({ status, quantity: "10", filled_quantity: "10" })),
       );
-      expect(parsed.status).toBe("ok");
-      if (parsed.status !== "ok") return;
-      expect(parsed.skips.map((entry) => entry.problem)).toEqual(["not-resting"]);
+      // `continue`, never `return`: one bad spelling must not silently take the other
+      // three words' coverage with it.
+      expect(parsed.status, status).toBe("ok");
+      if (parsed.status !== "ok") continue;
+      expect(parsed.skips.map((entry) => entry.problem), status).toEqual(["not-resting"]);
     }
   });
 
@@ -299,11 +303,11 @@ describe("the remainder is decided before the status vocabulary is consulted", (
     expect(parsed.orders).toHaveLength(1);
   });
 
-  // THE ONE ACCEPTED RECLASSIFICATION. The quantities are now read first, so a row that
-  // is unreadable in BOTH the quantity columns and the status word is reported as
-  // `malformed` rather than `unknown-status`. Both classes are unweighed, so the #184
-  // alarm is unchanged; only the operator-facing label moves, and `malformed` is the more
-  // actionable of the two — the quantity cell is what could not be read.
+  // THE ACCEPTED RECLASSIFICATION. The quantities are now read just above the status word,
+  // so a row that is unreadable in BOTH the quantity columns and the status word is
+  // reported as `malformed` rather than `unknown-status`. Both classes are unweighed, so
+  // the #184 alarm is unchanged; only the operator-facing label moves, and `malformed` is
+  // the more actionable of the two — the quantity cell is what could not be read.
   it("reports an unknown word with an unreadable quantity as malformed, not unknown-status", () => {
     const parsed = parseBitgetOpenOrdersCsv(csv(row({ status: "Filled", quantity: "abc" })));
     expect(parsed.status).toBe("ok");
@@ -313,13 +317,53 @@ describe("the remainder is decided before the status vocabulary is consulted", (
     expect(parsed.skips.every((entry) => leavesRungUnweighed(entry.problem))).toBe(true);
   });
 
-  it("reports an unreadable filled_quantity as malformed whatever the word says", () => {
+  it("reports a NEGATIVE filled_quantity as malformed whatever the word says", () => {
+    // Parseable but impossible: a venue cannot have filled less than nothing.
     const parsed = parseBitgetOpenOrdersCsv(
       csv(row({ status: "Filled", quantity: "10", filled_quantity: "-1" })),
     );
     expect(parsed.status).toBe("ok");
     if (parsed.status !== "ok") return;
     expect(parsed.skips.map((entry) => entry.problem)).toEqual(["malformed"]);
+  });
+
+  it("reports an UNPARSEABLE filled_quantity as malformed whatever the word says", () => {
+    // Not a number at all — the other half of "unreadable", and the one a negative
+    // fixture never exercised.
+    const parsed = parseBitgetOpenOrdersCsv(
+      csv(row({ status: "Filled", quantity: "10", filled_quantity: "n/a" })),
+    );
+    expect(parsed.status).toBe("ok");
+    if (parsed.status !== "ok") return;
+    expect(parsed.skips.map((entry) => entry.problem)).toEqual(["malformed"]);
+  });
+
+  // THE PLACEMENT ITSELF, PINNED. The quantity reads sit above the STATUS WORD and below
+  // the row's IDENTITY columns (timestamp, pair, side, price) — no higher. Hoisting them
+  // to the top of the pipeline would reclassify a settled row whose timestamp cannot be
+  // read from `malformed` to `not-resting`, and `not-resting` is the ONE class excluded
+  // from `leavesRungUnweighed` — the incomplete-import alarm would go quiet on a corrupt
+  // row. This case fails against any such re-hoist.
+  it("still reports a SETTLED row with an unreadable timestamp as malformed", () => {
+    const parsed = parseBitgetOpenOrdersCsv(
+      csv(row({ status: "Filled", quantity: "10", filled_quantity: "10", timestamp: "nonsense" })),
+    );
+    expect(parsed.status).toBe("ok");
+    if (parsed.status !== "ok") return;
+    expect(parsed.orders).toHaveLength(0);
+    expect(parsed.skips.map((entry) => entry.problem)).toEqual(["malformed"]);
+    // The alarm SURVIVES: we cannot weigh a row we cannot even identify.
+    expect(parsed.skips.every((entry) => leavesRungUnweighed(entry.problem))).toBe(true);
+  });
+
+  it("still reports a SETTLED row in an unpriced pair as unknown-quote-currency", () => {
+    const parsed = parseBitgetOpenOrdersCsv(
+      csv(row({ status: "Filled", quantity: "10", filled_quantity: "10", pair: "XYZ/ZZZ" })),
+    );
+    expect(parsed.status).toBe("ok");
+    if (parsed.status !== "ok") return;
+    expect(parsed.skips.map((entry) => entry.problem)).toEqual(["unknown-quote-currency"]);
+    expect(parsed.skips.every((entry) => leavesRungUnweighed(entry.problem))).toBe(true);
   });
 });
 

--- a/packages/engine/src/orders/bitget.ts
+++ b/packages/engine/src/orders/bitget.ts
@@ -62,6 +62,14 @@ export const BITGET_OPEN_ORDERS_HEADER = [
  * while a row printed as partially filled was skipped whole — the rung vanished from the
  * book and the capital it encumbers was reported FREE, which is the direction that costs
  * money. The REMAINDER decides now; the word only has to be one this reader knows.
+ *
+ * AND THE REMAINDER IS COMPUTED FIRST. The vocabulary check sits BELOW the remainder gate
+ * in `parseBitgetOpenOrdersCsv`, so a row with nothing left is `not-resting` whatever the
+ * venue printed. Asking the word first left the rule true only on paper: a rung that
+ * filled between export and import prints a terminal word (`Filled`, `Cancelled`, …) that
+ * is not in this vocabulary, so it landed in `unknown-status` and fired the #184
+ * money-direction alarm about a row we can weigh, and weigh at zero. The word is still
+ * only consulted for rows the quantities CANNOT answer — one with a remainder open.
  */
 export const BITGET_RESTING_STATUS = "unfilled";
 
@@ -297,8 +305,49 @@ export function parseBitgetOpenOrdersCsv(csv: string): BitgetOpenOrdersParse {
       continue;
     }
 
-    // VOCABULARY CHECK, NOT AN ADMISSION GATE. A word this reader does not know is still
-    // refused; a word it knows only gets the row as far as the remainder test below.
+    // THE ADMISSION GATE (#173), AND IT RUNS FIRST. A row still claims capital exactly
+    // when something is left unfilled, and the two quantity columns say so without help
+    // from the status word — so they are read BEFORE the vocabulary is consulted. Asking
+    // the word first made the rule a lie for the one ordinary event #184 exists for: a
+    // rung that fills between the operator's export and their import prints a terminal
+    // word this reader does not know, and refusing it there raised a money-direction
+    // alarm about a row we can in fact weigh, and weigh at zero.
+    //
+    // AUTHORITATIVE. `order_value` is read past and dropped: it drifts by cents against
+    // this column and must never be the thing anything reconciles on.
+    const quantity = canonicalDecimal(column(fields, "quantity"));
+    if (quantity === undefined || Number(quantity) <= 0) {
+      skips.push(skip(lineNumber, "malformed", "quantity must be a positive decimal"));
+      continue;
+    }
+
+    const filledQuantity = canonicalDecimal(column(fields, "filled_quantity"));
+    if (filledQuantity === undefined || Number(filledQuantity) < 0) {
+      skips.push(skip(lineNumber, "malformed", "filled_quantity must be a non-negative decimal"));
+      continue;
+    }
+
+    // Nothing left is not a claim: it is correctly out of the resting book, whatever the
+    // venue printed, and reported so it is not silent.
+    const remainder = Number(quantity) - Number(filledQuantity);
+    if (remainder <= 0) {
+      skips.push(
+        skip(
+          lineNumber,
+          "not-resting",
+          `the venue shows ${filledQuantity} of ${quantity} filled, so nothing is still ` +
+            `claimed; this row is not a resting order`,
+        ),
+      );
+      continue;
+    }
+
+    // VOCABULARY CHECK, NOT AN ADMISSION GATE. Reached only by a row that still has a
+    // remainder open — which is exactly the row whose status we cannot infer from the
+    // quantities. A word this reader does not know is refused HERE, because a remainder
+    // under an unrecognized word could be resting or could be dead, and guessing means a
+    // claim on capital the venue never confirmed. The vocabulary is deliberately NOT
+    // widened to absorb terminal words: the remainder above already answers those.
     const status = normalizeStatus(column(fields, "status"));
     const known =
       status === BITGET_RESTING_STATUS ||
@@ -345,36 +394,6 @@ export function parseBitgetOpenOrdersCsv(csv: string): BitgetOpenOrdersParse {
     const price = canonicalDecimal(column(fields, "price"));
     if (price === undefined || Number(price) <= 0) {
       skips.push(skip(lineNumber, "malformed", "price must be a positive decimal"));
-      continue;
-    }
-
-    // AUTHORITATIVE. `order_value` is read past and dropped: it drifts by cents against
-    // this column and must never be the thing anything reconciles on.
-    const quantity = canonicalDecimal(column(fields, "quantity"));
-    if (quantity === undefined || Number(quantity) <= 0) {
-      skips.push(skip(lineNumber, "malformed", "quantity must be a positive decimal"));
-      continue;
-    }
-
-    const filledQuantity = canonicalDecimal(column(fields, "filled_quantity"));
-    if (filledQuantity === undefined || Number(filledQuantity) < 0) {
-      skips.push(skip(lineNumber, "malformed", "filled_quantity must be a non-negative decimal"));
-      continue;
-    }
-
-    // THE ADMISSION GATE (#173). A row still claims capital exactly when something is left
-    // unfilled, whichever of the known words the venue printed. Nothing left is not a
-    // claim: it is correctly out of the resting book, and reported so it is not silent.
-    const remainder = Number(quantity) - Number(filledQuantity);
-    if (remainder <= 0) {
-      skips.push(
-        skip(
-          lineNumber,
-          "not-resting",
-          `the venue shows ${filledQuantity} of ${quantity} filled, so nothing is still ` +
-            `claimed; this row is not a resting order`,
-        ),
-      );
       continue;
     }
 

--- a/packages/engine/src/orders/bitget.ts
+++ b/packages/engine/src/orders/bitget.ts
@@ -63,13 +63,19 @@ export const BITGET_OPEN_ORDERS_HEADER = [
  * book and the capital it encumbers was reported FREE, which is the direction that costs
  * money. The REMAINDER decides now; the word only has to be one this reader knows.
  *
- * AND THE REMAINDER IS COMPUTED FIRST. The vocabulary check sits BELOW the remainder gate
- * in `parseBitgetOpenOrdersCsv`, so a row with nothing left is `not-resting` whatever the
- * venue printed. Asking the word first left the rule true only on paper: a rung that
- * filled between export and import prints a terminal word (`Filled`, `Cancelled`, …) that
- * is not in this vocabulary, so it landed in `unknown-status` and fired the #184
- * money-direction alarm about a row we can weigh, and weigh at zero. The word is still
- * only consulted for rows the quantities CANNOT answer — one with a remainder open.
+ * AND THE REMAINDER IS COMPUTED BEFORE THE WORD IS READ. In `parseBitgetOpenOrdersCsv`
+ * the quantity columns are consulted after the row's IDENTITY columns (timestamp, pair,
+ * side, price) and immediately BEFORE this vocabulary check, so an identified row with
+ * nothing left is `not-resting` whatever the venue printed. Asking the word first left
+ * the rule true only on paper: a rung that filled between export and import prints a
+ * terminal word (`Filled`, `Cancelled`, …) that is not in this vocabulary, so it landed
+ * in `unknown-status` and fired the #184 money-direction alarm about a row we can weigh,
+ * and weigh at zero. The word is still only consulted for rows the quantities CANNOT
+ * answer — one with a remainder open.
+ *
+ * The quantities are NOT read above the identity columns: a settled row whose timestamp
+ * or pair is unreadable must stay `malformed` / `unknown-quote-currency` and keep firing
+ * the alarm, rather than being excused as `not-resting`.
  */
 export const BITGET_RESTING_STATUS = "unfilled";
 
@@ -305,13 +311,56 @@ export function parseBitgetOpenOrdersCsv(csv: string): BitgetOpenOrdersParse {
       continue;
     }
 
-    // THE ADMISSION GATE (#173), AND IT RUNS FIRST. A row still claims capital exactly
-    // when something is left unfilled, and the two quantity columns say so without help
-    // from the status word — so they are read BEFORE the vocabulary is consulted. Asking
-    // the word first made the rule a lie for the one ordinary event #184 exists for: a
-    // rung that fills between the operator's export and their import prints a terminal
-    // word this reader does not know, and refusing it there raised a money-direction
-    // alarm about a row we can in fact weigh, and weigh at zero.
+    // THE ROW'S IDENTITY COLUMNS COME FIRST, and they are unmoved. A row whose timestamp,
+    // pair, side or price cannot be read is a row we cannot weigh at all, so it must reach
+    // `malformed` / `unknown-quote-currency` — the two classes the #184 alarm counts —
+    // rather than being answered by quantities we would then be reporting about an
+    // unidentifiable row.
+    const observedAt = normalizeTimestamp(column(fields, "timestamp"));
+    if (observedAt === undefined) {
+      skips.push(skip(lineNumber, "malformed", "timestamp must be a second-granular local stamp"));
+      continue;
+    }
+
+    const pair = readPair(column(fields, "pair"));
+    if (pair === undefined) {
+      skips.push(
+        skip(
+          lineNumber,
+          "unknown-quote-currency",
+          `pair ${JSON.stringify(column(fields, "pair").trim())} does not end in a quote ` +
+            `currency this build prices`,
+        ),
+      );
+      continue;
+    }
+
+    const side = readSide(column(fields, "side"));
+    if (side === undefined) {
+      skips.push(skip(lineNumber, "malformed", "side must be Buy or Sell"));
+      continue;
+    }
+
+    const price = canonicalDecimal(column(fields, "price"));
+    if (price === undefined || Number(price) <= 0) {
+      skips.push(skip(lineNumber, "malformed", "price must be a positive decimal"));
+      continue;
+    }
+
+    // THE ADMISSION GATE (#173), AND IT RUNS BEFORE THE STATUS WORD. A row still claims
+    // capital exactly when something is left unfilled, and the two quantity columns say so
+    // without help from the vocabulary — so they are consulted after the row's identity
+    // columns above and BEFORE the word below. Asking the word first made the rule a lie
+    // for the one ordinary event #184 exists for: a rung that fills between the operator's
+    // export and their import prints a terminal word this reader does not know, and
+    // refusing it there raised a money-direction alarm about a row we can in fact weigh,
+    // and weigh at zero.
+    //
+    // NOT HIGHER THAN THIS. Hoisting these reads to the top of the loop would let a
+    // SETTLED row with an unreadable timestamp, pair, side or price answer `not-resting` —
+    // the one class `leavesRungUnweighed` excludes — and the incomplete-import alarm would
+    // go quiet on a corrupt row. `bitget-ingest.test.ts` pins the placement from both
+    // sides.
     //
     // AUTHORITATIVE. `order_value` is read past and dropped: it drifts by cents against
     // this column and must never be the thing anything reconciles on.
@@ -342,12 +391,12 @@ export function parseBitgetOpenOrdersCsv(csv: string): BitgetOpenOrdersParse {
       continue;
     }
 
-    // VOCABULARY CHECK, NOT AN ADMISSION GATE. Reached only by a row that still has a
-    // remainder open — which is exactly the row whose status we cannot infer from the
-    // quantities. A word this reader does not know is refused HERE, because a remainder
-    // under an unrecognized word could be resting or could be dead, and guessing means a
-    // claim on capital the venue never confirmed. The vocabulary is deliberately NOT
-    // widened to absorb terminal words: the remainder above already answers those.
+    // VOCABULARY CHECK, NOT AN ADMISSION GATE. Reached only by an identified row that
+    // still has a remainder open — which is exactly the row whose status we cannot infer
+    // from the quantities. A word this reader does not know is refused HERE, because a
+    // remainder under an unrecognized word could be resting or could be dead, and guessing
+    // means a claim on capital the venue never confirmed. The vocabulary is deliberately
+    // NOT widened to absorb terminal words: the remainder above already answers those.
     const status = normalizeStatus(column(fields, "status"));
     const known =
       status === BITGET_RESTING_STATUS ||
@@ -363,37 +412,6 @@ export function parseBitgetOpenOrdersCsv(csv: string): BitgetOpenOrdersParse {
             `may still be resting`,
         ),
       );
-      continue;
-    }
-
-    const observedAt = normalizeTimestamp(column(fields, "timestamp"));
-    if (observedAt === undefined) {
-      skips.push(skip(lineNumber, "malformed", "timestamp must be a second-granular local stamp"));
-      continue;
-    }
-
-    const pair = readPair(column(fields, "pair"));
-    if (pair === undefined) {
-      skips.push(
-        skip(
-          lineNumber,
-          "unknown-quote-currency",
-          `pair ${JSON.stringify(column(fields, "pair").trim())} does not end in a quote ` +
-            `currency this build prices`,
-        ),
-      );
-      continue;
-    }
-
-    const side = readSide(column(fields, "side"));
-    if (side === undefined) {
-      skips.push(skip(lineNumber, "malformed", "side must be Buy or Sell"));
-      continue;
-    }
-
-    const price = canonicalDecimal(column(fields, "price"));
-    if (price === undefined || Number(price) <= 0) {
-      skips.push(skip(lineNumber, "malformed", "price must be a positive decimal"));
       continue;
     }
 


### PR DESCRIPTION
Audit finding 6 noted that the vocabulary check ran ahead of the remainder test in `parseBitgetOpenOrdersCsv`, so a row that still claimed capital could be refused before the quantities were ever read. This reorders the reads so `quantity` and `filled_quantity` are consulted first, and the status word is consulted only for rows the quantities cannot already answer.

Three reclassifications follow, all alarm-neutral — none of these move a row into a weighed class:

1. Terminal or otherwise unrecognized status with a remainder of zero or less now lands as not-resting instead of unknown-status — this is the audit finding 6 fix, and it stops the imported-partial alarm from firing on ordinary between-export-and-import fills.
2. Unknown status combined with an unreadable quantity now lands as malformed instead of unknown-status.
3. Unknown status combined with an unreadable identity column (timestamp, pair, side, or price) now lands under that column's own label — malformed or unknown-quote-currency — instead of unknown-status.
