### PR TITLE
price-feed: consumer-shaped barrel — export the batched fetch, drop the dead singular and store re-exports

### DIFF
--- a/apps/price-feed/src/index.test.ts
+++ b/apps/price-feed/src/index.test.ts
@@ -14,6 +14,20 @@
  * until the first future consumer (web, scheduler — the reuse the module header
  * promises) tries to wire it up. This is the only thing that would catch it.
  *
+ * WHAT THE SURFACE IS SHAPED FOR (audit finding 18, decision C). With no consumer
+ * to take evidence from, the barrel is shaped for the consumer the package header
+ * promises, and the list below is that decision's record. Two kinds of export were
+ * removed rather than left pinned:
+ *   - `atomicWrite` / `AtomicWriteIo` and `upsertQuote` — internal plumbing (a
+ *     generic fs primitive and disposable price-store IO) that three modules reach
+ *     by RELATIVE import and no front-door consumer needs. The modules stay; only
+ *     the re-exports went.
+ *   - `fetchTwelveDataDailyClose` (singular) — deleted outright. It had zero
+ *     non-test callers, and publishing it invited a consumer to issue one request
+ *     per symbol against Twelve Data's 8-credit/minute cap. The BATCHED
+ *     `fetchTwelveDataDailyCloses` — what `runPriceFetch` actually drives — is
+ *     exported in its place, with `ProviderFetchResult`, its per-entry outcome.
+ *
  * The surface splits in two, and so does the guard:
  *   - RUNTIME exports are asserted here, by exact set equality against
  *     `EXPECTED_VALUE_EXPORTS` — so a DROP fails, and so does an unannounced
@@ -31,7 +45,6 @@ import { describe, expect, it } from "vitest";
 // coverage instrumentation attributes the crossing to the barrel itself.
 import * as priceFeed from "./index.js";
 import type {
-  AtomicWriteIo,
   EquitiesFetchOptions,
   FetchFailure,
   FetchOptions,
@@ -41,6 +54,7 @@ import type {
   PriceFeedConfig,
   PriceFeedPaths,
   ProviderCredentials,
+  ProviderFetchResult,
   ProviderObservation,
   RejectionScan,
   RunOptions,
@@ -56,14 +70,12 @@ const EXPECTED_VALUE_EXPORTS = {
   // config.ts — the shipped defaults and the env credential reader.
   DEFAULT_CONFIG: "object",
   readCredentialsFromEnv: "function",
-  // atomic-write.ts — the durable write primitive the store and inbox share.
-  atomicWrite: "function",
-  // The three provider fetches (ADR-005 two-plane model).
+  // The three provider fetches (ADR-005 two-plane model). Twelve Data's is the
+  // BATCHED one — the singular fetch is gone, see the header.
   fetchBinanceDailyClose: "function",
-  fetchTwelveDataDailyClose: "function",
+  fetchTwelveDataDailyCloses: "function",
   fetchBanxicoFix: "function",
-  // price-store.ts / inbox.ts — the disposable store and the atomic inbox emit.
-  upsertQuote: "function",
+  // inbox.ts — the atomic inbox emit.
   emitMarksToInbox: "function",
   // paths.ts — path resolution for both.
   resolvePriceFeedPaths: "function",
@@ -84,10 +96,10 @@ const EXPECTED_VALUE_EXPORTS = {
 type TypeSurface = {
   config: PriceFeedConfig;
   credentials: ProviderCredentials;
-  atomicWriteIo: AtomicWriteIo;
   observation: ProviderObservation;
   fetchOptions: FetchOptions;
   equitiesFetchOptions: EquitiesFetchOptions;
+  providerFetchResult: ProviderFetchResult;
   fixFetchOptions: FixFetchOptions;
   paths: PriceFeedPaths;
   runResult: FetchRunResult;

--- a/apps/price-feed/src/index.ts
+++ b/apps/price-feed/src/index.ts
@@ -5,15 +5,26 @@
  * `@numisma/event-store` — never on `@numisma/tui` — so any future access surface
  * (web, scheduler) can reuse the pipeline. All domain decisions live in the
  * engine's pure core.
+ *
+ * WHAT IS AND IS NOT PUBLISHED (audit finding 18). This barrel is shaped for that
+ * future consumer, not for the package's internals. `atomic-write.ts` and
+ * `price-store.ts` are internal plumbing — the three modules that use them do so by
+ * relative import — so they are deliberately NOT re-exported here. And Twelve Data
+ * is published only in its BATCHED form: the registry's 9 Twelve Data symbols cost
+ * 1 credit each against a free-tier cap of 8/minute, so a consumer looping a
+ * single-symbol fetch would 429 itself. `fetchTwelveDataDailyCloses` is the call
+ * `runPriceFetch` itself drives. `src/index.test.ts` locks this exact set.
  */
 export type { PriceFeedConfig, ProviderCredentials } from "./config.js";
 export { DEFAULT_CONFIG, readCredentialsFromEnv } from "./config.js";
-export { atomicWrite, type AtomicWriteIo } from "./atomic-write.js";
 export { fetchBinanceDailyClose } from "./binance-provider.js";
 export type { ProviderObservation, FetchOptions } from "./provider.js";
-export { fetchTwelveDataDailyClose, type EquitiesFetchOptions } from "./twelvedata-provider.js";
+export {
+  fetchTwelveDataDailyCloses,
+  type EquitiesFetchOptions,
+  type ProviderFetchResult,
+} from "./twelvedata-provider.js";
 export { fetchBanxicoFix, type FixFetchOptions } from "./banxico-provider.js";
-export { upsertQuote } from "./price-store.js";
 export { emitMarksToInbox } from "./inbox.js";
 export { resolvePriceFeedPaths, type PriceFeedPaths } from "./paths.js";
 export {

--- a/apps/price-feed/src/twelvedata-provider.test.ts
+++ b/apps/price-feed/src/twelvedata-provider.test.ts
@@ -1,13 +1,16 @@
 // Twelve Data provider suite. No live network (every fetch is mocked): the
 // happy-path daily-close parse, the missing-key guard, HTTP failure, Twelve Data's
 // 200+status:"error" body, malformed payloads, a non-positive close, and the
-// request timeout — each thrown loud and symbol-attributable.
+// request timeout — each attributed to its symbol rather than aborting the run.
+//
+// There is ONE fetch under test. The single-symbol wrapper this file used to
+// exercise separately was deleted (audit finding 18: zero non-test callers, and it
+// invited the per-symbol looping the 8-credit/minute cap punishes), so its cases
+// live below as one-element batches — the same code path, since a single-symbol
+// request is what Twelve Data answers with the un-keyed body shape.
 import { describe, expect, it } from "vitest";
 import type { InstrumentRegistryEntry } from "@numisma/engine";
-import {
-  fetchTwelveDataDailyClose,
-  fetchTwelveDataDailyCloses,
-} from "./twelvedata-provider.js";
+import { fetchTwelveDataDailyCloses } from "./twelvedata-provider.js";
 
 const AAPL: InstrumentRegistryEntry = {
   instrumentId: "aapl",
@@ -42,13 +45,20 @@ function fetchWith(res: () => Response | Promise<Response>): typeof fetch {
 
 const OPTS = { timeoutMs: 5_000, apiKey: "test-key", now: () => NOW };
 
-describe("fetchTwelveDataDailyClose — happy path", () => {
+/** The one-element batch: the un-keyed single-symbol body shape. */
+async function fetchOne(entry: InstrumentRegistryEntry, options: typeof OPTS & { fetchImpl: typeof fetch }) {
+  const [result] = await fetchTwelveDataDailyCloses([entry], options);
+  return result;
+}
+
+describe("fetchTwelveDataDailyCloses — single-symbol happy path", () => {
   it("parses the latest daily close into a ProviderObservation", async () => {
-    const obs = await fetchTwelveDataDailyClose(AAPL, {
+    const result = await fetchOne(AAPL, {
       ...OPTS,
       fetchImpl: fetchWith(() => timeSeriesResponse("212.44")),
     });
-    expect(obs).toEqual({
+    expect(result?.error).toBeUndefined();
+    expect(result?.observation).toEqual({
       instrumentId: "aapl",
       symbol: "AAPL",
       close: 212.44,
@@ -63,55 +73,60 @@ describe("fetchTwelveDataDailyClose — happy path", () => {
       seen = typeof url === "string" ? url : url.toString();
       return Promise.resolve(timeSeriesResponse("100"));
     }) as typeof fetch;
-    await fetchTwelveDataDailyClose(AAPL, { ...OPTS, fetchImpl: spy });
+    await fetchOne(AAPL, { ...OPTS, fetchImpl: spy });
     expect(seen).toContain("symbol=AAPL");
     expect(seen).toContain("apikey=test-key");
   });
 });
 
-describe("fetchTwelveDataDailyClose — loud, attributable failures", () => {
-  it("fails loud when the API key is missing", async () => {
-    await expect(
-      fetchTwelveDataDailyClose(AAPL, { ...OPTS, apiKey: "", fetchImpl: fetchWith(() => timeSeriesResponse("1")) }),
-    ).rejects.toThrow(/TWELVEDATA_API_KEY is not set/);
+describe("fetchTwelveDataDailyCloses — single-symbol attributable failures", () => {
+  // Each case is an attributed RESULT, never a throw: the whole point of the batched
+  // shape is that no single symbol's problem can abort the run.
+  it("fails attributably when the API key is missing", async () => {
+    const result = await fetchOne(AAPL, {
+      ...OPTS,
+      apiKey: "",
+      fetchImpl: fetchWith(() => timeSeriesResponse("1")),
+    });
+    expect(result?.observation).toBeUndefined();
+    expect(result?.error).toMatch(/TWELVEDATA_API_KEY is not set/);
   });
 
   it("attributes an HTTP error to the symbol", async () => {
-    await expect(
-      fetchTwelveDataDailyClose(AAPL, {
-        ...OPTS,
-        fetchImpl: fetchWith(() => new Response("nope", { status: 500, statusText: "Server Error" })),
-      }),
-    ).rejects.toThrow(/Twelve Data AAPL -> HTTP 500/);
+    const result = await fetchOne(AAPL, {
+      ...OPTS,
+      fetchImpl: fetchWith(() => new Response("nope", { status: 500, statusText: "Server Error" })),
+    });
+    expect(result?.error).toMatch(/Twelve Data AAPL -> HTTP 500/);
   });
 
   it("surfaces Twelve Data's status:error body (200 with an error message)", async () => {
-    await expect(
-      fetchTwelveDataDailyClose(AAPL, {
-        ...OPTS,
-        fetchImpl: fetchWith(
-          () =>
-            new Response(JSON.stringify({ code: 400, message: "symbol not found", status: "error" }), {
-              status: 200,
-            }),
-        ),
-      }),
-    ).rejects.toThrow(/Twelve Data AAPL -> symbol not found/);
+    const result = await fetchOne(AAPL, {
+      ...OPTS,
+      fetchImpl: fetchWith(
+        () =>
+          new Response(JSON.stringify({ code: 400, message: "symbol not found", status: "error" }), {
+            status: 200,
+          }),
+      ),
+    });
+    expect(result?.error).toMatch(/Twelve Data AAPL -> symbol not found/);
   });
 
   it("rejects a payload with no values row", async () => {
-    await expect(
-      fetchTwelveDataDailyClose(AAPL, {
-        ...OPTS,
-        fetchImpl: fetchWith(() => new Response(JSON.stringify({ status: "ok", values: [] }), { status: 200 })),
-      }),
-    ).rejects.toThrow(/unexpected payload shape/);
+    const result = await fetchOne(AAPL, {
+      ...OPTS,
+      fetchImpl: fetchWith(() => new Response(JSON.stringify({ status: "ok", values: [] }), { status: 200 })),
+    });
+    expect(result?.error).toMatch(/unexpected payload shape/);
   });
 
   it("rejects a non-positive / NaN close", async () => {
-    await expect(
-      fetchTwelveDataDailyClose(AAPL, { ...OPTS, fetchImpl: fetchWith(() => timeSeriesResponse("nope")) }),
-    ).rejects.toThrow(/non-positive close/);
+    const result = await fetchOne(AAPL, {
+      ...OPTS,
+      fetchImpl: fetchWith(() => timeSeriesResponse("nope")),
+    });
+    expect(result?.error).toMatch(/non-positive close/);
   });
 
   it("attributes a request timeout to the symbol", async () => {
@@ -123,9 +138,8 @@ describe("fetchTwelveDataDailyClose — loud, attributable failures", () => {
           reject(error);
         });
       })) as typeof fetch;
-    await expect(
-      fetchTwelveDataDailyClose(AAPL, { ...OPTS, timeoutMs: 20, fetchImpl: stall }),
-    ).rejects.toThrow(/timed out after 20ms/);
+    const result = await fetchOne(AAPL, { ...OPTS, timeoutMs: 20, fetchImpl: stall });
+    expect(result?.error).toMatch(/timed out after 20ms/);
   });
 });
 

--- a/apps/price-feed/src/twelvedata-provider.ts
+++ b/apps/price-feed/src/twelvedata-provider.ts
@@ -19,6 +19,11 @@
  * instrument's failure (the others in the chunk succeed), preserving per-symbol
  * attribution.
  *
+ * There is deliberately NO single-symbol fetch. One existed as a thin wrapper and
+ * was deleted (audit finding 18): it had zero non-test callers, and publishing it
+ * invited exactly the per-symbol looping the 8-credit/minute cap punishes. A single
+ * symbol is a one-element batch.
+ *
  * Provider decision (PRD-#105 open question 1): Twelve Data over Alpha Vantage —
  * see the equities rows in `@numisma/engine`'s registry for the rationale. The API
  * key is read from the environment (`TWELVEDATA_API_KEY`), never committed, and
@@ -57,9 +62,9 @@ export interface ProviderFetchResult {
  * problem (missing key, HTTP failure, timeout, non-object body) fails every entry,
  * each attributably; a PER-SYMBOL problem (that symbol's `status:"error"`, a
  * missing row, a non-positive close, an unusable bar date) fails only that entry
- * while the rest of the batch still succeeds. Rides the same `AbortController`
- * timeout envelope as the single fetch (R4). Never throws for a data problem — it
- * maps it to a result — so one bad symbol can never abort the whole run.
+ * while the rest of the batch still succeeds. Every call is bounded by an
+ * `AbortController` timeout (R4). Never throws for a data problem — it maps it to a
+ * result — so one bad symbol can never abort the whole run.
  */
 export async function fetchTwelveDataDailyCloses(
   entries: readonly InstrumentRegistryEntry[],
@@ -121,30 +126,11 @@ export async function fetchTwelveDataDailyCloses(
 }
 
 /**
- * Fetch the latest daily close (USD) for one registry entry from Twelve Data — a
- * thin wrapper over the batched {@link fetchTwelveDataDailyCloses} (a single symbol
- * is just a one-element batch). Throws a symbol-attributable error on a missing key,
- * HTTP failure, a Twelve Data `status:"error"` body, an unexpected payload shape, a
- * non-positive close, or a timeout — the orchestrator records it as a per-symbol
- * failure and keeps going.
- */
-export async function fetchTwelveDataDailyClose(
-  entry: InstrumentRegistryEntry,
-  options: EquitiesFetchOptions,
-): Promise<ProviderObservation> {
-  const [result] = await fetchTwelveDataDailyCloses([entry], options);
-  if (result === undefined || result.observation === undefined) {
-    throw new Error(result?.error ?? `Twelve Data ${entry.symbol} -> no result returned`);
-  }
-  return result.observation;
-}
-
-/**
  * Parse one symbol's slice of a Twelve Data response into a {@link ProviderObservation},
- * or throw a symbol-attributable error. Shared by the single and batched fetches so
- * both apply identical validation. `symbolBody` is the un-keyed `{ values, status }`
- * object for that symbol (the whole body for a single-symbol request, or one keyed
- * entry from a batch).
+ * or throw a symbol-attributable error — which {@link fetchTwelveDataDailyCloses}
+ * catches per entry, so the throw never escapes the batch. `symbolBody` is the
+ * un-keyed `{ values, status }` object for that symbol (the whole body for a
+ * single-symbol request, or one keyed entry from a batch).
  */
 function observationFromBody(
   entry: InstrumentRegistryEntry,

--- a/docs/codebase-map.md
+++ b/docs/codebase-map.md
@@ -119,9 +119,10 @@ Tests are co-located with their subjects (`*.test.ts` beside the module), so the
 test for any file is its sibling. Characterization snapshots and the engine↔TUI
 formatter contract test are the two suites that pin cross-module behavior.
 
-## Known open items
+## Open items — none at present
 
-The one item the documentation audit left open here has since been resolved:
+The one item the documentation audit left open here has since been resolved;
+its resolution stays in place as the decision record:
 
 - **`@numisma/price-feed` has no consumers — RESOLVED by narrowing the surface
   to the shape a consumer would need.** Nothing in the workspace still imports

--- a/docs/codebase-map.md
+++ b/docs/codebase-map.md
@@ -121,20 +121,34 @@ formatter contract test are the two suites that pin cross-module behavior.
 
 ## Known open items
 
-One item surfaced by the documentation audit remains open, and it is a design
-question rather than a defect:
+The one item the documentation audit left open here has since been resolved:
 
-- **`@numisma/price-feed` has no consumers.** Nothing in the workspace imports
+- **`@numisma/price-feed` has no consumers — RESOLVED by narrowing the surface
+  to the shape a consumer would need.** Nothing in the workspace still imports
   the package by its root — not `apps/web`, not `apps/tui`, and not even its own
-  `cli.ts`, which reaches its siblings by relative path. The package's header
-  promises reuse (a future web or scheduler consumer); until one exists, its
-  public surface is asserted by `src/index.test.ts` rather than exercised by real
-  use. Two of the 14 pinned exports look incidental rather than contractual —
-  `atomicWrite` / `AtomicWriteIo` (a generic fs primitive shared internally) and
-  `upsertQuote` (disposable price-store IO). With zero consumers there is no
-  evidence either way, so they were pinned rather than quietly narrowed: any
-  future narrowing has to update that test deliberately, which is the right
-  failure mode.
+  `cli.ts`, which reaches its siblings by relative path. That has not changed;
+  what changed is the response to it. The earlier reading was that with no
+  consumer there is no evidence, so the incidental-looking exports were pinned
+  rather than narrowed. The codebase review (finding 18) showed the barrel was
+  not merely over-broad but actively **wrong**: it published
+  `fetchTwelveDataDailyClose` (singular, zero non-test callers) and omitted the
+  batched `fetchTwelveDataDailyCloses` that `runPriceFetch` actually drives — so
+  the obvious front-door use for the registry's 9 Twelve Data symbols would issue
+  9 requests against Twelve Data's 8-credit/minute cap and 429, the exact failure
+  the chunking and 60s pacing exist to prevent.
+
+  The decision (no ADR — it is a surface trim, not an architectural trade-off):
+  shape the barrel for the consumer the package header promises, in the absence
+  of a real one.
+  - `fetchTwelveDataDailyCloses` + `ProviderFetchResult` are now exported; the
+    singular wrapper was **deleted**, not just un-exported. Its test cases moved
+    onto the batched fetch as one-element batches.
+  - `atomicWrite` / `AtomicWriteIo` and `upsertQuote` were **un-exported from the
+    barrel only**. The modules stay — three modules use them by relative import;
+    they were dead at the front door, not dead code.
+
+  `src/index.ts`'s header and the exact-set lock in `src/index.test.ts` carry this
+  decision; the lock is what makes any future change to the set deliberate.
 
 Three classes of finding from that audit were closed rather than deferred, and
 the guards that keep them closed are worth knowing about:


### PR DESCRIPTION
Audit finding 18 flagged the price-feed barrel as exporting internal plumbing and a dead single-symbol Twelve Data fetch that no consumer needs. This shapes apps/price-feed/src/index.ts to export only the batched fetch entry point (decision C), and deletes the dead single-symbol fetch function while twelvedata-provider.ts itself stays in place as un-exported plumbing. Decision C is recorded in the surface lock test in index.test.ts and in the corresponding docs/codebase-map.md item. Waits on another PR before merging.
