### PR TITLE
tui: extract spine argv parsing to spine-args.ts

### DIFF
--- a/apps/tui/src/event-store.test.ts
+++ b/apps/tui/src/event-store.test.ts
@@ -16,12 +16,7 @@ import {
   resolveEventStorePaths,
   type EventStorePaths,
 } from "@numisma/event-store";
-import {
-  ingestInbox,
-  migrateLegacyLog,
-  parseMagnitudeThresholdArg,
-  SPINE_MAGNITUDE_THRESHOLD_ENV,
-} from "./event-store.js";
+import { ingestInbox, migrateLegacyLog } from "./event-store.js";
 import type { SuppliedCashLeg } from "@numisma/engine";
 import { afterEach, describe, expect, it, vi } from "vitest";
 
@@ -344,52 +339,6 @@ describe("ingestInbox — magnitude override lands a genuine big move (Finding 6
     // A +33% mark is inside ±50%; a >50% mark stays rejected without an override.
     const rejects = await makeStore({ inbox: [markAapl(300, "big")] });
     await expect(ingestInbox(rejects)).rejects.toThrowError(/cross-reference.*price/);
-  });
-});
-
-describe("parseMagnitudeThresholdArg — opt-in operator override, fail-loud on garbage", () => {
-  it("returns undefined when neither flag nor env is set (the default run)", () => {
-    expect(parseMagnitudeThresholdArg(["node", "spine"], {})).toBeUndefined();
-  });
-
-  it("reads --magnitude-threshold=<n>", () => {
-    expect(parseMagnitudeThresholdArg(["node", "spine", "--magnitude-threshold=1.5"], {})).toBe(1.5);
-  });
-
-  it("reads the space-separated --magnitude-threshold <n>", () => {
-    expect(parseMagnitudeThresholdArg(["node", "spine", "--magnitude-threshold", "0.75"], {})).toBe(0.75);
-  });
-
-  it("reads the env var when no flag is present", () => {
-    expect(
-      parseMagnitudeThresholdArg(["node", "spine"], { [SPINE_MAGNITUDE_THRESHOLD_ENV]: "2" }),
-    ).toBe(2);
-  });
-
-  it("lets the flag win over the env var", () => {
-    expect(
-      parseMagnitudeThresholdArg(["node", "spine", "--magnitude-threshold=1.5"], {
-        [SPINE_MAGNITUDE_THRESHOLD_ENV]: "9",
-      }),
-    ).toBe(1.5);
-  });
-
-  it("fails loud on a non-numeric value", () => {
-    expect(() => parseMagnitudeThresholdArg(["node", "spine", "--magnitude-threshold=huge"], {})).toThrow(
-      /Invalid magnitude-threshold/,
-    );
-  });
-
-  it("fails loud on a non-positive value", () => {
-    expect(() => parseMagnitudeThresholdArg(["node", "spine"], { [SPINE_MAGNITUDE_THRESHOLD_ENV]: "0" })).toThrow(
-      /Invalid magnitude-threshold/,
-    );
-  });
-
-  it("fails loud on a missing flag value", () => {
-    expect(() => parseMagnitudeThresholdArg(["node", "spine", "--magnitude-threshold"], {})).toThrow(
-      /Missing value for --magnitude-threshold/,
-    );
   });
 });
 

--- a/apps/tui/src/event-store.ts
+++ b/apps/tui/src/event-store.ts
@@ -1,7 +1,6 @@
 /**
  * WRITE half of the event-sourcing spine — the inbox ingest, dedup persistence,
- * atomic append, archival, the one-shot legacy migration, and the argv/env
- * operator knobs that ADR-001 keeps OUT of `@numisma/engine`. The pure fold +
+ * atomic append, archival, and the one-shot legacy migration. The pure fold +
  * event validation live in the engine (`foldEvents` / `parseEvent`); the durable
  * log's READ path — path resolution, genesis load, log load, quarantine, the
  * folded review — has moved to `@numisma/event-store`, shared with the web push,
@@ -22,6 +21,10 @@
  *     then refuses to fold a partial log.
  *   - Append is atomic (write a full next image to a sibling temp file, then
  *     rename over the log) so an interrupted write cannot truncate a line.
+ *
+ * The spine's argv/env operator knobs (`--as-of`, `--magnitude-threshold` /
+ * `SPINE_MAGNITUDE_THRESHOLD`) are NOT here: they are pure CLI parsing with no
+ * durable-log stake, and live in `./spine-args.ts` (audit finding 35).
  */
 import { mkdir, rename, rm, stat, writeFile } from "node:fs/promises";
 import { dirname, join } from "node:path";
@@ -49,90 +52,6 @@ export interface IngestReport {
   newCount: number;
   duplicateCount: number;
   archivedTo?: string;
-}
-
-/**
- * Parse an `--as-of <date>` / `--as-of=<date>` flag, if present. Returns the
- * date string for the fold, or undefined for current state. Throws on a flag
- * with a missing or malformed value so startup fails loud.
- */
-export function parseAsOfArg(args: string[]): string | undefined {
-  for (let index = 2; index < args.length; index += 1) {
-    const arg = args[index];
-    if (arg === "--as-of") {
-      return requireAsOfValue(args[index + 1]);
-    }
-    if (arg?.startsWith("--as-of=")) {
-      return requireAsOfValue(arg.slice("--as-of=".length));
-    }
-  }
-  return undefined;
-}
-
-function requireAsOfValue(value: string | undefined): string {
-  if (!value || !/^\d{4}-\d{2}-\d{2}$/.test(value)) {
-    throw new Error("Missing or invalid value for --as-of (expected YYYY-MM-DD).");
-  }
-  return value;
-}
-
-/** The env var that raises the ingest magnitude guard for a single conscious run. */
-export const SPINE_MAGNITUDE_THRESHOLD_ENV = "SPINE_MAGNITUDE_THRESHOLD";
-
-/**
- * Parse the OPT-IN magnitude-guard override for a single `pnpm spine` run, from
- * either the `--magnitude-threshold=<n>` / `--magnitude-threshold <n>` CLI flag or
- * the `SPINE_MAGNITUDE_THRESHOLD` env var (the flag wins when both are set).
- * Returns `undefined` when NEITHER is set — the overwhelmingly common case — so the
- * engine keeps its own ±50% default and the run is byte-for-byte a normal run.
- *
- * Deliberately conspicuous, never a routine dial: this widens the fat-finger guard,
- * so a present-but-malformed value (non-numeric, non-finite, or ≤ 0 — a value that
- * cannot be a real relative deviation) FAILS LOUD rather than silently falling back
- * to the default. `0.75` means ±75% from the instrument's last close; the operator
- * raises it only to land a mark they have confirmed reflects a genuine big move.
- */
-export function parseMagnitudeThresholdArg(
-  args: string[],
-  env: Record<string, string | undefined> = process.env,
-): number | undefined {
-  const raw = magnitudeThresholdSource(args, env);
-  if (raw === undefined) {
-    return undefined;
-  }
-  const value = Number(raw.value);
-  if (raw.value.trim() === "" || !Number.isFinite(value) || value <= 0) {
-    throw new Error(
-      `Invalid magnitude-threshold override from ${raw.origin}: '${raw.value}'. ` +
-        `Expected a positive number (a relative deviation, e.g. 1.5 for ±150%).`,
-    );
-  }
-  return value;
-}
-
-/** The override's raw string and where it came from, flag taking precedence. */
-function magnitudeThresholdSource(
-  args: string[],
-  env: Record<string, string | undefined>,
-): { value: string; origin: string } | undefined {
-  for (let index = 2; index < args.length; index += 1) {
-    const arg = args[index];
-    if (arg === "--magnitude-threshold") {
-      const value = args[index + 1];
-      if (value === undefined || value.startsWith("--")) {
-        throw new Error("Missing value for --magnitude-threshold (expected a positive number).");
-      }
-      return { value, origin: "--magnitude-threshold" };
-    }
-    if (arg?.startsWith("--magnitude-threshold=")) {
-      return { value: arg.slice("--magnitude-threshold=".length), origin: "--magnitude-threshold" };
-    }
-  }
-  const fromEnv = env[SPINE_MAGNITUDE_THRESHOLD_ENV];
-  if (fromEnv !== undefined) {
-    return { value: fromEnv, origin: SPINE_MAGNITUDE_THRESHOLD_ENV };
-  }
-  return undefined;
 }
 
 /**

--- a/apps/tui/src/report.ts
+++ b/apps/tui/src/report.ts
@@ -6,7 +6,7 @@ import {
 import { loadFoldedReview, resolveEventStorePaths } from "@numisma/event-store";
 import { loadOrders, resolveOrdersPath } from "@numisma/preferences";
 import { loadAvailableCapital } from "./available-capital.js";
-import { parseAsOfArg } from "./event-store.js";
+import { parseAsOfArg } from "./spine-args.js";
 
 // Single source of truth (ADR-003 slice 4): `pnpm report` renders the FOLD over
 // the durable genesis + event log, the same read model `pnpm dev` (app.ts) and the

--- a/apps/tui/src/spine-args.test.ts
+++ b/apps/tui/src/spine-args.test.ts
@@ -1,0 +1,84 @@
+// The spine's argv/env operator knobs, tested at their own seam. These parsers used
+// to live in `event-store.ts` (audit finding 35): pure string→value functions with no
+// filesystem, no durable log, and no reason to be reachable from the module that owns
+// the append path. Extracting them left BEHAVIOR untouched — the cases below are the
+// ones that guarded them there, plus the `--as-of` shape guard startup relies on.
+import { describe, expect, it } from "vitest";
+import {
+  parseAsOfArg,
+  parseMagnitudeThresholdArg,
+  SPINE_MAGNITUDE_THRESHOLD_ENV,
+} from "./spine-args.js";
+
+describe("parseAsOfArg — the windowed-fold flag, fail-loud on a bad value", () => {
+  it("returns undefined when the flag is absent (fold to current state)", () => {
+    expect(parseAsOfArg(["node", "spine"])).toBeUndefined();
+  });
+
+  it("reads the space-separated --as-of <date>", () => {
+    expect(parseAsOfArg(["node", "spine", "--as-of", "2026-06-04"])).toBe("2026-06-04");
+  });
+
+  it("reads --as-of=<date>", () => {
+    expect(parseAsOfArg(["node", "spine", "--as-of=2026-06-04"])).toBe("2026-06-04");
+  });
+
+  it("ignores argv[0..1] (the node binary and the script path)", () => {
+    // A script literally named `--as-of=2026-01-01` must not be read as the flag.
+    expect(parseAsOfArg(["node", "--as-of=2026-01-01"])).toBeUndefined();
+  });
+
+  it("fails loud on a malformed value", () => {
+    expect(() => parseAsOfArg(["node", "spine", "--as-of", "nope"])).toThrow(/--as-of/);
+  });
+
+  it("fails loud on a missing value", () => {
+    expect(() => parseAsOfArg(["node", "spine", "--as-of"])).toThrow(/--as-of/);
+  });
+});
+
+describe("parseMagnitudeThresholdArg — opt-in operator override, fail-loud on garbage", () => {
+  it("returns undefined when neither flag nor env is set (the default run)", () => {
+    expect(parseMagnitudeThresholdArg(["node", "spine"], {})).toBeUndefined();
+  });
+
+  it("reads --magnitude-threshold=<n>", () => {
+    expect(parseMagnitudeThresholdArg(["node", "spine", "--magnitude-threshold=1.5"], {})).toBe(1.5);
+  });
+
+  it("reads the space-separated --magnitude-threshold <n>", () => {
+    expect(parseMagnitudeThresholdArg(["node", "spine", "--magnitude-threshold", "0.75"], {})).toBe(0.75);
+  });
+
+  it("reads the env var when no flag is present", () => {
+    expect(
+      parseMagnitudeThresholdArg(["node", "spine"], { [SPINE_MAGNITUDE_THRESHOLD_ENV]: "2" }),
+    ).toBe(2);
+  });
+
+  it("lets the flag win over the env var", () => {
+    expect(
+      parseMagnitudeThresholdArg(["node", "spine", "--magnitude-threshold=1.5"], {
+        [SPINE_MAGNITUDE_THRESHOLD_ENV]: "9",
+      }),
+    ).toBe(1.5);
+  });
+
+  it("fails loud on a non-numeric value", () => {
+    expect(() => parseMagnitudeThresholdArg(["node", "spine", "--magnitude-threshold=huge"], {})).toThrow(
+      /Invalid magnitude-threshold/,
+    );
+  });
+
+  it("fails loud on a non-positive value", () => {
+    expect(() => parseMagnitudeThresholdArg(["node", "spine"], { [SPINE_MAGNITUDE_THRESHOLD_ENV]: "0" })).toThrow(
+      /Invalid magnitude-threshold/,
+    );
+  });
+
+  it("fails loud on a missing flag value", () => {
+    expect(() => parseMagnitudeThresholdArg(["node", "spine", "--magnitude-threshold"], {})).toThrow(
+      /Missing value for --magnitude-threshold/,
+    );
+  });
+});

--- a/apps/tui/src/spine-args.ts
+++ b/apps/tui/src/spine-args.ts
@@ -1,0 +1,97 @@
+/**
+ * The spine's argv/env OPERATOR KNOBS — the `--as-of` fold window and the opt-in
+ * magnitude-guard override. Pure string→value parsing: no filesystem, no durable
+ * log, no engine. ADR-001 keeps these knobs out of `@numisma/engine`; they lived in
+ * `event-store.ts` until audit finding 35 pointed out that the module owning the
+ * append path had no business also owning CLI flag parsing. The entry points
+ * (`spine.ts`, `startup.ts`, `report.ts`) import them from here; `event-store.ts`
+ * keeps its durable-log responsibilities only.
+ *
+ * Behavior is byte-identical to the pre-extraction functions, messages included —
+ * these flags are an operator's contract, and a reworded failure is a changed
+ * contract.
+ */
+
+/**
+ * Parse an `--as-of <date>` / `--as-of=<date>` flag, if present. Returns the
+ * date string for the fold, or undefined for current state. Throws on a flag
+ * with a missing or malformed value so startup fails loud.
+ */
+export function parseAsOfArg(args: string[]): string | undefined {
+  for (let index = 2; index < args.length; index += 1) {
+    const arg = args[index];
+    if (arg === "--as-of") {
+      return requireAsOfValue(args[index + 1]);
+    }
+    if (arg?.startsWith("--as-of=")) {
+      return requireAsOfValue(arg.slice("--as-of=".length));
+    }
+  }
+  return undefined;
+}
+
+function requireAsOfValue(value: string | undefined): string {
+  if (!value || !/^\d{4}-\d{2}-\d{2}$/.test(value)) {
+    throw new Error("Missing or invalid value for --as-of (expected YYYY-MM-DD).");
+  }
+  return value;
+}
+
+/** The env var that raises the ingest magnitude guard for a single conscious run. */
+export const SPINE_MAGNITUDE_THRESHOLD_ENV = "SPINE_MAGNITUDE_THRESHOLD";
+
+/**
+ * Parse the OPT-IN magnitude-guard override for a single `pnpm spine` run, from
+ * either the `--magnitude-threshold=<n>` / `--magnitude-threshold <n>` CLI flag or
+ * the `SPINE_MAGNITUDE_THRESHOLD` env var (the flag wins when both are set).
+ * Returns `undefined` when NEITHER is set — the overwhelmingly common case — so the
+ * engine keeps its own ±50% default and the run is byte-for-byte a normal run.
+ *
+ * Deliberately conspicuous, never a routine dial: this widens the fat-finger guard,
+ * so a present-but-malformed value (non-numeric, non-finite, or ≤ 0 — a value that
+ * cannot be a real relative deviation) FAILS LOUD rather than silently falling back
+ * to the default. `0.75` means ±75% from the instrument's last close; the operator
+ * raises it only to land a mark they have confirmed reflects a genuine big move.
+ */
+export function parseMagnitudeThresholdArg(
+  args: string[],
+  env: Record<string, string | undefined> = process.env,
+): number | undefined {
+  const raw = magnitudeThresholdSource(args, env);
+  if (raw === undefined) {
+    return undefined;
+  }
+  const value = Number(raw.value);
+  if (raw.value.trim() === "" || !Number.isFinite(value) || value <= 0) {
+    throw new Error(
+      `Invalid magnitude-threshold override from ${raw.origin}: '${raw.value}'. ` +
+        `Expected a positive number (a relative deviation, e.g. 1.5 for ±150%).`,
+    );
+  }
+  return value;
+}
+
+/** The override's raw string and where it came from, flag taking precedence. */
+function magnitudeThresholdSource(
+  args: string[],
+  env: Record<string, string | undefined>,
+): { value: string; origin: string } | undefined {
+  for (let index = 2; index < args.length; index += 1) {
+    const arg = args[index];
+    if (arg === "--magnitude-threshold") {
+      const value = args[index + 1];
+      if (value === undefined || value.startsWith("--")) {
+        throw new Error("Missing value for --magnitude-threshold (expected a positive number).");
+      }
+      return { value, origin: "--magnitude-threshold" };
+    }
+    if (arg?.startsWith("--magnitude-threshold=")) {
+      return { value: arg.slice("--magnitude-threshold=".length), origin: "--magnitude-threshold" };
+    }
+  }
+  const fromEnv = env[SPINE_MAGNITUDE_THRESHOLD_ENV];
+  if (fromEnv !== undefined) {
+    return { value: fromEnv, origin: SPINE_MAGNITUDE_THRESHOLD_ENV };
+  }
+  return undefined;
+}

--- a/apps/tui/src/spine.ts
+++ b/apps/tui/src/spine.ts
@@ -19,7 +19,8 @@
  */
 import { buildCompositionReport, formatCompositionReport } from "@numisma/engine";
 import { loadFoldedReview, resolveEventStorePaths } from "@numisma/event-store";
-import { ingestInbox, parseAsOfArg, parseMagnitudeThresholdArg } from "./event-store.js";
+import { ingestInbox } from "./event-store.js";
+import { parseAsOfArg, parseMagnitudeThresholdArg } from "./spine-args.js";
 import { plural } from "./plural.js";
 
 try {

--- a/apps/tui/src/startup.ts
+++ b/apps/tui/src/startup.ts
@@ -13,7 +13,8 @@
  */
 import type { FundReviewData } from "@numisma/engine";
 import { loadFoldedReview, type EventStorePaths } from "@numisma/event-store";
-import { ingestInbox, parseAsOfArg, type IngestReport } from "./event-store.js";
+import { ingestInbox, type IngestReport } from "./event-store.js";
+import { parseAsOfArg } from "./spine-args.js";
 import { formatGapCheckFailure } from "./gap-lines.js";
 
 /** What the renderer needs after the startup data path runs. */


### PR DESCRIPTION
This addresses audit finding 35: the asOf and magnitude-threshold argv parsers move verbatim out of event-store.ts into a dedicated spine-args.ts module. spine.ts, startup.ts, and report.ts — a fourth consumer the audit didn't name — now re-point to the new module instead of event-store.ts. The moved parser tests relocate to spine-args.test.ts, and parseAsOfArg gains its first direct unit cases.