### PR TITLE
engine: derive KEY_ORDER from a Record<keyof OrderPlacedRecord, true> table

### DIFF
--- a/packages/engine/src/orders/bitget-ingest.test.ts
+++ b/packages/engine/src/orders/bitget-ingest.test.ts
@@ -395,11 +395,11 @@ describe("the null sentinel and the authoritative column (testing decision 4)", 
  * #205 — THE DESCRIPTORS SURVIVE THE WRITE.
  *
  * These are the `KEY_ORDER` guard. `serializeOrderRecord` copies ONLY the keys named in
- * `KEY_ORDER.orderPlaced`, so a field added to `OrderPlacedRecord` and forgotten there is
- * dropped at write with a green `pnpm typecheck` and no other failing test — the value is
- * on the object in memory and absent from every line on disk. Asserting the round trip
- * (build → serialize → parse) rather than the record's own properties is what makes that
- * omission fail here.
+ * `KEY_ORDER.orderPlaced`, so a field added to `OrderPlacedRecord` and forgotten there
+ * would be dropped at write — the value on the object in memory, absent from every line
+ * on disk. Since `records.ts` derives `KEY_ORDER` from `Record<keyof …, true>` tables,
+ * that omission is a compile error first; asserting the round trip (build → serialize →
+ * parse) rather than the record's own properties keeps the runtime backstop.
  */
 describe("the placement descriptors round-trip through the record contract (#205)", () => {
   function placedFrom(overrides: Partial<Record<string, string>> = {}) {
@@ -416,8 +416,8 @@ describe("the placement descriptors round-trip through the record contract (#205
     const parsed = parseOrderRecord(JSON.parse(line));
     expect(parsed.status).toBe("ok");
     if (parsed.status !== "ok") return;
-    // THROUGH the line, not off the in-memory record: a missing `KEY_ORDER` entry fails
-    // exactly here.
+    // THROUGH the line, not off the in-memory record: a dropped key would fail exactly
+    // here (the compile-time table latch in records.ts fires first).
     expect(parsed.record).toMatchObject({ orderType: "Limit", timeInForce: "GTC" });
     // Byte-equal on the way back out, which is what `KEY_ORDER` exists to guarantee.
     expect(serializeOrderRecord(parsed.record)).toBe(line);

--- a/packages/engine/src/orders/records.test.ts
+++ b/packages/engine/src/orders/records.test.ts
@@ -13,7 +13,12 @@
  * Synthetic throughout: invented pair, round sizes, round prices.
  */
 import { describe, expect, it } from "vitest";
-import { parseOrderRecord } from "./records.js";
+import {
+  buildOrderFillObserved,
+  parseOrderRecord,
+  serializeOrderRecord,
+  type OrderPlacedRecord,
+} from "./records.js";
 
 describe("parseOrderRecord refuses a non-object line attributably", () => {
   it("names the shape, not a field, for an array line", () => {
@@ -49,5 +54,125 @@ describe("parseOrderRecord refuses a non-object line attributably", () => {
       problem: "malformed",
       message: "id must be a non-empty string",
     });
+  });
+});
+
+/**
+ * THE CANONICAL KEY ORDER, PINNED (#12 of the 2026-08-07 audit).
+ *
+ * `KEY_ORDER` is derived by `Object.keys` over per-kind `Record<keyof …Record, true>`
+ * tables, so the TYPE now catches the omission the module's own comment admitted it could
+ * not — a field added to `OrderPlacedRecord` and forgotten no longer compiles. What a type
+ * cannot catch is the other half: `Object.keys` returns the TABLE's insertion order, so a
+ * key moved (or a new one appended in the wrong place) still typechecks while every line
+ * written after it changes shape. Round-tripping an append-only file is byte-equality, so
+ * the sequence is behavior and is asserted here rather than trusted to the table's layout.
+ *
+ * Synthetic throughout: invented pair, round sizes, round prices.
+ */
+describe("serializeOrderRecord emits the canonical key order", () => {
+  const emittedKeys = (line: string): string[] => Object.keys(JSON.parse(line) as object);
+
+  it("writes every `orderPlaced` key, descriptors and partial included, in order", () => {
+    const placed: OrderPlacedRecord = {
+      id: "rung-synthetic",
+      observedAt: "2026-01-01T09:30:00",
+      kind: "orderPlaced",
+      currency: "USD",
+      symbol: "SYNTH/USD",
+      side: "buy",
+      price: 100,
+      quantity: 2,
+      orderType: "limit",
+      timeInForce: "GTC",
+      triggerPrice: 95,
+      observedFilledQuantity: 1,
+      fundingReserveId: "reserve-synthetic",
+    };
+    expect(emittedKeys(serializeOrderRecord(placed))).toEqual([
+      "id",
+      "observedAt",
+      "kind",
+      "currency",
+      "symbol",
+      "side",
+      "price",
+      "quantity",
+      "orderType",
+      "timeInForce",
+      "triggerPrice",
+      "observedFilledQuantity",
+      "fundingReserveId",
+    ]);
+  });
+
+  it("drops the absent optionals of an `orderPlaced` line without disturbing the rest", () => {
+    const bare: OrderPlacedRecord = {
+      id: "rung-synthetic",
+      observedAt: "2026-01-01T09:30:00",
+      kind: "orderPlaced",
+      currency: "USD",
+      symbol: "SYNTH/USD",
+      side: "buy",
+      price: 100,
+      quantity: 2,
+      fundingReserveId: "reserve-synthetic",
+    };
+    expect(emittedKeys(serializeOrderRecord(bare))).toEqual([
+      "id",
+      "observedAt",
+      "kind",
+      "currency",
+      "symbol",
+      "side",
+      "price",
+      "quantity",
+      "fundingReserveId",
+    ]);
+  });
+
+  it("writes the three state-change kinds in order", () => {
+    expect(
+      emittedKeys(
+        serializeOrderRecord({
+          id: "rung-synthetic",
+          observedAt: "2026-01-01T09:30:00",
+          kind: "orderCancelled",
+          currency: "USD",
+        }),
+      ),
+    ).toEqual(["id", "observedAt", "kind", "currency"]);
+
+    expect(
+      emittedKeys(
+        serializeOrderRecord({
+          id: "rung-synthetic",
+          observedAt: "2026-01-01T09:30:00",
+          kind: "orderFilled",
+          currency: "USD",
+          filledQuantity: 2,
+        }),
+      ),
+    ).toEqual(["id", "observedAt", "kind", "currency", "filledQuantity"]);
+
+    // The observation line is only constructible through its constructor — the compile-time
+    // witness makes an object literal of the right shape unassignable — so it is built here.
+    const built = buildOrderFillObserved({
+      id: "rung-synthetic",
+      observedAt: "2026-01-01T09:30:00",
+      currency: "USD",
+      observedFilledQuantity: 1,
+    });
+    expect(built.status).toBe("ok");
+    if (built.status !== "ok") return;
+    // FIVE KEYS, and no trace of the type-only witness: the symbol is excluded from the
+    // table deliberately, so a line on disk never carries it.
+    expect(emittedKeys(serializeOrderRecord(built.record))).toEqual([
+      "id",
+      "observedAt",
+      "kind",
+      "currency",
+      "observedFilledQuantity",
+    ]);
   });
 });

--- a/packages/engine/src/orders/records.ts
+++ b/packages/engine/src/orders/records.ts
@@ -295,39 +295,90 @@ export function formatObservedAt(instant: Date): string {
 }
 
 /**
+ * THE WHITELIST IS THE WRITE (#205), SO THE TYPE HOLDS IT (audit finding 12).
+ *
+ * `serializeOrderRecord` copies ONLY the keys named below, and the failure that makes
+ * these four tables worth their shape is asymmetric and permanent: a field added to a
+ * record interface and forgotten here is DROPPED at write, `orders.jsonl` is append-only,
+ * and every line written before the omission is discovered is missing it with no
+ * migration path. #205 walked exactly that path once.
+ *
+ * So each table is a `Record<keyof …Record, true>` — the same union-derived idiom
+ * {@link KNOWN_KINDS} uses one screen up. A key missing from a table fails `pnpm
+ * typecheck`; so does a key that is not on the record. An OPTIONAL field is caught too:
+ * `keyof` erases optionality, so `orderType` is a REQUIRED entry here even though the
+ * field itself is optional — which is the case that actually bit, since a widening adds
+ * optional fields.
+ *
+ * ORDER IS SEMANTICS, AND THE TYPE DOES NOT CHECK IT. `Object.keys` returns these keys in
+ * the table's own INSERTION order (all of them are non-numeric strings, so no
+ * integer-index reshuffle applies), and that sequence is the byte layout of every line
+ * written from here on. Reordering a table rewrites the file's shape while typechecking
+ * clean, so the emitted sequence is pinned by test in `./records.test.ts`.
+ */
+const ORDER_PLACED_KEYS: Record<keyof OrderPlacedRecord, true> = {
+  id: true,
+  observedAt: true,
+  kind: true,
+  currency: true,
+  symbol: true,
+  side: true,
+  price: true,
+  quantity: true,
+  orderType: true,
+  timeInForce: true,
+  triggerPrice: true,
+  // Absent when nothing had filled: `JSON.stringify` drops an `undefined` value, so a
+  // rung with no partial serializes to exactly the bytes it always did — which is
+  // equally true of the three descriptors above.
+  observedFilledQuantity: true,
+  fundingReserveId: true,
+};
+
+const ORDER_CANCELLED_KEYS: Record<keyof OrderCancelledRecord, true> = {
+  id: true,
+  observedAt: true,
+  kind: true,
+  currency: true,
+};
+
+const ORDER_FILLED_KEYS: Record<keyof OrderFilledRecord, true> = {
+  id: true,
+  observedAt: true,
+  kind: true,
+  currency: true,
+  filledQuantity: true,
+};
+
+/**
+ * FIVE KEYS. No `quantity`, no `symbol`, no `price` — an observation restates ONE fact
+ * and joins to its placement line by id for the rest.
+ *
+ * The witness is EXCLUDED, not forgotten: {@link OBSERVED_THROUGH_CONSTRUCTOR} is a
+ * compile-time-only key that never exists on a real object, so listing it would put a
+ * key on disk that nothing can write and every reader would have to ignore.
+ */
+const ORDER_FILL_OBSERVED_KEYS: Record<
+  Exclude<keyof OrderFillObservedRecord, typeof OBSERVED_THROUGH_CONSTRUCTOR>,
+  true
+> = {
+  id: true,
+  observedAt: true,
+  kind: true,
+  currency: true,
+  observedFilledQuantity: true,
+};
+
+/**
  * CANONICAL key order, one per record kind. Serialization goes through this rather than
  * through the caller's object so a round-trip (write → load → re-serialize) is
  * BYTE-EQUAL by construction, not by the caller's luck in field ordering.
  */
 const KEY_ORDER: Record<OrderKind, readonly string[]> = {
-  orderPlaced: [
-    "id",
-    "observedAt",
-    "kind",
-    "currency",
-    "symbol",
-    "side",
-    "price",
-    "quantity",
-    // THE WHITELIST IS THE WRITE (#205). `serializeOrderRecord` copies ONLY the keys named
-    // here, so a field added to `OrderPlacedRecord` and forgotten in this list is DROPPED
-    // at write with a green typecheck and no failing test. The descriptors are pinned by a
-    // round trip through a real file rather than by a type — see the `#205` cases in
-    // `./bitget-ingest.test.ts`.
-    "orderType",
-    "timeInForce",
-    "triggerPrice",
-    // Absent when nothing had filled: `JSON.stringify` drops an `undefined` value, so a
-    // rung with no partial serializes to exactly the bytes it always did — which is
-    // equally true of the three descriptors above.
-    "observedFilledQuantity",
-    "fundingReserveId",
-  ],
-  orderCancelled: ["id", "observedAt", "kind", "currency"],
-  orderFilled: ["id", "observedAt", "kind", "currency", "filledQuantity"],
-  // FIVE KEYS. No `quantity`, no `symbol`, no `price` — an observation restates ONE fact
-  // and joins to its placement line by id for the rest.
-  orderFillObserved: ["id", "observedAt", "kind", "currency", "observedFilledQuantity"],
+  orderPlaced: Object.keys(ORDER_PLACED_KEYS),
+  orderCancelled: Object.keys(ORDER_CANCELLED_KEYS),
+  orderFilled: Object.keys(ORDER_FILLED_KEYS),
+  orderFillObserved: Object.keys(ORDER_FILL_OBSERVED_KEYS),
 };
 
 /** Serialize ONE record to its canonical JSON line (no trailing newline). */


### PR DESCRIPTION
Audit finding 12 flagged that the orders serializer's KEY_ORDER entries were plain string arrays: a field added to a record interface and left off its array is dropped at write with a green typecheck and no failing test. This idiom is now applied to all four record tables in the module — each key order is derived via Object.keys over a private Record<keyof XRecord, true> table, so a missing or misspelled key fails typecheck instead of failing silently at write time.

The orderFillObserved table excludes the OBSERVED_THROUGH_CONSTRUCTOR symbol, since it is a compile-time-only key with no real on-disk representation. Because keyof erases optionality, optional fields (like orderType) still appear as required table entries, which keeps adding a new optional field a deliberate, typechecked table update rather than a silent gap.