### PR TITLE
tui: extract renderClaimDifferences

### DIFF
--- a/apps/tui/src/import-orders-changed-claims.test.ts
+++ b/apps/tui/src/import-orders-changed-claims.test.ts
@@ -14,6 +14,7 @@ import type { BitgetOpenOrder, ChangedClaim, RestingOrder } from "@numisma/engin
 import { describe, expect, it } from "vitest";
 import {
   partitionChangedClaims,
+  renderClaimDifferences,
   weighRemainders,
 } from "./import-orders-changed-claims.js";
 
@@ -260,5 +261,35 @@ describe("weighRemainders", () => {
       onFile: 10,
       atVenue: 10,
     });
+  });
+});
+
+/**
+ * THE DETAIL TEMPLATE, ASSERTED ONCE — the reason it left `import-orders.ts`. Two refusals
+ * printed the same fold over `ClaimDifference` and only one of them was covered, so a
+ * change to how a difference reads had to be made twice and could be verified once.
+ */
+describe("renderClaimDifferences", () => {
+  it("renders a single difference as `field known → observed`", () => {
+    expect(renderClaimDifferences([filledDifference(6, 8)])).toBe("observedFilledQuantity 6 → 8");
+  });
+
+  it("joins several differences with `, ` in the order the claim carries them", () => {
+    // The mixed union in one call: the template is well-typed over BOTH members, which is
+    // why the two refusal sites could share it rather than branch on the field's type.
+    expect(
+      renderClaimDifferences([
+        filledDifference(6, 8),
+        { field: "timeInForce", known: "GTC", observed: "IOC" },
+        { field: "quantity", known: 10, observed: 12 },
+      ]),
+    ).toBe("observedFilledQuantity 6 → 8, timeInForce GTC → IOC, quantity 10 → 12");
+  });
+
+  it("renders an empty difference list as the empty string", () => {
+    // Unreachable from the partition — a `ChangedClaim` exists BECAUSE something differs —
+    // but the empty fold is what both call sites relied on implicitly, so it is pinned here
+    // rather than left to `Array.prototype.join`'s reputation.
+    expect(renderClaimDifferences([])).toBe("");
   });
 });

--- a/apps/tui/src/import-orders-changed-claims.ts
+++ b/apps/tui/src/import-orders-changed-claims.ts
@@ -14,15 +14,18 @@
  * that a comment was the only thing holding in place. See
  * `import-orders-changed-claims.test.ts`.
  *
- * THE WORDS STAY IN THE SHELL. Nothing here renders an operator line; each class is
- * returned and `importBitgetOpenOrders` owns the refusal it raises over it, in the order
- * hazard demands.
+ * THE REFUSAL WORDS STAY IN THE SHELL, AND {@link renderClaimDifferences} IS NOT ONE. Each
+ * class is returned and `importBitgetOpenOrders` owns the refusal it raises over it, in the
+ * order hazard demands; what came across is the FOLD OVER A DIFFERENCE LIST that two of
+ * those refusals both printed (#36) — a rendering of this module's own union, beside the
+ * function that classifies it, not a sentence addressed to the operator.
  */
 import {
   isDescriptorDifference,
   isFilledDifference,
   type BitgetOpenOrder,
   type ChangedClaim,
+  type ClaimDifference,
   type RestingOrder,
 } from "@numisma/engine";
 import type { RecordedObservation } from "./import-orders-report.js";
@@ -222,6 +225,28 @@ export function partitionChangedClaims(
   }
 
   return { amended, backwards, descriptors, restated };
+}
+
+/**
+ * The differences one claim carries, as the operator reads them — `field known → observed`,
+ * comma-separated.
+ *
+ * ONE TEMPLATE FOR BOTH REFUSALS, and that is the whole of it (#36). `amended` and
+ * `descriptors` printed this same fold at two sites in `import-orders.ts`, with a comment
+ * at the second saying so, and only one of them was covered by a test: a change to how a
+ * difference reads — units, the `→` in a narrow terminal, quoting a text value — had to be
+ * made twice and could be verified once.
+ *
+ * WELL-TYPED OVER BOTH MEMBERS OF THE UNION, which is what let the two sites share it
+ * rather than branch. `known` and `observed` are a number pair or a string pair depending
+ * on the field, and neither is formatted here beyond interpolation — a `NumericClaimField`
+ * is printed exactly as the engine derived it, so the figure the operator is shown is the
+ * one the comparison was made on.
+ */
+export function renderClaimDifferences(differences: readonly ClaimDifference[]): string {
+  return differences
+    .map((difference) => `${difference.field} ${difference.known} → ${difference.observed}`)
+    .join(", ");
 }
 
 /**

--- a/apps/tui/src/import-orders.ts
+++ b/apps/tui/src/import-orders.ts
@@ -35,7 +35,11 @@ import {
 } from "@numisma/engine";
 import type { OrdersLoad } from "@numisma/preferences";
 import { appendKey, currentClaimKeys } from "./import-orders-append-filter.js";
-import { partitionChangedClaims, weighRemainders } from "./import-orders-changed-claims.js";
+import {
+  partitionChangedClaims,
+  renderClaimDifferences,
+  weighRemainders,
+} from "./import-orders-changed-claims.js";
 import { declareFunding } from "./import-orders-funding-declaration.js";
 import { describeMerge } from "./import-orders-merge-notice.js";
 import {
@@ -352,9 +356,7 @@ export async function importBitgetOpenOrders(
   if (amended.length > 0) {
     const detail = amended
       .map((claim) => {
-        const differences = claim.differences
-          .map((difference) => `${difference.field} ${difference.known} → ${difference.observed}`)
-          .join(", ");
+        const differences = renderClaimDifferences(claim.differences);
         // The remainder clause is appended ONLY when the remainder test is what refused
         // this claim, because otherwise it is not the reason and printing it would send
         // the operator after the wrong disagreement. A changed `quantity` refuses on its
@@ -398,16 +400,10 @@ export async function importBitgetOpenOrders(
   }
 
   if (descriptors.length > 0) {
-    // The SAME detail template the amendment refusal renders, over the same
-    // `ClaimDifference` union — `known` and `observed` are a number pair or a string pair
-    // depending on the field, and the template is well-typed over both.
+    // The SAME detail template the amendment refusal renders — literally the same function
+    // since #36, so a change to how a difference reads reaches both refusals at once.
     const detail = descriptors
-      .map((claim) => {
-        const differences = claim.differences
-          .map((difference) => `${difference.field} ${difference.known} → ${difference.observed}`)
-          .join(", ");
-        return `${claim.id} (${differences})`;
-      })
+      .map((claim) => `${claim.id} (${renderClaimDifferences(claim.differences)})`)
       .join("; ");
     return reject(
       io,


### PR DESCRIPTION
Audit finding 36 noted that import-orders.ts rendered claim differences at two separate call sites with duplicated logic. Both now call a single exported renderClaimDifferences function placed beside the claim-partition logic in import-orders-changed-claims.ts, with byte-identical output. The module docstring's words-stay-in-the-shell claim is rescoped accordingly so it still holds.