### PR TITLE
docs: narrow the orders→fold claim to what ADR-013 actually asserts

### DIFF
--- a/docs/codebase-map.md
+++ b/docs/codebase-map.md
@@ -51,10 +51,17 @@ These are the seams most likely to be misread from the tree alone:
 
 2. **Orders are not events.** An Order is a claim on capital that has not become
    a transaction. It lives in `orders.jsonl` and is joined to the fold at *read*
-   time — never folded into `FundReviewData` or NAV
+   time. The invariant ADR-013 actually guards is narrower than "orders/ cannot
+   reach the fold": a line in `orders.jsonl` is never a `PortfolioEvent` —
+   `parseEvent` rejects it, pinned by `orders-not-events.test.ts`
    ([ADR-013](../context/adr/ADR-013-order-a-claim-on-capital-recorded-beside-the-log.md)).
-   `packages/engine/src/orders/` depends on `contracts.ts` but deliberately never
-   on `events/types.ts`, so it structurally cannot reach the fold.
+   The ADR declines to decide module structure, and one deliberate crossing
+   exists: `packages/engine/src/orders/fill.ts` imports `PortfolioEvent` /
+   `PositionOpenedEvent` / `PositionAddedToEvent` directly — still the only
+   direct `events/types.ts` import in `orders/` — because the fill act
+   constructs the fold events it writes. `orders/attribution.ts` and
+   `orders/coverage.ts` reach folded state too, but only transitively, through
+   `compose/canonical.js`.
 
 ## Runbooks and operational docs
 

--- a/docs/codebase-map.md
+++ b/docs/codebase-map.md
@@ -55,13 +55,14 @@ These are the seams most likely to be misread from the tree alone:
    reach the fold": a line in `orders.jsonl` is never a `PortfolioEvent` —
    `parseEvent` rejects it, pinned by `orders-not-events.test.ts`
    ([ADR-013](../context/adr/ADR-013-order-a-claim-on-capital-recorded-beside-the-log.md)).
-   The ADR declines to decide module structure, and one deliberate crossing
+   The ADR leaves module structure undecided, and one deliberate crossing
    exists: `packages/engine/src/orders/fill.ts` imports `PortfolioEvent` /
-   `PositionOpenedEvent` / `PositionAddedToEvent` directly — still the only
-   direct `events/types.ts` import in `orders/` — because the fill act
-   constructs the fold events it writes. `orders/attribution.ts` and
-   `orders/coverage.ts` reach folded state too, but only transitively, through
-   `compose/canonical.js`.
+   `PositionOpenedEvent` / `PositionAddedToEvent` / `PositionDecision` directly
+   — still the only non-test direct `events/types.ts` import in `orders/` —
+   because the fill act constructs the fold events it writes.
+   `orders/attribution.ts`, `orders/coverage.ts`, and `orders/available.ts`
+   reach folded state too, but only transitively — through
+   `compose/canonical.js`, which `attribution.ts` alone imports.
 
 ## Runbooks and operational docs
 

--- a/packages/engine/README.md
+++ b/packages/engine/README.md
@@ -112,10 +112,11 @@ The `orders/*` modules are recorded beside the event log, never in it: a line
 in `orders.jsonl` is never a `PortfolioEvent` — `parseEvent` rejects it, pinned
 by `orders-not-events.test.ts` (ADR-013). The ADR leaves module structure
 undecided; `orders/fill.ts` is the one deliberate crossing — still the only
-direct `events/types.ts` import in `orders/` — because it constructs the
-`PositionOpened` / `PositionAddedTo` events the fill act writes.
-`orders/attribution.ts` and `orders/coverage.ts` reach folded state too, but
-only transitively, through `compose/canonical.js`. `calendar.ts` and
+non-test direct `events/types.ts` import in `orders/` — because it constructs
+the `PositionOpened` / `PositionAddedTo` events the fill act writes.
+`orders/attribution.ts`, `orders/coverage.ts`, and `orders/available.ts` reach
+folded state too, but only transitively — through `compose/canonical.js`, which
+`attribution.ts` alone imports. `calendar.ts` and
 `data-dir.ts` have no in-package imports at all. The event modules reuse
 `parseFundReview` (to re-validate genesis) and the composition read model;
 `contracts.ts` depends on nothing else in the package, so there are no cycles.

--- a/packages/engine/README.md
+++ b/packages/engine/README.md
@@ -108,12 +108,17 @@ Dependency direction: `contracts.ts` → (`internal.ts`, `price-journey.ts`) →
 `parse.ts` / `compose/*` / `events/*` / `price-feed/*` / `orders/*` / `format.ts`
 → `index.ts`. The `price-feed/*` modules depend only on `contracts.ts` (the
 `Currency` type) and `events/types.ts` (the `PriceMarkedEvent` they construct).
-The `orders/*` modules are recorded beside the event log, never in it: they
-depend on `contracts.ts` but not on `events/types.ts`, and nothing they say
-reaches `foldEvents` or `fundValueUsd`. `calendar.ts` and `data-dir.ts` have no
-in-package imports at all. The event modules reuse `parseFundReview` (to
-re-validate genesis) and the composition read model; `contracts.ts` depends on
-nothing else in the package, so there are no cycles.
+The `orders/*` modules are recorded beside the event log, never in it: a line
+in `orders.jsonl` is never a `PortfolioEvent` — `parseEvent` rejects it, pinned
+by `orders-not-events.test.ts` (ADR-013). The ADR leaves module structure
+undecided; `orders/fill.ts` is the one deliberate crossing — still the only
+direct `events/types.ts` import in `orders/` — because it constructs the
+`PositionOpened` / `PositionAddedTo` events the fill act writes.
+`orders/attribution.ts` and `orders/coverage.ts` reach folded state too, but
+only transitively, through `compose/canonical.js`. `calendar.ts` and
+`data-dir.ts` have no in-package imports at all. The event modules reuse
+`parseFundReview` (to re-validate genesis) and the composition read model;
+`contracts.ts` depends on nothing else in the package, so there are no cycles.
 
 Two subpath exports exist beside the package root: `@numisma/engine/format`
 (the shared formatters, standalone) and `@numisma/engine/calendar` (the


### PR DESCRIPTION
Audit finding 4 noted that docs/codebase-map.md and packages/engine/README.md overreached past what ADR-013 actually asserts. ADR-013 pins only that a line in orders.jsonl is never a PortfolioEvent — parseEvent rejects it, per orders-not-events.test.ts — and deliberately declines to prescribe module structure beyond that. Both docs now state that invariant precisely and name the sanctioned crossings instead of implying a stricter boundary: fill.ts:39 directly, since it constructs the fill act's fold events and remains the only direct event-types import in orders/, and attribution/coverage transitively via compose/canonical.js.