### PR TITLE
tui: split record-fill.ts authoring interview from the two-file act protocol

### DIFF
--- a/apps/tui/src/record-fill-funding.test.ts
+++ b/apps/tui/src/record-fill-funding.test.ts
@@ -95,7 +95,7 @@ function rung(overrides: Partial<CommittedRung> = {}): CommittedRung {
     currency: "USD",
     fundingReserveId: "reserve-synthetic",
     ...overrides,
-  } as CommittedRung;
+  } satisfies CommittedRung;
 }
 
 /** Answers keyed by a prompt SUBSTRING; an unanticipated prompt throws rather than blanks. */

--- a/apps/tui/src/record-fill-funding.test.ts
+++ b/apps/tui/src/record-fill-funding.test.ts
@@ -1,0 +1,407 @@
+// THE SEAM'S OWN TESTS for the cash leg and the tier (#audit-14).
+//
+// WHAT THE END-TO-END SUITES COULD NOT REACH CHEAPLY. Every branch below used to need a
+// whole fill act to arrive at: a sidecar, a genesis, a prior log, a torn-act check, a rung
+// pick, a book observation, a verdict confirmation and a ladder resolution — all of it
+// spelled by index in a fifteen-element answer array — before the FIRST question this
+// module asks. Two of the arms (`untiered` prompts for a tier; the override lands on a
+// reserve the report does not place) needed a fixture shaped for them all the way down.
+// Here they are a reserve literal and one closure.
+//
+// THE ARITHMETIC IS THE SUBJECT. `D1` weighs the EXCESS over `price × quantity`, never
+// post-act available, and the tests below trace the three regions of that number —
+// negative (a downward correction, always free), zero (the default, available-neutral BY
+// CONSTRUCTION) and positive (the only guarded one) — which the flow-level tests could
+// only ever sample one point of.
+//
+// EVERY FIXTURE IS SYNTHETIC (`O7`). Invented instrument, round decade prices, round
+// balances.
+import { describe, expect, it } from "vitest";
+import {
+  parseFundReview,
+  pickRestingOrdersAsOf,
+  type CommittedRung,
+  type FundReviewData,
+  type ReserveRecord,
+  type RestingOrder,
+} from "@numisma/engine";
+import { resolveFunding } from "./record-fill-funding.js";
+
+function reserve(overrides: Partial<ReserveRecord> = {}): ReserveRecord {
+  return {
+    id: "reserve-synthetic",
+    portfolioId: "portfolio-synthetic",
+    tempo: "Capital",
+    executionMode: "live",
+    accountId: "account-synthetic",
+    currency: "USD",
+    amount: 10000,
+    lots: [{ quantity: 10000, tier: "c1" }],
+    ...overrides,
+  };
+}
+
+/**
+ * A reserve with NO tier attribution at all — `lots` absent, not empty.
+ *
+ * It needs its own builder because `exactOptionalPropertyTypes` makes the distinction real:
+ * `lots: undefined` is not the same type as an omitted `lots`, and `deriveFundingTier`'s
+ * `untiered` arm is exactly the omitted case.
+ */
+function untieredReserve(): ReserveRecord {
+  return {
+    id: "reserve-synthetic",
+    portfolioId: "portfolio-synthetic",
+    tempo: "Capital",
+    executionMode: "live",
+    accountId: "account-synthetic",
+    currency: "USD",
+    amount: 10000,
+  };
+}
+
+/** A synthetic fund holding exactly the reserve under test, so the report can place it. */
+function fold(funder: ReserveRecord): FundReviewData {
+  const parsed = parseFundReview({
+    fund: { id: "fund-synthetic", name: "Synthetic", baseCurrency: "USD" },
+    review: { asOf: "2026-01-01", usdMxn: 20 },
+    portfolios: [{ id: "portfolio-synthetic", name: "Synthetic" }],
+    accounts: [
+      { id: "account-synthetic", name: "Synthetic Venue", platform: "SYNTH", currency: "USD" },
+    ],
+    instruments: [
+      { id: "instrument-synthetic", name: "Synthetic Asset", symbol: "TEST", currency: "USD" },
+    ],
+    reserves: [funder],
+    positions: [],
+  });
+  if (parsed.kind !== "ok") {
+    throw new Error(`synthetic fold is invalid: ${JSON.stringify(parsed)}`);
+  }
+  return parsed.value;
+}
+
+/** The rung being filled: 10 at 400, so `price × quantity` is a round 4000 at full size. */
+function rung(overrides: Partial<CommittedRung> = {}): CommittedRung {
+  return {
+    orderId: "rung-400",
+    observedAt: "2026-01-02T09:00:00",
+    symbol: "TEST/USD",
+    side: "buy",
+    price: 400,
+    quantity: 10,
+    remainingQuantity: 10,
+    committed: 4000,
+    currency: "USD",
+    fundingReserveId: "reserve-synthetic",
+    ...overrides,
+  } as CommittedRung;
+}
+
+/** Answers keyed by a prompt SUBSTRING; an unanticipated prompt throws rather than blanks. */
+function scripted(answers: Record<string, string>) {
+  const asked: string[] = [];
+  return {
+    asked,
+    ask: async (question: string): Promise<string> => {
+      asked.push(question);
+      const hit = Object.entries(answers).find(([key]) => question.includes(key));
+      if (!hit) {
+        throw new Error(`unscripted prompt: ${JSON.stringify(question)}`);
+      }
+      return hit[1];
+    },
+  };
+}
+
+const NO_RESTING: readonly RestingOrder[] = [];
+
+/**
+ * One resting rung of 10 at 400 against the reserve — 4000 of `committed`.
+ *
+ * THIS IS HOW A RESERVE RUNS OUT OF AVAILABLE in these tests, and it is deliberately not
+ * "set the balance to zero": `available = value − committed`, and a reserve with a zero
+ * balance also has zero tier attribution (`deriveFundingTier` filters `quantity > 0`), so
+ * it would exercise the `untiered` prompt instead of the guard. A funded reserve whose
+ * capital is fully claimed by a resting ladder is both the realistic shape and the one that
+ * isolates `D1`.
+ */
+function restingRung(): readonly RestingOrder[] {
+  return pickRestingOrdersAsOf([
+    {
+      id: "rung-400",
+      observedAt: "2026-01-02T09:00:00",
+      kind: "orderPlaced",
+      currency: "USD",
+      symbol: "TEST/USD",
+      side: "buy",
+      price: 400,
+      quantity: 10,
+      fundingReserveId: "reserve-synthetic",
+    },
+  ]);
+}
+
+describe("resolveFunding — the cash debited", () => {
+  it("defaults to price × quantity on a blank line, and says so in the prompt", async () => {
+    const io = scripted({ "Cash debited": "" });
+
+    const outcome = await resolveFunding(io.ask, fold(reserve()), NO_RESTING, reserve(), rung(), 10);
+
+    expect(outcome).toEqual({ status: "resolved", fundingAmount: 4000, tier: "c1" });
+    // The default is SHOWN. An operator who cannot see the neutral figure cannot tell that
+    // Enter is the available-neutral answer.
+    expect(io.asked).toEqual(["Cash debited [4000]: "]);
+  });
+
+  it("computes the default from THIS fill's quantity, not the rung's whole claim", async () => {
+    const io = scripted({ "Cash debited": "" });
+
+    // A partial: 4 of the 10 still claimed.
+    const outcome = await resolveFunding(io.ask, fold(reserve()), NO_RESTING, reserve(), rung(), 4);
+
+    expect(outcome).toEqual({ status: "resolved", fundingAmount: 1600, tier: "c1" });
+    expect(io.asked).toEqual(["Cash debited [1600]: "]);
+  });
+
+  it("refuses a cash figure that is not a positive number", async () => {
+    for (const answer of ["nonsense", "0", "-1"]) {
+      const io = scripted({ "Cash debited": answer });
+
+      const outcome = await resolveFunding(
+        io.ask,
+        fold(reserve()),
+        NO_RESTING,
+        reserve(),
+        rung(),
+        10,
+      );
+
+      // The message quotes the answer TRIMMED — what a blank reports is `''`, not `'  '`.
+      expect(outcome).toEqual({
+        status: "rejected",
+        reason: "bad-quantity",
+        message: `'${answer}' is not a positive cash amount`,
+      });
+    }
+  });
+
+  it("treats a WHITESPACE-ONLY line as the default, not as a bad figure", async () => {
+    // The prompt advertises `[4000]`, and in this flow a bracketed prompt means a bare
+    // Enter takes the default — so the answer is trimmed BEFORE it is judged. Contrast the
+    // bracketless `filled_quantity observed` prompt in `record-fill.ts`, where blank
+    // REFUSES. The two rules look alike and are opposite, which is why this is asserted
+    // rather than assumed.
+    const io = scripted({ "Cash debited": "   " });
+
+    const outcome = await resolveFunding(io.ask, fold(reserve()), NO_RESTING, reserve(), rung(), 10);
+
+    expect(outcome).toEqual({ status: "resolved", fundingAmount: 4000, tier: "c1" });
+  });
+});
+
+describe("resolveFunding — `D1`, the override guard, and only upward", () => {
+  it("lets a DOWNWARD correction through untouched — it frees availability", async () => {
+    // A reserve with NOTHING available: 4000 of capital, all 4000 of it committed to the
+    // resting ladder. A downward correction must still pass — it spends LESS than the
+    // fill's own available-neutral figure, so it cannot drive a reserve negative however
+    // fully claimed the reserve is.
+    const spent = reserve({ amount: 4000, lots: [{ quantity: 4000, tier: "c1" }] });
+    const io = scripted({ "Cash debited": "3900" });
+
+    const outcome = await resolveFunding(io.ask, fold(spent), restingRung(), spent, rung(), 10);
+
+    expect(outcome).toEqual({ status: "resolved", fundingAmount: 3900, tier: "c1" });
+  });
+
+  it("lets the NEUTRAL default through on a reserve with nothing available", async () => {
+    // THE EXEMPTION, ISOLATED. `Δavailable = price × quantity − cash debited` is exactly
+    // zero here, so the act cannot break `available ≥ 0` whatever shape the book is in.
+    // A guard written as "post-act available ≥ 0" would refuse this, and refusing a fill
+    // that really happened at the venue is the failure this arm exists to prevent.
+    const spent = reserve({ amount: 4000, lots: [{ quantity: 4000, tier: "c1" }] });
+    const io = scripted({ "Cash debited": "" });
+
+    const outcome = await resolveFunding(io.ask, fold(spent), restingRung(), spent, rung(), 10);
+
+    expect(outcome).toEqual({ status: "resolved", fundingAmount: 4000, tier: "c1" });
+  });
+
+  it("admits an upward override the reserve can cover", async () => {
+    // 10000 in the reserve, 4000 of it committed to the resting rung — 6000 available. The
+    // excess is 100 and there is room.
+    const io = scripted({ "Cash debited": "4100" });
+
+    const outcome = await resolveFunding(
+      io.ask,
+      fold(reserve()),
+      restingRung(),
+      reserve(),
+      rung(),
+      10,
+    );
+
+    expect(outcome).toEqual({ status: "resolved", fundingAmount: 4100, tier: "c1" });
+  });
+
+  it("refuses an upward override larger than the reserve's available, naming the arithmetic", async () => {
+    // 4050 of capital, 4000 committed to the resting rung — 50 available against a 100
+    // excess.
+    const small = reserve({ amount: 4050, lots: [{ quantity: 4050, tier: "c1" }] });
+    const io = scripted({ "Cash debited": "4100" });
+
+    const outcome = await resolveFunding(io.ask, fold(small), restingRung(), small, rung(), 10);
+
+    // ONLY THE EXCESS IS WEIGHED — 100 against 4050 available — and the message shows the
+    // operator all three numbers so they can see which one bound.
+    expect(outcome).toEqual({
+      status: "rejected",
+      reason: "uncovered-override",
+      message:
+        "you asked to debit 4100 against 'reserve-synthetic', 100 more than the 4000 this " +
+        "fill accounts for, and 'reserve-synthetic' has only 50 available (4050 balance " +
+        "less 4000 committed). The fill's own arithmetic is available-neutral; only the " +
+        "extra is spending capital that is not there, and a negative available is an " +
+        "IMPOSSIBLE state rather than a warning. Record the fill at 4000, or record the " +
+        "fee or funding difference as its own act",
+    });
+  });
+
+  it("refuses an upward override against a reserve the report cannot place", async () => {
+    // Paper execution mode: the available-capital report declines to place it, so there is
+    // nothing to weigh the excess against. A DIFFERENT refusal from "not enough", because
+    // it needs a different next move.
+    const paper = reserve({ executionMode: "paper" });
+    const io = scripted({ "Cash debited": "4100" });
+
+    const outcome = await resolveFunding(io.ask, fold(paper), NO_RESTING, paper, rung(), 10);
+
+    expect(outcome).toEqual({
+      status: "rejected",
+      reason: "uncovered-override",
+      message:
+        "you asked to debit 4100 against 'reserve-synthetic' — 100 more than the 4000 this " +
+        "fill accounts for — but the available-capital report does not place that reserve " +
+        "(paper execution mode, an unsupported currency, a dangling account reference), so " +
+        "the excess cannot be weighed against anything. The fill itself is recordable at " +
+        "the default figure",
+    });
+  });
+
+  it("never consults the report at all when the override is not upward", async () => {
+    // A paper reserve is unplaceable, so ANY call into the report would refuse. The neutral
+    // and downward answers resolve, which is how we know the guard was never entered.
+    const paper = reserve({ executionMode: "paper" });
+    for (const answer of ["", "3999"]) {
+      const io = scripted({ "Cash debited": answer });
+      const outcome = await resolveFunding(io.ask, fold(paper), NO_RESTING, paper, rung(), 10);
+      expect(outcome.status).toBe("resolved");
+    }
+  });
+});
+
+describe("resolveFunding — the tier is READ, never re-decided (T4)", () => {
+  it("derives the tier from a single-tier reserve without asking", async () => {
+    const io = scripted({ "Cash debited": "" });
+
+    const outcome = await resolveFunding(
+      io.ask,
+      fold(reserve({ lots: [{ quantity: 10000, tier: "c2" }] })),
+      NO_RESTING,
+      reserve({ lots: [{ quantity: 10000, tier: "c2" }] }),
+      rung(),
+      10,
+    );
+
+    expect(outcome).toEqual({ status: "resolved", fundingAmount: 4000, tier: "c2" });
+    // No tier prompt. Asking when the answer is already attributed would be a chance to
+    // contradict the Transfer that set it.
+    expect(io.asked).toEqual(["Cash debited [4000]: "]);
+  });
+
+  it("refuses rather than prompts when the reserve holds more than one tier", async () => {
+    const mixed = reserve({
+      lots: [
+        { quantity: 6000, tier: "c1" },
+        { quantity: 4000, tier: "c3" },
+      ],
+    });
+    const io = scripted({ "Cash debited": "" });
+
+    const outcome = await resolveFunding(io.ask, fold(mixed), NO_RESTING, mixed, rung(), 10);
+
+    expect(outcome).toEqual({
+      status: "rejected",
+      reason: "ambiguous-tier",
+      message:
+        "'reserve-synthetic' holds c1 and c3; the tier ordering was decided at Transfer " +
+        "time and this act does not get to re-decide it",
+    });
+    // THE ABSENCE OF A PROMPT IS THE ASSERTION. An ask here would let the operator re-order
+    // capital at fill time, which is the one thing `T4` forbids — and the scripted stub
+    // would throw on it rather than quietly answering.
+    expect(io.asked).toEqual(["Cash debited [4000]: "]);
+  });
+
+  it("asks for a tier ONLY when the reserve carries no attribution at all", async () => {
+    const untiered = untieredReserve();
+    const io = scripted({ "Cash debited": "", "Capital tier": "c3" });
+
+    const outcome = await resolveFunding(io.ask, fold(untiered), NO_RESTING, untiered, rung(), 10);
+
+    expect(outcome).toEqual({ status: "resolved", fundingAmount: 4000, tier: "c3" });
+    // There is no prior ordering to honor and none to violate, so naming a tier here is a
+    // FIRST naming, not an override.
+    expect(io.asked).toEqual(["Cash debited [4000]: ", "  Capital tier for this lot (c1/c2/c3): "]);
+  });
+
+  it("refuses anything that is not one of the three tiers, including a near miss", async () => {
+    for (const answer of ["c4", "C1", "", "c1 c2", "tier1"]) {
+      const untiered = untieredReserve();
+      const io = scripted({ "Cash debited": "", "Capital tier": answer });
+
+      const outcome = await resolveFunding(
+        io.ask,
+        fold(untiered),
+        NO_RESTING,
+        untiered,
+        rung(),
+        10,
+      );
+
+      expect(outcome).toEqual({
+        status: "rejected",
+        reason: "ambiguous-tier",
+        message: `'${answer.trim()}' is not a capital tier`,
+      });
+    }
+  });
+
+  it("accepts each of the three tiers, trimmed", async () => {
+    for (const tier of ["c1", "c2", "c3"] as const) {
+      const untiered = untieredReserve();
+      const io = scripted({ "Cash debited": "", "Capital tier": `  ${tier}  ` });
+
+      const outcome = await resolveFunding(
+        io.ask,
+        fold(untiered),
+        NO_RESTING,
+        untiered,
+        rung(),
+        10,
+      );
+
+      expect(outcome).toEqual({ status: "resolved", fundingAmount: 4000, tier });
+    }
+  });
+
+  it("asks for the cash BEFORE the tier, and never reaches the tier on a bad cash figure", async () => {
+    const untiered = untieredReserve();
+    const io = scripted({ "Cash debited": "nonsense", "Capital tier": "c1" });
+
+    const outcome = await resolveFunding(io.ask, fold(untiered), NO_RESTING, untiered, rung(), 10);
+
+    expect(outcome.status).toBe("rejected");
+    expect(io.asked).toEqual(["Cash debited [4000]: "]);
+  });
+});

--- a/apps/tui/src/record-fill-funding.ts
+++ b/apps/tui/src/record-fill-funding.ts
@@ -1,0 +1,149 @@
+/**
+ * THE CASH LEG AND THE TIER — the second half of the interview `record-fill.ts` used to
+ * hold inline (#audit-14).
+ *
+ * IT LEFT FOR THE REASON `record-fill-ladder-target.ts` LEFT. The host file's header
+ * argues a DURABILITY protocol; this decides how much cash the fill debits and which
+ * Capital Tier the lot is born into. Neither question moves when the two-file rename order
+ * or the rollback argument moves, and the `D1` override guard has changed twice for reasons
+ * (#177, #179) that never touched a write.
+ *
+ * IT TAKES THE PROMPT CHANNEL, NOT THE IO BAG — `ask` and nothing else, the narrowing
+ * `declareFunding` (`import-orders-funding-declaration.ts:64`) established. Unlike its
+ * ladder-target sibling this needs no `out`: every line it emits is a prompt or a refusal.
+ *
+ * IT IS HANDED THE RESERVE, NOT ASKED TO FIND ONE. `record-fill.ts` resolves
+ * `filled.fundingReserveId` against the fold ONCE and both halves of the interview are
+ * handed the result, so `unknown-reserve` stays a single refusal in a single place rather
+ * than a duplicated lookup that could drift.
+ *
+ * REJECTIONS ARE RETURNED, NOT PRINTED, and every message is byte-identical to what the
+ * inline code fed `reject(io, …)`. The reason union is declared narrowly here rather than
+ * imported from `RecordFillRejection` — no back-edge — and is assignable at the call site.
+ */
+import {
+  composeAvailableCapital,
+  deriveFundingTier,
+  type CapitalTier,
+  type CommittedRung,
+  type FundReviewData,
+  type ReserveRecord,
+  type RestingOrder,
+} from "@numisma/engine";
+
+export type FundingOutcome =
+  | { status: "resolved"; fundingAmount: number; tier: CapitalTier }
+  | {
+      status: "rejected";
+      reason: "bad-quantity" | "uncovered-override" | "ambiguous-tier";
+      message: string;
+    };
+
+/**
+ * Ask for the cash debited and resolve the lot's tier.
+ *
+ * `folded` and `resting` are here for ONE reason — `composeAvailableCapital`, which is only
+ * reached on an upward override. They are the report's own inputs so the guard weighs the
+ * figure the operator was shown, rather than a second implementation of `value − committed`
+ * that could drift from it.
+ */
+export async function resolveFunding(
+  ask: (question: string) => Promise<string>,
+  folded: FundReviewData,
+  resting: readonly RestingOrder[],
+  reserve: ReserveRecord,
+  filled: CommittedRung,
+  filledQuantity: number,
+): Promise<FundingOutcome> {
+  const proposedFunding = filled.price * filledQuantity;
+  const fundingAnswer = (await ask(`Cash debited [${proposedFunding}]: `)).trim();
+  const fundingAmount = fundingAnswer === "" ? proposedFunding : Number(fundingAnswer);
+  if (!Number.isFinite(fundingAmount) || fundingAmount <= 0) {
+    return {
+      status: "rejected",
+      reason: "bad-quantity",
+      message: `'${fundingAnswer}' is not a positive cash amount`,
+    };
+  }
+
+  // `D1` (#177) — THE ACT IS EXEMPT; THE OVERRIDE IS GUARDED, and only upward.
+  //
+  // The arithmetic decides where the guard goes. `available = value − committed`, and this
+  // act moves BOTH terms: the `orderFilled` line drops `committed` by `price × quantity`
+  // and the cash leg drops `value` by the amount debited. So
+  //
+  //     Δavailable = price × quantity − cash debited
+  //
+  // and the DEFAULT answer — `proposedFunding`, the two multiplied — is exactly
+  // available-neutral BY CONSTRUCTION. The fill itself therefore cannot break the
+  // `available ≥ 0` invariant no matter what shape the book is in, which is why this flow
+  // does NOT call `checkFundingCoverage`: that guard weighs the WHOLE book and refuses it
+  // if ANY rung anywhere in it is unplaceable (#179), so one stale `fundingReserveId` on
+  // an unrelated rung would refuse a fill that really happened at the venue. A fill is an
+  // observed fact; the flow does not get to disbelieve it.
+  //
+  // The override is not an observed fact. It is the operator asserting a figure nothing at
+  // the venue vouches for, and it is the ONLY input in this act that can drive a reserve
+  // negative. What is weighed is the EXCESS over the neutral figure — never "post-act
+  // available ≥ 0", which would brick every fill, neutral ones included, on any book that
+  // already sits negative from some other cause. A downward correction FREES availability
+  // and never reaches this branch.
+  const excess = fundingAmount - proposedFunding;
+  if (excess > 0) {
+    // The report's own arithmetic, over the report's own admission policy — not a second
+    // implementation of `value − committed` that could drift from the rendered figure.
+    const capital = composeAvailableCapital(folded, resting);
+    const funder = capital.reserves.find((entry) => entry.reserveId === reserve.id);
+    if (!funder) {
+      return {
+        status: "rejected",
+        reason: "uncovered-override",
+        message:
+          `you asked to debit ${fundingAmount} against '${reserve.id}' — ${excess} more than the ` +
+          `${proposedFunding} this fill accounts for — but the available-capital report does ` +
+          `not place that reserve (paper execution mode, an unsupported currency, a dangling ` +
+          `account reference), so the excess cannot be weighed against anything. The fill ` +
+          `itself is recordable at the default figure`,
+      };
+    }
+    if (excess > funder.available) {
+      return {
+        status: "rejected",
+        reason: "uncovered-override",
+        message:
+          `you asked to debit ${fundingAmount} against '${reserve.id}', ${excess} more than the ` +
+          `${proposedFunding} this fill accounts for, and '${reserve.id}' has only ` +
+          `${funder.available} available (${funder.value} balance less ${funder.committed} ` +
+          `committed). The fill's own arithmetic is available-neutral; only the extra is ` +
+          `spending capital that is not there, and a negative available is an IMPOSSIBLE ` +
+          `state rather than a warning. Record the fill at ${proposedFunding}, or record the ` +
+          `fee or funding difference as its own act`,
+      };
+    }
+  }
+
+  const fundingTier = deriveFundingTier(reserve);
+  if (fundingTier.status === "derived") {
+    return { status: "resolved", fundingAmount, tier: fundingTier.tier };
+  }
+  if (fundingTier.status === "ambiguous") {
+    // `T4` — the tier ordering was applied ONCE, at Transfer time. Asking here would
+    // re-decide it, which is the one thing this increment must not do.
+    return {
+      status: "rejected",
+      reason: "ambiguous-tier",
+      message:
+        `'${reserve.id}' holds ${fundingTier.tiers.join(" and ")}; the tier ordering was decided ` +
+        `at Transfer time and this act does not get to re-decide it`,
+    };
+  }
+  const answer = (await ask("  Capital tier for this lot (c1/c2/c3): ")).trim();
+  if (answer !== "c1" && answer !== "c2" && answer !== "c3") {
+    return {
+      status: "rejected",
+      reason: "ambiguous-tier",
+      message: `'${answer}' is not a capital tier`,
+    };
+  }
+  return { status: "resolved", fundingAmount, tier: answer };
+}

--- a/apps/tui/src/record-fill-ladder-target.test.ts
+++ b/apps/tui/src/record-fill-ladder-target.test.ts
@@ -1,0 +1,346 @@
+// THE SEAM'S OWN TESTS — the point of the extraction (#audit-14), and the thing the
+// fifteen-element positional array could not buy.
+//
+// WHAT THE END-TO-END SUITES COULD NOT HOLD. Before the split, the only way to reach the
+// "open the Position" branch was `openTopRungAnswers()` — fifteen answers by INDEX, mirrored
+// across ~30 call sites in two suites, where inserting one prompt silently shifts every
+// later answer and fails as a wrong-looking assertion somewhere downstream. Two of those
+// fifteen are already conditional, so the array's meaning depends on the fixture's shape.
+// Here every answer is keyed BY PROMPT, so a reordered or renamed prompt is a named
+// failure at the prompt, and adding a sixth decision field breaks nothing that is not
+// about the sixth decision field.
+//
+// AND THE PROMPT STRINGS ARE ASSERTED, not just the answers. The `[Y/n]` on the append
+// gate and the `[reserve.tempo]` default hint in the Tempo prompt are output rules that
+// nothing held before: both could be deleted and the whole suite stayed green, because the
+// stub answered by position and never read what it was asked.
+//
+// EVERY FIXTURE IS SYNTHETIC (`O7`). Invented instrument, round decade prices, round
+// balances. No real price, quantity, balance, rung or Tempo percentage appears here.
+import { describe, expect, it } from "vitest";
+import type { PositionRecord, ReserveRecord } from "@numisma/engine";
+import { authorLadderTarget } from "./record-fill-ladder-target.js";
+
+function reserve(overrides: Partial<ReserveRecord> = {}): ReserveRecord {
+  return {
+    id: "reserve-synthetic",
+    portfolioId: "portfolio-synthetic",
+    tempo: "Capital",
+    executionMode: "live",
+    accountId: "account-synthetic",
+    currency: "USD",
+    amount: 10000,
+    lots: [{ quantity: 10000, tier: "c1" }],
+    ...overrides,
+  };
+}
+
+function position(id: string, overrides: Partial<PositionRecord> = {}): PositionRecord {
+  return {
+    id,
+    portfolioId: "portfolio-synthetic",
+    tempo: "Capital",
+    executionMode: "live",
+    accountId: "account-synthetic",
+    currency: "USD",
+    instrumentId: "instrument-synthetic",
+    direction: "long",
+    markPrice: 400,
+    lots: [{ quantity: 10, tier: "c1", cost: 4000 }],
+    ...overrides,
+  };
+}
+
+/**
+ * The whole test surface of this module: two closures.
+ *
+ * Answers are keyed by a SUBSTRING of the prompt, not by index — that is the seam's payoff.
+ * An unmatched prompt throws rather than defaulting to `""`, so a prompt this test did not
+ * anticipate is a loud failure instead of a silently-blank answer that happens to abandon.
+ */
+function scripted(answers: Record<string, string>) {
+  const asked: string[] = [];
+  const printed: string[] = [];
+  return {
+    asked,
+    printed,
+    ask: async (question: string): Promise<string> => {
+      asked.push(question);
+      const hit = Object.entries(answers).find(([key]) => question.includes(key));
+      if (!hit) {
+        throw new Error(`unscripted prompt: ${JSON.stringify(question)}`);
+      }
+      return hit[1];
+    },
+    out: (message: string): void => {
+      printed.push(message);
+    },
+  };
+}
+
+const FIVE_FIELDS = {
+  "Entry thesis": "synthetic entry thesis",
+  "Invalidation condition": "synthetic invalidation condition",
+  "Risk budget": "synthetic risk budget",
+  "Planned holding horizon": "synthetic horizon",
+  Strategy: "synthetic strategy",
+};
+
+describe("authorLadderTarget — the ladder already has a Position", () => {
+  it("appends to it on the default answer, and asks with a [Y/n] default-yes hint", async () => {
+    const io = scripted({ "Append this lot": "" });
+
+    const outcome = await authorLadderTarget(
+      io.ask,
+      io.out,
+      [position("position-synthetic")],
+      reserve(),
+      "instrument-synthetic",
+    );
+
+    expect(outcome).toEqual({
+      status: "authored",
+      target: { mode: "add", positionId: "position-synthetic" },
+    });
+    // The gate names the Position it would append to — the operator cannot confirm a
+    // ladder they were not shown — and `[Y/n]` says a bare Enter appends.
+    expect(io.asked).toEqual(["Append this lot to 'position-synthetic'? [Y/n]: "]);
+    // The existing-Position branch is SILENT. The "First fill" notice belongs to the other
+    // branch and printing it here would tell the operator the opposite of what happened.
+    expect(io.printed).toEqual([]);
+  });
+
+  it("abandons on an explicit no — and only on a NEGATIVE, not on anything-but-yes", async () => {
+    for (const answer of ["n", "N", "no", " NO "]) {
+      const io = scripted({ "Append this lot": answer });
+      const outcome = await authorLadderTarget(
+        io.ask,
+        io.out,
+        [position("position-synthetic")],
+        reserve(),
+        "instrument-synthetic",
+      );
+      expect(outcome).toEqual({
+        status: "abandoned",
+        message: "the ladder's existing Position was declined",
+      });
+    }
+    // The default is YES, so an unrecognized answer APPENDS rather than abandoning. This is
+    // the asymmetry `[Y/n]` advertises, and it is the opposite of every other gate in the
+    // fill flow — worth an assertion of its own.
+    for (const answer of ["y", "", "maybe", "nope"]) {
+      const io = scripted({ "Append this lot": answer });
+      const outcome = await authorLadderTarget(
+        io.ask,
+        io.out,
+        [position("position-synthetic")],
+        reserve(),
+        "instrument-synthetic",
+      );
+      expect(outcome.status).toBe("authored");
+    }
+  });
+
+  it("refuses when two Positions are open on the same (account, instrument)", async () => {
+    // Nothing is asked: guessing which decision the lot belongs to is the failure, so there
+    // is no question that could resolve it.
+    const io = scripted({});
+
+    const outcome = await authorLadderTarget(
+      io.ask,
+      io.out,
+      [position("position-a"), position("position-b")],
+      reserve(),
+      "instrument-synthetic",
+    );
+
+    expect(outcome).toEqual({
+      status: "rejected",
+      reason: "ambiguous-ladder-position",
+      message:
+        "position-a and position-b are both open on instrument-synthetic in " +
+        'account-synthetic; "one Position per ladder" is already violated, and guessing ' +
+        "which decision this lot belongs to would put it in the wrong one",
+    });
+    expect(io.asked).toEqual([]);
+  });
+
+  it("scopes the ladder by BOTH account and instrument, so a neighbour is not a match", async () => {
+    // A Position on the same instrument in a DIFFERENT account, and one in the same account
+    // on a DIFFERENT instrument. Neither is this ladder; two of them are not an ambiguity.
+    const io = scripted({ "Position id": "", ...FIVE_FIELDS });
+
+    const outcome = await authorLadderTarget(
+      io.ask,
+      io.out,
+      [
+        position("position-elsewhere", { accountId: "account-other" }),
+        position("position-other-asset", { instrumentId: "instrument-other" }),
+      ],
+      reserve(),
+      "instrument-synthetic",
+    );
+
+    // Falls through to the OPEN branch — there is no Position on this ladder — and
+    // abandons on the blank id, which is how we know it never found one to append to.
+    expect(outcome).toEqual({ status: "abandoned", message: "no position id was given" });
+  });
+});
+
+describe("authorLadderTarget — first fill on the ladder opens the Position (T6)", () => {
+  it("builds the Position from the funding reserve and the five authored fields", async () => {
+    const io = scripted({ "Position id": "position-synthetic", Tempo: "", ...FIVE_FIELDS });
+
+    const outcome = await authorLadderTarget(io.ask, io.out, [], reserve(), "instrument-synthetic");
+
+    expect(outcome).toEqual({
+      status: "authored",
+      target: {
+        mode: "open",
+        position: {
+          id: "position-synthetic",
+          // EVERY ONE OF THESE IS READ OFF THE RESERVE, never asked. The lot is born into
+          // the portfolio, execution mode, account and currency that funded it; asking
+          // would be a second chance to disagree with the Transfer.
+          portfolioId: "portfolio-synthetic",
+          tempo: "Capital",
+          executionMode: "live",
+          accountId: "account-synthetic",
+          instrumentId: "instrument-synthetic",
+          // A fill against a resting BUY rung is always long. There is no short path here.
+          direction: "long",
+          currency: "USD",
+        },
+        decision: {
+          entryThesis: "synthetic entry thesis",
+          invalidationCondition: "synthetic invalidation condition",
+          riskBudget: "synthetic risk budget",
+          plannedHoldingHorizon: "synthetic horizon",
+          strategy: "synthetic strategy",
+        },
+      },
+    });
+    // The notice says WHY five prompts just appeared, and it is printed BEFORE them —
+    // interleaved into the transcript, which is why it cannot be hoisted to the caller.
+    expect(io.printed).toEqual(["First fill on this ladder — opening the Position.\n"]);
+  });
+
+  it("offers the reserve's tempo as the default and takes an override", async () => {
+    const withDefault = scripted({
+      "Position id": "position-synthetic",
+      Tempo: "",
+      ...FIVE_FIELDS,
+    });
+    await authorLadderTarget(
+      withDefault.ask,
+      withDefault.out,
+      [],
+      reserve({ tempo: "Tempo Synthetic" }),
+      "instrument-synthetic",
+    );
+    // The DEFAULT HINT names the reserve's own tempo. Nothing held this before: the hint
+    // could be dropped entirely and every positional test stayed green.
+    expect(withDefault.asked).toContain("  Tempo [Tempo Synthetic]: ");
+
+    const overridden = scripted({
+      "Position id": "position-synthetic",
+      Tempo: "  Tempo Other  ",
+      ...FIVE_FIELDS,
+    });
+    const outcome = await authorLadderTarget(
+      overridden.ask,
+      overridden.out,
+      [],
+      reserve({ tempo: "Tempo Synthetic" }),
+      "instrument-synthetic",
+    );
+    expect(outcome.status === "authored" && outcome.target.mode === "open").toBe(true);
+    if (outcome.status === "authored" && outcome.target.mode === "open") {
+      // Trimmed, and the reserve's value is NOT used once an override is given.
+      expect(outcome.target.position.tempo).toBe("Tempo Other");
+    }
+  });
+
+  it("abandons on a blank position id, before asking for a tempo or any decision field", async () => {
+    const io = scripted({ "Position id": "   " });
+
+    const outcome = await authorLadderTarget(io.ask, io.out, [], reserve(), "instrument-synthetic");
+
+    expect(outcome).toEqual({ status: "abandoned", message: "no position id was given" });
+    // ORDERING IS THE ASSERTION. The five decision fields are real authoring work, and a
+    // flow that collected them and THEN discovered the missing id would have wasted it. The
+    // scripted stub throws on any prompt beyond the id, so this holds by construction.
+    expect(io.asked).toEqual(["  Position id: "]);
+  });
+
+  it("refuses when ANY ONE of the five decision fields is blank — none has a default", async () => {
+    for (const missing of Object.keys(FIVE_FIELDS)) {
+      const io = scripted({
+        "Position id": "position-synthetic",
+        Tempo: "",
+        ...FIVE_FIELDS,
+        [missing]: "   ",
+      });
+
+      const outcome = await authorLadderTarget(
+        io.ask,
+        io.out,
+        [],
+        reserve(),
+        "instrument-synthetic",
+      );
+
+      expect(outcome).toEqual({
+        status: "rejected",
+        reason: "incomplete-decision",
+        message:
+          "all five decision fields are required to open a Position; none of them has a default",
+      });
+      // ALL FIVE ARE ASKED BEFORE ANY IS JUDGED. Bailing at the first blank would make the
+      // operator re-run the interview to find the second one.
+      expect(io.asked).toHaveLength(7);
+    }
+  });
+
+  it("trims every authored field, so whitespace never lands in the durable decision", async () => {
+    const io = scripted({
+      "Position id": "  position-synthetic  ",
+      Tempo: "",
+      "Entry thesis": "  synthetic entry thesis  ",
+      "Invalidation condition": "  synthetic invalidation condition  ",
+      "Risk budget": "  synthetic risk budget  ",
+      "Planned holding horizon": "  synthetic horizon  ",
+      Strategy: "  synthetic strategy  ",
+    });
+
+    const outcome = await authorLadderTarget(io.ask, io.out, [], reserve(), "instrument-synthetic");
+
+    expect(outcome.status).toBe("authored");
+    if (outcome.status === "authored" && outcome.target.mode === "open") {
+      expect(outcome.target.position.id).toBe("position-synthetic");
+      expect(outcome.target.decision).toEqual({
+        entryThesis: "synthetic entry thesis",
+        invalidationCondition: "synthetic invalidation condition",
+        riskBudget: "synthetic risk budget",
+        plannedHoldingHorizon: "synthetic horizon",
+        strategy: "synthetic strategy",
+      });
+    }
+  });
+
+  it("asks the five fields in the order the operator reads them", async () => {
+    const io = scripted({ "Position id": "position-synthetic", Tempo: "", ...FIVE_FIELDS });
+
+    await authorLadderTarget(io.ask, io.out, [], reserve(), "instrument-synthetic");
+
+    expect(io.asked).toEqual([
+      "  Position id: ",
+      "  Tempo [Capital]: ",
+      "  Entry thesis: ",
+      "  Invalidation condition: ",
+      "  Risk budget: ",
+      "  Planned holding horizon: ",
+      "  Strategy: ",
+    ]);
+  });
+});

--- a/apps/tui/src/record-fill-ladder-target.ts
+++ b/apps/tui/src/record-fill-ladder-target.ts
@@ -1,0 +1,152 @@
+/**
+ * THE LADDER'S POSITION, AUTHORED — the first half of the interview `record-fill.ts` used
+ * to hold inline (#audit-14).
+ *
+ * WHY IT LEFT. `record-fill.ts`'s header describes a DURABILITY PROTOCOL: two files, one
+ * act, validation up front, log-then-sidecar, rollback, and a named crash window. None of
+ * that is what this code does. This resolves a ladder to a Position and, when there is no
+ * Position yet, interviews the operator for the decision context the venue has never heard
+ * of (`T6`). It changes when the authoring questions change; the protocol changes when the
+ * durability argument changes. Two reasons, two files.
+ *
+ * IT TAKES THE PROMPT CHANNELS, NOT THE IO BAG — the same narrowing `declareFunding`
+ * (`import-orders-funding-declaration.ts:64`) made, and for the same two reasons: taking
+ * `RecordFillIo` would import the type BACK from the module this left, and "reads nothing
+ * but `ask` and `out`" could then only be held at runtime by a stub whose other members
+ * throw. Narrowed, the compiler holds it and the stub is two closures.
+ *
+ * THE `out` CHANNEL IS NOT DECORATION. The "First fill on this ladder" line is the only
+ * thing that tells the operator WHY the next five prompts appeared, and it must be
+ * interleaved with them in the transcript — so it cannot be hoisted to the caller, which
+ * does not yet know which branch this takes. That is the one member beyond `ask`.
+ *
+ * WHAT DELIBERATELY STAYED IN THE CALLER. `io.loadFolded()`, the reserve lookup
+ * (`unknown-reserve`) and the conditional instrument-id ask (`unknown-instrument`) all run
+ * BEFORE this: the fold and the funding reserve are read once and used by BOTH halves of
+ * the interview, and the instrument ask is conditional on a fold lookup the caller already
+ * performed. Pulling them in would either duplicate the lookups or make this function's
+ * two rejection arms four.
+ *
+ * REJECTIONS ARE RETURNED, NOT PRINTED. Every arm carries the reason token and the exact
+ * message `record-fill.ts` fed `reject(io, …)` before the split, and the caller feeds them
+ * to the same function — so the operator's bytes are unchanged. The reason union is
+ * declared narrowly HERE rather than imported from `RecordFillRejection`, which keeps the
+ * back-edge out; it is assignable to the wider token set at the call site.
+ */
+import {
+  resolveLadderPosition,
+  type LadderTarget,
+  type PositionDecision,
+  type PositionRecord,
+  type ReserveRecord,
+} from "@numisma/engine";
+
+export type LadderTargetOutcome =
+  | { status: "authored"; target: LadderTarget }
+  /** The operator declined a confirmation gate. The caller has written nothing. */
+  | { status: "abandoned"; message: string }
+  | {
+      status: "rejected";
+      reason: "ambiguous-ladder-position" | "incomplete-decision";
+      message: string;
+    };
+
+function isNegative(answer: string): boolean {
+  const normalized = answer.trim().toLowerCase();
+  return normalized === "n" || normalized === "no";
+}
+
+/** The five authored decision fields. All required; a blank one abandons the act. */
+async function askDecision(
+  ask: (question: string) => Promise<string>,
+): Promise<PositionDecision | undefined> {
+  const entryThesis = (await ask("  Entry thesis: ")).trim();
+  const invalidationCondition = (await ask("  Invalidation condition: ")).trim();
+  const riskBudget = (await ask("  Risk budget: ")).trim();
+  const plannedHoldingHorizon = (await ask("  Planned holding horizon: ")).trim();
+  const strategy = (await ask("  Strategy: ")).trim();
+  if (
+    !entryThesis ||
+    !invalidationCondition ||
+    !riskBudget ||
+    !plannedHoldingHorizon ||
+    !strategy
+  ) {
+    return undefined;
+  }
+  return { entryThesis, invalidationCondition, riskBudget, plannedHoldingHorizon, strategy };
+}
+
+/**
+ * Resolve the ladder's Position — first fill OPENS, every fill after APPENDS.
+ *
+ * `positions` is the WHOLE fold's open book, not a pre-filtered set: the ambiguity verdict
+ * is exactly "more than one open Position on this (account, instrument)", so the filtering
+ * is `resolveLadderPosition`'s to do and a caller that narrowed first could only narrow the
+ * ambiguity away.
+ */
+export async function authorLadderTarget(
+  ask: (question: string) => Promise<string>,
+  out: (message: string) => void,
+  positions: readonly PositionRecord[],
+  reserve: ReserveRecord,
+  instrumentId: string,
+): Promise<LadderTargetOutcome> {
+  const ladder = resolveLadderPosition(positions, {
+    accountId: reserve.accountId,
+    instrumentId,
+  });
+  if (ladder.status === "ambiguous") {
+    return {
+      status: "rejected",
+      reason: "ambiguous-ladder-position",
+      message:
+        `${ladder.positionIds.join(" and ")} are both open on ${instrumentId} in ` +
+        `${reserve.accountId}; "one Position per ladder" is already violated, and guessing ` +
+        `which decision this lot belongs to would put it in the wrong one`,
+    };
+  }
+
+  if (ladder.status === "one") {
+    if (isNegative(await ask(`Append this lot to '${ladder.positionId}'? [Y/n]: `))) {
+      return { status: "abandoned", message: "the ladder's existing Position was declined" };
+    }
+    return { status: "authored", target: { mode: "add", positionId: ladder.positionId } };
+  }
+
+  // FIRST FILL, WITH NO PLAN BEHIND IT — `T6`, and this path is permanent. The venue has
+  // never heard of a Tempo, so the decision context is authored here, at the moment of
+  // the fill, and nowhere else.
+  out("First fill on this ladder — opening the Position.\n");
+  const positionId = (await ask("  Position id: ")).trim();
+  if (!positionId) {
+    return { status: "abandoned", message: "no position id was given" };
+  }
+  const tempoAnswer = (await ask(`  Tempo [${reserve.tempo}]: `)).trim();
+  const decision = await askDecision(ask);
+  if (!decision) {
+    return {
+      status: "rejected",
+      reason: "incomplete-decision",
+      message:
+        "all five decision fields are required to open a Position; none of them has a default",
+    };
+  }
+  return {
+    status: "authored",
+    target: {
+      mode: "open",
+      position: {
+        id: positionId,
+        portfolioId: reserve.portfolioId,
+        tempo: tempoAnswer === "" ? reserve.tempo : tempoAnswer,
+        executionMode: reserve.executionMode,
+        accountId: reserve.accountId,
+        instrumentId,
+        direction: "long",
+        currency: reserve.currency,
+      },
+      decision,
+    },
+  };
+}

--- a/apps/tui/src/record-fill.ts
+++ b/apps/tui/src/record-fill.ts
@@ -55,18 +55,14 @@ import {
   buildEventReference,
   buildFillAct,
   committedRungs,
-  composeAvailableCapital,
   crossReferenceEvent,
-  deriveFundingTier,
   isObservedAtStamp,
   parseEvent,
   pickRestingOrdersAsOf,
   proposeFillVerdicts,
   reconcileFillActs,
-  resolveLadderPosition,
   scopeBookForFill,
   type BookObservation,
-  type CapitalTier,
   type CommittedRung,
   type FillAct,
   type FundReviewData,
@@ -74,11 +70,12 @@ import {
   type ObservedRungState,
   type OrderRecord,
   type PortfolioEvent,
-  type PositionDecision,
   type ProposedVerdict,
 } from "@numisma/engine";
 import type { OrdersLoad } from "@numisma/preferences";
 import { nextLogImage, serializeEvent } from "./event-store.js";
+import { resolveFunding } from "./record-fill-funding.js";
+import { authorLadderTarget } from "./record-fill-ladder-target.js";
 import { renderSkipMessage } from "./skip-message.js";
 
 /** Everything this act touches that is not a pure function, in one injectable bag. */
@@ -171,11 +168,6 @@ function reject(
 function isAffirmative(answer: string): boolean {
   const normalized = answer.trim().toLowerCase();
   return normalized === "y" || normalized === "yes";
-}
-
-function isNegative(answer: string): boolean {
-  const normalized = answer.trim().toLowerCase();
-  return normalized === "n" || normalized === "no";
 }
 
 /** The rung list the fill prompt renders from — the same rows `S7` substantiates with. */
@@ -295,25 +287,6 @@ async function observeBook(
   }
 
   return { status: "observed", observation: { observedAt, present } };
-}
-
-/** The five authored decision fields. All required; a blank one abandons the act. */
-async function askDecision(io: RecordFillIo): Promise<PositionDecision | undefined> {
-  const entryThesis = (await io.ask("  Entry thesis: ")).trim();
-  const invalidationCondition = (await io.ask("  Invalidation condition: ")).trim();
-  const riskBudget = (await io.ask("  Risk budget: ")).trim();
-  const plannedHoldingHorizon = (await io.ask("  Planned holding horizon: ")).trim();
-  const strategy = (await io.ask("  Strategy: ")).trim();
-  if (
-    !entryThesis ||
-    !invalidationCondition ||
-    !riskBudget ||
-    !plannedHoldingHorizon ||
-    !strategy
-  ) {
-    return undefined;
-  }
-  return { entryThesis, invalidationCondition, riskBudget, plannedHoldingHorizon, strategy };
 }
 
 /**
@@ -568,142 +541,34 @@ export async function recordFill(io: RecordFillIo): Promise<RecordFillOutcome> {
     );
   }
 
-  const ladder = resolveLadderPosition(folded.positions, {
-    accountId: reserve.accountId,
+  // The authoring interview, behind its own seam (#audit-14). Its rejection arms carry the
+  // reason token and the message this flow used to build inline, so `reject` still prints
+  // the identical bytes; `abandoned` passes straight through, nothing having been written.
+  const authored = await authorLadderTarget(
+    io.ask,
+    io.out,
+    folded.positions,
+    reserve,
     instrumentId,
-  });
-  if (ladder.status === "ambiguous") {
-    return reject(
-      io,
-      "ambiguous-ladder-position",
-      `${ladder.positionIds.join(" and ")} are both open on ${instrumentId} in ` +
-        `${reserve.accountId}; "one Position per ladder" is already violated, and guessing ` +
-        `which decision this lot belongs to would put it in the wrong one`,
-    );
+  );
+  if (authored.status === "rejected") {
+    return reject(io, authored.reason, authored.message);
   }
-
-  let target: LadderTarget;
-  if (ladder.status === "one") {
-    if (isNegative(await io.ask(`Append this lot to '${ladder.positionId}'? [Y/n]: `))) {
-      return { status: "abandoned", message: "the ladder's existing Position was declined" };
-    }
-    target = { mode: "add", positionId: ladder.positionId };
-  } else {
-    // FIRST FILL, WITH NO PLAN BEHIND IT — `T6`, and this path is permanent. The venue has
-    // never heard of a Tempo, so the decision context is authored here, at the moment of
-    // the fill, and nowhere else.
-    io.out("First fill on this ladder — opening the Position.\n");
-    const positionId = (await io.ask("  Position id: ")).trim();
-    if (!positionId) {
-      return { status: "abandoned", message: "no position id was given" };
-    }
-    const tempoAnswer = (await io.ask(`  Tempo [${reserve.tempo}]: `)).trim();
-    const decision = await askDecision(io);
-    if (!decision) {
-      return reject(
-        io,
-        "incomplete-decision",
-        "all five decision fields are required to open a Position; none of them has a default",
-      );
-    }
-    target = {
-      mode: "open",
-      position: {
-        id: positionId,
-        portfolioId: reserve.portfolioId,
-        tempo: tempoAnswer === "" ? reserve.tempo : tempoAnswer,
-        executionMode: reserve.executionMode,
-        accountId: reserve.accountId,
-        instrumentId,
-        direction: "long",
-        currency: reserve.currency,
-      },
-      decision,
-    };
+  if (authored.status === "abandoned") {
+    return authored;
   }
+  const target: LadderTarget = authored.target;
 
   // ---- 6. the cash leg and the tier that is READ, never re-decided ----
-  const proposedFunding = filled.price * filledQuantity;
-  const fundingAnswer = (await io.ask(`Cash debited [${proposedFunding}]: `)).trim();
-  const fundingAmount = fundingAnswer === "" ? proposedFunding : Number(fundingAnswer);
-  if (!Number.isFinite(fundingAmount) || fundingAmount <= 0) {
-    return reject(io, "bad-quantity", `'${fundingAnswer}' is not a positive cash amount`);
+  //
+  // Behind its own seam (#audit-14), handed the reserve this flow already resolved. Its
+  // rejection arms carry the reason token and the message this flow used to build inline,
+  // so `reject` still prints the identical bytes.
+  const funding = await resolveFunding(io.ask, folded, resting, reserve, filled, filledQuantity);
+  if (funding.status === "rejected") {
+    return reject(io, funding.reason, funding.message);
   }
-
-  // `D1` (#177) — THE ACT IS EXEMPT; THE OVERRIDE IS GUARDED, and only upward.
-  //
-  // The arithmetic decides where the guard goes. `available = value − committed`, and this
-  // act moves BOTH terms: the `orderFilled` line drops `committed` by `price × quantity`
-  // and the cash leg drops `value` by the amount debited. So
-  //
-  //     Δavailable = price × quantity − cash debited
-  //
-  // and the DEFAULT answer — `proposedFunding`, the two multiplied — is exactly
-  // available-neutral BY CONSTRUCTION. The fill itself therefore cannot break the
-  // `available ≥ 0` invariant no matter what shape the book is in, which is why this flow
-  // does NOT call `checkFundingCoverage`: that guard weighs the WHOLE book and refuses it
-  // if ANY rung anywhere in it is unplaceable (#179), so one stale `fundingReserveId` on
-  // an unrelated rung would refuse a fill that really happened at the venue. A fill is an
-  // observed fact; the flow does not get to disbelieve it.
-  //
-  // The override is not an observed fact. It is the operator asserting a figure nothing at
-  // the venue vouches for, and it is the ONLY input in this act that can drive a reserve
-  // negative. What is weighed is the EXCESS over the neutral figure — never "post-act
-  // available ≥ 0", which would brick every fill, neutral ones included, on any book that
-  // already sits negative from some other cause. A downward correction FREES availability
-  // and never reaches this branch.
-  const excess = fundingAmount - proposedFunding;
-  if (excess > 0) {
-    // The report's own arithmetic, over the report's own admission policy — not a second
-    // implementation of `value − committed` that could drift from the rendered figure.
-    const capital = composeAvailableCapital(folded, resting);
-    const funder = capital.reserves.find((entry) => entry.reserveId === reserve.id);
-    if (!funder) {
-      return reject(
-        io,
-        "uncovered-override",
-        `you asked to debit ${fundingAmount} against '${reserve.id}' — ${excess} more than the ` +
-          `${proposedFunding} this fill accounts for — but the available-capital report does ` +
-          `not place that reserve (paper execution mode, an unsupported currency, a dangling ` +
-          `account reference), so the excess cannot be weighed against anything. The fill ` +
-          `itself is recordable at the default figure`,
-      );
-    }
-    if (excess > funder.available) {
-      return reject(
-        io,
-        "uncovered-override",
-        `you asked to debit ${fundingAmount} against '${reserve.id}', ${excess} more than the ` +
-          `${proposedFunding} this fill accounts for, and '${reserve.id}' has only ` +
-          `${funder.available} available (${funder.value} balance less ${funder.committed} ` +
-          `committed). The fill's own arithmetic is available-neutral; only the extra is ` +
-          `spending capital that is not there, and a negative available is an IMPOSSIBLE ` +
-          `state rather than a warning. Record the fill at ${proposedFunding}, or record the ` +
-          `fee or funding difference as its own act`,
-      );
-    }
-  }
-
-  const fundingTier = deriveFundingTier(reserve);
-  let tier: CapitalTier;
-  if (fundingTier.status === "derived") {
-    tier = fundingTier.tier;
-  } else if (fundingTier.status === "ambiguous") {
-    // `T4` — the tier ordering was applied ONCE, at Transfer time. Asking here would
-    // re-decide it, which is the one thing this increment must not do.
-    return reject(
-      io,
-      "ambiguous-tier",
-      `'${reserve.id}' holds ${fundingTier.tiers.join(" and ")}; the tier ordering was decided ` +
-        `at Transfer time and this act does not get to re-decide it`,
-    );
-  } else {
-    const answer = (await io.ask("  Capital tier for this lot (c1/c2/c3): ")).trim();
-    if (answer !== "c1" && answer !== "c2" && answer !== "c3") {
-      return reject(io, "ambiguous-tier", `'${answer}' is not a capital tier`);
-    }
-    tier = answer;
-  }
+  const { fundingAmount, tier } = funding;
 
   // ---- 7. BOTH records, built together and validated together, before any write ----
   const act = buildFillAct({


### PR DESCRIPTION
Audit finding 14 identified record-fill.ts as conflating two responsibilities: the authoring interview (ladder-target resolution and funding/tier resolution) and the two-file act protocol that writes the fill. This extracts the two decision seams into record-fill-ladder-target.ts and record-fill-funding.ts, leaving the caller holding only the two hoists that belong there — loadFolded and the conditional instrument-id ask.

The extraction is behavior-preserving: rejection messages are byte-identical to their inline predecessors, and the existing positional-answer test suites are untouched. Each extracted helper also gets its own direct seam test rather than relying solely on indirect coverage through record-fill's own suite.

The two extractions landed as a single commit rather than split further — the import-list hunk in record-fill.ts removes symbols belonging to both seams together, and the two replaced call sites sit close enough in the function that git merges their diffs into one hunk.