### PR TITLE
refactor(web): one declared home for SUPPRESSION_KEYS

### DIFF
--- a/apps/web/src/glance/row-view.ts
+++ b/apps/web/src/glance/row-view.ts
@@ -44,6 +44,9 @@
  */
 import type { CompositionRow } from "@numisma/engine";
 import type { SnapshotAnchor } from "../projection/contract.ts";
+// The header keys are read from their one declared home, never re-spelled here — a
+// hand-typed literal compiles while the reader silently stops suppressing (finding 7).
+import { SUPPRESSION_KEYS } from "../projection/contract.ts";
 import { referenceLabel, resolveReferenceAnchor } from "./verdict.ts";
 
 /**
@@ -188,8 +191,8 @@ export function composeBigPicture(
     costBasisLabel: COST_BASIS_LABEL,
     // See the header: the percentage descends from NAV for EVERY row, so it is a
     // page-level absence rather than a per-row one.
-    percentOfFundRendered: !suppressed.has("summary.fundValueUsd"),
-    fundValueRendered: !suppressed.has("summary.fundValueUsd"),
+    percentOfFundRendered: !suppressed.has(SUPPRESSION_KEYS.fundValue),
+    fundValueRendered: !suppressed.has(SUPPRESSION_KEYS.fundValue),
     rows,
   };
 }

--- a/apps/web/src/glance/row-view.ts
+++ b/apps/web/src/glance/row-view.ts
@@ -43,10 +43,12 @@
  * them rather than the push shipping a key it would have to version.
  */
 import type { CompositionRow } from "@numisma/engine";
-import type { SnapshotAnchor } from "../projection/contract.ts";
-// The header keys are read from their one declared home, never re-spelled here — a
-// hand-typed literal compiles while the reader silently stops suppressing (finding 7).
-import { SUPPRESSION_KEYS } from "../projection/contract.ts";
+// The header keys are read from their one declared home, never re-spelled here — see
+// the {@link SUPPRESSION_KEYS} docstring in `../projection/contract.ts` for why.
+import {
+  SUPPRESSION_KEYS,
+  type SnapshotAnchor,
+} from "../projection/contract.ts";
 import { referenceLabel, resolveReferenceAnchor } from "./verdict.ts";
 
 /**

--- a/apps/web/src/glance/suppression-seam.test.ts
+++ b/apps/web/src/glance/suppression-seam.test.ts
@@ -1,0 +1,129 @@
+/**
+ * THE PUSH↔READER SUPPRESSION SEAM (audit finding 7).
+ *
+ * `glance.suppressed` is a list of KEYS: the push names a number it refuses to
+ * stand behind, and the reader recognises the name and leaves the slot empty. That
+ * is a contract between two modules that share no compiler-checked surface — the
+ * key is a bare `string` on the wire — so before this suite a key renamed push-side
+ * still compiled everywhere and the reader silently stopped suppressing, rendering a
+ * NAV computed from a mark that never arrived. The false *no* the design forbids.
+ *
+ * The fix is one declared home ({@link SUPPRESSION_KEYS} in `projection/contract.ts`,
+ * the pg-free wire contract both halves already import). This suite is what keeps it
+ * the ONLY home, in three parts that fail for three different reasons:
+ *
+ *  1. the declared set is pinned, so a rename is a deliberate, visible edit;
+ *  2. no production speller hand-types a key — a new bare literal fails here even
+ *     though it compiles;
+ *  3. the keys the push emits really do empty the reader's slots, end to end, so the
+ *     shared constant is proven load-bearing rather than merely imported.
+ */
+import { readFileSync } from "node:fs";
+import { fileURLToPath } from "node:url";
+import { dirname, resolve } from "node:path";
+import { describe, expect, it } from "vitest";
+import type { SnapshotAnchor } from "../projection/contract.ts";
+import { SUPPRESSION_KEYS } from "../projection/contract.ts";
+import { loadAnchorFixture } from "../push/anchor-fixture.ts";
+import { computeVerdict } from "./verdict.ts";
+import { composeBigPicture } from "./row-view.ts";
+
+const HERE = dirname(fileURLToPath(import.meta.url));
+
+describe("the declared suppression keys", () => {
+  it("pins the closed set of three header keys", () => {
+    // Both directions: the values a renamer would change, and the key set itself, so
+    // a fourth header key cannot arrive without this line being edited.
+    expect(SUPPRESSION_KEYS).toEqual({
+      fundValue: "summary.fundValueUsd",
+      change: "summary.change",
+      reserve: "summary.reserve",
+    });
+    expect(Object.keys(SUPPRESSION_KEYS).sort()).toEqual([
+      "change",
+      "fundValue",
+      "reserve",
+    ]);
+  });
+
+  it("lives in the pg-free contract, which both the push and the reader import", () => {
+    // `contract.test.ts` proves the contract stays pg-free from the module graph.
+    // This proves THIS constant is the thing that property was needed for: a shared
+    // RUNTIME value the browser-reachable reader can import without a driver.
+    const contract = readFileSync(resolve(HERE, "../projection/contract.ts"), "utf-8");
+    expect(contract).toContain("export const SUPPRESSION_KEYS");
+  });
+});
+
+/**
+ * The one declared home, enforced against the source rather than trusted to review.
+ *
+ * These are the three modules the audit found spelling the keys by hand. A literal
+ * here compiles and passes every behavioural test in the repo while being wrong in
+ * exactly the way finding 7 describes, so the only guard that can catch it is a
+ * textual one. Prose mentions in comments are untouched — the pattern requires STRING
+ * quotes, and the repo's docs quote a key in backticks, so naming a key in a comment
+ * (which these modules do, and should) stays legal while spelling one in code does not.
+ */
+describe("no production module hand-types a suppression key", () => {
+  const SPELLERS = ["../push/glance.ts", "./verdict.ts", "./row-view.ts"];
+  const LITERAL = /["']summary\.(?:fundValueUsd|change|reserve)["']/g;
+
+  for (const relative of SPELLERS) {
+    it(`${relative} reads them from the contract`, () => {
+      const source = readFileSync(resolve(HERE, relative), "utf-8");
+      const literals = source.match(LITERAL) ?? [];
+      expect(
+        literals,
+        `${relative} spells a suppression key by hand; import SUPPRESSION_KEYS instead`,
+      ).toEqual([]);
+      expect(source).toContain("SUPPRESSION_KEYS");
+    });
+  }
+});
+
+/**
+ * End to end: the keys the PUSH emits are the keys the READER acts on.
+ *
+ * Part 2 above proves nobody re-spells them; this proves the spelling still does its
+ * job. Together they are what makes a rename safe — change the constant and both
+ * halves move, because there is nothing else to move.
+ */
+describe("keys emitted by the push empty the reader's slots", () => {
+  /** The newest fixture anchor, with every header key marked suppressed. */
+  async function fullySuppressed(): Promise<{
+    anchors: SnapshotAnchor[];
+    latest: SnapshotAnchor;
+  }> {
+    const anchors = structuredClone(await loadAnchorFixture());
+    const latest = anchors[anchors.length - 1] as SnapshotAnchor;
+    latest.report.glance.suppressed = Object.values(SUPPRESSION_KEYS);
+    return { anchors, latest };
+  }
+
+  it("leaves all three verdict slots unrendered", async () => {
+    const { anchors, latest } = await fullySuppressed();
+    const verdict = computeVerdict(latest, anchors, new Date(`${latest.asOf}T12:00:00Z`));
+
+    expect(verdict.slots.fundValue.rendered).toBe(false);
+    expect(verdict.slots.change.rendered).toBe(false);
+    expect(verdict.slots.reserve.rendered).toBe(false);
+  });
+
+  it("withholds the fund value and the percent-of-fund column on /big-picture", async () => {
+    const { anchors, latest } = await fullySuppressed();
+    const view = composeBigPicture(latest, anchors);
+
+    expect(view.fundValueRendered).toBe(false);
+    expect(view.percentOfFundRendered).toBe(false);
+  });
+
+  it("renders all three when nothing is suppressed — the guard is not vacuous", async () => {
+    const { anchors, latest } = await fullySuppressed();
+    latest.report.glance.suppressed = [];
+    const verdict = computeVerdict(latest, anchors, new Date(`${latest.asOf}T12:00:00Z`));
+
+    expect(verdict.slots.fundValue.rendered).toBe(true);
+    expect(composeBigPicture(latest, anchors).fundValueRendered).toBe(true);
+  });
+});

--- a/apps/web/src/glance/suppression-seam.test.ts
+++ b/apps/web/src/glance/suppression-seam.test.ts
@@ -1,26 +1,25 @@
 /**
  * THE PUSH↔READER SUPPRESSION SEAM (audit finding 7).
  *
- * `glance.suppressed` is a list of KEYS: the push names a number it refuses to
- * stand behind, and the reader recognises the name and leaves the slot empty. That
- * is a contract between two modules that share no compiler-checked surface — the
- * key is a bare `string` on the wire — so before this suite a key renamed push-side
- * still compiled everywhere and the reader silently stopped suppressing, rendering a
- * NAV computed from a mark that never arrived. The false *no* the design forbids.
+ * `glance.suppressed` is a list of KEYS: the push names a number it refuses to stand
+ * behind, and the reader recognises the name and leaves the slot empty. The key is a
+ * bare `string` on the wire, so the compiler cannot relate the writer's spelling to
+ * the reader's — see the {@link SUPPRESSION_KEYS} docstring in
+ * `../projection/contract.ts` for the full rationale and why one declared home fixes
+ * it.
  *
- * The fix is one declared home ({@link SUPPRESSION_KEYS} in `projection/contract.ts`,
- * the pg-free wire contract both halves already import). This suite is what keeps it
- * the ONLY home, in three parts that fail for three different reasons:
+ * This suite is what keeps it the ONLY home, in three parts that fail for three
+ * different reasons:
  *
  *  1. the declared set is pinned, so a rename is a deliberate, visible edit;
- *  2. no production speller hand-types a key — a new bare literal fails here even
+ *  2. no production module hand-types a key — a new bare literal fails here even
  *     though it compiles;
- *  3. the keys the push emits really do empty the reader's slots, end to end, so the
- *     shared constant is proven load-bearing rather than merely imported.
+ *  3. the keys the push emits really do empty the reader's slots, end to end, ONE KEY
+ *     AT A TIME, so each key is proven load-bearing rather than merely imported.
  */
-import { readFileSync } from "node:fs";
+import { readdirSync, readFileSync } from "node:fs";
 import { fileURLToPath } from "node:url";
-import { dirname, resolve } from "node:path";
+import { dirname, relative, resolve } from "node:path";
 import { describe, expect, it } from "vitest";
 import type { SnapshotAnchor } from "../projection/contract.ts";
 import { SUPPRESSION_KEYS } from "../projection/contract.ts";
@@ -29,28 +28,26 @@ import { computeVerdict } from "./verdict.ts";
 import { composeBigPicture } from "./row-view.ts";
 
 const HERE = dirname(fileURLToPath(import.meta.url));
+/** `apps/web/src` — the tree the textual guard below walks. */
+const SRC = resolve(HERE, "..");
 
 describe("the declared suppression keys", () => {
   it("pins the closed set of three header keys", () => {
-    // Both directions: the values a renamer would change, and the key set itself, so
-    // a fourth header key cannot arrive without this line being edited.
+    // Exhaustive by construction: `toEqual` on an object literal fails both on a
+    // changed value and on a fourth key arriving, so a rename cannot be silent.
     expect(SUPPRESSION_KEYS).toEqual({
       fundValue: "summary.fundValueUsd",
       change: "summary.change",
       reserve: "summary.reserve",
     });
-    expect(Object.keys(SUPPRESSION_KEYS).sort()).toEqual([
-      "change",
-      "fundValue",
-      "reserve",
-    ]);
   });
 
-  it("lives in the pg-free contract, which both the push and the reader import", () => {
-    // `contract.test.ts` proves the contract stays pg-free from the module graph.
-    // This proves THIS constant is the thing that property was needed for: a shared
-    // RUNTIME value the browser-reachable reader can import without a driver.
-    const contract = readFileSync(resolve(HERE, "../projection/contract.ts"), "utf-8");
+  it("is DECLARED in the pg-free contract, not re-exported from somewhere else", () => {
+    // `contract.test.ts` proves the contract stays pg-free from the module graph; this
+    // proves the constant's declaration is the thing standing on that property. A
+    // `export { SUPPRESSION_KEYS } from "../push/glance.ts"` would satisfy every other
+    // test in this file while putting the real home back on the push side.
+    const contract = readFileSync(resolve(SRC, "projection/contract.ts"), "utf-8");
     expect(contract).toContain("export const SUPPRESSION_KEYS");
   });
 });
@@ -58,72 +55,142 @@ describe("the declared suppression keys", () => {
 /**
  * The one declared home, enforced against the source rather than trusted to review.
  *
- * These are the three modules the audit found spelling the keys by hand. A literal
- * here compiles and passes every behavioural test in the repo while being wrong in
- * exactly the way finding 7 describes, so the only guard that can catch it is a
- * textual one. Prose mentions in comments are untouched — the pattern requires STRING
- * quotes, and the repo's docs quote a key in backticks, so naming a key in a comment
- * (which these modules do, and should) stays legal while spelling one in code does not.
+ * A hand-typed literal compiles and passes every behavioural test in the repo while
+ * being wrong in exactly the way finding 7 describes, so the only guard that can catch
+ * it is a textual one — and it scans the WHOLE tree rather than a hardcoded list of
+ * today's spellers, because the next drift will be in a file that does not exist yet.
+ *
+ * Comments are stripped before matching (whitespace-for-comment, so line numbers still
+ * point at the source): naming a key in prose is legal and these modules rightly do it,
+ * while spelling one in code — in any quote style, backticks included — is not.
  */
 describe("no production module hand-types a suppression key", () => {
-  const SPELLERS = ["../push/glance.ts", "./verdict.ts", "./row-view.ts"];
-  const LITERAL = /["']summary\.(?:fundValueUsd|change|reserve)["']/g;
+  const LITERAL = /["'`]summary\.(?:fundValueUsd|change|reserve)["'`]/;
+  const COMMENT = /\/\*[\s\S]*?\*\/|\/\/[^\n]*/g;
 
-  for (const relative of SPELLERS) {
-    it(`${relative} reads them from the contract`, () => {
-      const source = readFileSync(resolve(HERE, relative), "utf-8");
-      const literals = source.match(LITERAL) ?? [];
-      expect(
-        literals,
-        `${relative} spells a suppression key by hand; import SUPPRESSION_KEYS instead`,
-      ).toEqual([]);
-      expect(source).toContain("SUPPRESSION_KEYS");
-    });
-  }
+  /** Every non-test module under `apps/web/src`, minus the keys' declared home. */
+  const scanned = readdirSync(SRC, { recursive: true, encoding: "utf-8" })
+    .filter((rel) => rel.endsWith(".ts") && !rel.endsWith(".test.ts"))
+    .filter((rel) => resolve(SRC, rel) !== resolve(SRC, "projection/contract.ts"))
+    .map((rel) => resolve(SRC, rel))
+    .sort();
+
+  it("walks the whole source tree, not a list that can go stale", () => {
+    // A glob that silently matched nothing would make the guard below vacuous.
+    expect(scanned.length).toBeGreaterThan(10);
+    for (const speller of ["push/glance.ts", "glance/verdict.ts", "glance/row-view.ts"]) {
+      expect(scanned).toContain(resolve(SRC, speller));
+    }
+  });
+
+  it("spells no key in code, in any module", () => {
+    const offenders: string[] = [];
+    for (const absolute of scanned) {
+      const source = readFileSync(absolute, "utf-8").replace(COMMENT, (block) =>
+        block.replace(/[^\n]/g, " "),
+      );
+      source.split("\n").forEach((line, index) => {
+        if (LITERAL.test(line)) offenders.push(`${relative(SRC, absolute)}:${index + 1}`);
+      });
+    }
+
+    expect(
+      offenders,
+      "these spell a suppression key by hand; import SUPPRESSION_KEYS instead",
+    ).toEqual([]);
+  });
+
+  it("reads them from the contract in each module that needs them", () => {
+    // The negative above passes trivially for a module that stopped suppressing
+    // altogether; this is the positive half for the three that must.
+    for (const speller of ["push/glance.ts", "glance/verdict.ts", "glance/row-view.ts"]) {
+      expect(readFileSync(resolve(SRC, speller), "utf-8")).toContain("SUPPRESSION_KEYS");
+    }
+  });
 });
 
 /**
  * End to end: the keys the PUSH emits are the keys the READER acts on.
+ *
+ * ONE KEY AT A TIME, because the reader's checks are ordered and an all-three payload
+ * short-circuits on the first: `reserveSlot` returns on the suppressed `fundValue`
+ * long before it reaches its own key's branch, so a single fully-suppressed fixture
+ * asserts nothing about `reserve` at all. Each key therefore gets a payload where it
+ * is the ONLY thing suppressed.
  *
  * Part 2 above proves nobody re-spells them; this proves the spelling still does its
  * job. Together they are what makes a rename safe — change the constant and both
  * halves move, because there is nothing else to move.
  */
 describe("keys emitted by the push empty the reader's slots", () => {
-  /** The newest fixture anchor, with every header key marked suppressed. */
-  async function fullySuppressed(): Promise<{
+  /**
+   * The newest fixture anchor with exactly `keys` suppressed. `loadAnchorFixture`
+   * re-parses the committed file per call, so mutating what it returns is safe.
+   */
+  async function suppressing(...keys: string[]): Promise<{
     anchors: SnapshotAnchor[];
     latest: SnapshotAnchor;
   }> {
-    const anchors = structuredClone(await loadAnchorFixture());
+    const anchors = await loadAnchorFixture();
     const latest = anchors[anchors.length - 1] as SnapshotAnchor;
-    latest.report.glance.suppressed = Object.values(SUPPRESSION_KEYS);
+    latest.report.glance.suppressed = keys;
     return { anchors, latest };
   }
 
-  it("leaves all three verdict slots unrendered", async () => {
-    const { anchors, latest } = await fullySuppressed();
-    const verdict = computeVerdict(latest, anchors, new Date(`${latest.asOf}T12:00:00Z`));
+  function verdictFor(latest: SnapshotAnchor, anchors: SnapshotAnchor[]) {
+    return computeVerdict(latest, anchors, new Date(`${latest.asOf}T12:00:00Z`));
+  }
+
+  it("empties the fund-value slot, and the /big-picture columns that divide by it", async () => {
+    const { anchors, latest } = await suppressing(SUPPRESSION_KEYS.fundValue);
+    const verdict = verdictFor(latest, anchors);
+    const view = composeBigPicture(latest, anchors);
+
+    expect(verdict.slots.fundValue.rendered).toBe(false);
+    expect(view.fundValueRendered).toBe(false);
+    expect(view.percentOfFundRendered).toBe(false);
+  });
+
+  it("empties the change slot alone, leaving the other two standing", async () => {
+    const { anchors, latest } = await suppressing(SUPPRESSION_KEYS.change);
+    const verdict = verdictFor(latest, anchors);
+
+    expect(verdict.slots.change.rendered).toBe(false);
+    expect(verdict.slots.fundValue.rendered).toBe(true);
+    expect(verdict.slots.reserve.rendered).toBe(true);
+  });
+
+  it("empties the reserve slot alone — the branch an all-three payload never reaches", async () => {
+    const { anchors, latest } = await suppressing(SUPPRESSION_KEYS.reserve);
+    // The two inputs that would return EARLIER for a different reason, so a pass here
+    // is the reserve KEY doing the work and not an absent focus or an absent floor.
+    expect(latest.report.dashboard.summary.reserve).toBeDefined();
+    expect(latest.report.glance.reserveTargetPct).toBeDefined();
+
+    const verdict = verdictFor(latest, anchors);
+
+    expect(verdict.slots.reserve.rendered).toBe(false);
+    expect(verdict.slots.reserve.suppressedBy).toBe("unexpected-absence");
+    expect(verdict.slots.fundValue.rendered).toBe(true);
+    expect(verdict.slots.change.rendered).toBe(true);
+  });
+
+  it("leaves all three unrendered when the push emits all three", async () => {
+    const { anchors, latest } = await suppressing(...Object.values(SUPPRESSION_KEYS));
+    const verdict = verdictFor(latest, anchors);
 
     expect(verdict.slots.fundValue.rendered).toBe(false);
     expect(verdict.slots.change.rendered).toBe(false);
     expect(verdict.slots.reserve.rendered).toBe(false);
   });
 
-  it("withholds the fund value and the percent-of-fund column on /big-picture", async () => {
-    const { anchors, latest } = await fullySuppressed();
-    const view = composeBigPicture(latest, anchors);
-
-    expect(view.fundValueRendered).toBe(false);
-    expect(view.percentOfFundRendered).toBe(false);
-  });
-
   it("renders all three when nothing is suppressed — the guard is not vacuous", async () => {
-    const { anchors, latest } = await fullySuppressed();
-    latest.report.glance.suppressed = [];
-    const verdict = computeVerdict(latest, anchors, new Date(`${latest.asOf}T12:00:00Z`));
+    const { anchors, latest } = await suppressing();
+    const verdict = verdictFor(latest, anchors);
 
     expect(verdict.slots.fundValue.rendered).toBe(true);
+    expect(verdict.slots.change.rendered).toBe(true);
+    expect(verdict.slots.reserve.rendered).toBe(true);
     expect(composeBigPicture(latest, anchors).fundValueRendered).toBe(true);
   });
 });

--- a/apps/web/src/glance/verdict.test.ts
+++ b/apps/web/src/glance/verdict.test.ts
@@ -310,7 +310,8 @@ describe("same-day precedence — chosen, not measured", () => {
 
     expect(verdict.fired.map((t) => t.name)).toEqual(["reserveFloor", "navMove"]);
     expect(verdict.sentence).toBe("Reserve is 8.2%, below its 10% floor");
-    // Everything that fired is still carried, for /big-picture to list.
+    // Everything that fired is still carried on `fired`, even though only the winner
+    // becomes the sentence — no component renders the rest today.
     expect(verdict.fired[1]?.sentence).toBe("Fund moved more than 1.5% since Mon 13 Jul");
   });
 });

--- a/apps/web/src/glance/verdict.ts
+++ b/apps/web/src/glance/verdict.ts
@@ -7,9 +7,12 @@
  * filesystem, no network, no `Date.now()` — the wall clock arrives as an argument.
  * That is what makes the 28-anchor replay in `verdict-replay.test.ts` possible at
  * all, and it is achievable only because slice #148 put every push-side conclusion on
- * the wire. Its type imports from `../projection/contract.ts` are `import type` on
- * purpose: a VALUE import from that module would drag the `pg` driver into the
- * browser bundle and fail `client-bundle.integration.test.ts`.
+ * the wire. What it takes from `../projection/contract.ts` is the wire contract's
+ * types plus ONE runtime value, `SUPPRESSION_KEYS` — safe only because that module is
+ * now pg-free (the driver moved to `../projection/snapshot-reader.ts`) and
+ * `projection/contract.test.ts` holds it that way from the module graph. A value
+ * import of anything that reaches `pg` would drag the driver into the browser bundle
+ * and fail `client-bundle.integration.test.ts`.
  *
  * THE RULE THAT DECIDES WHAT MAY LIVE HERE: *does this computation need data D8 keeps
  * off the wire?* If yes the PUSH computes it and ships the conclusion (that is
@@ -29,6 +32,7 @@ import type {
   DashboardSummary,
 } from "@numisma/engine";
 import type { GlanceBlock, SnapshotAnchor } from "../projection/contract.ts";
+import { SUPPRESSION_KEYS } from "../projection/contract.ts";
 import { addDays, asOfSortKey, calendarDateOf, daysBetween } from "../projection/as-of.ts";
 
 /* ────────────────────────────── the four triggers ─────────────────────────────── */
@@ -394,14 +398,16 @@ export function computeVerdict(
  * is there. An empty slot means *suppressed*, which is diagnostic in itself, and a
  * slot that vanished would destroy that.
  *
- * The suppression keys are the push's own (V5, `push/glance.ts`), read here rather
- * than re-derived — the reader cannot see the mark dates that produced them.
+ * The suppression keys are read from {@link SUPPRESSION_KEYS} — their one declared
+ * home on the wire contract — rather than re-derived or re-spelled: the reader cannot
+ * see the mark dates that produced them, and a hand-typed literal would compile while
+ * silently ceasing to match what the push emits (finding 7).
  */
 function fundValueSlot(
   summary: DashboardSummary,
   suppressed: ReadonlySet<string>,
 ): FundValueSlot {
-  if (suppressed.has("summary.fundValueUsd")) {
+  if (suppressed.has(SUPPRESSION_KEYS.fundValue)) {
     return { rendered: false, suppressedBy: "unexpected-absence" };
   }
   return { rendered: true, usdValue: summary.fundValueUsd };
@@ -428,13 +434,13 @@ function changeSlot(
           referenceLabel: referenceLabel(reference.asOf),
         };
 
-  if (suppressed.has("summary.change")) {
+  if (suppressed.has(SUPPRESSION_KEYS.change)) {
     return { rendered: false, suppressedBy: "unexpected-absence", ...named };
   }
   if (reference === undefined) {
     return { rendered: false, suppressedBy: "no-earlier-anchor" };
   }
-  if (reference.report.glance.suppressed.includes("summary.fundValueUsd")) {
+  if (reference.report.glance.suppressed.includes(SUPPRESSION_KEYS.fundValue)) {
     return { rendered: false, suppressedBy: "reference-withheld", ...named };
   }
 
@@ -462,13 +468,13 @@ function reserveSlot(
   suppressed: ReadonlySet<string>,
 ): ReserveSlot {
   const reserve: DashboardFocus | undefined = summary.reserve;
-  if (reserve === undefined || suppressed.has("summary.fundValueUsd")) {
+  if (reserve === undefined || suppressed.has(SUPPRESSION_KEYS.fundValue)) {
     return { rendered: false, suppressedBy: "unexpected-absence" };
   }
   if (glance.reserveTargetPct === undefined) {
     return { rendered: false, suppressedBy: "no-policy" };
   }
-  if (suppressed.has("summary.reserve")) {
+  if (suppressed.has(SUPPRESSION_KEYS.reserve)) {
     return { rendered: false, suppressedBy: "unexpected-absence" };
   }
   return {
@@ -521,7 +527,7 @@ function breachDurationDays(
   for (const anchor of history) {
     const floor = anchor.report.glance.reserveTargetPct;
     const pct = anchor.report.dashboard.summary.reserve?.percentOfFund;
-    const withheld = anchor.report.glance.suppressed.includes("summary.reserve");
+    const withheld = anchor.report.glance.suppressed.includes(SUPPRESSION_KEYS.reserve);
     if (floor === undefined || pct === undefined || withheld || pct >= floor) break;
     days += 1;
   }

--- a/apps/web/src/glance/verdict.ts
+++ b/apps/web/src/glance/verdict.ts
@@ -200,7 +200,11 @@ export interface Verdict {
   needsYou: boolean;
   /** The ONE line. `fired[0]`'s sentence, or the standing *no*. */
   sentence: string;
-  /** Everything that fired, in precedence order. `/big-picture` lists it. */
+  /**
+   * Everything that fired, in precedence order. No component renders it —
+   * `/big-picture` does not list it — but it is NOT dead: the replay suites read
+   * it to pin trigger precedence (audit finding 39).
+   */
   fired: FiredTrigger[];
   /** D3's closed set of exactly three standing numbers. All three always render. */
   slots: {

--- a/apps/web/src/glance/verdict.ts
+++ b/apps/web/src/glance/verdict.ts
@@ -31,8 +31,11 @@ import type {
   DashboardFocus,
   DashboardSummary,
 } from "@numisma/engine";
-import type { GlanceBlock, SnapshotAnchor } from "../projection/contract.ts";
-import { SUPPRESSION_KEYS } from "../projection/contract.ts";
+import {
+  SUPPRESSION_KEYS,
+  type GlanceBlock,
+  type SnapshotAnchor,
+} from "../projection/contract.ts";
 import { addDays, asOfSortKey, calendarDateOf, daysBetween } from "../projection/as-of.ts";
 
 /* ────────────────────────────── the four triggers ─────────────────────────────── */
@@ -403,9 +406,7 @@ export function computeVerdict(
  * slot that vanished would destroy that.
  *
  * The suppression keys are read from {@link SUPPRESSION_KEYS} — their one declared
- * home on the wire contract — rather than re-derived or re-spelled: the reader cannot
- * see the mark dates that produced them, and a hand-typed literal would compile while
- * silently ceasing to match what the push emits (finding 7).
+ * home on the wire contract — never re-spelled here; that docstring says why.
  */
 function fundValueSlot(
   summary: DashboardSummary,
@@ -478,6 +479,9 @@ function reserveSlot(
   if (glance.reserveTargetPct === undefined) {
     return { rendered: false, suppressedBy: "no-policy" };
   }
+  // Defensive against STORED snapshots: today's push never emits `reserve` without
+  // also emitting `fundValue`, but a reserve-only key list is constructible data the
+  // reader may be handed, so this branch stays. Kept honest by `suppression-seam.test.ts`.
   if (suppressed.has(SUPPRESSION_KEYS.reserve)) {
     return { rendered: false, suppressedBy: "unexpected-absence" };
   }

--- a/apps/web/src/projection/contract.ts
+++ b/apps/web/src/projection/contract.ts
@@ -129,12 +129,44 @@ export interface GlanceBlock {
    * present here means "this number would be wrong, so it is not rendered".
    *
    * A LIST OF KEYS, NOT N BOOLEANS, and that encoding is the point: this slice
-   * emits the three header keys (`summary.fundValueUsd`, `summary.change`,
-   * `summary.reserve`); slice 5 adds `CompositionRow.id`s to the SAME array, at no
-   * schema cost. There is no v4 for that extension (C5).
+   * emits the three header keys ({@link SUPPRESSION_KEYS}); slice 5 adds
+   * `CompositionRow.id`s to the SAME array, at no schema cost. There is no v4 for
+   * that extension (C5).
    */
   suppressed: string[];
 }
+
+/**
+ * THE ONE DECLARED HOME for the three header suppression keys — the closed set of
+ * standing numbers D3 names, spelled here and nowhere else (audit finding 7).
+ *
+ * WHY IT LIVES ON THE WIRE CONTRACT AND NOT PUSH-SIDE, where it was born: these are
+ * not the push's private names. They are values that cross the wire in
+ * {@link GlanceBlock.suppressed} as bare `string`s, so the type system cannot relate
+ * the writer's spelling to the reader's. Before this constant was shared, a rename
+ * push-side still compiled everywhere and the reader silently stopped suppressing —
+ * rendering a NAV computed from a mark that never arrived, the false *no* the design
+ * forbids. One home makes a rename move both halves at once.
+ *
+ * It is a RUNTIME value in a module every browser-reachable surface imports, which is
+ * only safe because this file is pg-free and `contract.test.ts` holds it that way
+ * from the module graph (audit finding 8). That property is what this constant is
+ * standing on; do not import a driver here to save it a hop.
+ *
+ * `glance/suppression-seam.test.ts` pins the set, forbids a hand-typed literal in any
+ * production speller, and drives push-emitted keys through the reader end to end.
+ *
+ * Slice #151 adds `CompositionRow.id`s to the SAME array (see `suppressedRowIds` in
+ * `push/glance.ts`), which costs no schema change: that is the whole reason
+ * `suppressed` was a key list and not N booleans, and it is why v3 is still v3. A
+ * reader therefore tells the two apart by the key itself — the header keys are these
+ * three literals, everything else is a row id.
+ */
+export const SUPPRESSION_KEYS = {
+  fundValue: "summary.fundValueUsd",
+  change: "summary.change",
+  reserve: "summary.reserve",
+} as const;
 
 /**
  * The pushed payload: the engine `Pick` above PLUS a third top-level branch the

--- a/apps/web/src/push/glance.test.ts
+++ b/apps/web/src/push/glance.test.ts
@@ -27,7 +27,8 @@ import {
 import { loadFoldedReview, resolveEventStorePaths } from "@numisma/event-store";
 import { anchorAt, loadAnchorFixture } from "./anchor-fixture.ts";
 import { NAV_JITTER_PP } from "./fixture-synthesis.ts";
-import { buildGlanceBlock, SUPPRESSION_KEYS } from "./glance.ts";
+import { SUPPRESSION_KEYS } from "../projection/contract.ts";
+import { buildGlanceBlock } from "./glance.ts";
 
 /** The measured quiet Sunday. Marks that day: btc, eth, render, gram — the 4 crypto. */
 const QUIET_SUNDAY = "2026-07-26";

--- a/apps/web/src/push/glance.ts
+++ b/apps/web/src/push/glance.ts
@@ -39,21 +39,7 @@ import type {
 } from "@numisma/engine";
 import { addDays, composeRowDependencies, instrumentsForSource } from "@numisma/engine";
 import type { GlanceBlock, GlanceMissingMark } from "../projection/contract.ts";
-
-/**
- * The three header keys — the closed set of standing numbers D3 names.
- *
- * Slice #151 adds `CompositionRow.id`s to the SAME array (see
- * {@link suppressedRowIds}), which costs no schema change: that is the whole reason
- * `suppressed` was a key list and not N booleans, and it is why v3 is still v3.
- * A reader therefore tells the two apart by the key itself — the header keys are
- * these three literals, everything else is a row id.
- */
-export const SUPPRESSION_KEYS = {
-  fundValue: "summary.fundValueUsd",
-  change: "summary.change",
-  reserve: "summary.reserve",
-} as const;
+import { SUPPRESSION_KEYS } from "../projection/contract.ts";
 
 /** How often a venue is expected to produce a mark. */
 type VenueCadence = "daily" | "weekdays";

--- a/apps/web/src/push/push-core.fixtures.ts
+++ b/apps/web/src/push/push-core.fixtures.ts
@@ -19,7 +19,7 @@ import { tmpdir } from "node:os";
 import { fileURLToPath } from "node:url";
 import { dirname, resolve } from "node:path";
 import type { CompositionReport } from "@numisma/engine";
-import type { GlanceBlock } from "../projection/contract.ts";
+import { SUPPRESSION_KEYS, type GlanceBlock } from "../projection/contract.ts";
 import {
   resolveEventStorePaths,
   type EventStorePaths,
@@ -108,5 +108,5 @@ export const TEST_GLANCE: GlanceBlock = {
       { rowId: "instrument:googl", label: "GOOGL (Alphabet Inc.)" },
     ],
   },
-  suppressed: ["summary.fundValueUsd", "summary.change", "summary.reserve"],
+  suppressed: Object.values(SUPPRESSION_KEYS),
 };


### PR DESCRIPTION
## Summary

Gives `SUPPRESSION_KEYS` one declared home in `apps/web/src/projection/contract.ts`, on the wire contract, instead of the set being hand-typed as bare string literals in each consumer. `push/glance.ts`, `glance/verdict.ts`, and `glance/row-view.ts` all re-point to import the constant from that one home rather than re-spelling the suppression-key literals locally. Prior to this, a hand-typed literal could compile while silently ceasing to match what the push emits — audit finding 7 names exactly this drift risk.

Adds `apps/web/src/glance/suppression-seam.test.ts`, a three-part seam suite:
1. pins the `SUPPRESSION_KEYS` set itself so a change to the keys is a deliberate, visible diff,
2. scans the glance/push sources for bare suppression-key string literals living outside the declared home, and
3. exercises suppression end-to-end through the push/read path.

Also corrects a stale docstring on `Verdict.fired` (`glance/verdict.ts`): it claimed `/big-picture` lists the field, but no component renders it. It is not dead code — the replay suites read it to pin trigger precedence — which is what audit finding 39 flagged as the doc/behavior mismatch to fix.

## Test plan

- [x] `apps/web` typecheck clean
- [x] `apps/web` vitest: 24 files / 260 passed, including the new `suppression-seam.test.ts`
