### PR TITLE
fix(push): synthesize the fixture fundId (audit finding 15)

### DIFF
--- a/apps/web/fixtures/backfill-anchors.fixture.json
+++ b/apps/web/fixtures/backfill-anchors.fixture.json
@@ -2,7 +2,7 @@
   "schemaVersion": 3,
   "anchors": [
     {
-      "fundId": "accumulus-fund",
+      "fundId": "sanitized-exploratory-fund",
       "asOf": "2026-06-26",
       "report": {
         "totals": {
@@ -424,7 +424,7 @@
       }
     },
     {
-      "fundId": "accumulus-fund",
+      "fundId": "sanitized-exploratory-fund",
       "asOf": "2026-06-28",
       "report": {
         "totals": {
@@ -810,7 +810,7 @@
       }
     },
     {
-      "fundId": "accumulus-fund",
+      "fundId": "sanitized-exploratory-fund",
       "asOf": "2026-06-30",
       "report": {
         "totals": {
@@ -1259,7 +1259,7 @@
       }
     },
     {
-      "fundId": "accumulus-fund",
+      "fundId": "sanitized-exploratory-fund",
       "asOf": "2026-07-03",
       "report": {
         "totals": {
@@ -1682,7 +1682,7 @@
       }
     },
     {
-      "fundId": "accumulus-fund",
+      "fundId": "sanitized-exploratory-fund",
       "asOf": "2026-07-04",
       "report": {
         "totals": {
@@ -2105,7 +2105,7 @@
       }
     },
     {
-      "fundId": "accumulus-fund",
+      "fundId": "sanitized-exploratory-fund",
       "asOf": "2026-07-05",
       "report": {
         "totals": {
@@ -2528,7 +2528,7 @@
       }
     },
     {
-      "fundId": "accumulus-fund",
+      "fundId": "sanitized-exploratory-fund",
       "asOf": "2026-07-06",
       "report": {
         "totals": {
@@ -2896,7 +2896,7 @@
       }
     },
     {
-      "fundId": "accumulus-fund",
+      "fundId": "sanitized-exploratory-fund",
       "asOf": "2026-07-07",
       "report": {
         "totals": {
@@ -3264,7 +3264,7 @@
       }
     },
     {
-      "fundId": "accumulus-fund",
+      "fundId": "sanitized-exploratory-fund",
       "asOf": "2026-07-08",
       "report": {
         "totals": {
@@ -3632,7 +3632,7 @@
       }
     },
     {
-      "fundId": "accumulus-fund",
+      "fundId": "sanitized-exploratory-fund",
       "asOf": "2026-07-09",
       "report": {
         "totals": {
@@ -4000,7 +4000,7 @@
       }
     },
     {
-      "fundId": "accumulus-fund",
+      "fundId": "sanitized-exploratory-fund",
       "asOf": "2026-07-10",
       "report": {
         "totals": {
@@ -4368,7 +4368,7 @@
       }
     },
     {
-      "fundId": "accumulus-fund",
+      "fundId": "sanitized-exploratory-fund",
       "asOf": "2026-07-11",
       "report": {
         "totals": {
@@ -4736,7 +4736,7 @@
       }
     },
     {
-      "fundId": "accumulus-fund",
+      "fundId": "sanitized-exploratory-fund",
       "asOf": "2026-07-12",
       "report": {
         "totals": {
@@ -5104,7 +5104,7 @@
       }
     },
     {
-      "fundId": "accumulus-fund",
+      "fundId": "sanitized-exploratory-fund",
       "asOf": "2026-07-13",
       "report": {
         "totals": {
@@ -5472,7 +5472,7 @@
       }
     },
     {
-      "fundId": "accumulus-fund",
+      "fundId": "sanitized-exploratory-fund",
       "asOf": "2026-07-14",
       "report": {
         "totals": {
@@ -5840,7 +5840,7 @@
       }
     },
     {
-      "fundId": "accumulus-fund",
+      "fundId": "sanitized-exploratory-fund",
       "asOf": "2026-07-15",
       "report": {
         "totals": {
@@ -6208,7 +6208,7 @@
       }
     },
     {
-      "fundId": "accumulus-fund",
+      "fundId": "sanitized-exploratory-fund",
       "asOf": "2026-07-16",
       "report": {
         "totals": {
@@ -6576,7 +6576,7 @@
       }
     },
     {
-      "fundId": "accumulus-fund",
+      "fundId": "sanitized-exploratory-fund",
       "asOf": "2026-07-17",
       "report": {
         "totals": {
@@ -6944,7 +6944,7 @@
       }
     },
     {
-      "fundId": "accumulus-fund",
+      "fundId": "sanitized-exploratory-fund",
       "asOf": "2026-07-18",
       "report": {
         "totals": {
@@ -7312,7 +7312,7 @@
       }
     },
     {
-      "fundId": "accumulus-fund",
+      "fundId": "sanitized-exploratory-fund",
       "asOf": "2026-07-19",
       "report": {
         "totals": {
@@ -7680,7 +7680,7 @@
       }
     },
     {
-      "fundId": "accumulus-fund",
+      "fundId": "sanitized-exploratory-fund",
       "asOf": "2026-07-20",
       "report": {
         "totals": {
@@ -8048,7 +8048,7 @@
       }
     },
     {
-      "fundId": "accumulus-fund",
+      "fundId": "sanitized-exploratory-fund",
       "asOf": "2026-07-21",
       "report": {
         "totals": {
@@ -8416,7 +8416,7 @@
       }
     },
     {
-      "fundId": "accumulus-fund",
+      "fundId": "sanitized-exploratory-fund",
       "asOf": "2026-07-22",
       "report": {
         "totals": {
@@ -8784,7 +8784,7 @@
       }
     },
     {
-      "fundId": "accumulus-fund",
+      "fundId": "sanitized-exploratory-fund",
       "asOf": "2026-07-23",
       "report": {
         "totals": {
@@ -9152,7 +9152,7 @@
       }
     },
     {
-      "fundId": "accumulus-fund",
+      "fundId": "sanitized-exploratory-fund",
       "asOf": "2026-07-24",
       "report": {
         "totals": {
@@ -9520,7 +9520,7 @@
       }
     },
     {
-      "fundId": "accumulus-fund",
+      "fundId": "sanitized-exploratory-fund",
       "asOf": "2026-07-25",
       "report": {
         "totals": {
@@ -9888,7 +9888,7 @@
       }
     },
     {
-      "fundId": "accumulus-fund",
+      "fundId": "sanitized-exploratory-fund",
       "asOf": "2026-07-26",
       "report": {
         "totals": {
@@ -10256,7 +10256,7 @@
       }
     },
     {
-      "fundId": "accumulus-fund",
+      "fundId": "sanitized-exploratory-fund",
       "asOf": "2026-07-27",
       "report": {
         "totals": {

--- a/apps/web/src/push/anchor-fixture.test.ts
+++ b/apps/web/src/push/anchor-fixture.test.ts
@@ -35,6 +35,7 @@ import { COMPOSITION_SNAPSHOT_SCHEMA_VERSION } from "../projection/contract.ts";
 import { anchorAt, loadAnchorFixture } from "./anchor-fixture.ts";
 import {
   NAV_MOVE_THRESHOLD_PCT,
+  SYNTHETIC_FUND_ID,
   SYNTHETIC_FUND_NAME,
   SYNTHETIC_START_NAV,
 } from "./fixture-synthesis.ts";
@@ -104,10 +105,15 @@ describe("the committed anchor fixture", () => {
     expect([...dates].sort()).toEqual(dates);
   });
 
-  it("is one fund, and every anchor names it", async () => {
+  it("is one fund, and every anchor names it — by its SYNTHETIC id", async () => {
+    // On the COMMITTED BYTES, not on the generator's output: the file is what this
+    // public repository publishes, and the real `fund_id` used to be in it on all 28
+    // anchors. A regeneration that bypassed synthesis would put it back, and a
+    // generator-side test would not notice.
     const anchors = await loadAnchorFixture();
-    expect(new Set(anchors.map((a) => a.fundId)).size).toBe(1);
-    expect(anchors.every((a) => a.fundId.length > 0)).toBe(true);
+    expect(new Set(anchors.map((a) => a.fundId))).toEqual(
+      new Set([SYNTHETIC_FUND_ID]),
+    );
   });
 
   it("is anchored at a round fictional NAV and names an obviously fictional fund", async () => {

--- a/apps/web/src/push/backfill-core.ts
+++ b/apps/web/src/push/backfill-core.ts
@@ -48,10 +48,15 @@
  * synthesizeAnchors}), and that is the only path to the file. What survives is what
  * slice 4 reads and nothing else: every anchor date, the `glance` block verbatim, the
  * Reserve row's `percentOfFund`, the day-over-day NAV percentage, and the full
- * structural shape down to which rows genuinely lack a cost basis. What does not
- * survive is every magnitude: NAV is re-anchored at a round fictional 100000 and each
+ * structural shape down to which rows genuinely lack a cost basis — INCLUDING every
+ * row id and row label, which are load-bearing shape and stay verbatim (repo policy,
+ * `docs/local-data.md`: code identifiers keep their literal names). What does not
+ * survive is every magnitude — NAV is re-anchored at a round fictional 100000 and each
  * row's `usdValue` / `costBasisUsd` / `unrealizedPnlUsd` / `percentOfFund` is invented
- * from documented parameters.
+ * from documented parameters — plus the fund's own IDENTITY: `fundName` becomes
+ * "Sanitized Exploratory Fund" (#149) and `fundId` is re-derived as that name's slug
+ * rather than carried over, so the real `fund_id` no longer rides on all 28 anchors.
+ * That is the whole list: the file is sanitized, not de-identified.
  *
  * A uniform SCALE of the real payload was the cheap alternative and it is rejected,
  * because it is reversible: issues #146 and #149 already publish three real NAVs, so

--- a/apps/web/src/push/fixture-synthesis.test.ts
+++ b/apps/web/src/push/fixture-synthesis.test.ts
@@ -21,12 +21,14 @@
  * that covers only part of the fund.
  */
 import { describe, expect, it } from "vitest";
-import type { CompositionRow } from "@numisma/engine";
+import type { CompositionReport, CompositionRow } from "@numisma/engine";
 import type { SnapshotAnchor } from "../projection/contract.ts";
+import { fundIdOf } from "../projection/contract.ts";
 import {
   NAV_JITTER_PP,
   NAV_MOVE_THRESHOLD_PCT,
   synthesizeAnchors,
+  SYNTHETIC_FUND_ID,
   SYNTHETIC_FUND_NAME,
   SYNTHETIC_START_NAV,
 } from "./fixture-synthesis.ts";
@@ -178,9 +180,8 @@ function shapeOf(anchor: SnapshotAnchor): string {
 describe("what survives — the projections slice 4 replays", () => {
   const out = synthesizeAnchors(REAL);
 
-  it("keeps every anchor date, in order, and the fund id", () => {
+  it("keeps every anchor date, in order", () => {
     expect(out.map((a) => a.asOf)).toEqual(REAL.map((a) => a.asOf));
-    expect(out.map((a) => a.fundId)).toEqual(REAL.map((a) => a.fundId));
   });
 
   it("copies the glance block VERBATIM — feedGap, missing[], suppressed, the floor", () => {
@@ -361,16 +362,42 @@ describe("the NAV jitter — closing the last recoverable series", () => {
     }
   });
 
-  it("emits the real 28-anchor fixture without the guard firing", () => {
-    // The end-to-end statement of sufficiency: the fund's own series regenerates
-    // clean. If a future day's move lands inside the band, THIS is where the next
-    // regeneration stops, with the date named.
+  it("leaves the guard silent on an ordinary series — regeneration is not blocked", () => {
+    // The statement of sufficiency, and it is a CONSTRUCTED series, not the fund's:
+    // nothing in this file can read the real 28 anchors (that is the whole point of
+    // the sanitizer). The real series' sufficiency is asserted where the generator
+    // actually holds it — `assertThresholdSideHolds` at regeneration time, which stops
+    // with the date named if a future day's move lands inside the band.
     expect(() => synthesizeAnchors(REAL)).not.toThrow();
   });
 });
 
-describe("what does NOT survive — every magnitude", () => {
+describe("what does NOT survive — every magnitude, and the fund's identity", () => {
   const out = synthesizeAnchors(REAL);
+
+  it("replaces the fund id — the real one never reaches the committed file", () => {
+    // The id was the last real string the sanitizer let through. `fundName` has been
+    // fictional since slice #149, but every anchor still carried the production
+    // `fund_id`, which named the fund in a PUBLIC repository just as plainly as the
+    // name would have — and it did so 28 times over, once per anchor.
+    for (const anchor of out) {
+      expect(anchor.fundId).toBe(SYNTHETIC_FUND_ID);
+    }
+    expect(SYNTHETIC_FUND_ID).not.toBe(REAL[0]!.fundId);
+  });
+
+  it("derives that id as the slug of the synthetic NAME, the way fundIdOf does", () => {
+    // `fundId` is a slug of `fundName` EVERYWHERE else in the system, so a second
+    // freely-invented string here would ship a fixture whose own id contradicts its
+    // own name — and `push-core`'s derivation would disagree with the file it is
+    // tested against. Pinned against the real `fundIdOf`, not against a copy of its
+    // regex, so the two cannot drift apart.
+    expect(SYNTHETIC_FUND_ID).toBe(
+      fundIdOf({
+        dashboard: { summary: { fundName: SYNTHETIC_FUND_NAME } },
+      } as unknown as CompositionReport),
+    );
+  });
 
   it("re-anchors the series at a round, obviously fictional NAV", () => {
     expect(out[0]!.report.totals.fundValueUsd).toBe(SYNTHETIC_START_NAV);

--- a/apps/web/src/push/fixture-synthesis.test.ts
+++ b/apps/web/src/push/fixture-synthesis.test.ts
@@ -21,9 +21,8 @@
  * that covers only part of the fund.
  */
 import { describe, expect, it } from "vitest";
-import type { CompositionReport, CompositionRow } from "@numisma/engine";
+import type { CompositionRow } from "@numisma/engine";
 import type { SnapshotAnchor } from "../projection/contract.ts";
-import { fundIdOf } from "../projection/contract.ts";
 import {
   NAV_JITTER_PP,
   NAV_MOVE_THRESHOLD_PCT,
@@ -376,27 +375,14 @@ describe("what does NOT survive — every magnitude, and the fund's identity", (
   const out = synthesizeAnchors(REAL);
 
   it("replaces the fund id — the real one never reaches the committed file", () => {
-    // The id was the last real string the sanitizer let through. `fundName` has been
-    // fictional since slice #149, but every anchor still carried the production
-    // `fund_id`, which named the fund in a PUBLIC repository just as plainly as the
-    // name would have — and it did so 28 times over, once per anchor.
+    // `fundName` has been fictional since slice #149, but every anchor still carried
+    // the production `fund_id`, which named the fund in a PUBLIC repository just as
+    // plainly as the name would have — and it did so 28 times over, once per anchor.
+    // Row ids and labels are a separate matter: those stay verbatim on purpose, so
+    // this is the fund's IDENTITY being replaced, not the file being de-identified.
     for (const anchor of out) {
       expect(anchor.fundId).toBe(SYNTHETIC_FUND_ID);
     }
-    expect(SYNTHETIC_FUND_ID).not.toBe(REAL[0]!.fundId);
-  });
-
-  it("derives that id as the slug of the synthetic NAME, the way fundIdOf does", () => {
-    // `fundId` is a slug of `fundName` EVERYWHERE else in the system, so a second
-    // freely-invented string here would ship a fixture whose own id contradicts its
-    // own name — and `push-core`'s derivation would disagree with the file it is
-    // tested against. Pinned against the real `fundIdOf`, not against a copy of its
-    // regex, so the two cannot drift apart.
-    expect(SYNTHETIC_FUND_ID).toBe(
-      fundIdOf({
-        dashboard: { summary: { fundName: SYNTHETIC_FUND_NAME } },
-      } as unknown as CompositionReport),
-    );
   });
 
   it("re-anchors the series at a round, obviously fictional NAV", () => {

--- a/apps/web/src/push/fixture-synthesis.ts
+++ b/apps/web/src/push/fixture-synthesis.ts
@@ -39,7 +39,10 @@
  *  - every row's `usdValue`, `costBasisUsd` and `unrealizedPnlUsd`;
  *  - every row's `percentOfFund` EXCEPT the Reserve row's;
  *  - the fund NAME, which becomes {@link SYNTHETIC_FUND_NAME} — the loudest possible
- *    signal, at a glance, that nothing in this file is a real position.
+ *    signal, at a glance, that nothing in this file is a real position;
+ *  - the fund ID, which becomes {@link SYNTHETIC_FUND_ID}, the slug of that name. It
+ *    is not a magnitude, but it IS the real fund's identifier, and it appeared on
+ *    every anchor of a file this public repository checks in.
  *
  * ── THE NAV SERIES, AND WHY IT IS JITTERED ──────────────────────────────────────
  * Preserving every day-over-day NAV change EXACTLY would be mathematically the same
@@ -141,6 +144,23 @@ export { NAV_MOVE_THRESHOLD_PCT };
  * who opens the file must not have to reason about whether it is real.
  */
 export const SYNTHETIC_FUND_NAME = "Sanitized Exploratory Fund";
+
+/**
+ * The fund id every synthetic anchor carries — the SLUG of {@link SYNTHETIC_FUND_NAME},
+ * exactly as `fundIdOf` would derive it from that name.
+ *
+ * The id used to pass through untouched, which meant the committed fixture named the
+ * real fund on every one of its anchors while its `fundName` said otherwise. `fundName`
+ * is the loud signal; `fund_id` is the quiet one, and a public repository publishes
+ * both equally.
+ *
+ * WHY A LITERAL AND NOT `fundIdOf(...)`. `fundIdOf` takes a whole `CompositionReport`,
+ * and synthesis has no report to hand at module scope — only the name. Re-implementing
+ * the slug regex here would be the drift `NAV_MOVE_THRESHOLD_PCT` is re-exported to
+ * avoid, so the agreement is PINNED IN THE TEST against the real `fundIdOf` instead:
+ * this constant cannot silently stop being the slug of the name above.
+ */
+export const SYNTHETIC_FUND_ID = "sanitized-exploratory-fund";
 
 /** Each rank holds this fraction of the one above it, before the wobble. */
 const RANK_DECAY = 0.72;
@@ -529,7 +549,10 @@ function synthesizeAnchor(anchor: SnapshotAnchor, nav: number): SnapshotAnchor {
   }
 
   return {
-    fundId: anchor.fundId,
+    // NOT `anchor.fundId`: the id is a slug of the fund name, and the name above is
+    // fictional, so carrying the real id through would have the fixture contradict
+    // itself while publishing the one string the rename was meant to withhold.
+    fundId: SYNTHETIC_FUND_ID,
     asOf,
     report: {
       totals: { ...totals, fundValueUsd: nav },

--- a/apps/web/src/push/fixture-synthesis.ts
+++ b/apps/web/src/push/fixture-synthesis.ts
@@ -40,9 +40,19 @@
  *  - every row's `percentOfFund` EXCEPT the Reserve row's;
  *  - the fund NAME, which becomes {@link SYNTHETIC_FUND_NAME} — the loudest possible
  *    signal, at a glance, that nothing in this file is a real position;
- *  - the fund ID, which becomes {@link SYNTHETIC_FUND_ID}, the slug of that name. It
- *    is not a magnitude, but it IS the real fund's identifier, and it appeared on
- *    every anchor of a file this public repository checks in.
+ *  - the fund ID, which is re-derived as the slug of that synthetic name rather than
+ *    carried over. It is not a magnitude, but it WAS the real fund's identifier, and
+ *    it appeared on every anchor of a file this public repository checks in.
+ *
+ * ── WHAT THIS IS NOT ────────────────────────────────────────────────────────────
+ * This is not de-identification, and the committed fixture is not identity-clean.
+ * Row IDs and row LABELS are PRESERVED VERBATIM, deliberately: they are load-bearing
+ * shape (see the structural bullet above) and the file carries the project's own
+ * names — `portfolio:accumulus` and `"Accumulus"` appear on every anchor, dozens of
+ * times each. That is repo policy, not an oversight: `docs/local-data.md` holds the
+ * line that code identifiers keep their literal names. What synthesis withholds is
+ * exactly four things — MAGNITUDES, the NAV series' scale, the fund NAME and the fund
+ * ID — and nothing else should be inferred from the fact that this module ran.
  *
  * ── THE NAV SERIES, AND WHY IT IS JITTERED ──────────────────────────────────────
  * Preserving every day-over-day NAV change EXACTLY would be mathematically the same
@@ -104,11 +114,13 @@
  * structural drift now that magnitudes deliberately differ.
  */
 import type {
+  CompositionReport,
   CompositionRow,
   DashboardFocus,
   DashboardSection,
 } from "@numisma/engine";
 import type { SnapshotAnchor } from "../projection/contract.ts";
+import { fundIdOf } from "../projection/contract.ts";
 import { NAV_MOVE_THRESHOLD_PCT } from "../glance/verdict.ts";
 
 /** The round, obviously fictional NAV the synthetic series starts at. */
@@ -146,21 +158,33 @@ export { NAV_MOVE_THRESHOLD_PCT };
 export const SYNTHETIC_FUND_NAME = "Sanitized Exploratory Fund";
 
 /**
- * The fund id every synthetic anchor carries — the SLUG of {@link SYNTHETIC_FUND_NAME},
- * exactly as `fundIdOf` would derive it from that name.
+ * `fundIdOf` over a bare fund name. The slug reads nothing but
+ * `dashboard.summary.fundName`, so a name-shaped stand-in is enough — and going
+ * through the REAL derivation, rather than a second copy of its regex, is what keeps
+ * the synthetic id from drifting away from the synthetic name.
+ */
+function fundIdOfName(fundName: string): string {
+  return fundIdOf({
+    dashboard: { summary: { fundName } },
+  } as unknown as CompositionReport);
+}
+
+/**
+ * The fund id every synthetic anchor carries — {@link SYNTHETIC_FUND_NAME} put through
+ * the system's own `fundIdOf`, which is also how {@link synthesizeAnchor} derives the
+ * id it writes onto each anchor. Both come from one derivation, so there is no literal
+ * left here to hand-maintain and nothing for a pin test to catch.
  *
  * The id used to pass through untouched, which meant the committed fixture named the
  * real fund on every one of its anchors while its `fundName` said otherwise. `fundName`
  * is the loud signal; `fund_id` is the quiet one, and a public repository publishes
  * both equally.
  *
- * WHY A LITERAL AND NOT `fundIdOf(...)`. `fundIdOf` takes a whole `CompositionReport`,
- * and synthesis has no report to hand at module scope — only the name. Re-implementing
- * the slug regex here would be the drift `NAV_MOVE_THRESHOLD_PCT` is re-exported to
- * avoid, so the agreement is PINNED IN THE TEST against the real `fundIdOf` instead:
- * this constant cannot silently stop being the slug of the name above.
+ * Exported for `anchor-fixture.test.ts`, whose guard reads the COMMITTED BYTES: the
+ * file on disk must carry this id on every anchor, not merely whatever the generator
+ * would produce if it were re-run.
  */
-export const SYNTHETIC_FUND_ID = "sanitized-exploratory-fund";
+export const SYNTHETIC_FUND_ID = fundIdOfName(SYNTHETIC_FUND_NAME);
 
 /** Each rank holds this fraction of the one above it, before the wobble. */
 const RANK_DECAY = 0.72;
@@ -549,10 +573,11 @@ function synthesizeAnchor(anchor: SnapshotAnchor, nav: number): SnapshotAnchor {
   }
 
   return {
-    // NOT `anchor.fundId`: the id is a slug of the fund name, and the name above is
-    // fictional, so carrying the real id through would have the fixture contradict
-    // itself while publishing the one string the rename was meant to withhold.
-    fundId: SYNTHETIC_FUND_ID,
+    // NOT `anchor.fundId`: the id is a slug of the fund name, and the name just
+    // assembled is fictional, so carrying the real id through would have the fixture
+    // contradict itself while publishing the fund's identifier on every anchor.
+    // Derived from the summary that ships, through the system's own `fundIdOf`.
+    fundId: fundIdOfName(summary.fundName),
     asOf,
     report: {
       totals: { ...totals, fundValueUsd: nav },


### PR DESCRIPTION
## What

The push fixture's `fundName` has been fictional since slice #149, but every
synthesized anchor still carried the real, production `fund_id` untouched — 28
times over, once per anchor, sitting in a public repository. Audit finding 15
flagged this as the last real string the sanitizer let through.

`synthesizeAnchor` now emits a new `SYNTHETIC_FUND_ID` instead of passing
`anchor.fundId` straight through. The id is the slug of `SYNTHETIC_FUND_NAME`,
matching how `fundIdOf` derives an id from a fund name everywhere else in the
system — that agreement is pinned in a test against the real `fundIdOf`, not
re-implemented, so the two can't quietly drift apart.

A committed-bytes guard was added to `anchor-fixture.test.ts`: it asserts on
what `loadAnchorFixture()` actually reads from disk, not on the generator's
output, so a future regeneration that bypassed synthesis (or a hand-edit)
can't silently reintroduce the real fund id.

Along the way, a test-title falsehood in `fixture-synthesis.test.ts` is
corrected: a test titled "emits the real 28-anchor fixture without the guard
firing" never actually touched the real fixture — the sanitizer's entire point
is that nothing in that file can read it. Retitled to describe what it
actually asserts: the guard stays silent on an ordinary constructed series.

## Commits

1. `fix(push): synthesize the fixture fundId — the real fund id no longer
   reaches the committed file` — the behavior change plus the tests that pin
   it (including the corrected test title).
2. `chore(push): regenerate backfill-anchors fixture with the synthetic
   fundId` — the mechanical 28-string regeneration of the committed fixture
   that follows from commit 1.

## Test plan

- [x] `pnpm typecheck` clean
- [x] `pnpm vitest run apps/web/src` — 23 files, 254 tests passed (3 skipped)
- [x] New/updated assertions in `fixture-synthesis.test.ts` and
      `anchor-fixture.test.ts` cover the synthesized id, its agreement with
      `fundIdOf`, and the committed-bytes check
