### PR TITLE
feat(engine): reject position verbs dated before their target's birth

### DIFF
--- a/packages/engine/src/events/crossref.ts
+++ b/packages/engine/src/events/crossref.ts
@@ -129,6 +129,20 @@ export interface EventReference {
    * open, and the fold keeps it in `positions`.
    */
   closedPositionIds: Set<string>;
+  /**
+   * Every known position id → the date it came into existence: `genesis.review.asOf`
+   * for a genesis-held position, the `PositionOpened`'s own `asOf` for a log-born
+   * one. What makes "does this position exist" answerable AS OF A DATE; see
+   * {@link requirePositionBornBy}. The position-side twin of
+   * {@link ReserveView.bornAsOf}.
+   *
+   * INVARIANT: its key set is exactly {@link positionIds} — every known id is
+   * datable, INCLUDING a retired one. `requirePositionBornBy` answers existence off
+   * `positionBornAsOf.get(id) === undefined`, so a known-but-undatable id would be
+   * reported as a dangling reference and the operator would be told the wrong thing
+   * about a position that plainly did exist.
+   */
+  positionBornAsOf: Map<string, string>;
   /** Latest known close per instrument: the magnitude guard's comparison point. */
   lastClose: Map<string, { price: number; asOf: string }>;
   /**
@@ -212,6 +226,33 @@ export function buildEventReference(
     }
   }
 
+  // Each known position's BIRTH DATE, read off the folded book and only off it. Unlike
+  // a Reserve's, a position's birth date IS carried by the folded record, so there is
+  // no reason to rescan `priorEvents` for it — and a second derivation path for a fact
+  // the fold already carries would re-acquire exactly the divergence class ADR-015
+  // deleted the shadow to remove. One rule holds in this function: read the fold where
+  // the fold carries the fact, read the inputs only where it does not.
+  //
+  // `?? genesisAsOf` is LOAD-BEARING, not defensive. `openedAsOf` is optional on both
+  // record types and is absent precisely for a GENESIS-HELD position — one opened
+  // before the log existed (the fold sets it only at `PositionOpened` and carries it
+  // through the close). A genesis-held position is born with the world, the same rule
+  // `reserveBalances.bornAsOf` applies to a seeded Reserve.
+  //
+  // Survivors first, closed-book rows only for ids not already present: a PARTIAL
+  // (trim) row shares its id with a still-OPEN position, and the open row is the
+  // authority. Together the two passes cover exactly `positionIds`, which is the
+  // key-set invariant `requirePositionBornBy` relies on to answer existence.
+  const positionBornAsOf = new Map<string, string>();
+  for (const position of folded.positions) {
+    positionBornAsOf.set(position.id, position.openedAsOf ?? genesisAsOf);
+  }
+  for (const row of folded.closedPositions ?? []) {
+    if (!positionBornAsOf.has(row.positionId)) {
+      positionBornAsOf.set(row.positionId, row.openedAsOf ?? genesisAsOf);
+    }
+  }
+
   // Latest close per instrument, from the fold's own `closes[]`: the genesis-provided
   // closes, the t0 `markPrice` anchors the fold seeds, every `PriceMarked`, and any
   // entry/blend cost baseline the fold minted. Later-or-equal `asOf` wins, so a mark
@@ -253,6 +294,7 @@ export function buildEventReference(
     instrumentIds: new Set(folded.instruments.map((instrument) => instrument.id)),
     genesisAsOf,
     closedPositionIds,
+    positionBornAsOf,
     lastClose,
     reserveBalances,
     positionLots: new Map(
@@ -421,12 +463,9 @@ function crossReferenceInvalidation(
   event: InvalidationMarkedEvent,
   reference: EventReference,
 ): EventParseResult {
-  if (!reference.positionIds.has(event.positionId)) {
-    return eventError(
-      "positionId",
-      `InvalidationMarked references position id '${event.positionId}', which neither ` +
-        `the genesis seed nor the log contains.`,
-    );
+  const bornBy = requirePositionBornBy(reference, event.positionId, event.asOf, "positionId");
+  if (bornBy) {
+    return { ...bornBy, message: `InvalidationMarked ${bornBy.message}` };
   }
   if (reference.closedPositionIds.has(event.positionId)) {
     return eventError(
@@ -516,6 +555,84 @@ function requireReserveBornBy(
 }
 
 /**
+ * THE ONE PLACE THAT ANSWERS "DOES THIS POSITION EXIST AS OF THIS DATE."
+ *
+ * {@link requireReserveBornBy}'s twin for the CONTAINER the position verbs target, and
+ * the follow-up ADR-015 named rather than took (its "third delta class"). The same two
+ * orderings disagree here: THIS GATE JUDGES IN LOG ORDER, `foldEvents` applies in
+ * (`asOf`, then log) order. A close/trim/add/invalidation dated before its target's
+ * `PositionOpened` reaches the fold FIRST, hits `if (closing)` / `if (trimming)` /
+ * `if (adding)`, and never lands.
+ *
+ * Measured, on `[PositionOpened asOf 06-05 btc-pos, PositionClosed asOf 06-03
+ * btc-pos]`: both passed both gates and were durably appended, the close sorted first
+ * at fold, the cash leg was skipped and NO closed-book row was minted — so
+ * {@link EventReference.closedPositionIds} never gained the id, and a SECOND backdated
+ * close carrying a fresh event id (log dedup keys on `event.id` alone) then cleared the
+ * post-close guard too. Two closes in the log, zero effect on the book, `warnings: []`,
+ * and `foldEvents` has no diagnostics channel to say otherwise.
+ *
+ * IT OWNS BOTH HALVES OF THE QUESTION — unknown id AND not-born-yet — as the reserve
+ * helper does, which is why every call site's own `positionIds.has()` check is gone.
+ * Existence is answered off `positionBornAsOf.get(id)`; `undefined` means unknown, and
+ * that is exactly what the key-set invariant on {@link EventReference.positionBornAsOf}
+ * guarantees is never true of a known id.
+ *
+ * Returns `null` on success and never throws — `checkDebit`'s shape, since unlike the
+ * reserve helper there is no resolved view to hand back. No error-code enum: `path` is
+ * the machine-readable half, the message the human one. The CALLER prefixes the verb
+ * name, matching the reserve call sites, which keeps the unknown-id strings
+ * byte-identical to the ones each site composed inline before.
+ *
+ * ORDERED FIRST at every call site, ahead of the already-closed check. A verb that is
+ * both backdated and aimed at a retired position therefore reports "not born until"
+ * rather than "already closed": the birth fact holds regardless of retirement, and it
+ * mirrors the reserve side where existence and birth are one function's single answer.
+ * It also makes an interaction disappear rather than requiring anyone to reason about
+ * it — a backdated close used to reach the settlement-magnitude gate carrying the
+ * position's FULL lots, comparing proceeds against a quantity it was never going to
+ * remove.
+ *
+ * Deliberately NOT fixed at the fold, for the reason {@link requireReserveBornBy}
+ * records: `foldEvents` is the READ path for the TUI, the web push and the daily
+ * price-feed job, and throwing there would turn an ingest-time defect into a total
+ * dashboard outage.
+ */
+function requirePositionBornBy(
+  reference: EventReference,
+  positionId: string,
+  asOf: string,
+  path: string,
+): EventError | null {
+  const bornAsOf = reference.positionBornAsOf.get(positionId);
+  if (bornAsOf === undefined) {
+    return eventError(
+      path,
+      `references position id '${positionId}', which neither ` +
+        `the genesis seed nor the log contains.`,
+    );
+  }
+  if (asOf < bornAsOf) {
+    // The remedy branches on WHICH KIND of position this is, because one of the two
+    // fixes is impossible for a genesis-held one: it has no `PositionOpened` to move,
+    // so "open the position earlier" would send the operator hunting for an event that
+    // does not exist. Only a log-born position has a birth the operator can redate.
+    const held = bornAsOf === reference.genesisAsOf;
+    const remedy = held
+      ? `Date it on or after the genesis review date, ${bornAsOf}.`
+      : `Date it ${bornAsOf} or later, or open the position earlier.`;
+    return eventError(
+      path,
+      `references position '${positionId}' as of ${asOf}, but that position is not born ` +
+        `until ${bornAsOf}. The fold applies events in date order, so this one would run ` +
+        `BEFORE the position exists and its leg would vanish silently. ` +
+        remedy,
+    );
+  }
+  return null;
+}
+
+/**
  * Per-Tier SUFFICIENCY for a debit, and nothing else. Returns null on success.
  * `amount` here is the cash leaving; an untiered reserve is checked against its
  * total balance, a tiered one against the named Tier's available quantity. Fails
@@ -563,12 +680,9 @@ function crossReferenceClose(
   reference: EventReference,
   threshold = SETTLEMENT_MAGNITUDE_THRESHOLD,
 ): EventParseResult {
-  if (!reference.positionIds.has(event.positionId)) {
-    return eventError(
-      "positionId",
-      `PositionClosed references position id '${event.positionId}', which neither ` +
-        `the genesis seed nor the log contains.`,
-    );
+  const bornBy = requirePositionBornBy(reference, event.positionId, event.asOf, "positionId");
+  if (bornBy) {
+    return { ...bornBy, message: `PositionClosed ${bornBy.message}` };
   }
   // A close retires the id, so a SECOND close of it can never fold to anything — the
   // fold drops it silently, with no warning. Log dedup keys on event id alone and
@@ -632,12 +746,9 @@ function crossReferenceTrim(
   reference: EventReference,
   threshold = SETTLEMENT_MAGNITUDE_THRESHOLD,
 ): EventParseResult {
-  if (!reference.positionIds.has(event.positionId)) {
-    return eventError(
-      "positionId",
-      `PositionTrimmed references position id '${event.positionId}', which neither ` +
-        `the genesis seed nor the log contains.`,
-    );
+  const bornBy = requirePositionBornBy(reference, event.positionId, event.asOf, "positionId");
+  if (bornBy) {
+    return { ...bornBy, message: `PositionTrimmed ${bornBy.message}` };
   }
   if (reference.closedPositionIds.has(event.positionId)) {
     return eventError(
@@ -727,12 +838,9 @@ function crossReferenceAddedTo(
   event: PositionAddedToEvent,
   reference: EventReference,
 ): EventParseResult {
-  if (!reference.positionIds.has(event.positionId)) {
-    return eventError(
-      "positionId",
-      `PositionAddedTo references position id '${event.positionId}', which neither ` +
-        `the genesis seed nor the log contains.`,
-    );
+  const bornBy = requirePositionBornBy(reference, event.positionId, event.asOf, "positionId");
+  if (bornBy) {
+    return { ...bornBy, message: `PositionAddedTo ${bornBy.message}` };
   }
   if (reference.closedPositionIds.has(event.positionId)) {
     return eventError(

--- a/packages/engine/src/events/crossref.ts
+++ b/packages/engine/src/events/crossref.ts
@@ -136,6 +136,10 @@ export interface EventReference {
    * {@link requirePositionBornBy}. The position-side twin of
    * {@link ReserveView.bornAsOf}.
    *
+   * "Genesis-held" is decided by MEMBERSHIP IN THE SEED, not by the folded record's
+   * `openedAsOf` being absent — nothing validates that field on a hand-written seed,
+   * and trusting it let a genesis position claim a birth date before the world's.
+   *
    * INVARIANT: its key set is exactly {@link positionIds} — every known id is
    * datable, INCLUDING a retired one. `requirePositionBornBy` answers existence off
    * `positionBornAsOf.get(id) === undefined`, so a known-but-undatable id would be
@@ -182,8 +186,10 @@ export interface EventReference {
  * positions are open, which are retired, each open position's running lots, and the
  * last known close per instrument. The gate therefore cannot be wrong about the world
  * the fold will produce; it is looking at that world. The only facts NOT on the folded
- * output are `genesisAsOf` (the fold restamps `review.asOf` to the latest event) and
- * each Reserve's `bornAsOf`, both of which are read off the inputs directly.
+ * output are `genesisAsOf` (the fold restamps `review.asOf` to the latest event), each
+ * Reserve's `bornAsOf`, and WHICH position ids the seed itself held (the fold clones a
+ * genesis position verbatim, so it cannot tell a seeded one from a logged one on the
+ * record alone) — all read off the inputs directly.
  *
  * COST, and the standing budget. This is O(log length) per call — measured on a
  * MARK-HEAVY synthetic log (the durable log is 98.5% `PriceMarked`, and the original
@@ -226,28 +232,61 @@ export function buildEventReference(
     }
   }
 
-  // Each known position's BIRTH DATE, read off the folded book and only off it. Unlike
-  // a Reserve's, a position's birth date IS carried by the folded record, so there is
-  // no reason to rescan `priorEvents` for it — and a second derivation path for a fact
-  // the fold already carries would re-acquire exactly the divergence class ADR-015
-  // deleted the shadow to remove. One rule holds in this function: read the fold where
-  // the fold carries the fact, read the inputs only where it does not.
+  // Each known position's BIRTH DATE. A LOG-BORN position's is read off the folded
+  // book and only off it: unlike a Reserve's, that date IS carried by the folded
+  // record, so there is no reason to rescan `priorEvents` for it — and a second
+  // derivation path for a fact the fold already carries would re-acquire exactly the
+  // divergence class ADR-015 deleted the shadow to remove. The function's one rule
+  // holds: read the fold where the fold carries the fact, read the inputs only where it
+  // does not. A GENESIS-HELD position is the "does not" case — it is born with the
+  // world by definition, which is a fact about the SEED, not a date the fold derives.
   //
-  // `?? genesisAsOf` is LOAD-BEARING, not defensive. `openedAsOf` is optional on both
-  // record types and is absent precisely for a GENESIS-HELD position — one opened
-  // before the log existed (the fold sets it only at `PositionOpened` and carries it
-  // through the close). A genesis-held position is born with the world, the same rule
-  // `reserveBalances.bornAsOf` applies to a seeded Reserve.
+  // `?? genesisAsOf` stays LOAD-BEARING behind the seeding, not defensive. `openedAsOf`
+  // is optional on both record types and the fold sets it only at `PositionOpened`,
+  // carrying it through the close — so a position the fold knows but cannot date is
+  // one that existed before the log, and it gets the same answer
+  // `reserveBalances.bornAsOf` gives a seeded Reserve.
   //
-  // Survivors first, closed-book rows only for ids not already present: a PARTIAL
-  // (trim) row shares its id with a still-OPEN position, and the open row is the
-  // authority. Together the two passes cover exactly `positionIds`, which is the
-  // key-set invariant `requirePositionBornBy` relies on to answer existence.
-  const positionBornAsOf = new Map<string, string>();
+  // GENESIS IDS ARE SEEDED FIRST, and the not-already-present precedence below then
+  // makes them UN-OVERRIDABLE. A genesis-held position is born with the world by
+  // definition, and `?? genesisAsOf` alone trusted a field nothing enforces: the
+  // contract says `openedAsOf` is absent for a genesis-held position, but
+  // `parseFundReview` passes the seed through as `value as FundReviewData` and
+  // `foldEvents` `structuredClone`s each genesis position verbatim, so a seed carrying
+  // an explicit `openedAsOf: "2025-03-01"` reached the map intact. Two things then went
+  // wrong at once: `InvalidationMarked` — the only position verb with no reserve leg,
+  // hence the only one `requireReserveBornBy` does not independently catch — was
+  // accepted before the genesis review, so the two gates disagreed about where the
+  // world begins; and `held` below went false, sending the operator to "open the
+  // position earlier" for a position that has no `PositionOpened` to redate, which is
+  // precisely what the two-branch remedy exists to prevent. Log-born positions are
+  // untouched: their ids are not in the seed.
+  //
+  // Then survivors, then closed-book rows, each only for ids not already present: a
+  // PARTIAL (trim) row shares its id with a still-OPEN position, and the open row is
+  // the authority. The three passes cover exactly `positionIds` — the key-set
+  // invariant `requirePositionBornBy` relies on to answer existence — because a genesis
+  // position always leaves the fold either surviving in `positions` or carrying a
+  // full-close row in `closedPositions`, never neither. Pinned by the invariant tests,
+  // including one that fully closes a genesis-held position.
+  const positionBornAsOf = new Map<string, string>(
+    genesis.positions.map((position) => [position.id, genesisAsOf]),
+  );
   for (const position of folded.positions) {
-    positionBornAsOf.set(position.id, position.openedAsOf ?? genesisAsOf);
+    if (!positionBornAsOf.has(position.id)) {
+      positionBornAsOf.set(position.id, position.openedAsOf ?? genesisAsOf);
+    }
   }
   for (const row of folded.closedPositions ?? []) {
+    // INERT TODAY, AND KEPT ON PURPOSE. `buildClosedPosition` copies `openedAsOf` off
+    // the very `PositionRecord` the surviving row came from, so a partial row's date is
+    // always byte-equal to the open row's and last-write-wins would produce an
+    // identical map through every path the fold can currently produce. This guard is
+    // here so that a future change to how closed rows carry `openedAsOf` — a
+    // re-derivation, a normalization, a trim that stamps its own date — cannot silently
+    // restate a still-open position's birth date, which would move the gate's answer
+    // for every later verb aimed at it. Do not delete it as redundant without first
+    // making that coupling explicit somewhere else.
     if (!positionBornAsOf.has(row.positionId)) {
       positionBornAsOf.set(row.positionId, row.openedAsOf ?? genesisAsOf);
     }

--- a/packages/engine/src/position-born-by.test.ts
+++ b/packages/engine/src/position-born-by.test.ts
@@ -367,9 +367,38 @@ describe("the position gate learns time", () => {
       expect(reference.positionBornAsOf.get("btc-core")).toBe(GENESIS_AS_OF);
     });
 
-    // A trim's PARTIAL closed-book row shares its id with the still-open position.
-    // The open row is the authority; the partial must not overwrite it.
-    it("a partial (trim) row does not restate an open position's birth date", () => {
+    // The path that keeps the genesis SEEDING (below) safe for the key-set invariant.
+    // Seeding ids straight off `genesis.positions` would put a key in the map that
+    // `positionIds` lacks if the fold could ever drop a genesis position without
+    // minting a closed-book row. It cannot — a genesis position is in `positions` from
+    // t0, so its close always finds it and always pushes a full row — and this is the
+    // case that holds that reasoning to account rather than leaving it in a comment.
+    it("after a genesis-HELD position is fully closed", () => {
+      const reference = buildEventReference(genesis(), [
+        accepted({
+          id: "evt-close-core",
+          asOf: "2026-06-10",
+          type: "PositionClosed",
+          positionId: "btc-core",
+          settlement: { reserveId: "pulse-cash", proceeds: 200 },
+        }),
+      ]);
+
+      expect(reference.closedPositionIds.has("btc-core")).toBe(true);
+      expectSameKeys(reference);
+      expect(reference.positionBornAsOf.get("btc-core")).toBe(GENESIS_AS_OF);
+    });
+
+    // WHAT THIS PROVES, STATED HONESTLY: that a trimmed-but-still-open position is
+    // datable to its log birth, and that the survivor pass and the closed-book pass
+    // AGREE on the value for the id they share. It does NOT prove the
+    // not-already-present guard is load-bearing, and it cannot: `buildClosedPosition`
+    // copies `openedAsOf` off the very `PositionRecord` the surviving row came from, so
+    // last-write-wins would produce a byte-identical map here and through every other
+    // path the fold can currently produce. The guard is inert today and kept for a
+    // future change to how closed rows carry that date; that argument lives at the
+    // guard itself, because no test can carry it.
+    it("dates a trimmed-but-still-open position to its log birth, both passes agreeing", () => {
       const reference = buildEventReference(genesis(), [
         accepted(openLate()),
         accepted({
@@ -385,6 +414,157 @@ describe("the position gate learns time", () => {
       expect(reference.closedPositionIds.has("btc-late")).toBe(false);
       expectSameKeys(reference);
       expect(reference.positionBornAsOf.get("btc-late")).toBe(OPENED_AS_OF);
+    });
+  });
+
+  // THE ACCEPT SIDE FOR A LOG-BORN POSITION, THROUGH THE FULL GATE. The matrix above
+  // only proves these four verbs can be REFUSED; without this, a call site that
+  // rejected unconditionally would pass every rejection case in this file. Dated after
+  // the birth, and on the birth date itself — the boundary is `<`, so a verb dated
+  // exactly on the birth date is legal, the same rule the Reserve side applies.
+  describe("a verb dated on or after a log-born position's birth is accepted", () => {
+    const afterOpening = (verb: Record<string, unknown>, asOf: string) =>
+      ingestBatch([openLate(), { asOf, ...verb }]).rejection;
+
+    const verbs: [string, Record<string, unknown>][] = [
+      [
+        "PositionClosed",
+        {
+          id: "evt-close",
+          type: "PositionClosed",
+          positionId: "btc-late",
+          settlement: { reserveId: "pulse-cash", proceeds: 100 },
+        },
+      ],
+      [
+        "PositionTrimmed",
+        {
+          id: "evt-trim",
+          type: "PositionTrimmed",
+          positionId: "btc-late",
+          removals: [{ quantity: 0.5, tier: "c1" }],
+          settlement: { reserveId: "pulse-cash", proceeds: 50 },
+        },
+      ],
+      [
+        "PositionAddedTo",
+        {
+          id: "evt-add",
+          type: "PositionAddedTo",
+          positionId: "btc-late",
+          lot: { quantity: 1, cost: 100, tier: "c1" },
+          funding: { reserveId: "pulse-cash", amount: 100 },
+        },
+      ],
+      [
+        "InvalidationMarked",
+        {
+          id: "evt-invalidation",
+          type: "InvalidationMarked",
+          positionId: "btc-late",
+          price: 80,
+          direction: "below",
+        },
+      ],
+    ];
+
+    it.each(verbs)("%s dated after the birth", (_verb, input) => {
+      expect(afterOpening(input, "2026-06-20")).toBeNull();
+    });
+
+    it.each(verbs)("%s dated ON the birth date itself", (_verb, input) => {
+      expect(afterOpening(input, OPENED_AS_OF)).toBeNull();
+    });
+  });
+
+  // A GENESIS POSITION CANNOT CLAIM A BIRTH BEFORE THE WORLD'S. `openedAsOf` is
+  // documented as absent for a genesis-held position, but nothing enforces it:
+  // `parseFundReview` passes the seed through as `value as FundReviewData` and
+  // `foldEvents` `structuredClone`s each genesis position verbatim, so a hand-written
+  // seed carrying one reached the birth map intact and dated the position years early.
+  describe("a genesis position's explicit openedAsOf does not move its birth", () => {
+    /** The seed above, with a bogus pre-genesis `openedAsOf` on the held position. */
+    function seededEarly(): FundReviewData {
+      const seed = genesis();
+      return {
+        ...seed,
+        positions: seed.positions.map((position) => ({ ...position, openedAsOf: "2025-03-01" })),
+      };
+    }
+
+    /** After the bogus date, BEFORE the genesis review — the window the bug opened. */
+    const IN_THE_GAP = "2025-06-01";
+
+    it("dates it to the genesis review, not to the field", () => {
+      const reference = buildEventReference(seededEarly());
+
+      expect(reference.positionBornAsOf.get("btc-core")).toBe(GENESIS_AS_OF);
+    });
+
+    // `InvalidationMarked` is the only position verb with NO reserve leg, so it is the
+    // only one `requireReserveBornBy` does not independently catch — the verb where the
+    // two gates would have visibly disagreed about where the world begins.
+    it("rejects an InvalidationMarked dated in the gap between the two dates", () => {
+      const { rejection } = ingestBatch(
+        [
+          {
+            id: "evt-invalidation-early",
+            asOf: IN_THE_GAP,
+            type: "InvalidationMarked",
+            positionId: "btc-core",
+            price: 80,
+            direction: "below",
+          },
+        ],
+        seededEarly(),
+      );
+
+      expect(rejection).not.toBeNull();
+      expect(rejection?.path).toBe("positionId");
+      expect(rejection?.message).toContain("not born until");
+      expect(rejection?.message).toContain(IN_THE_GAP);
+      expect(rejection?.message).toContain(GENESIS_AS_OF);
+      expect(rejection?.message).not.toContain("2025-03-01");
+    });
+
+    // THE REMEDY MUST BE ONE THE OPERATOR CAN PERFORM. A genesis-held position has no
+    // `PositionOpened` to redate, so the log-born branch's advice would send them
+    // hunting for an event that does not exist — which is exactly what a birth date
+    // read off the bogus field produced, since `held` compares against `genesisAsOf`.
+    it("takes the genesis-seeded remedy branch, never 'open the position earlier'", () => {
+      const { rejection } = ingestBatch(
+        [
+          {
+            id: "evt-close-early",
+            asOf: IN_THE_GAP,
+            type: "PositionClosed",
+            positionId: "btc-core",
+            settlement: { reserveId: "pulse-cash", proceeds: 200 },
+          },
+        ],
+        seededEarly(),
+      );
+
+      // The path and the verb prefix are load-bearing here, not decoration: without
+      // them this passes vacuously on the REJECTION FROM THE OTHER GATE. A close in
+      // this window also predates `pulse-cash`, so `requireReserveBornBy` refuses it at
+      // `settlement.reserveId` with its own near-identical genesis-seeded remedy — and
+      // that is precisely the disagreement being pinned, so the assertion has to insist
+      // the POSITION gate is the one speaking.
+      expect(rejection?.path).toBe("positionId");
+      expect(rejection?.message).toMatch(/^PositionClosed references position /);
+      expect(rejection?.message).toContain("not born until");
+      expect(rejection?.message).toContain("genesis review date");
+      expect(rejection?.message).not.toContain("open the position earlier");
+    });
+
+    it("leaves a log-born position's birth alone", () => {
+      const reference = buildEventReference(seededEarly(), [accepted(openLate())]);
+
+      expect(reference.positionBornAsOf.get("btc-late")).toBe(OPENED_AS_OF);
+      expect([...reference.positionBornAsOf.keys()].sort()).toEqual(
+        [...reference.positionIds].sort(),
+      );
     });
   });
 

--- a/packages/engine/src/position-born-by.test.ts
+++ b/packages/engine/src/position-born-by.test.ts
@@ -1,0 +1,442 @@
+// ADR-015's THIRD DELTA CLASS, closed — the position-side twin of
+// `requireReserveBornBy`.
+//
+// The gate walks a batch in LOG order; `foldEvents` applies in (`asOf`, then log)
+// order, and nothing reconciled the two on the position side. Measured on
+// `[PositionOpened asOf 06-05 btc-late, PositionClosed asOf 06-03 btc-late]`: both
+// events passed both gates and were durably appended, the close sorted FIRST at
+// fold, `positions.get(...)` missed, the cash leg was skipped and NO closed-book row
+// was pushed — so `closedPositionIds` never gained the id, and a SECOND backdated
+// close with a fresh event id (log dedup keys on `event.id` alone) sailed past the
+// A1 post-close guard too. Two closes in the log, zero effect on the book,
+// `warnings: []`.
+//
+// Mirrors `reserve-opened.test.ts:341-620` deliberately: same `ingestBatch` shape,
+// same per-call-site regression matrix, same `expectBornByRejection` helper, and the
+// same Z2 discipline — EVERY claim is a DELTA (after − before === 0), never a
+// resting state, because a test that asserts absolute balances passes this bug
+// vacuously.
+import {
+  buildEventReference,
+  crossReferenceEvent,
+  foldEvents,
+  parseEvent,
+  type FundReviewData,
+  type PortfolioEvent,
+} from "./index.js";
+import { describe, expect, it } from "vitest";
+
+const GENESIS_AS_OF = "2026-06-01";
+/** The log-born position's own birth date. */
+const OPENED_AS_OF = "2026-06-05";
+/** Before `btc-late` is born, after the genesis review: the ADR's measured case. */
+const BACKDATED_AS_OF = "2026-06-03";
+
+/**
+ * One genesis-HELD position (`btc-core` — no `openedAsOf` anywhere, which is exactly
+ * the population the `?? genesisAsOf` fallback exists for) and one funded Reserve.
+ */
+function genesis(): FundReviewData {
+  return {
+    fund: { id: "fund-1", name: "Accumulus", baseCurrency: "USD" },
+    review: { asOf: GENESIS_AS_OF, usdMxn: 20 },
+    portfolios: [{ id: "core", name: "Core" }],
+    accounts: [{ id: "bitget-usd", name: "Bitget", platform: "BITGET", currency: "USD" }],
+    instruments: [{ id: "btc-usd", name: "Bitcoin", symbol: "BTC", currency: "USD" }],
+    reserves: [
+      {
+        id: "pulse-cash",
+        portfolioId: "core",
+        tempo: "Pulse",
+        executionMode: "live",
+        accountId: "bitget-usd",
+        currency: "USD",
+        amount: 1000,
+        lots: [
+          { quantity: 600, tier: "c1" },
+          { quantity: 400, tier: "c2" },
+        ],
+      },
+    ],
+    positions: [
+      {
+        id: "btc-core",
+        portfolioId: "core",
+        tempo: "Capital",
+        executionMode: "live",
+        accountId: "bitget-usd",
+        instrumentId: "btc-usd",
+        direction: "long",
+        markPrice: 100,
+        currency: "USD",
+        lots: [{ quantity: 2, cost: 100, tier: "c1" }],
+      },
+    ],
+  };
+}
+
+/** The LOG-BORN position: `btc-late`, born 2026-06-05, one lot of 1 @ 100. */
+function openLate(overrides: Record<string, unknown> = {}): Record<string, unknown> {
+  return {
+    id: "evt-open-late",
+    asOf: OPENED_AS_OF,
+    type: "PositionOpened",
+    position: {
+      id: "btc-late",
+      portfolioId: "core",
+      tempo: "Capital",
+      executionMode: "live",
+      accountId: "bitget-usd",
+      instrumentId: "btc-usd",
+      direction: "long",
+      currency: "USD",
+      lots: [{ quantity: 1, cost: 100, tier: "c1" }],
+    },
+    decision: {
+      entryThesis: "thesis",
+      invalidationCondition: "invalidation",
+      riskBudget: "1R",
+      plannedHoldingHorizon: "weeks",
+      strategy: "trend",
+    },
+    funding: { reserveId: "pulse-cash", amount: 100 },
+    ...overrides,
+  };
+}
+
+/** parseEvent, asserting success, so a test can hand the typed event onward. */
+function accepted(input: Record<string, unknown>): PortfolioEvent {
+  const result = parseEvent(input);
+  if (result.kind !== "ok") {
+    throw new Error(`expected parse to accept: ${result.path}: ${result.message}`);
+  }
+  return result.value;
+}
+
+/**
+ * The ingest contract in miniature: parse then cross-reference each event in LOG
+ * order, rebuilding the reference from genesis + everything committed so far
+ * (ADR-015), and ABORT THE WHOLE BATCH on the first rejection. All-or-nothing.
+ */
+function ingestBatch(
+  inputs: Record<string, unknown>[],
+  seed: FundReviewData = genesis(),
+): { committed: PortfolioEvent[]; rejection: { path: string; message: string } | null } {
+  const committed: PortfolioEvent[] = [];
+  for (const input of inputs) {
+    const parsed = parseEvent(input);
+    if (parsed.kind !== "ok") {
+      return { committed: [], rejection: { path: parsed.path, message: parsed.message } };
+    }
+    const checked = crossReferenceEvent(parsed.value, buildEventReference(seed, committed));
+    if (checked.kind !== "ok") {
+      return { committed: [], rejection: { path: checked.path, message: checked.message } };
+    }
+    committed.push(parsed.value);
+  }
+  return { committed, rejection: null };
+}
+
+const totalCash = (fund: FundReviewData): number =>
+  fund.reserves.reduce((sum, reserve) => sum + reserve.amount, 0);
+
+/** Every rejection must name BOTH dates, or the operator cannot see the ordering. */
+function expectBornByRejection(
+  rejection: { path: string; message: string } | null,
+  path: string,
+): void {
+  expect(rejection).not.toBeNull();
+  expect(rejection?.path).toBe(path);
+  expect(rejection?.message).toContain("not born until");
+  expect(rejection?.message).toContain(BACKDATED_AS_OF);
+  expect(rejection?.message).toContain(OPENED_AS_OF);
+}
+
+describe("the position gate learns time", () => {
+  /** The ADR's measured pair, in the log order an inbox would hand them over. */
+  function backdatedBatch(): Record<string, unknown>[] {
+    return [
+      openLate(),
+      {
+        id: "evt-close-1",
+        asOf: BACKDATED_AS_OF, // BEFORE `btc-late` is born on 2026-06-05.
+        type: "PositionClosed",
+        positionId: "btc-late",
+        settlement: { reserveId: "pulse-cash", proceeds: 100 },
+      },
+    ];
+  }
+
+  it("rejects a PositionClosed dated before the position it closes was born", () => {
+    const { rejection } = ingestBatch(backdatedBatch());
+
+    expectBornByRejection(rejection, "positionId");
+    // The verb names itself, exactly as the reserve call sites do.
+    expect(rejection?.message).toMatch(/^PositionClosed /);
+    // The fold-order explanation is the actionable half.
+    expect(rejection?.message).toContain("date order");
+    expect(rejection?.message).toContain("open the position earlier");
+  });
+
+  // Z2 — THE ASSERTION IS THE DELTA, NOT THE RESTING STATE.
+  it("moves no cash and mints no closed-book row when the batch is rejected", () => {
+    const before = foldEvents(genesis(), []);
+    const { committed } = ingestBatch(backdatedBatch());
+    const after = foldEvents(genesis(), committed);
+
+    expect(totalCash(after) - totalCash(before)).toBe(0);
+    expect((after.closedPositions ?? []).length - (before.closedPositions ?? []).length).toBe(0);
+    expect(after.positions.length - before.positions.length).toBe(0);
+  });
+
+  // THE DOUBLE-CLOSE CHAIN IS NOW UNREACHABLE. Pre-fix, close #1 was admitted, folded
+  // to nothing, left `closedPositionIds` empty — and close #2, carrying a fresh event
+  // id, cleared the A1 post-close guard on that empty set. With the born-by rule in
+  // front, close #1 is refused and #2 never gets its chance.
+  it("makes the double-close chain unreachable — the FIRST backdated close is refused", () => {
+    const before = foldEvents(genesis(), []);
+    const { committed, rejection } = ingestBatch([
+      ...backdatedBatch(),
+      {
+        id: "evt-close-2-reauthored",
+        asOf: BACKDATED_AS_OF,
+        type: "PositionClosed",
+        positionId: "btc-late",
+        settlement: { reserveId: "pulse-cash", proceeds: 100 },
+      },
+    ]);
+    const after = foldEvents(genesis(), committed);
+
+    expectBornByRejection(rejection, "positionId");
+    expect(committed).toHaveLength(0);
+    expect(totalCash(after) - totalCash(before)).toBe(0);
+    expect((after.closedPositions ?? []).length - (before.closedPositions ?? []).length).toBe(0);
+  });
+
+  // PER-CALL-SITE REGRESSION MATRIX. Four position-targeting verbs, one case each,
+  // so mutating any single call site reddens exactly one case below.
+  describe("every position-targeting call site rejects a verb dated before the position's birth", () => {
+    /** `[PositionOpened, <verb backdated before it>]` — the ADR's shape, per verb. */
+    function afterOpening(verb: Record<string, unknown>): { path: string; message: string } | null {
+      return ingestBatch([openLate(), { asOf: BACKDATED_AS_OF, ...verb }]).rejection;
+    }
+
+    it("PositionClosed — positionId", () => {
+      expectBornByRejection(
+        afterOpening({
+          id: "evt-close",
+          type: "PositionClosed",
+          positionId: "btc-late",
+          settlement: { reserveId: "pulse-cash", proceeds: 100 },
+        }),
+        "positionId",
+      );
+    });
+
+    it("PositionTrimmed — positionId", () => {
+      expectBornByRejection(
+        afterOpening({
+          id: "evt-trim",
+          type: "PositionTrimmed",
+          positionId: "btc-late",
+          removals: [{ quantity: 0.5, tier: "c1" }],
+          settlement: { reserveId: "pulse-cash", proceeds: 50 },
+        }),
+        "positionId",
+      );
+    });
+
+    it("PositionAddedTo — positionId", () => {
+      expectBornByRejection(
+        afterOpening({
+          id: "evt-add",
+          type: "PositionAddedTo",
+          positionId: "btc-late",
+          lot: { quantity: 1, cost: 100, tier: "c1" },
+          funding: { reserveId: "pulse-cash", amount: 100 },
+        }),
+        "positionId",
+      );
+    });
+
+    it("InvalidationMarked — positionId", () => {
+      expectBornByRejection(
+        afterOpening({
+          id: "evt-invalidation",
+          type: "InvalidationMarked",
+          positionId: "btc-late",
+          price: 80,
+          direction: "below",
+        }),
+        "positionId",
+      );
+    });
+  });
+
+  // POSITIVE CONTROL, and the thing that pins `?? genesisAsOf`. A genesis-HELD
+  // position carries no `openedAsOf` on either the surviving or the closed record, so
+  // without the fallback its birth date would be `undefined` and every one of these
+  // four legal verbs would be refused — the rule would eat the whole seeded book.
+  describe("a genesis-held position is born with the world", () => {
+    const onGenesisDay = (verb: Record<string, unknown>) =>
+      ingestBatch([{ asOf: GENESIS_AS_OF, ...verb }]).rejection;
+
+    it("PositionClosed on the genesis review date is accepted", () => {
+      expect(
+        onGenesisDay({
+          id: "evt-close-core",
+          type: "PositionClosed",
+          positionId: "btc-core",
+          settlement: { reserveId: "pulse-cash", proceeds: 200 },
+        }),
+      ).toBeNull();
+    });
+
+    it("PositionTrimmed on the genesis review date is accepted", () => {
+      expect(
+        onGenesisDay({
+          id: "evt-trim-core",
+          type: "PositionTrimmed",
+          positionId: "btc-core",
+          removals: [{ quantity: 1, tier: "c1" }],
+          settlement: { reserveId: "pulse-cash", proceeds: 100 },
+        }),
+      ).toBeNull();
+    });
+
+    it("PositionAddedTo on the genesis review date is accepted", () => {
+      expect(
+        onGenesisDay({
+          id: "evt-add-core",
+          type: "PositionAddedTo",
+          positionId: "btc-core",
+          lot: { quantity: 1, cost: 100, tier: "c1" },
+          funding: { reserveId: "pulse-cash", amount: 100 },
+        }),
+      ).toBeNull();
+    });
+
+    it("InvalidationMarked on the genesis review date is accepted", () => {
+      expect(
+        onGenesisDay({
+          id: "evt-invalidation-core",
+          type: "InvalidationMarked",
+          positionId: "btc-core",
+          price: 80,
+          direction: "below",
+        }),
+      ).toBeNull();
+    });
+  });
+
+  // STRUCTURAL INVARIANT. `requirePositionBornBy` answers EXISTENCE off
+  // `positionBornAsOf.get(id) === undefined`, so an id that is in `positionIds` but
+  // missing from the map would be reported as unknown — a retired position would
+  // start lying about why it was refused. Every known id must be datable.
+  describe("positionBornAsOf's key set is exactly positionIds", () => {
+    const expectSameKeys = (reference: ReturnType<typeof buildEventReference>) => {
+      expect([...reference.positionBornAsOf.keys()].sort()).toEqual(
+        [...reference.positionIds].sort(),
+      );
+    };
+
+    it("at genesis", () => {
+      expectSameKeys(buildEventReference(genesis()));
+    });
+
+    it("with a log-born position open", () => {
+      expectSameKeys(buildEventReference(genesis(), [accepted(openLate())]));
+    });
+
+    it("after a FULL close — a retired id stays datable", () => {
+      const reference = buildEventReference(genesis(), [
+        accepted(openLate()),
+        accepted({
+          id: "evt-close-late",
+          asOf: "2026-06-20",
+          type: "PositionClosed",
+          positionId: "btc-late",
+          settlement: { reserveId: "pulse-cash", proceeds: 100 },
+        }),
+      ]);
+
+      expect(reference.closedPositionIds.has("btc-late")).toBe(true);
+      expectSameKeys(reference);
+      // And it is datable to its LOG birth, not to genesis.
+      expect(reference.positionBornAsOf.get("btc-late")).toBe(OPENED_AS_OF);
+      expect(reference.positionBornAsOf.get("btc-core")).toBe(GENESIS_AS_OF);
+    });
+
+    // A trim's PARTIAL closed-book row shares its id with the still-open position.
+    // The open row is the authority; the partial must not overwrite it.
+    it("a partial (trim) row does not restate an open position's birth date", () => {
+      const reference = buildEventReference(genesis(), [
+        accepted(openLate()),
+        accepted({
+          id: "evt-trim-late",
+          asOf: "2026-06-20",
+          type: "PositionTrimmed",
+          positionId: "btc-late",
+          removals: [{ quantity: 0.5, tier: "c1" }],
+          settlement: { reserveId: "pulse-cash", proceeds: 50 },
+        }),
+      ]);
+
+      expect(reference.closedPositionIds.has("btc-late")).toBe(false);
+      expectSameKeys(reference);
+      expect(reference.positionBornAsOf.get("btc-late")).toBe(OPENED_AS_OF);
+    });
+  });
+
+  // THREE CONDITIONS, THREE MESSAGES, ONE PATH. Collapsing any two would tell the
+  // operator the wrong thing about a position that plainly did exist — the same
+  // argument the A1 guard's comment already makes for the already-closed case.
+  it("keeps unknown-id, not-born-yet and already-closed distinct on the same path", () => {
+    const world = buildEventReference(genesis(), [
+      accepted(openLate()),
+      accepted({
+        id: "evt-close-core-first",
+        asOf: "2026-06-10",
+        type: "PositionClosed",
+        positionId: "btc-core",
+        settlement: { reserveId: "pulse-cash", proceeds: 200 },
+      }),
+    ]);
+    const reject = (input: Record<string, unknown>) => {
+      const result = crossReferenceEvent(accepted(input), world);
+      expect(result.kind).toBe("event-error");
+      if (result.kind !== "event-error") throw new Error("unreachable");
+      return result;
+    };
+
+    const unknown = reject({
+      id: "evt-close-ghost",
+      asOf: "2026-06-20",
+      type: "PositionClosed",
+      positionId: "ghost",
+      settlement: { reserveId: "pulse-cash", proceeds: 100 },
+    });
+    const notBorn = reject({
+      id: "evt-close-early",
+      asOf: BACKDATED_AS_OF,
+      type: "PositionClosed",
+      positionId: "btc-late",
+      settlement: { reserveId: "pulse-cash", proceeds: 100 },
+    });
+    const retired = reject({
+      id: "evt-close-core-second",
+      asOf: "2026-06-20",
+      type: "PositionClosed",
+      positionId: "btc-core",
+      settlement: { reserveId: "pulse-cash", proceeds: 200 },
+    });
+
+    for (const error of [unknown, notBorn, retired]) {
+      expect(error.path).toBe("positionId");
+    }
+    expect(unknown.message).toContain("neither the genesis seed nor the log contains");
+    expect(notBorn.message).toContain("not born until");
+    expect(retired.message).toContain("already closed");
+    expect(new Set([unknown.message, notBorn.message, retired.message]).size).toBe(3);
+  });
+});


### PR DESCRIPTION
## What

The ingest gate (`crossReferenceEvent`) admitted a position-targeting verb
dated before its target position was born. `foldEvents` applies events in
date order, so such an event hit the fold's skip branches and landed as a
silent log no-op: no cash leg, no closed-book row. That meant
`closedPositionIds` never gained the id, so the second-close guard lost
its reach and a second backdated close (fresh event id, invisible to log
dedup which keys on `event.id`) was admitted too. Two closes durably
logged, zero effect, no warnings -- the fold has no diagnostics channel
at all.

This closes ADR-015's third delta class **as that ADR words it** — "a verb dated
before the event that creates its target" (`ADR-015-…md:238-243`). Read the scope
precisely: the *birth* side is shut, the *shape* is not. The death-side twin
remains open and is filed as a separate increment — a verb dated after its target
is retired vanishes just as silently. Measured: `[PositionOpened 06-05,
PositionTrimmed 06-18, PositionClosed 06-10]` all pass the gate, then at fold the
close sorts first and retires the position, so the trim's credit disappears with
`warnings: []`. Fixing that needs a *retirement* date in the gate's projection,
which `positionBornAsOf` does not carry — so it is its own increment, not a
follow-on edit to this one.

## Fix

- New `requirePositionBornBy` helper, mirroring the Reserve rule that
  already shipped (`requireReserveBornBy`).
- New `positionBornAsOf: Map<string,string>` on `EventReference`,
  populated from the fold; genesis-held positions date to the genesis
  review date.
- Wired into all four position-targeting verbs -- `PositionClosed`,
  `PositionTrimmed`, `PositionAddedTo`, `InvalidationMarked` -- ordered
  ahead of the already-closed and magnitude gates, so a backdated close
  no longer reaches the magnitude gate carrying the position's full lots.

## Migration safety

The legacy-migration path takes the rule with no exemption. That is safe
on evidence: a read-only detector was run against the real durable log --
388 events scanned, 2 position-targeting, 0 backdated, 0 unknown-target,
no unparseable lines, clean. The rule adds zero rejections to the
existing corpus.

## Verification

- `pnpm typecheck` clean across all six packages.
- `pnpm test`: 114 files / 1499 passed / 19 skipped, up from the
  113 / 1483 / 19 baseline -- exactly +1 file and +16 tests, nothing
  moved from passed to failed or skipped (the 19 skips are DB-gated
  suites, `NUMISMA_TEST_DATABASE_URL` unset).
- `reserve-opened.test.ts` canary suite is green and untouched.
- Unknown-id rejection messages verified byte-identical to the previous
  implementation by executing assertions against strings copied from
  `git show HEAD`.

No `EVENT_SCHEMA_VERSION` change, no persisted record-shape change, no
log migration.

## Review fix round (commit `88520a3`)

Three findings from review, all addressed:

1. **A vacuous test.** The case claiming to pin the closed-book merge precedence
   could not fail — `buildClosedPosition` (`fold.ts:617`) copies `openedAsOf` off
   the same `PositionRecord` the surviving row came from, so the guard it
   "tested" is inert through every path the fold can produce. Renamed to state
   what it actually proves (both population passes agree on the value), and the
   guard gained a comment naming the future change it defends against so nobody
   deletes it as redundant.
2. **A genesis position carrying an explicit `openedAsOf` dated itself too
   early.** The contract says that field is absent for genesis-held positions,
   but nothing enforces it (`parseFundReview` is a raw pass-through, `foldEvents`
   clones genesis positions verbatim). A bogus value made `InvalidationMarked` —
   the one position verb with no reserve leg — disagree with every
   reserve-touching verb about where the world begins, and sent the operator the
   wrong remedy branch. Fixed by seeding `positionBornAsOf` from
   `genesis.positions` before the fold passes, which the existing
   not-already-present precedence makes un-overridable. A log-born date still
   comes only from the fold; genesis *membership* is a fact about the seed that
   the fold cannot recover, and the surrounding docs now say so.
3. **A gap on the accept side** — the suite never drove a legitimate later-dated
   verb on a log-born position through the full gate. Added, including cases
   dated exactly on the birth date to pin the strict `<` boundary.

The new pins were checked against a revert of the fix rather than assumed, which
caught a defect in one of them: it initially passed *without* the fix, because
the reserve gate refused the same event with near-identical prose. It now asserts
`path === "positionId"` so only the position gate can satisfy it.

Final: `pnpm typecheck` clean across all six packages; `pnpm test` 114 files /
**1512 passed** / 19 skipped (from the 1483 baseline; +29 tests, nothing moved
from passed to failed or skipped). Canary `reserve-opened.test.ts` 45/45 and
byte-untouched. No pre-existing assertion moved.

Closes #255
