### PR TITLE
feat(engine): reject a PositionClosed that seals behind an accepted verb

### DIFF
--- a/packages/engine/src/events/crossref.ts
+++ b/packages/engine/src/events/crossref.ts
@@ -76,6 +76,20 @@ export interface ReserveView {
 }
 
 /**
+ * The latest position-targeting event the log has accepted for one position: WHEN it
+ * landed, and WHICH VERB it was. Both halves are load-bearing in the rejection message
+ * {@link requirePositionUntouchedAfter} composes — the date shows the ordering a close
+ * would have destroyed, the verb tells the operator what would have been buried, which
+ * is the difference between "something is wrong with this date" and "your trim on the
+ * 18th would vanish". Kept as ONE record rather than two parallel maps so the two halves
+ * cannot disagree about which event they describe.
+ */
+export interface PositionTouch {
+  asOf: string;
+  type: PortfolioEvent["type"];
+}
+
+/**
  * The known world an event is cross-referenced against: every id the genesis seed
  * and the durable log have introduced, plus the last known close per instrument
  * for the magnitude guard. A READ-ONLY PROJECTION of `foldEvents(genesis,
@@ -147,6 +161,28 @@ export interface EventReference {
    * about a position that plainly did exist.
    */
   positionBornAsOf: Map<string, string>;
+  /**
+   * Every position id the LOG has touched → the latest `asOf` among the
+   * position-targeting events accepted so far. The death-side twin of
+   * {@link positionBornAsOf}: birth is the EARLIEST bound on a verb's date, this is
+   * the LATEST bound on a close's — a close dated before it would seal behind an
+   * event already durably accepted, which the fold's (`asOf`, then log) ordering then
+   * drops silently.
+   *
+   * Covers all five position-targeting verbs — `PositionOpened`, `PositionClosed`,
+   * `PositionTrimmed`, `PositionAddedTo`, `InvalidationMarked`. `PriceMarked` targets
+   * an INSTRUMENT, not a position, and is not scanned. `PositionOpened` is counted
+   * even though `requirePositionBornBy` independently refuses a verb dated before
+   * birth: it costs one branch, and it makes the map's meaning unconditional — the
+   * latest date at which this position was touched — rather than a set with a
+   * carve-out.
+   *
+   * INVARIANT: its key set is a SUBSET of {@link positionIds}, NOT equal to it —
+   * unlike `positionBornAsOf`, whose key set is exactly `positionIds`. A genesis-held
+   * position no log event has ever touched has NO entry, and that absence is the
+   * meaningful answer ("nothing to seal behind"), not a gap wanting a fallback.
+   */
+  positionLastVerbAsOf: Map<string, PositionTouch>;
   /** Latest known close per instrument: the magnitude guard's comparison point. */
   lastClose: Map<string, { price: number; asOf: string }>;
   /**
@@ -187,9 +223,11 @@ export interface EventReference {
  * last known close per instrument. The gate therefore cannot be wrong about the world
  * the fold will produce; it is looking at that world. The only facts NOT on the folded
  * output are `genesisAsOf` (the fold restamps `review.asOf` to the latest event), each
- * Reserve's `bornAsOf`, and WHICH position ids the seed itself held (the fold clones a
+ * Reserve's `bornAsOf`, WHICH position ids the seed itself held (the fold clones a
  * genesis position verbatim, so it cannot tell a seeded one from a logged one on the
- * record alone) — all read off the inputs directly.
+ * record alone), and each position's LATEST accepted verb date (`InvalidationLevel` and
+ * `PositionLot` carry no `asOf`, so the folded book cannot answer it) — all read off the
+ * inputs directly.
  *
  * COST, and the standing budget. This is O(log length) per call — measured on a
  * MARK-HEAVY synthetic log (the durable log is 98.5% `PriceMarked`, and the original
@@ -216,6 +254,42 @@ export function buildEventReference(
   for (const event of priorEvents) {
     if (event.type === "ReserveOpened") {
       bornAsOf.set(event.reserve.id, event.asOf);
+    }
+  }
+
+  // The latest verb date per position is the other fact the folded record does not
+  // carry, and for a sharper reason than the Reserve's: `InvalidationLevel` and
+  // `PositionLot` carry no `asOf` at all, so a fold-only projection would see the trim
+  // (a partial row's `closedAsOf`) and miss the invalidation and the add-to entirely.
+  // Not a shadow of the fold either — birth is a fact about the WORLD, which the fold
+  // owns and carries, whereas "what have I already accepted for this id" is a fact
+  // about the LOG, which the fold never claimed to answer. Max, not last-write-wins:
+  // the events arrive in LOG order, which is not date order.
+  const positionLastVerbAsOf = new Map<string, PositionTouch>();
+  const touchPosition = (positionId: string, event: PortfolioEvent): void => {
+    const latest = positionLastVerbAsOf.get(positionId);
+    if (latest === undefined || event.asOf > latest.asOf) {
+      positionLastVerbAsOf.set(positionId, { asOf: event.asOf, type: event.type });
+    }
+  };
+  for (const event of priorEvents) {
+    switch (event.type) {
+      // The open keys off the position it MINTS; every other verb names an id it found.
+      case "PositionOpened":
+        touchPosition(event.position.id, event);
+        break;
+      case "PositionClosed":
+      case "PositionTrimmed":
+      case "PositionAddedTo":
+      case "InvalidationMarked":
+        touchPosition(event.positionId, event);
+        break;
+      // Everything else — `PriceMarked` above all — targets an instrument or a
+      // Reserve, never a position. Marking a price must not date a position: the feed
+      // marks daily, so scanning it would seal every position holding that instrument
+      // behind today for a reason having nothing to do with the position.
+      default:
+        break;
     }
   }
 
@@ -334,6 +408,7 @@ export function buildEventReference(
     genesisAsOf,
     closedPositionIds,
     positionBornAsOf,
+    positionLastVerbAsOf,
     lastClose,
     reserveBalances,
     positionLots: new Map(

--- a/packages/engine/src/events/crossref.ts
+++ b/packages/engine/src/events/crossref.ts
@@ -747,6 +747,69 @@ function requirePositionBornBy(
 }
 
 /**
+ * A close may not SEAL BEHIND an event the log has already accepted for the same
+ * position. The death-side twin of {@link requirePositionBornBy}: birth is the earliest
+ * bound on a verb's date, this is the latest bound on a close's.
+ *
+ * THE HOLE THIS SHUTS IS INVISIBLE TO BOTH EVENTS INDIVIDUALLY. When the trim is gated
+ * the close does not exist yet; when the close is gated nothing is retired yet, so
+ * `closedPositionIds` cannot see it either. Both pass, and the fold's (`asOf`, then log)
+ * ordering then applies the close FIRST and drops every event dated after it — and the
+ * drop is UNOBSERVABLE AFTER THE FACT, because `foldEvents` has no diagnostics channel
+ * to report it on: it returns a `FundReviewData`, which carries no warnings field at
+ * all. That is ledger 18's shape, and it is exactly why this rule has to sit at INGEST.
+ * A fold that could complain would still be complaining about an event already durably
+ * logged; a fold that cannot complain leaves nothing behind to notice.
+ *
+ * Measured at 80827b6 on `[Opened 06-05, Trimmed 06-18, Closed 06-10 @ 50]`: a position
+ * that broke even reported `realizedPnlUsd: -50` at full size, because the close landed
+ * on lots the trim should have removed. The add-to case is wider still, and its damage
+ * is quieter than it first looks — the dropped add-to's funding DEBIT never fires, so
+ * the cash STAYS in the reserve and the net cash delta is 0. Nothing in the balances
+ * looks wrong. The lie is in the SIZE: the closed row reports a position of 1 against a
+ * deployment of 2, so a cash-only assertion cannot see this case at all.
+ *
+ * IT OWNS ONE HALF OF THE QUESTION, NOT TWO. Existence and birth are already answered by
+ * {@link requirePositionBornBy}, which runs ahead of it at the call site, so a MISSING
+ * map entry here is SUCCESS — a genesis-held position the log has never touched has
+ * nothing to seal behind — and never a dangling reference. That is the whole reason
+ * `positionLastVerbAsOf`'s key set is a SUBSET of `positionIds` rather than equal to it.
+ *
+ * THE COMPARISON IS STRICT, AND THAT IS LOAD-BEARING. `asOf < latest` rejects; EQUAL IS
+ * ACCEPTED. Trim-then-close on the same day is an ordinary trading sequence, and the
+ * fold sorts by (`asOf`, THEN LOG INDEX), so with equal dates the trim — earlier in the
+ * log — still applies first and the close lands on the already-reduced lots. A `<=`
+ * would refuse correct, common behavior.
+ *
+ * Returns `null` on success and never throws, matching {@link requirePositionBornBy}
+ * exactly: no error-code enum, `path` is the machine-readable half and the message the
+ * human one, and the CALLER prefixes the verb name. The message names BOTH dates and the
+ * blocking verb, so the operator can see the ordering that would have been destroyed.
+ *
+ * NO LEGACY-MIGRATION EXEMPTION, on evidence: the real durable log was scanned at 388
+ * events — 2 position-targeting, 0 backdated. No historical log can trip this rule, so
+ * an exemption would buy nothing and cost the guarantee that the rule holds everywhere.
+ */
+function requirePositionUntouchedAfter(
+  reference: EventReference,
+  positionId: string,
+  asOf: string,
+  path: string,
+): EventError | null {
+  const latest = reference.positionLastVerbAsOf.get(positionId);
+  if (latest === undefined || asOf >= latest.asOf) {
+    return null;
+  }
+  return eventError(
+    path,
+    `closes position '${positionId}' as of ${asOf}, but a ${latest.type} dated ` +
+      `${latest.asOf} has already been accepted for it. The fold applies events in date ` +
+      `order, so this close would run FIRST and that later event would vanish silently, ` +
+      `taking its cash leg with it. Date the close ${latest.asOf} or later.`,
+  );
+}
+
+/**
  * Per-Tier SUFFICIENCY for a debit, and nothing else. Returns null on success.
  * `amount` here is the cash leaving; an untiered reserve is checked against its
  * total balance, a tiered one against the named Tier's available quantity. Fails
@@ -812,6 +875,27 @@ function crossReferenceClose(
       "positionId",
       `PositionClosed targets position id '${event.positionId}', which is already closed.`,
     );
+  }
+  // THE SEAL CHECK, AND THE ONLY CALL SITE IT NEEDS. `PositionClosed` is the sole
+  // retiring verb — a trim that would remove every lot is already refused below ("a full
+  // retirement. A trim must leave the position open; use PositionClosed") — so no other
+  // verb can seal anything behind it.
+  //
+  // ORDERED AHEAD OF THE MAGNITUDE GATE, with evidence. This same batch at
+  // `proceeds: 100` was already refused before this rule, but by magnitude and for the
+  // WRONG REASON: "proceeds 100 deviate 100.0% from expected 50.00" blames the fill size
+  // when the fill was honest and the ORDERING was the defect. Checking the seal first
+  // replaces an accidental rejection carrying a misleading reason with a deliberate one
+  // carrying the real reason, and makes the interaction disappear rather than requiring
+  // anyone to reason about it. Behind born-by, which answers existence for it.
+  const untouched = requirePositionUntouchedAfter(
+    reference,
+    event.positionId,
+    event.asOf,
+    "positionId",
+  );
+  if (untouched) {
+    return { ...untouched, message: `PositionClosed ${untouched.message}` };
   }
   const settlesInto = requireReserveBornBy(
     reference,

--- a/packages/engine/src/events/crossref.ts
+++ b/packages/engine/src/events/crossref.ts
@@ -177,10 +177,21 @@ export interface EventReference {
    * latest date at which this position was touched — rather than a set with a
    * carve-out.
    *
-   * INVARIANT: its key set is a SUBSET of {@link positionIds}, NOT equal to it —
-   * unlike `positionBornAsOf`, whose key set is exactly `positionIds`. A genesis-held
-   * position no log event has ever touched has NO entry, and that absence is the
-   * meaningful answer ("nothing to seal behind"), not a gap wanting a fallback.
+   * KEY SET: strictly SMALLER than {@link positionIds} in the direction that matters —
+   * a genesis-held position no log event has ever touched has NO entry, and that absence
+   * is the meaningful answer ("nothing to seal behind"), not a gap wanting a fallback.
+   * That is the opposite of `positionBornAsOf`, whose key set is exactly `positionIds`.
+   *
+   * IT IS NOT, HOWEVER, A GUARANTEED SUBSET, and the difference matters now that this
+   * field is on the exported {@link EventReference}. The scan keys off the event's OWN
+   * `positionId` without asking whether that id exists, so an accepted event naming an
+   * unknown position would put a DANGLING key here that `positionIds` lacks. Nothing can
+   * reach that state through the ingest path — `crossReferenceEvent` refuses an unknown
+   * position id at every position-targeting verb, so no such event is ever accepted —
+   * but `buildEventReference` is a pure function and will happily build one if handed
+   * such an event directly. The containment is therefore CALL-SITE-DEFENDED, not
+   * structural. Safe for the seal check, which runs behind `requirePositionBornBy` and
+   * never sees an unknown id; NOT something a new consumer may assume without checking.
    */
   positionLastVerbAsOf: Map<string, PositionTouch>;
   /** Latest known close per instrument: the magnitude guard's comparison point. */
@@ -266,9 +277,17 @@ export function buildEventReference(
   // about the LOG, which the fold never claimed to answer. Max, not last-write-wins:
   // the events arrive in LOG order, which is not date order.
   const positionLastVerbAsOf = new Map<string, PositionTouch>();
+  // `>=`, so among verbs sharing the max date the LAST-LOGGED one wins the type slot.
+  // Not a coin-flip: `foldEvents` sorts by (`asOf`, THEN LOG INDEX), so the last-logged
+  // of a same-dated group is the one applied LAST — the event actually sitting on top,
+  // and therefore the one a close would bury first. With `>` the message named the
+  // FIRST-logged instead: `[Trimmed 06-18, AddedTo 06-18, Closed 06-10]` blamed the
+  // trim while the add-to was the buried event carrying the unfired funding debit. No
+  // accept/reject outcome turns on this — the DATE is identical either way, and equal
+  // dates are accepted regardless — only which verb the operator is sent to look at.
   const touchPosition = (positionId: string, event: PortfolioEvent): void => {
     const latest = positionLastVerbAsOf.get(positionId);
-    if (latest === undefined || event.asOf > latest.asOf) {
+    if (latest === undefined || event.asOf >= latest.asOf) {
       positionLastVerbAsOf.set(positionId, { asOf: event.asOf, type: event.type });
     }
   };
@@ -284,12 +303,34 @@ export function buildEventReference(
       case "InvalidationMarked":
         touchPosition(event.positionId, event);
         break;
-      // Everything else — `PriceMarked` above all — targets an instrument or a
-      // Reserve, never a position. Marking a price must not date a position: the feed
+      // DELIBERATELY NOT SCANNED, and said in code rather than only in a comment.
+      // `PriceMarked` targets an INSTRUMENT and the rest target a Reserve or nothing at
+      // all; none of them dates a position. Marking a price above all must not: the feed
       // marks daily, so scanning it would seal every position holding that instrument
-      // behind today for a reason having nothing to do with the position.
-      default:
+      // behind today, for a reason having nothing to do with the position.
+      case "PriceMarked":
+      case "Deposit":
+      case "Withdraw":
+      case "Transfer":
+      case "ReserveOpened":
         break;
+      default: {
+        // EXHAUSTIVENESS LATCH, in the idiom of `fold.ts`'s and `orders/ingest.ts`'s.
+        // This switch has no return obligation, so a `default: break` let verb eleven
+        // compile clean and be silently skipped here — which would reintroduce exactly
+        // the bug this projection exists to close, since a position touched only by the
+        // new verb would look untouched and a close could seal behind it.
+        //
+        // AND THE FALSE ALL-CLEAR IS THE REAL TRAP. `crossReferenceEvent`'s dispatch
+        // has no `default`, so a new verb DOES fail to compile there. An author who
+        // adds one gets a loud error, fixes that one site, sees green, and never learns
+        // this scan needed an arm too. The `never` assignment makes verb eleven a
+        // COMPILE ERROR here as well; `pnpm typecheck` is its proof, and no test can
+        // reach this arm while the switch stays exhaustive.
+        const _never: never = event;
+        void _never;
+        break;
+      }
     }
   }
 
@@ -800,12 +841,37 @@ function requirePositionUntouchedAfter(
   if (latest === undefined || asOf >= latest.asOf) {
     return null;
   }
+  // `InvalidationMarked` is the ONE position verb with no reserve leg (see
+  // `crossReferenceInvalidation`), so the cash clause has to be conditional. Claiming a
+  // vanished cash leg on case D sends the operator hunting for a movement that never
+  // existed — and it is the branch that also decides the remedy below.
+  const movesCash = latest.type !== "InvalidationMarked";
+  const article = movesCash ? "a" : "an";
+  const loss = movesCash
+    ? `that later event would vanish silently, taking its cash leg with it`
+    : `that later event would vanish silently — the level itself, though it moves no cash`;
+  // THE REMEDY BRANCHES, AND THE REASON IS DATA CORRUPTION, not politeness. "Date the
+  // close later" is the WRONG advice whenever the close's date is the true one: a
+  // position opened 06-05, stop moved 06-20, honestly closed 06-15 would be told to
+  // write 06-20 — five days after the trade actually ended — putting a false
+  // `closedAsOf` in the durable log and a false holding period in everything downstream.
+  // The blocking event is the one that can move without lying, and when it is an
+  // invalidation it can move for FREE, because it has no settlement to re-settle. The
+  // sibling `requirePositionBornBy` branches its remedy for the same class of reason:
+  // a single-branch remedy sends the operator after something they cannot honestly do.
+  const remedy = movesCash
+    ? `If the close truly happened on ${asOf}, redate or remove the ${latest.type} ` +
+      `instead — but note its own cash leg moves with it. Only date the close ` +
+      `${latest.asOf} or later if that is genuinely when it closed.`
+    : `If the close truly happened on ${asOf}, redate or retract the ${latest.type} ` +
+      `instead — it has no cash leg, so moving it settles nothing and costs nothing. ` +
+      `Only date the close ${latest.asOf} or later if that is genuinely when it closed.`;
   return eventError(
     path,
-    `closes position '${positionId}' as of ${asOf}, but a ${latest.type} dated ` +
+    `closes position '${positionId}' as of ${asOf}, but ${article} ${latest.type} dated ` +
       `${latest.asOf} has already been accepted for it. The fold applies events in date ` +
-      `order, so this close would run FIRST and that later event would vanish silently, ` +
-      `taking its cash leg with it. Date the close ${latest.asOf} or later.`,
+      `order, so this close would run FIRST and ${loss}. ` +
+      remedy,
   );
 }
 
@@ -888,6 +954,14 @@ function crossReferenceClose(
   // replaces an accidental rejection carrying a misleading reason with a deliberate one
   // carrying the real reason, and makes the interaction disappear rather than requiring
   // anyone to reason about it. Behind born-by, which answers existence for it.
+  //
+  // IT DISPLACES `requireReserveBornBy` TOO, which is the less obvious half. A close
+  // that both seals behind a verb AND settles into a not-yet-born reserve used to report
+  // the reserve fact and now reports the seal. That follows the file's convention —
+  // position facts before reserve facts, the same order `requirePositionBornBy` already
+  // sits in — and the position fact is the more fundamental one here: the settlement leg
+  // is a detail of a close that should not exist at this date at all. Recorded because
+  // it is a real change in which message an operator sees, not only a reordering.
   const untouched = requirePositionUntouchedAfter(
     reference,
     event.positionId,

--- a/packages/engine/src/position-seal.test.ts
+++ b/packages/engine/src/position-seal.test.ts
@@ -445,3 +445,203 @@ describe("a PositionClosed may not seal behind a verb already in the log", () =>
     });
   });
 });
+
+// THE OTHER HALF OF THE RULE: what it must NOT refuse. A gate that rejects everything
+// passes every test in the block above, so these are the cases that give those their
+// meaning. Each one folds the ACCEPTED batch and asserts what the fold produced — an
+// acceptance test that only checks `rejection === null` would pass even if the close
+// silently swallowed the trim, which is the very defect this increment closes.
+describe("the seal rule refuses nothing it should not", () => {
+  // CASE 1, AND THE ONLY TEST IN THE INCREMENT THAT EXERCISES STRICTNESS. Trim and
+  // close on the SAME DAY, trim first in the log — an ordinary trading sequence. The
+  // comparison is `asOf < latest` rejects, so equal is accepted; a non-strict `<=`
+  // would refuse this batch outright and the first assertion would go red.
+  //
+  // The fold sorts by (`asOf`, THEN LOG INDEX), so the trim still applies first even at
+  // equal dates and the close lands on the already-reduced lots. That is what the
+  // `costBasisUsd: 50` below proves, and it is the load-bearing assertion here: had the
+  // trim been dropped, the full-close row would read `costBasisUsd: 100` — exactly the
+  // fabricated figure case A produces. Same-day acceptance is worth nothing if the
+  // close still buries the trim.
+  it("case 1 — accepts a same-day trim-then-close, and folds BOTH legs", () => {
+    const result = ingestBatch([
+      openLate(),
+      trimPayload("evt-trim", "2026-06-10", 0.5, 50),
+      closePayload("evt-close", "2026-06-10", 50),
+    ]);
+
+    expect(result.rejection).toBeNull();
+    // Two rows: the trim's PARTIAL and the close's FULL. Cash nets to zero — out 100 at
+    // the open, back 50 + 50.
+    expect(ledgerDelta(result.committed)).toEqual({ cash: 0, closedRows: 2 });
+
+    const folded = foldEvents(genesis(), result.committed);
+    const rows = folded.closedPositions ?? [];
+    expect(rows.map((row) => Boolean(row.partial))).toEqual([true, false]);
+    // THE ASSERTION THAT MAKES THIS TEST NON-VACUOUS: the full-close row is sized 50,
+    // not 100, so the close demonstrably ran on lots the trim had already reduced.
+    expect(rows[1]).toMatchObject({
+      positionId: "btc-late",
+      costBasisUsd: 50,
+      proceedsUsd: 50,
+      realizedPnlUsd: 0,
+    });
+    expect(rows[0]).toMatchObject({ costBasisUsd: 50, proceedsUsd: 50, realizedPnlUsd: 0 });
+    expect(folded.positions.map((position) => position.id)).toEqual(["btc-core"]);
+  });
+
+  // CASE 2 — the ordinary sequence the rule must leave completely alone. If this ever
+  // reddens, the comparison direction has been inverted.
+  it("case 2 — accepts an ordinary trim-then-later-close, unchanged", () => {
+    const result = ingestBatch([
+      openLate(),
+      trimPayload("evt-trim", "2026-06-10", 0.5, 50),
+      closePayload("evt-close", "2026-06-18", 50),
+    ]);
+
+    expect(result.rejection).toBeNull();
+    expect(ledgerDelta(result.committed)).toEqual({ cash: 0, closedRows: 2 });
+
+    const rows = foldEvents(genesis(), result.committed).closedPositions ?? [];
+    expect(rows.map((row) => row.closedAsOf)).toEqual(["2026-06-10", "2026-06-18"]);
+    expect(rows[1]).toMatchObject({ costBasisUsd: 50, realizedPnlUsd: 0 });
+  });
+
+  // CASE 3 — THE SUBSET INVARIANT, READ FROM THE CONSUMING SIDE. `btc-core` is
+  // genesis-held and no log event has ever touched it, so `positionLastVerbAsOf` has no
+  // entry for it and the helper's missing-entry branch must return SUCCESS, not a
+  // dangling reference. Slice 1 pins the absence; this pins that the absence is read as
+  // "nothing to seal behind". A helper that treated a missing entry as an error would
+  // make every genesis-held position uncloseable — the loudest possible regression, and
+  // one no rejection test in this file would catch.
+  it("case 3 — accepts a close against a genesis-held position the log never touched", () => {
+    const seed = genesis();
+    const reference = buildEventReference(seed);
+    expect(reference.positionLastVerbAsOf.has("btc-core")).toBe(false);
+
+    const result = ingestBatch([
+      {
+        id: "evt-close-core",
+        asOf: "2026-06-10",
+        type: "PositionClosed",
+        positionId: "btc-core",
+        settlement: { reserveId: "pulse-cash", proceeds: 200 },
+      },
+    ]);
+
+    expect(result.rejection).toBeNull();
+    expect(ledgerDelta(result.committed)).toEqual({ cash: 200, closedRows: 1 });
+
+    const folded = foldEvents(genesis(), result.committed);
+    expect(folded.closedPositions?.[0]).toMatchObject({
+      positionId: "btc-core",
+      costBasisUsd: 200,
+      proceedsUsd: 200,
+      realizedPnlUsd: 0,
+    });
+    expect(folded.positions).toEqual([]);
+  });
+});
+
+// FOUR GATES, ONE PATH. `positionId` is the machine-readable half of all four
+// rejections a close can draw, so the MESSAGE is the only thing distinguishing them —
+// which makes "are they actually distinguishable" a real question rather than a
+// formality. Pairwise distinctness is the assertion; four regexes each matching its own
+// message would still pass if two gates emitted the same string.
+describe("the four position-id rejections a close can draw are distinguishable", () => {
+  const rejections = () => ({
+    unknown: ingestBatch([
+      {
+        id: "evt-close-ghost",
+        asOf: "2026-06-10",
+        type: "PositionClosed",
+        positionId: "ghost",
+        settlement: { reserveId: "pulse-cash", proceeds: 100 },
+      },
+    ]).rejection,
+    // Ordered ahead of the seal check, so a close that is BOTH backdated before birth
+    // and behind an accepted verb reports the birth fact. That ordering is what this
+    // entry silently pins.
+    notBorn: ingestBatch([openLate(), closePayload("evt-close", "2026-06-03")]).rejection,
+    alreadyClosed: ingestBatch([
+      openLate(),
+      closePayload("evt-close", "2026-06-18"),
+      closePayload("evt-close-again", "2026-06-20"),
+    ]).rejection,
+    sealsBehind: ingestBatch([
+      openLate(),
+      trimPayload("evt-trim", "2026-06-18", 0.5, 50),
+      closePayload("evt-close", "2026-06-10", 50),
+    ]).rejection,
+  });
+
+  it("all four land on path 'positionId'", () => {
+    for (const rejection of Object.values(rejections())) {
+      expect(rejection?.path).toBe("positionId");
+    }
+  });
+
+  it("each says its own thing", () => {
+    const { unknown, notBorn, alreadyClosed, sealsBehind } = rejections();
+
+    expect(unknown?.message).toContain("neither the genesis seed nor the log contains");
+    expect(notBorn?.message).toContain("not born until");
+    expect(alreadyClosed?.message).toContain("already closed");
+    expect(sealsBehind?.message).toContain("has already been accepted for it");
+  });
+
+  it("and no two of them are the same string", () => {
+    const messages = Object.values(rejections()).map((rejection) => rejection?.message);
+
+    expect(new Set(messages).size).toBe(4);
+  });
+});
+
+// CASE C — A DELIBERATE OVER-REJECTION, PINNED SO THAT CHANGING IT IS A DECISION.
+// `[Opened 06-05, Closed 06-10, Trimmed 06-08]`: the trim sorts BEFORE the close and
+// would fold perfectly correctly, so refusing it is stricter than the fold requires.
+// It stays refused on purpose — relaxing it means admitting retroactive edits to a
+// closed position's history, which is a policy question about the book, not a gate bug.
+// Filed as ledger item 21. This test exists so that a future relaxation is deliberate
+// rather than drift, and it is equally a pin on the SEAL rule's reach: the seal check
+// guards closes only, so the trim must still be refused by the already-closed guard and
+// must NOT report the seal message.
+describe("case C stays refused as already-closed, deliberately (ledger 21)", () => {
+  const caseC = () => [
+    openLate(),
+    closePayload("evt-close", "2026-06-10"),
+    trimPayload("evt-trim", "2026-06-08", 0.5, 50),
+  ];
+
+  it("rejects the backdated trim with the already-closed message, not the seal one", () => {
+    const result = ingestBatch(caseC());
+
+    expect(result.rejection?.path).toBe("positionId");
+    expect(result.rejection?.message).toContain("PositionTrimmed");
+    expect(result.rejection?.message).toContain("already closed");
+    expect(result.rejection?.message).not.toContain("has already been accepted for it");
+    expect(ledgerDelta(result.committed)).toEqual({ cash: 0, closedRows: 0 });
+  });
+
+  // What today's refusal costs, stated so the ledger-21 decision can be weighed on
+  // evidence rather than intuition: these events WOULD have folded correctly.
+  it("although that trim would have folded correctly — which is why 21 is open", () => {
+    const folded = foldEvents(genesis(), caseC().map(accepted));
+    const rows = folded.closedPositions ?? [];
+
+    expect(rows.map((row) => row.closedAsOf)).toEqual(["2026-06-08", "2026-06-10"]);
+    expect(rows[1]).toMatchObject({ costBasisUsd: 50, proceedsUsd: 100, realizedPnlUsd: 50 });
+  });
+});
+
+// CASE 6 — CANARY CONFIRMATION, recorded rather than re-run. These suites already run
+// on every `pnpm test`; duplicating them here would only add a second place to update.
+// Measured green and byte-untouched with the seal check in place:
+//
+//   position-born-by.test.ts   29 tests — the seal check sits BEHIND born-by's own call,
+//                                         so any moved message or path means the
+//                                         call-site ordering is wrong.
+//   reserve-opened.test.ts     45 tests — the standing canary from the born-by increment.
+//   event-ingest.test.ts       64 tests — including the post-close guard, whose two
+//                                         `/already closed/` assertions are positive
+//                                         evidence the seal check did not pre-empt it.

--- a/packages/engine/src/position-seal.test.ts
+++ b/packages/engine/src/position-seal.test.ts
@@ -1,0 +1,278 @@
+// Ledger 20, the DEATH side: a close may not SEAL BEHIND an event already in the log.
+//
+// Two halves. `EventReference.positionLastVerbAsOf` is the projection — the latest
+// position-targeting event already accepted, per position id — and its tests are
+// STRUCTURAL, about the map's key set and its values. `requirePositionUntouchedAfter`
+// is the rule that reads it, and its tests are the three measured reproductions (A, D,
+// E) plus the ordering pin that keeps it ahead of the settlement-magnitude gate.
+//
+// Fixtures mirror `position-born-by.test.ts` (same genesis seed, same `openLate`, same
+// `accepted` helper) so the two files describe the same world from opposite ends: birth
+// is the EARLIEST bound on a verb's date, this map is the LATEST bound on a close's.
+import {
+  buildEventReference,
+  crossReferenceEvent,
+  foldEvents,
+  parseEvent,
+  type FundReviewData,
+  type PortfolioEvent,
+} from "./index.js";
+import { describe, expect, it } from "vitest";
+
+const GENESIS_AS_OF = "2026-06-01";
+/** The log-born position's own birth date. */
+const OPENED_AS_OF = "2026-06-05";
+
+/**
+ * One genesis-HELD position (`btc-core`, which the log below never touches — the
+ * population the SUBSET invariant exists for) and one funded Reserve.
+ */
+function genesis(): FundReviewData {
+  return {
+    fund: { id: "fund-1", name: "Accumulus", baseCurrency: "USD" },
+    review: { asOf: GENESIS_AS_OF, usdMxn: 20 },
+    portfolios: [{ id: "core", name: "Core" }],
+    accounts: [{ id: "bitget-usd", name: "Bitget", platform: "BITGET", currency: "USD" }],
+    instruments: [{ id: "btc-usd", name: "Bitcoin", symbol: "BTC", currency: "USD" }],
+    reserves: [
+      {
+        id: "pulse-cash",
+        portfolioId: "core",
+        tempo: "Pulse",
+        executionMode: "live",
+        accountId: "bitget-usd",
+        currency: "USD",
+        amount: 1000,
+        lots: [
+          { quantity: 600, tier: "c1" },
+          { quantity: 400, tier: "c2" },
+        ],
+      },
+    ],
+    positions: [
+      {
+        id: "btc-core",
+        portfolioId: "core",
+        tempo: "Capital",
+        executionMode: "live",
+        accountId: "bitget-usd",
+        instrumentId: "btc-usd",
+        direction: "long",
+        markPrice: 100,
+        currency: "USD",
+        lots: [{ quantity: 2, cost: 100, tier: "c1" }],
+      },
+    ],
+  };
+}
+
+/** The LOG-BORN position: `btc-late`, born 2026-06-05, one lot of 1 @ 100. */
+function openLate(overrides: Record<string, unknown> = {}): Record<string, unknown> {
+  return {
+    id: "evt-open-late",
+    asOf: OPENED_AS_OF,
+    type: "PositionOpened",
+    position: {
+      id: "btc-late",
+      portfolioId: "core",
+      tempo: "Capital",
+      executionMode: "live",
+      accountId: "bitget-usd",
+      instrumentId: "btc-usd",
+      direction: "long",
+      currency: "USD",
+      lots: [{ quantity: 1, cost: 100, tier: "c1" }],
+    },
+    decision: {
+      entryThesis: "thesis",
+      invalidationCondition: "invalidation",
+      riskBudget: "1R",
+      plannedHoldingHorizon: "weeks",
+      strategy: "trend",
+    },
+    funding: { reserveId: "pulse-cash", amount: 100 },
+    ...overrides,
+  };
+}
+
+/** parseEvent, asserting success, so a test can hand the typed event onward. */
+function accepted(input: Record<string, unknown>): PortfolioEvent {
+  const result = parseEvent(input);
+  if (result.kind !== "ok") {
+    throw new Error(`expected parse to accept: ${result.path}: ${result.message}`);
+  }
+  return result.value;
+}
+
+// RAW payloads, so the same fixtures feed both the structural tests (which build the
+// reference from parsed events directly) and the `ingestBatch` harness (which must
+// parse them itself, exactly as the real ingest path does).
+const trimPayload = (
+  id: string,
+  asOf: string,
+  quantity = 0.25,
+  proceeds = 25,
+): Record<string, unknown> => ({
+  id,
+  asOf,
+  type: "PositionTrimmed",
+  positionId: "btc-late",
+  removals: [{ quantity, tier: "c1" }],
+  settlement: { reserveId: "pulse-cash", proceeds },
+});
+
+const addToPayload = (id: string, asOf: string): Record<string, unknown> => ({
+  id,
+  asOf,
+  type: "PositionAddedTo",
+  positionId: "btc-late",
+  lot: { quantity: 1, cost: 100, tier: "c1" },
+  funding: { reserveId: "pulse-cash", amount: 100 },
+});
+
+const invalidatePayload = (id: string, asOf: string): Record<string, unknown> => ({
+  id,
+  asOf,
+  type: "InvalidationMarked",
+  positionId: "btc-late",
+  price: 80,
+  direction: "below",
+});
+
+const closePayload = (id: string, asOf: string, proceeds = 100): Record<string, unknown> => ({
+  id,
+  asOf,
+  type: "PositionClosed",
+  positionId: "btc-late",
+  settlement: { reserveId: "pulse-cash", proceeds },
+});
+
+const trimLate = (id: string, asOf: string): PortfolioEvent => accepted(trimPayload(id, asOf));
+const addToLate = (id: string, asOf: string): PortfolioEvent => accepted(addToPayload(id, asOf));
+const invalidateLate = (id: string, asOf: string): PortfolioEvent =>
+  accepted(invalidatePayload(id, asOf));
+const closeLate = (id: string, asOf: string): PortfolioEvent => accepted(closePayload(id, asOf));
+
+const markBtc = (id: string, asOf: string): PortfolioEvent =>
+  accepted({ id, asOf, type: "PriceMarked", instrumentId: "btc-usd", price: 110 });
+const keysOf = (reference: ReturnType<typeof buildEventReference>): string[] =>
+  [...reference.positionLastVerbAsOf.keys()].sort();
+
+/**
+ * THE INVARIANT THAT DISTINGUISHES THIS MAP FROM `positionBornAsOf`, whose key set is
+ * EXACTLY `positionIds`. Here it is a SUBSET: a position the log has never touched has
+ * no entry, and that absence is the meaningful answer — "nothing to seal behind" — not
+ * a gap to be filled with a fallback.
+ */
+function expectSubsetOfPositionIds(reference: ReturnType<typeof buildEventReference>): void {
+  for (const id of reference.positionLastVerbAsOf.keys()) {
+    expect(reference.positionIds.has(id)).toBe(true);
+  }
+}
+
+describe("positionLastVerbAsOf carries the latest verb date per position", () => {
+  describe("its key set is a SUBSET of positionIds, not equal to it", () => {
+    it("is EMPTY at genesis, though positionIds is not", () => {
+      const reference = buildEventReference(genesis());
+
+      expect(reference.positionIds.has("btc-core")).toBe(true);
+      expect(keysOf(reference)).toEqual([]);
+      expectSubsetOfPositionIds(reference);
+    });
+
+    it("leaves a genesis-held position the log never touched with NO entry", () => {
+      const reference = buildEventReference(genesis(), [
+        accepted(openLate()),
+        trimLate("evt-trim", "2026-06-12"),
+      ]);
+
+      expect(reference.positionIds.has("btc-core")).toBe(true);
+      expect(reference.positionLastVerbAsOf.has("btc-core")).toBe(false);
+      expect(keysOf(reference)).toEqual(["btc-late"]);
+      expectSubsetOfPositionIds(reference);
+    });
+
+    it("gains a genesis-held position only once a verb targets it", () => {
+      const reference = buildEventReference(genesis(), [
+        accepted({
+          id: "evt-invalidate-core",
+          asOf: "2026-06-09",
+          type: "InvalidationMarked",
+          positionId: "btc-core",
+          price: 80,
+          direction: "below",
+        }),
+      ]);
+
+      expect(reference.positionLastVerbAsOf.get("btc-core")?.asOf).toBe("2026-06-09");
+      expectSubsetOfPositionIds(reference);
+    });
+  });
+
+  describe("each value is the MAX asOf across that position's position-targeting events", () => {
+    it("counts the open itself — a freshly opened position is dated to its birth", () => {
+      const reference = buildEventReference(genesis(), [accepted(openLate())]);
+
+      expect(reference.positionLastVerbAsOf.get("btc-late")?.asOf).toBe(OPENED_AS_OF);
+    });
+
+    it("takes the max across all five verbs, not the last one in the log", () => {
+      // The invalidation is the LATEST by date but NOT last in the log: a
+      // last-write-wins scan would answer 06-12 and the seal rule would then admit a
+      // close that buries the level.
+      const reference = buildEventReference(genesis(), [
+        accepted(openLate()),
+        addToLate("evt-add", "2026-06-08"),
+        invalidateLate("evt-invalidate", "2026-06-20"),
+        trimLate("evt-trim", "2026-06-12"),
+      ]);
+
+      expect(reference.positionLastVerbAsOf.get("btc-late")?.asOf).toBe("2026-06-20");
+    });
+
+    it("counts a close, so a retired position is still dated", () => {
+      const reference = buildEventReference(genesis(), [
+        accepted(openLate()),
+        trimLate("evt-trim", "2026-06-12"),
+        closeLate("evt-close", "2026-06-18"),
+      ]);
+
+      expect(reference.closedPositionIds.has("btc-late")).toBe(true);
+      expect(reference.positionLastVerbAsOf.get("btc-late")?.asOf).toBe("2026-06-18");
+      expectSubsetOfPositionIds(reference);
+    });
+
+    it("keeps each position's max independent of the others", () => {
+      const reference = buildEventReference(genesis(), [
+        accepted(openLate()),
+        trimLate("evt-trim", "2026-06-12"),
+        accepted({
+          id: "evt-invalidate-core",
+          asOf: "2026-06-25",
+          type: "InvalidationMarked",
+          positionId: "btc-core",
+          price: 80,
+          direction: "below",
+        }),
+      ]);
+
+      expect(reference.positionLastVerbAsOf.get("btc-late")?.asOf).toBe("2026-06-12");
+      expect(reference.positionLastVerbAsOf.get("btc-core")?.asOf).toBe("2026-06-25");
+    });
+  });
+
+  // `PriceMarked` targets an INSTRUMENT, not a position. Scanning it would date every
+  // position holding that instrument to the last mark — and since the price feed marks
+  // daily, that would seal every position behind today, refusing ordinary backdated
+  // bookkeeping for a reason that has nothing to do with the position.
+  it("does not advance on a PriceMarked", () => {
+    const reference = buildEventReference(genesis(), [
+      accepted(openLate()),
+      trimLate("evt-trim", "2026-06-12"),
+      markBtc("evt-mark", "2026-06-30"),
+    ]);
+
+    expect(reference.positionLastVerbAsOf.get("btc-late")?.asOf).toBe("2026-06-12");
+    expect(keysOf(reference)).toEqual(["btc-late"]);
+  });
+});

--- a/packages/engine/src/position-seal.test.ts
+++ b/packages/engine/src/position-seal.test.ts
@@ -155,6 +155,64 @@ const closeLate = (id: string, asOf: string): PortfolioEvent => accepted(closePa
 
 const markBtc = (id: string, asOf: string): PortfolioEvent =>
   accepted({ id, asOf, type: "PriceMarked", instrumentId: "btc-usd", price: 110 });
+
+/**
+ * The ingest contract in miniature, copied from `position-born-by.test.ts`: parse then
+ * cross-reference each event in LOG order, rebuilding the reference from genesis +
+ * everything committed so far (ADR-015), and ABORT THE WHOLE BATCH on the first
+ * rejection. All-or-nothing — which is what makes the delta assertions below meaningful.
+ */
+function ingestBatch(
+  inputs: Record<string, unknown>[],
+  seed: FundReviewData = genesis(),
+): { committed: PortfolioEvent[]; rejection: { path: string; message: string } | null } {
+  const committed: PortfolioEvent[] = [];
+  for (const input of inputs) {
+    const parsed = parseEvent(input);
+    if (parsed.kind !== "ok") {
+      return { committed: [], rejection: { path: parsed.path, message: parsed.message } };
+    }
+    const checked = crossReferenceEvent(parsed.value, buildEventReference(seed, committed));
+    if (checked.kind !== "ok") {
+      return { committed: [], rejection: { path: checked.path, message: checked.message } };
+    }
+    committed.push(parsed.value);
+  }
+  return { committed, rejection: null };
+}
+
+const totalCash = (fund: FundReviewData): number =>
+  fund.reserves.reduce((sum, reserve) => sum + reserve.amount, 0);
+
+/**
+ * Z2: assert the DELTA, never the resting state. A test that asserts absolute balances
+ * passes this bug vacuously — the whole defect is that the batch was accepted and the
+ * numbers moved. Folds `genesis + committed` against `genesis + nothing`.
+ */
+function ledgerDelta(committed: PortfolioEvent[]): { cash: number; closedRows: number } {
+  const before = foldEvents(genesis(), []);
+  const after = foldEvents(genesis(), committed);
+  return {
+    cash: totalCash(after) - totalCash(before),
+    closedRows: (after.closedPositions?.length ?? 0) - (before.closedPositions?.length ?? 0),
+  };
+}
+
+/** Every seal rejection must name BOTH dates and the verb it would have buried. */
+function expectSealRejection(
+  rejection: { path: string; message: string } | null,
+  blockedAsOf: string,
+  latestAsOf: string,
+  verb: string,
+): void {
+  expect(rejection).not.toBeNull();
+  expect(rejection?.path).toBe("positionId");
+  expect(rejection?.message).toContain("PositionClosed");
+  expect(rejection?.message).toContain(blockedAsOf);
+  expect(rejection?.message).toContain(latestAsOf);
+  expect(rejection?.message).toContain(verb);
+}
+
 const keysOf = (reference: ReturnType<typeof buildEventReference>): string[] =>
   [...reference.positionLastVerbAsOf.keys()].sort();
 
@@ -274,5 +332,116 @@ describe("positionLastVerbAsOf carries the latest verb date per position", () =>
 
     expect(reference.positionLastVerbAsOf.get("btc-late")?.asOf).toBe("2026-06-12");
     expect(keysOf(reference)).toEqual(["btc-late"]);
+  });
+});
+
+// THE RULE ITSELF. Neither event can see the problem when it is judged: when the trim
+// is gated the close does not exist yet, and when the close is gated nothing is retired
+// yet. Both passed, and the fold's (`asOf`, then log) ordering then applied the close
+// first and dropped everything dated after it — silently, `warnings: []`.
+describe("a PositionClosed may not seal behind a verb already in the log", () => {
+  // CASE A, THE TRACER — and the only one that writes a WRONG NUMBER rather than merely
+  // dropping a leg. Open 1 @ 100, trim half for 50, close the rest for 50: a position
+  // that broke even. With the close sorted first it lands on the FULL lots.
+  describe("case A — a trim, and a close dated before it", () => {
+    const batch = (proceeds = 50) => [
+      openLate(),
+      trimPayload("evt-trim", "2026-06-18", 0.5, 50),
+      closePayload("evt-close", "2026-06-10", proceeds),
+    ];
+
+    it("is rejected, naming both dates and the trim, with nothing committed", () => {
+      const result = ingestBatch(batch());
+
+      expectSealRejection(result.rejection, "2026-06-10", "2026-06-18", "PositionTrimmed");
+      expect(result.committed).toEqual([]);
+      expect(ledgerDelta(result.committed)).toEqual({ cash: 0, closedRows: 0 });
+    });
+
+    // THE PRE-FIX DAMAGE, PINNED. Folded WITHOUT the gate — which is exactly what the
+    // durable log held before this rule — the same three events report a fabricated $50
+    // realized LOSS at full size on a position that broke even, and take $50 of cash
+    // with them. Measured at 80827b6. This is the number the gate exists to make
+    // unreachable; if the rule regresses, the assertion above goes green-to-red against
+    // these very figures.
+    it("would fabricate a realized loss if those events ever reached the fold", () => {
+      const folded = foldEvents(genesis(), batch().map(accepted));
+
+      expect(ledgerDelta(batch().map(accepted))).toEqual({ cash: -50, closedRows: 1 });
+      expect(folded.closedPositions?.[0]).toMatchObject({
+        positionId: "btc-late",
+        costBasisUsd: 100,
+        proceedsUsd: 50,
+        realizedPnlUsd: -50,
+      });
+      // And nothing anywhere says so: `foldEvents` has NO diagnostics channel to say it
+      // with (ledger 18, deliberately out of scope here), which is precisely why the
+      // rule has to live at INGEST rather than as a warning after the fact.
+    });
+
+    // CASE 4 — THE MAGNITUDE ACCIDENT, RE-POINTED. This same batch at `proceeds: 100`
+    // was already refused before this rule, but by the settlement-magnitude gate, and
+    // for the WRONG REASON: "proceeds 100 deviate 100.0% from expected 50.00" blames the
+    // fill size when the fill was honest and the ORDERING was the defect. The seal check
+    // sits AHEAD of magnitude, so the message must no longer mention the deviation. THIS
+    // IS THE TEST THAT PINS THE CALL-SITE ORDER — it reddens if the check lands after
+    // the magnitude gate.
+    it("is refused by the SEAL rule, not the magnitude gate, at proceeds 100", () => {
+      const result = ingestBatch(batch(100));
+
+      expectSealRejection(result.rejection, "2026-06-10", "2026-06-18", "PositionTrimmed");
+      expect(result.rejection?.message).not.toContain("deviate");
+      expect(result.rejection?.path).not.toBe("settlement.proceeds");
+    });
+  });
+
+  // CASE D — the verb the FOLD can never date. `InvalidationLevel` carries no `asOf`,
+  // so no fold-only projection could have caught this one; the level simply vanished.
+  it("case D — rejects a close dated before an accepted InvalidationMarked", () => {
+    const result = ingestBatch([
+      openLate(),
+      invalidatePayload("evt-invalidate", "2026-06-20"),
+      closePayload("evt-close", "2026-06-10"),
+    ]);
+
+    expectSealRejection(result.rejection, "2026-06-10", "2026-06-20", "InvalidationMarked");
+    expect(result.committed).toEqual([]);
+    expect(ledgerDelta(result.committed)).toEqual({ cash: 0, closedRows: 0 });
+  });
+
+  // CASE E, THE WIDEST — the case where MONEY moves against the operator's belief. The
+  // add-to is dropped whole, so its $100 funding DEBIT never fires: the operator thinks
+  // $100 was deployed into the position, and the book shows it in neither the position's
+  // lots nor as a debit against the reserve. Measured at 80827b6: cash delta 0 across
+  // open + add + close, and a closed row sized 1 rather than 2.
+  describe("case E — an add-to, and a close dated before it", () => {
+    const batch = () => [
+      openLate(),
+      addToPayload("evt-add", "2026-06-18"),
+      closePayload("evt-close", "2026-06-10"),
+    ];
+
+    it("is rejected, with the funding debit delta at zero", () => {
+      const result = ingestBatch(batch());
+
+      expectSealRejection(result.rejection, "2026-06-10", "2026-06-18", "PositionAddedTo");
+      expect(result.committed).toEqual([]);
+      expect(ledgerDelta(result.committed)).toEqual({ cash: 0, closedRows: 0 });
+    });
+
+    // The pre-fix damage, and why a cash-delta assertion ALONE cannot see it: the
+    // unfolded batch also nets to a cash delta of 0, because the $100 debit that should
+    // have fired never did. The lie is in the SIZE of what was closed.
+    it("would drop the add-to whole — its debit unfired, its lot unclosed", () => {
+      const folded = foldEvents(genesis(), batch().map(accepted));
+
+      expect(ledgerDelta(batch().map(accepted))).toEqual({ cash: 0, closedRows: 1 });
+      expect(folded.closedPositions?.[0]).toMatchObject({
+        positionId: "btc-late",
+        costBasisUsd: 100,
+        proceedsUsd: 100,
+      });
+      expect(folded.positions.map((position) => position.id)).toEqual(["btc-core"]);
+    });
   });
 });

--- a/packages/engine/src/position-seal.test.ts
+++ b/packages/engine/src/position-seal.test.ts
@@ -198,7 +198,39 @@ function ledgerDelta(committed: PortfolioEvent[]): { cash: number; closedRows: n
   };
 }
 
-/** Every seal rejection must name BOTH dates and the verb it would have buried. */
+/**
+ * WHAT THE GATE ACTUALLY PREVENTED, as a number: fold the events the gate LET THROUGH,
+ * fold the same batch with the gate bypassed entirely, and return the difference.
+ *
+ * This is the assertion with teeth, and the reason the obvious one has none. Asserting
+ * `ledgerDelta(result.committed)` is `{0, 0}` on a rejection proves nothing: the harness
+ * returns `committed: []` on any rejection, so that is `ledgerDelta([])` — zero for every
+ * possible implementation of `foldEvents`, already implied by asserting `committed` is
+ * empty, and unreachable anyway because the rejection assertion throws first. The
+ * counterfactual is what carries the meaning, and it must be JOINED to the gated result
+ * rather than measured beside it: if the rule regresses, the gate lets everything
+ * through, gated equals ungated, and this difference collapses to zero — red, against
+ * the exact figures the damage is worth.
+ */
+function damagePrevented(
+  inputs: Record<string, unknown>[],
+  committed: PortfolioEvent[],
+): { cash: number; closedRows: number } {
+  const gated = ledgerDelta(committed);
+  const ungated = ledgerDelta(inputs.map(accepted));
+  return {
+    cash: ungated.cash - gated.cash,
+    closedRows: ungated.closedRows - gated.closedRows,
+  };
+}
+
+/**
+ * Every seal rejection must name both dates AND BIND EACH TO ITS ROLE. Bare `toContain`
+ * on each date is order-blind: a message that swapped them — "your close as of 06-18 is
+ * blocked by a trim dated 06-10, date the close 06-10 or later" — would pass while
+ * instructing the operator to use the very date being rejected. The composed substrings
+ * below are what make the two dates non-interchangeable.
+ */
 function expectSealRejection(
   rejection: { path: string; message: string } | null,
   blockedAsOf: string,
@@ -207,10 +239,9 @@ function expectSealRejection(
 ): void {
   expect(rejection).not.toBeNull();
   expect(rejection?.path).toBe("positionId");
-  expect(rejection?.message).toContain("PositionClosed");
-  expect(rejection?.message).toContain(blockedAsOf);
-  expect(rejection?.message).toContain(latestAsOf);
-  expect(rejection?.message).toContain(verb);
+  expect(rejection?.message).toContain("PositionClosed closes position");
+  expect(rejection?.message).toContain(`as of ${blockedAsOf}`);
+  expect(rejection?.message).toContain(`${verb} dated ${latestAsOf}`);
 }
 
 const keysOf = (reference: ReturnType<typeof buildEventReference>): string[] =>
@@ -355,15 +386,20 @@ describe("a PositionClosed may not seal behind a verb already in the log", () =>
 
       expectSealRejection(result.rejection, "2026-06-10", "2026-06-18", "PositionTrimmed");
       expect(result.committed).toEqual([]);
-      expect(ledgerDelta(result.committed)).toEqual({ cash: 0, closedRows: 0 });
+      // What the gate PREVENTED, joined to what it did: $50 of cash and one fabricated
+      // closed row. Collapses to `{0, 0}` — red — if the rule ever stops rejecting.
+      expect(damagePrevented(batch(), result.committed)).toEqual({ cash: -50, closedRows: 1 });
     });
 
-    // THE PRE-FIX DAMAGE, PINNED. Folded WITHOUT the gate — which is exactly what the
-    // durable log held before this rule — the same three events report a fabricated $50
-    // realized LOSS at full size on a position that broke even, and take $50 of cash
-    // with them. Measured at 80827b6. This is the number the gate exists to make
-    // unreachable; if the rule regresses, the assertion above goes green-to-red against
-    // these very figures.
+    // THE SHAPE OF THAT DAMAGE, spelled out. Folded WITHOUT the gate — which is exactly
+    // what the durable log held before this rule — the same three events report a
+    // fabricated $50 realized LOSS at full size on a position that broke even. Measured
+    // at 80827b6.
+    //
+    // THIS TEST DOES NOT GUARD THE RULE, and an earlier comment here claimed it did.
+    // `crossReferenceEvent` is nowhere in its path, so every mutation that destroys the
+    // seal check leaves it green. It documents the figures; the `damagePrevented`
+    // assertion above is what reddens.
     it("would fabricate a realized loss if those events ever reached the fold", () => {
       const folded = foldEvents(genesis(), batch().map(accepted));
 
@@ -398,15 +434,19 @@ describe("a PositionClosed may not seal behind a verb already in the log", () =>
   // CASE D — the verb the FOLD can never date. `InvalidationLevel` carries no `asOf`,
   // so no fold-only projection could have caught this one; the level simply vanished.
   it("case D — rejects a close dated before an accepted InvalidationMarked", () => {
-    const result = ingestBatch([
+    const batch = [
       openLate(),
       invalidatePayload("evt-invalidate", "2026-06-20"),
       closePayload("evt-close", "2026-06-10"),
-    ]);
+    ];
+    const result = ingestBatch(batch);
 
     expectSealRejection(result.rejection, "2026-06-10", "2026-06-20", "InvalidationMarked");
     expect(result.committed).toEqual([]);
-    expect(ledgerDelta(result.committed)).toEqual({ cash: 0, closedRows: 0 });
+    // The prevented damage is a closed row, and NO cash — an invalidation has no reserve
+    // leg, which is exactly why the message must not claim a vanished cash leg here.
+    expect(damagePrevented(batch, result.committed)).toEqual({ cash: 0, closedRows: 1 });
+    expect(result.rejection?.message).not.toContain("taking its cash leg");
   });
 
   // CASE E, THE WIDEST — the case where MONEY moves against the operator's belief. The
@@ -426,7 +466,10 @@ describe("a PositionClosed may not seal behind a verb already in the log", () =>
 
       expectSealRejection(result.rejection, "2026-06-10", "2026-06-18", "PositionAddedTo");
       expect(result.committed).toEqual([]);
-      expect(ledgerDelta(result.committed)).toEqual({ cash: 0, closedRows: 0 });
+      // Cash nets to zero even UNGATED, because the debit that should have fired never
+      // did — so the prevented damage shows up only as the bogus closed row. This is the
+      // case that proves a cash-only assertion is not enough.
+      expect(damagePrevented(batch(), result.committed)).toEqual({ cash: 0, closedRows: 1 });
     });
 
     // The pre-fix damage, and why a cash-delta assertion ALONE cannot see it: the
@@ -563,10 +606,14 @@ describe("the four position-id rejections a close can draw are distinguishable",
     // and behind an accepted verb reports the birth fact. That ordering is what this
     // entry silently pins.
     notBorn: ingestBatch([openLate(), closePayload("evt-close", "2026-06-03")]).rejection,
+    // DATED BEFORE THE FIRST CLOSE, DELIBERATELY. A second close dated LATER is the one
+    // date where already-closed and the seal check AGREE on rejecting, so it pins
+    // nothing about their order; backdating it makes the two gates disagree, and the
+    // already-closed message is the one that must win. See the ordering test below.
     alreadyClosed: ingestBatch([
       openLate(),
       closePayload("evt-close", "2026-06-18"),
-      closePayload("evt-close-again", "2026-06-20"),
+      closePayload("evt-close-again", "2026-06-08"),
     ]).rejection,
     sealsBehind: ingestBatch([
       openLate(),
@@ -595,6 +642,103 @@ describe("the four position-id rejections a close can draw are distinguishable",
 
     expect(new Set(messages).size).toBe(4);
   });
+
+  // THE ONE GATE BOUNDARY NOTHING ELSE PINS. Its siblings are already guarded — moving
+  // the seal check ahead of `requirePositionBornBy` reddens five tests, moving it behind
+  // the magnitude gate reddens one — but seal-vs-already-closed was free to swap, because
+  // the only fixture exercising it used a second close dated LATER, where both orderings
+  // reject alike. Backdated, they disagree: already-closed must still win, because "this
+  // position is retired" is the more fundamental fact and the one the operator can act
+  // on. Under a reorder this test reports the seal message instead.
+  it("a second close dated BEFORE the first reports already-closed, not the seal", () => {
+    const result = ingestBatch([
+      openLate(),
+      closePayload("evt-close", "2026-06-18"),
+      closePayload("evt-close-again", "2026-06-08"),
+    ]);
+
+    expect(result.rejection?.path).toBe("positionId");
+    expect(result.rejection?.message).toContain("already closed");
+    expect(result.rejection?.message).not.toContain("has already been accepted for it");
+  });
+});
+
+// WHICH POSITION THE RULE IS ABOUT. The map is keyed by position id and the helper looks
+// up ONE key; a helper that ignored its `positionId` argument and took a global maximum
+// over every value would have passed the entire suite before this test existed. The
+// consequence is not subtle — every position becomes uncloseable the moment ANY other
+// position has a later verb, and the rejection cites a trim on an unrelated instrument.
+//
+// The suite had both halves and never joined them: one test reads the map without
+// running the rule, another runs the rule against a map with no entry for the target.
+// This is the join — two positions, BOTH with entries, and only one of them relevant.
+describe("the rule reads the CLOSING position's history, not the log's", () => {
+  const twoPositions = () => [
+    openLate(),
+    invalidatePayload("evt-invalidate-core", "2026-06-08"),
+    trimPayload("evt-trim-late", "2026-06-18", 0.5, 50),
+  ];
+
+  it("accepts a close whose own position is untouched after it, though another is not", () => {
+    // `btc-core` was last touched 06-08 and closes 06-10 — fine on its own history.
+    // `btc-late` was trimmed 06-18, LATER than that close, and is nobody's business here.
+    const batch = [
+      ...twoPositions(),
+      {
+        id: "evt-close-core",
+        asOf: "2026-06-10",
+        type: "PositionClosed",
+        positionId: "btc-core",
+        settlement: { reserveId: "pulse-cash", proceeds: 200 },
+      },
+    ];
+    const result = ingestBatch(batch);
+
+    // Both positions really do have entries — otherwise this proves nothing.
+    const reference = buildEventReference(genesis(), result.committed);
+    expect(reference.positionLastVerbAsOf.get("btc-late")?.asOf).toBe("2026-06-18");
+    expect(reference.positionLastVerbAsOf.get("btc-core")?.asOf).toBe("2026-06-10");
+
+    expect(result.rejection).toBeNull();
+    expect(result.committed).toHaveLength(4);
+  });
+
+  it("still rejects when the closing position's OWN history is the later one", () => {
+    // Same two-position world, but now the seal-breaking close targets `btc-late`, whose
+    // own trim is the blocker. Proves the acceptance above is about WHOSE history it
+    // read, not about the rule having gone quiet in a crowded log.
+    const result = ingestBatch([...twoPositions(), closePayload("evt-close", "2026-06-10", 50)]);
+
+    expectSealRejection(result.rejection, "2026-06-10", "2026-06-18", "PositionTrimmed");
+  });
+});
+
+// THE TIE-BREAK, WHICH ONLY THE MESSAGE CAN SEE. Two verbs share the max date, so the
+// date — and therefore every accept/reject verdict — is identical whichever wins the
+// type slot. What changes is which verb the operator is sent to look at, and `foldEvents`
+// sorts by (`asOf`, THEN LOG INDEX), so the LAST-logged of a same-dated group is the one
+// applied last: the event actually sitting on top, and the first thing a close buries.
+// Under `>` instead of `>=` the FIRST-logged kept the slot and this batch blamed the
+// trim while the add-to — the one carrying the unfired funding debit — was the casualty.
+it("names the LAST-logged verb when two share the latest date", () => {
+  const batch = [
+    openLate(),
+    trimPayload("evt-trim", "2026-06-18", 0.5, 50),
+    addToPayload("evt-add", "2026-06-18"),
+    closePayload("evt-close", "2026-06-10", 100),
+  ];
+  const reference = buildEventReference(genesis(), batch.slice(0, 3).map(accepted));
+
+  expect(reference.positionLastVerbAsOf.get("btc-late")).toEqual({
+    asOf: "2026-06-18",
+    type: "PositionAddedTo",
+  });
+  expectSealRejection(
+    ingestBatch(batch).rejection,
+    "2026-06-10",
+    "2026-06-18",
+    "PositionAddedTo",
+  );
 });
 
 // CASE C — A DELIBERATE OVER-REJECTION, PINNED SO THAT CHANGING IT IS A DECISION.
@@ -620,7 +764,7 @@ describe("case C stays refused as already-closed, deliberately (ledger 21)", () 
     expect(result.rejection?.message).toContain("PositionTrimmed");
     expect(result.rejection?.message).toContain("already closed");
     expect(result.rejection?.message).not.toContain("has already been accepted for it");
-    expect(ledgerDelta(result.committed)).toEqual({ cash: 0, closedRows: 0 });
+    expect(result.committed).toEqual([]);
   });
 
   // What today's refusal costs, stated so the ledger-21 decision can be weighed on


### PR DESCRIPTION
## The bug

A `PositionClosed` dated before an already-accepted verb for the same position was
silently accepted. The fold orders events by `(asOf, then log index)`, so a backdated
close applied first, and the later event just vanished — no error, no warning, nothing
downstream to notice. On the measured tracer (`[Opened 06-05, Trimmed 06-18, Closed
06-10 @ 50]`), that fabricated `realizedPnlUsd: -50` on a position that actually broke
even.

## What this adds

- `positionLastVerbAsOf` on `EventReference`: for every position id the log has
  touched, the latest `asOf` among the five position-targeting verbs
  (`PositionOpened`, `PositionClosed`, `PositionTrimmed`, `PositionAddedTo`,
  `InvalidationMarked`). `PriceMarked` targets an instrument, not a position, and is
  excluded.
- `requirePositionUntouchedAfter`, called from `crossReferenceClose` ahead of the
  settlement-magnitude gate: a close may not date itself before the latest verb the
  log has already accepted for that position.

Closes #258
Closes #259
Closes #260
Closes #257

## Deviations from the published spec (read before reviewing)

**1. Contract deviation.** #257 S1 and #258 both specify
`positionLastVerbAsOf: Map<string, string>`. Shipped as `Map<string, PositionTouch>`
where `PositionTouch = { asOf, type }`. Reason: #257 contradicts itself — S3 requires
the rejection message to name the blocking verb, which a bare date string cannot do.
Widening the value keeps the two halves in one record so they cannot disagree about
which event they describe; the alternative, a parallel `positionLastVerbType` map, can
drift. The subset invariant and max semantics are unchanged. The issue text is stale on
this point.

**2. Two corrections to #257's prose, both measured.**
- `foldEvents` returns `FundReviewData` and has NO `warnings` field, so the spec's
  "under `warnings: []`" is not real — the fold has no diagnostics channel to warn on
  at all, which is ledger 18's shape and precisely why this rule sits at ingest.
- Case E's damage is not "$100 in neither reserve nor position": the funding debit
  never fires, so the cash STAYS in the reserve and net cash delta is 0. The actual lie
  is a closed row reporting size 1 against a size-2 deployment, which is why a
  cash-only assertion is blind to case E.

**3. Evidence the rule is exercised, not just present.** The strict comparison was
verified by mutation — flipping `asOf >= latest.asOf` to `>` (making equal dates
reject) reddens TWO tests, not one as an earlier draft of this description claimed:
this file's same-day trim-then-close acceptance, and `position-born-by.test.ts`'s
"PositionClosed dated ON the birth date itself". The second is a free independent
canary in an unrelated file and strengthens the claim rather than weakening it. Then
reverted with an identical file hash.

**4. Test counts.** 1512 → 1538 passed, 19 skipped throughout. Canaries green and
byte-untouched: `position-born-by.test.ts` 29, `reserve-opened.test.ts` 45,
`event-ingest.test.ts` 64. No change to `EVENT_SCHEMA_VERSION`, no persisted record
shape change, no `events.jsonl` migration.

## Review round

Three read-only reviewers, each on a distinct lens: gate ordering and messages, test
vacuity, and the `priorEvents` scan. The gate logic itself came through with no
findings — ordering, comparison direction, missing-entry-is-success, and verb-set
completeness were all re-read independently against `types.ts` (ten verbs total,
exactly five position-targeting, no sixth), plus a measured cost check: the scan is
0.5% of `buildEventReference` at L=50k, and its share shrinks as L grows. Every
finding landed on the message surface or on test vacuity instead.

29 mutations were run against the whole engine suite; four killed nothing. Each of
those four is fixed and pinned in commit 5 (`test(engine): kill the mutations the seal
suite let through`):

- the tautological delta assertion (`ledgerDelta(result.committed)` after a rejection
  is `ledgerDelta([])`, zero for any implementation) — replaced with `damagePrevented`
- `expectSealRejection`'s order-blind date matching — now binds each date to its role
- the already-closed fixture's unpinned ordering against the seal check — re-pointed to
  a second close dated BEFORE the first, the only shape where the two gates disagree
- the missing wrong-position and tie-break coverage — new tests added

**Known, deliberate residuals, recorded rather than hidden:**
- `damagePrevented` is weaker on case D than on case A: a vanished invalidation LEVEL
  is invisible to a cash-and-closed-rows delta, so what it proves for D is that the
  bogus closed row was prevented, not that the level itself is accounted for.
- The second wrong-position test (`"still rejects when the closing position's OWN
  history is the later one"`) is a control that passes under the mutation, not a
  killer in its own right — its job is to rule out "the rule went quiet," not to catch
  a specific mutant.
- The two pre-fix damage-pin tests still cannot redden by construction: they call
  `foldEvents` directly and never touch `crossReferenceEvent`, so no mutation of the
  gate can reach them. They are kept as documentation of the measured figures, with a
  corrected comment saying so rather than implying they guard the rule.

