### PR TITLE
docs: reconcile docs sweep + bump to v0.8.0

### DIFF
--- a/apps/price-feed/package.json
+++ b/apps/price-feed/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@numisma/price-feed",
-  "version": "0.7.5",
+  "version": "0.8.0",
   "private": true,
   "type": "module",
   "exports": {

--- a/apps/tui/package.json
+++ b/apps/tui/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@numisma/tui",
-  "version": "0.7.5",
+  "version": "0.8.0",
   "private": true,
   "type": "module",
   "dependencies": {

--- a/apps/web/README.md
+++ b/apps/web/README.md
@@ -4,7 +4,7 @@ The hosted read-projection dashboard — a phone-checkable view of fund
 composition, backed by a disposable Postgres projection of the local event
 log. Built on **TanStack Start** (Vite-based full-stack React), chosen over
 Next.js in ADR-009. Package name `@numisma/web`, version tracks the monorepo
-root (`0.7.5`). Deployed to Vercel as project `numisma-web`; see
+root (`0.8.0`). Deployed to Vercel as project `numisma-web`; see
 `docs/web-deploy-runbook.md` for the deploy mechanism.
 
 ## What this app owns

--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@numisma/web",
-  "version": "0.7.5",
+  "version": "0.8.0",
   "private": true,
   "type": "module",
   "scripts": {

--- a/docs/codebase-map.md
+++ b/docs/codebase-map.md
@@ -86,7 +86,7 @@ These are the seams most likely to be misread from the tree alone:
 
 ## Decisions
 
-Fourteen ADRs, indexed with current status in
+Fifteen ADRs, indexed with current status in
 [`context/adr/INDEX.md`](../context/adr/INDEX.md). The ones that explain the
 most structure:
 
@@ -114,10 +114,10 @@ pnpm verify      # typecheck → test → smoke:startup, the full gate
 pnpm coverage    # the measured Node-side number
 ```
 
-`pnpm test` measured **1359 passed / 19 skipped across 105 files** at the time
-this map was written; re-run rather than trusting the figure. (The 19 skips are
-the Postgres integration suites, which opt out unless `NUMISMA_TEST_DATABASE_URL`
-is set — they are not failures.)
+`pnpm test` measured **1538 passed / 19 skipped across 115 files** (118 files
+total, 3 fully skipped) at the time this map was written; re-run rather than
+trusting the figure. (The 19 skips are the Postgres integration suites, which
+opt out unless `NUMISMA_TEST_DATABASE_URL` is set — they are not failures.)
 
 Tests are co-located with their subjects (`*.test.ts` beside the module), so the
 test for any file is its sibling. Characterization snapshots and the engine↔TUI

--- a/docs/coverage-rationale.md
+++ b/docs/coverage-rationale.md
@@ -204,9 +204,9 @@ holds only the write/ingest half (`ingestInbox`, `migrateLegacyLog`, inbox
 archival, magnitude-threshold env plumbing, `parseAsOfArg`); its read-path unit
 tests moved with the code into `packages/event-store/src/event-store.test.ts`.
 
-- **`packages/engine/src/events/*.ts`** (91.6% lines, measured) — the covered
+- **`packages/engine/src/events/*.ts`** (92.56% lines, measured) — the covered
   core is the fold itself (`events/fold.ts`, 96.91% lines) and the ingest
-  cross-reference (`events/crossref.ts`, 94.3% lines), exercised by
+  cross-reference (`events/crossref.ts`, 96.23% lines), exercised by
   `event-ingest.test.ts` and `fold.test.ts` — and, since the date-ordering
   gates landed, by `position-born-by.test.ts` (29 tests) and
   `position-seal.test.ts` (PR #261). Uncovered in both: **per-field
@@ -217,32 +217,23 @@ tests moved with the code into `packages/event-store/src/event-store.test.ts`.
   `parsePositionAddedTo`, and siblings), the "not every malformed-field
   fixture exists yet" gap the rest of the file already documents. This is a
   summary, not the full list (that would misrepresent a partial excerpt as
-  complete) — the two largest blocks are `:554-583` (`parsePositionTrimmed`'s
-  `positionId`/`removals`/`settlement.reserveId`/`settlement.proceeds` fields)
-  and `:600-623` (`parsePositionAddedTo`'s `positionId`/`funding.reserveId`/
-  `funding.amount` fields). `events/crossref.ts` adds `:361-365` (`ReserveOpened`
-  colliding with an existing position id), `:636-638,640-641,643-647`
-  (`PositionTrimmed`'s unknown-position-id and already-closed rejections),
-  `:707-714` (`PositionTrimmed`'s settlement-proceeds deviation-threshold
-  rejection), `:761-762` (`PositionAddedTo`'s funding-leg debit-check
-  error-message wrapping), and `:824-825,887-888` (the `Transfer`/
-  `PositionOpened` cross-reference error-message wrapping) — the
-  validator/cross-reference logic runs, but not every individual
-  malformed-field or error-wrapping fixture exists yet.
-
-  > **STALE, flagged 2026-08-08 — do not trust the `events/crossref.ts` figures
-  > or citations in this bullet until re-measured.** PR #261 (`e6ef2a5`) inserted
-  > ~237 lines into the middle of `events/crossref.ts` and added a 791-line
-  > `position-seal.test.ts`, so **every `crossref.ts` line citation above now
-  > points at unrelated code** (spot-checked: `:361` is prose in a doc comment,
-  > `:636` is `requireReserveBornBy`'s docblock, `:707` is a `};`, `:761` is a
-  > signature line, `:824-825` sits inside `requirePositionUntouchedAfter`'s
-  > docblock) and the 94.3% lines figure predates both the new code and the new
-  > tests. Re-anchoring them by hand would be guesswork: the uncovered RANGES
-  > themselves have moved, not just their numbers. Closing this needs a fresh
-  > `pnpm coverage` run read off the istanbul HTML / `coverage-final.json` — never
-  > the v8 text column. This is ledger item 14's class (citing coverage by line
-  > number) firing exactly as predicted.
+  complete) — the two largest blocks sit inside `:554-583`
+  (`parsePositionTrimmed`'s `positionId`/`removals`/`settlement.reserveId`/
+  `settlement.proceeds` fields) and `:607-623` (`parsePositionAddedTo`'s
+  `positionId`/`funding.reserveId`/`funding.amount` fields).
+  `events/crossref.ts` (re-measured 2026-08-08, after PR #261) adds `:330-333`
+  (the `_never` exhaustiveness latch on the event-type switch — unreachable at
+  runtime by construction, same category as `events/fold.ts`'s `:492-498` and
+  the other `_never` rows in §7), `:558-562` (`ReserveOpened` colliding with an
+  existing position id), `:1090-1097` (`PositionTrimmed`'s settlement-proceeds
+  deviation-threshold rejection), `:1141-1142` (`PositionAddedTo`'s
+  funding-leg debit-check error-message wrapping), and `:1204-1205,1267-1268`
+  (the `Transfer`/`PositionOpened` cross-reference error-message wrapping) —
+  the validator/cross-reference logic runs, but not every individual
+  malformed-field or error-wrapping fixture exists yet. (PR #261's
+  `position-seal.test.ts` closed the `PositionTrimmed` unknown-position-id and
+  already-closed rejection branches this bullet used to cite as open — they
+  measure covered in the fresh run.)
 
   `events/fold.ts` has four branches open, not the two this bullet
   used to claim: `:649-650` (the lot-selection helper's zero-`tierTotal` early

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "numisma",
-  "version": "0.7.5",
+  "version": "0.8.0",
   "private": true,
   "type": "module",
   "packageManager": "pnpm@11.1.2",

--- a/packages/engine/package.json
+++ b/packages/engine/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@numisma/engine",
-  "version": "0.7.5",
+  "version": "0.8.0",
   "private": true,
   "type": "module",
   "exports": {

--- a/packages/event-store/package.json
+++ b/packages/event-store/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@numisma/event-store",
-  "version": "0.7.5",
+  "version": "0.8.0",
   "private": true,
   "type": "module",
   "exports": {

--- a/packages/preferences/package.json
+++ b/packages/preferences/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@numisma/preferences",
-  "version": "0.7.5",
+  "version": "0.8.0",
   "private": true,
   "type": "module",
   "exports": {


### PR DESCRIPTION
## Summary

Two-part increment: a docs-reconciliation sweep against `main` (verified
against code, not against other docs) and a version bump to `0.8.0`.

## Docs reconciliation

Recent commits `d95894b` and `926630f` already did most of the reconciliation
work against the date-ordering gates (born-by gate, position-seal rule,
ADR-015's one-world-state change, the one-Lot-validity-predicate refactor).
This pass verified those against the code and found two things they left
behind, both fixed:

- **`docs/codebase-map.md`**
  - "Fourteen ADRs" → **"Fifteen ADRs"**. ADR-015 was accepted but never
    folded into this count.
  - `pnpm test` snapshot refreshed: `1359 passed / 19 skipped across 105
    files` → `1538 passed / 19 skipped across 115 files (118 files total,
    3 fully skipped)` — matches a fresh `pnpm test` run in this PR.

- **`docs/coverage-rationale.md`**
  - Resolved the `STALE, flagged 2026-08-08` blockquote that `d95894b` left
    in place: PR #261 shifted ~237 lines through `packages/engine/src/events/crossref.ts`
    and added `position-seal.test.ts`, invalidating every prior line
    citation in that bullet. Re-measured off a fresh istanbul HTML run and
    re-anchored the citations to their current lines (`:330-333`,
    `:558-562`, `:1090-1097`, `:1141-1142`, `:1204-1205,1267-1268`).
  - Coverage numbers refreshed: `events/crossref.ts` 94.3% → **96.23%**
    lines; `packages/engine/src/events/*.ts` overall 91.6% → **92.56%**.
  - Noted that PR #261's `position-seal.test.ts` closed the
    `PositionTrimmed` unknown-position-id / already-closed rejection
    branches this bullet previously cited as uncovered.
  - `events/parse.ts` citation corrected from `:600-623` to `:607-623`
    (exact uncovered range).

Everything else checked came back correct as-is — no changes needed:
`docs/scripts.md` (all 20 root scripts match `package.json`),
`docs/domain-model.md` (event-verb union matches
`packages/engine/src/events/types.ts`), `docs/local-data.md` (already fixed
by `d95894b`), `context/adr/INDEX.md` (all 15 ADRs indexed, ADR-015 present
with its 2026-08-08 follow-up note), `context/ubiquitous-language.md`
(already fixed by `926630f`), every package/app README's export and script
tables, and the runbooks under `docs/` (env vars, schema version, CI steps).
`context/product.md`'s MVP-boundary language was reviewed and judged
consistent under its own single-tenant/SaaS distinction; left unedited.

No source code changed in this part of the PR.

## Version bump

Root `package.json` and all six workspace manifests (`packages/engine`,
`packages/event-store`, `packages/preferences`, `apps/tui`, `apps/web`,
`apps/price-feed`) move `0.7.5` → `0.8.0`, plus the prose copy of the
version in `apps/web/README.md`. Precedent: `c19b88f`.

Left untouched, per the same precedent's rule about historical citations:
the `0.7.3` strings in `context/adr/ADR-009-*.md` and
`docs/web-deploy-runbook.md` (verbatim quotes from a specific past Vercel
build log) and the `0.7.2` literals in
`packages/engine/src/durable-log.test.ts` (arbitrary version fixtures
asserting `deriveHeadDigest`'s behavior, not claims about the current
release).

`pnpm typecheck` and `pnpm test` both pass on this branch (1538 passed / 19
skipped across 115 files, 19 skips are the Postgres-only integration suites
that opt out without `NUMISMA_TEST_DATABASE_URL`).

## Files over 600 lines (code only — report, no refactor)

Sorted descending, excluding node_modules/dist/lockfiles/generated
fixtures/.md:

| Lines | File | What it holds | Split candidate? |
|---|---|---|---|
| 1938 | `apps/tui/src/import-orders.test.ts` | Order-import CLI test suite | Test file — long but likely one seam (import flow); would need a look at internal grouping before judging |
| 1299 | `packages/engine/src/events/crossref.ts` | Second ingest gate — cross-reference validation against world-state (ADR-015) | Dense but a genuinely single, tightly-coupled seam (one gate, many event-type guards); doc comments already explain why it isn't split |
| 1027 | `apps/tui/src/record-fill.test.ts` | Fill-recording flow test suite | Test file, mirrors `record-fill.ts`'s scope |
| 830 | `packages/engine/src/fold.test.ts` | Fold-to-read-model test suite | Test file |
| 791 | `packages/engine/src/position-seal.test.ts` | Position-seal rule test suite (PR #261) | Test file, recent addition |
| 785 | `packages/engine/src/reserve-opened.test.ts` | ReserveOpened event test suite | Test file |
| 709 | `apps/web/src/push/glance.test.ts` | Push "glance" summary test suite | Test file |
| 692 | `packages/engine/src/events/fold.ts` | The fold to the read model + reserve/tier cash math (now also the ingest gate's world per ADR-015) | Two responsibilities (fold + cash-math helpers) that could split, but the doc comment explains why they're coupled post-ADR-015 — plausible future candidate, not urgent |
| 674 | `apps/tui/src/record-fill.ts` | The fill act: one act across two files (orders.jsonl + events.jsonl) | Deliberately monolithic per its own doc comment (all-validation-up-front, atomicity story) — not a seam-splitting candidate |
| 667 | `apps/web/src/push/fixture-synthesis.ts` | Public-repo anchor-fixture sanitizer | Single well-scoped responsibility |
| 665 | `apps/tui/src/event-store.test.ts` | Event-store test suite | Test file |
| 655 | `packages/event-store/src/heartbeat.test.ts` | Heartbeat test suite | Test file |
| 640 | `packages/engine/src/orders/records.ts` | `orders.jsonl` record contract (ADR-013 sidecar) | Single well-scoped responsibility |
| 637 | `packages/engine/src/orders/bitget-ingest.test.ts` | Bitget order-ingest test suite | Test file |
| 633 | `packages/engine/src/events/parse.ts` | First ingest gate — structural event parsing | Single well-scoped responsibility, mirrors crossref.ts's shape |
| 622 | `packages/engine/src/position-born-by.test.ts` | Born-by gate test suite | Test file, recent addition |
| 606 | `packages/engine/src/event-ingest.test.ts` | Combined ingest-gate test suite | Test file |

Report only — nothing here was refactored or split.

## Test plan

- [x] `pnpm typecheck` passes
- [x] `pnpm test` passes (1538 passed / 19 skipped across 115 files)
- [ ] Reviewer spot-checks the coverage-rationale.md line citations against `pnpm coverage`'s istanbul HTML output