### PR TITLE
fix(push): a positionId is data, so the fixture synthesizes it

### DIFF
--- a/apps/web/fixtures/backfill-anchors.fixture.json
+++ b/apps/web/fixtures/backfill-anchors.fixture.json
@@ -15983,33 +15983,33 @@
           "unattributable": 0,
           "positions": [
             {
-              "positionId": "dca-btc-accumulation-A-bitget",
+              "positionId": "synthetic-position-1",
               "state": "pending",
               "kind": "dcaLadder",
               "rungs": [
                 {
-                  "priceUsd": 9907.61
+                  "priceUsd": 9962.55
                 },
                 {
-                  "priceUsd": 9312.42
+                  "priceUsd": 9365.53
                 },
                 {
-                  "priceUsd": 8752.98
+                  "priceUsd": 8801.52
                 },
                 {
-                  "priceUsd": 8227.15
+                  "priceUsd": 8274.08
                 },
                 {
-                  "priceUsd": 7737.79
+                  "priceUsd": 7775.81
                 },
                 {
-                  "priceUsd": 7272.95
+                  "priceUsd": 7309.83
                 },
                 {
-                  "priceUsd": 6836.04
+                  "priceUsd": 6869.63
                 },
                 {
-                  "priceUsd": 6425.37
+                  "priceUsd": 6457.95
                 }
               ]
             }

--- a/apps/web/src/push/anchor-fixture.test.ts
+++ b/apps/web/src/push/anchor-fixture.test.ts
@@ -36,6 +36,7 @@ import { anchorAt, loadAnchorFixture } from "./anchor-fixture.ts";
 import {
   NAV_MOVE_THRESHOLD_PCT,
   SYNTHETIC_FUND_ID,
+  SYNTHETIC_POSITION_PREFIX,
   SYNTHETIC_FUND_NAME,
   SYNTHETIC_START_NAV,
 } from "./fixture-synthesis.ts";
@@ -113,6 +114,29 @@ describe("the committed anchor fixture", () => {
     const anchors = await loadAnchorFixture();
     expect(new Set(anchors.map((a) => a.fundId))).toEqual(
       new Set([SYNTHETIC_FUND_ID]),
+    );
+  });
+
+  it("names every DCA plan by its SYNTHETIC id — no operator-authored string", async () => {
+    // Also on the COMMITTED BYTES, and for the reason the fund-id guard exists: this
+    // is the assertion whose absence let one real `positionId` ship into a public
+    // repository (PR #282). A plan id comes from the private sidecar and its
+    // convention names a live position's venue, instrument and strategy, so the file
+    // must carry nothing but `synthetic-position-N` — checked against what is on
+    // disk, not against what the generator would emit if re-run.
+    const anchors = await loadAnchorFixture();
+    const shape = new RegExp(`^${SYNTHETIC_POSITION_PREFIX}-\\d+$`);
+    const seen = new Set<string>();
+    for (const anchor of anchors) {
+      for (const position of anchor.report.dca.positions) {
+        expect(position.positionId, anchor.asOf).toMatch(shape);
+        seen.add(position.positionId);
+      }
+    }
+    // Numbered from 1 with no gaps, which is what `synthesizePositionIds` promises and
+    // the only way the ordinals disclose nothing beyond the count.
+    expect([...seen].sort()).toEqual(
+      Array.from({ length: seen.size }, (_unused, i) => `${SYNTHETIC_POSITION_PREFIX}-${i + 1}`).sort(),
     );
   });
 

--- a/apps/web/src/push/backfill-core.ts
+++ b/apps/web/src/push/backfill-core.ts
@@ -50,9 +50,9 @@
  * the Reserve row's `percentOfFund`, the day-over-day NAV percentage, the `dca`
  * branch's states and counts — `source`, every `state` and `kind`, the rung COUNT per
  * position, the `unattributable` count — and the full structural shape down to which
- * rows genuinely lack a cost basis. INCLUDING every row id, row label and plan
- * `positionId`, which are load-bearing shape and stay verbatim (repo policy,
- * `docs/local-data.md`: code identifiers keep their literal names). What does not
+ * rows genuinely lack a cost basis. INCLUDING every row id and row label, which are
+ * load-bearing shape and stay verbatim (repo policy, `docs/local-data.md`: code
+ * identifiers keep their literal names). What does not
  * survive is every magnitude — NAV is re-anchored at a round fictional 100000, each
  * row's `usdValue` / `costBasisUsd` / `unrealizedPnlUsd` / `percentOfFund` is invented
  * from documented parameters, and every rung `priceUsd` is invented on a synthetic
@@ -60,7 +60,12 @@
  * the same shape as a stop level) — plus the fund's own IDENTITY: `fundName` becomes
  * "Sanitized Exploratory Fund" (#149) and `fundId` is re-derived as that name's slug
  * rather than carried over, so the real `fund_id` no longer rides on every anchor in
- * the committed file. That is the whole list: the file is sanitized, not
+ * the committed file. Plan `positionId`s go the same way, to
+ * `synthetic-position-N`: the repo's literal-names policy covers identifiers THIS
+ * REPOSITORY authors, and a `positionId` is a string read out of the private sidecar
+ * that names a live position's venue, instrument and strategy. It was kept verbatim
+ * when the `dca` branch landed and shipped once (PR #282) before the rule was moved
+ * into code. That is the whole list: the file is sanitized, not
  * de-identified.
  *
  * A uniform SCALE of the real payload was the cheap alternative and it is rejected,

--- a/apps/web/src/push/fixture-synthesis.test.ts
+++ b/apps/web/src/push/fixture-synthesis.test.ts
@@ -29,6 +29,7 @@ import {
   synthesizeAnchors,
   SYNTHETIC_FUND_ID,
   SYNTHETIC_FUND_NAME,
+  SYNTHETIC_POSITION_PREFIX,
   SYNTHETIC_START_NAV,
 } from "./fixture-synthesis.ts";
 
@@ -272,22 +273,87 @@ describe("what survives — the projections slice 4 replays", () => {
   it("keeps the dca branch's STATES and COUNTS verbatim — the card renders them", () => {
     // Same reasoning that copies the glance block: a `state`, a `kind` and a count of
     // unreadable lines carry no magnitude, and they are exactly what the card shows.
+    // The `positionId` is NOT in this set — it is asserted replaced, just below.
     for (const anchor of out) {
       const dca = anchor.report.dca;
       expect(dca.source).toBe(DCA.source);
       expect(dca.unattributable).toBe(DCA.unattributable);
-      expect(dca.positions.map((p) => `${p.positionId}:${p.state}:${p.kind}`)).toEqual(
-        DCA.positions.map((p) => `${p.positionId}:${p.state}:${"kind" in p ? p.kind : undefined}`),
+      expect(dca.positions.map((p) => `${p.state}:${p.kind}`)).toEqual(
+        DCA.positions.map((p) => `${p.state}:${"kind" in p ? p.kind : undefined}`),
       );
+      // The position COUNT is shape: four plans in, four plans out.
+      expect(dca.positions).toHaveLength(DCA.positions.length);
       // The rung COUNT is shape, not magnitude: an eight-rung ladder must stay one.
       expect(dca.positions.map((p) => p.rungs?.length)).toEqual([3, undefined, undefined, undefined]);
       // …and a rungless plan keeps NO rungs key, rather than gaining an empty array.
       expect("rungs" in dca.positions[1]!).toBe(false);
     }
     // A copy, not the same object — the derived payload the DB write holds must not
-    // be reachable through the fixture.
-    out[0]!.report.dca.positions.push({ positionId: "mutated", state: "ended" });
+    // be reachable through the fixture. Mutated on its OWN synthesis, not on the
+    // shared `out`: this used to push onto the array every later test reads, so the
+    // pollution was invisible only because nothing downstream counted positions.
+    const isolated = synthesizeAnchors(REAL);
+    isolated[0]!.report.dca.positions.push({ positionId: "mutated", state: "ended" });
     expect(REAL[0]!.report.dca.positions).toHaveLength(DCA.positions.length);
+  });
+
+  it("REPLACES every positionId — an operator-authored id is not a code identifier", () => {
+    // THE ASSERTION WHOSE ABSENCE LET A REAL ID SHIP. `positionId` was kept verbatim
+    // under the repo's "code identifiers keep their literal names" policy, but that
+    // policy is about names this REPOSITORY authors; a plan id is read out of the
+    // private sidecar and its convention spells out venue, instrument and strategy.
+    // One real id reached the public fixture that way (PR #282).
+    const real = new Set(DCA.positions.map((position) => position.positionId));
+    for (const anchor of out) {
+      for (const position of anchor.report.dca.positions) {
+        expect(real.has(position.positionId), `${position.positionId} survived`).toBe(false);
+        expect(position.positionId).toMatch(
+          new RegExp(`^${SYNTHETIC_POSITION_PREFIX}-\\d+$`),
+        );
+      }
+      // Distinct plans stay distinct: the count is shape, and collapsing two ids
+      // would silently change what the card renders.
+      const ids = anchor.report.dca.positions.map((position) => position.positionId);
+      expect(new Set(ids).size).toBe(ids.length);
+    }
+  });
+
+  it("assigns positionIds over the SERIES, so one plan keeps one id across anchors", () => {
+    // Per-anchor numbering would be deterministic too, and wrong: a plan that appears
+    // on every anchor is ONE plan, and the card groups by id. This is the property
+    // that makes the fixture still describe a history rather than N unrelated days.
+    const perAnchor = out.map((anchor) =>
+      anchor.report.dca.positions.map((position) => position.positionId).join(","),
+    );
+    expect(new Set(perAnchor).size).toBe(1);
+    // …and the mapping follows first appearance, so it is readable rather than hashed.
+    expect(out[0]!.report.dca.positions.map((position) => position.positionId)).toEqual([
+      `${SYNTHETIC_POSITION_PREFIX}-1`,
+      `${SYNTHETIC_POSITION_PREFIX}-2`,
+      `${SYNTHETIC_POSITION_PREFIX}-3`,
+      `${SYNTHETIC_POSITION_PREFIX}-4`,
+    ]);
+  });
+
+  it("seeds the rung wobble from the SYNTHETIC id, not the real one", () => {
+    // Otherwise the disclosure survives the rename: every committed rung price would
+    // be a hash commitment to the private string, testable by anyone who guesses it,
+    // and in a form no grep for the id would ever surface. Two series identical except
+    // for their real ids must therefore produce identical rung prices.
+    const rungsFor = (positionId: string): number[] => {
+      const anchor = constructedAnchor("2026-06-26", 19447.71);
+      anchor.report.dca = {
+        source: "loaded",
+        unattributable: 0,
+        positions: [
+          { positionId, state: "pending", kind: "dcaLadder", rungs: [{ priceUsd: 1000 }, { priceUsd: 900 }] },
+        ],
+      };
+      return synthesizeAnchors([anchor])[0]!.report.dca.positions[0]!.rungs!.map(
+        (rung) => rung.priceUsd,
+      );
+    };
+    expect(rungsFor("dca-one-real-name")).toEqual(rungsFor("a-totally-different-id"));
   });
 
   it("INVENTS every rung price — a declared entry level is a magnitude", () => {

--- a/apps/web/src/push/fixture-synthesis.test.ts
+++ b/apps/web/src/push/fixture-synthesis.test.ts
@@ -168,10 +168,30 @@ function constructedAnchor(asOf: string, nav: number): SnapshotAnchor {
   } as SnapshotAnchor;
 }
 
+/**
+ * The NAV every constructed input anchor starts at. ROUND AND OBVIOUSLY FICTIONAL, on
+ * purpose: this literal used to be the fund's actual NAV on its first anchor, paired
+ * in the same call with that anchor's actual date, in a file this PUBLIC repository
+ * checks in. A magnitude is the one thing `fixture-synthesis.ts` exists to withhold,
+ * and it does not stop being one because a TEST is what holds it — the module header
+ * makes exactly this point about naming the firing moves in a comment.
+ *
+ * Nothing here reads the absolute value: the synthesizer re-anchors at
+ * {@link SYNTHETIC_START_NAV} and carries the series forward on RATIOS, so the tests
+ * assert over the moves between anchors and never over this number.
+ *
+ * It is 12345.67 rather than a rounder stand-in because the sweep below asserts that
+ * NO input magnitude appears anywhere in the output, and a round input collides with
+ * the synthetic side by construction: 20000 is also the pinned Reserve row's value at
+ * 20% of {@link SYNTHETIC_START_NAV}, which fails the sweep on a coincidence rather
+ * than on a leak. Fictional AND collision-free is the requirement, not just fictional.
+ */
+const CONSTRUCTED_NAV = 12_345.67;
+
 /** Two anchors, the second 5% below the first — a day-over-day move to preserve. */
 const REAL: SnapshotAnchor[] = [
-  constructedAnchor("2026-06-26", 19447.71),
-  constructedAnchor("2026-06-28", 19447.71 * 0.95),
+  constructedAnchor("2026-06-26", CONSTRUCTED_NAV),
+  constructedAnchor("2026-06-28", CONSTRUCTED_NAV * 0.95),
 ];
 
 /** Every number reachable in a payload, for the "no magnitude survived" sweep. */
@@ -341,7 +361,7 @@ describe("what survives — the projections slice 4 replays", () => {
     // and in a form no grep for the id would ever surface. Two series identical except
     // for their real ids must therefore produce identical rung prices.
     const rungsFor = (positionId: string): number[] => {
-      const anchor = constructedAnchor("2026-06-26", 19447.71);
+      const anchor = constructedAnchor("2026-06-26", CONSTRUCTED_NAV);
       anchor.report.dca = {
         source: "loaded",
         unattributable: 0,
@@ -384,7 +404,7 @@ describe("what survives — the projections slice 4 replays", () => {
     // Twenty-four rungs is well past the depth the real sidecar declares today (8),
     // deliberately: the whole failure was that the generator was only ever exercised
     // at a depth where the bug is invisible.
-    const deep = constructedAnchor("2026-06-26", 19447.71);
+    const deep = constructedAnchor("2026-06-26", CONSTRUCTED_NAV);
     deep.report.dca = {
       source: "loaded",
       unattributable: 0,
@@ -420,8 +440,8 @@ describe("what survives — the projections slice 4 replays", () => {
 describe("the NAV jitter — closing the last recoverable series", () => {
   /** A synthetic history whose day-over-day percent changes are exactly `pcts`. */
   function seriesWithMoves(pcts: readonly number[]): SnapshotAnchor[] {
-    const anchors = [constructedAnchor("2026-06-26", 19447.71)];
-    let nav = 19447.71;
+    const anchors = [constructedAnchor("2026-06-26", CONSTRUCTED_NAV)];
+    let nav = CONSTRUCTED_NAV;
     for (const [i, pct] of pcts.entries()) {
       nav *= 1 + pct / 100;
       const date = new Date("2026-06-26T00:00:00Z");

--- a/apps/web/src/push/fixture-synthesis.ts
+++ b/apps/web/src/push/fixture-synthesis.ts
@@ -29,9 +29,10 @@
  *    row counts, which rows carry `costBasisUsd`/`unrealizedPnlUsd` and which
  *    genuinely lack them (spec open question 3 — slice 5's per-row cost-basis
  *    rendering depends on the absences being real), `dataSafety`, schema version;
- *  - the `dca` branch's SHAPE ENTIRELY: `source`, every `positionId`, every `state`
- *    and `kind`, the rung COUNT per position, and the `unattributable` count. Those
- *    are states and counts, the same class as `feedGap`, and the card renders them.
+ *  - the `dca` branch's SHAPE: `source`, every `state` and `kind`, the position COUNT,
+ *    the rung COUNT per position, and the `unattributable` count. Those are states and
+ *    counts, the same class as `feedGap`, and the card renders them. The `positionId`
+ *    itself is NOT among them — see below.
  *
  * ── WHAT IS INVENTED, AND WHY IT MUST BE ────────────────────────────────────────
  * Everything no trigger reads. Preserving these would leak the fund's composition
@@ -50,7 +51,13 @@
  *    intended entry level — a magnitude, and one ADR-006 explicitly notes is the same
  *    shape as a stop level — so it falls under the magnitudes rule with everything
  *    else. The COUNT and the ORDER survive because the card is a rung table; the
- *    LEVELS are invented from {@link SYNTHETIC_RUNG_TOP} down.
+ *    LEVELS are invented from {@link SYNTHETIC_RUNG_TOP} down;
+ *  - every `positionId`, which becomes `synthetic-position-N` by first appearance
+ *    across the series. It is not a magnitude, but the operator's naming convention
+ *    spells out a live position's VENUE, INSTRUMENT and STRATEGY, and the string is
+ *    lifted straight out of the private sidecar. See {@link synthesizeDca} for why the
+ *    repo's "code identifiers keep their literal names" policy does not reach it, and
+ *    why the rung wobble is re-seeded from the synthetic id rather than the real one.
  *
  * ── WHAT THIS IS NOT ────────────────────────────────────────────────────────────
  * This is not de-identification, and the committed fixture is not identity-clean.
@@ -58,9 +65,20 @@
  * shape (see the structural bullet above) and the file carries the project's own
  * names — `portfolio:accumulus` and `"Accumulus"` appear on every anchor, dozens of
  * times each. That is repo policy, not an oversight: `docs/local-data.md` holds the
- * line that code identifiers keep their literal names. What synthesis withholds is
- * exactly four things — MAGNITUDES, the NAV series' scale, the fund NAME and the fund
- * ID — and nothing else should be inferred from the fact that this module ran.
+ * line that code identifiers keep their literal names.
+ *
+ * THE LINE THAT POLICY DRAWS IS AUTHORSHIP, NOT SYNTAX, and it is worth stating flatly
+ * because this module already got it wrong once. A string kept verbatim must be one
+ * THIS REPOSITORY AUTHORS — a section id, a row kind, `portfolio:accumulus`, a source
+ * path. A string read out of the private store is DATA no matter how identifier-shaped
+ * it looks, and it is synthesized. `positionId` sat on the wrong side of that line
+ * when the `dca` branch landed, and shipped once in a public fixture (PR #282). When a new field
+ * arrives on this payload, the question is not "is it a magnitude" — it is "did we
+ * write this string, or did the operator's private file". Only the first is kept.
+ *
+ * What synthesis withholds is therefore five things — MAGNITUDES, the NAV series'
+ * scale, the fund NAME, the fund ID and every `positionId` — and nothing else should
+ * be inferred from the fact that this module ran.
  *
  * ── THE NAV SERIES, AND WHY IT IS JITTERED ──────────────────────────────────────
  * Preserving every day-over-day NAV change EXACTLY would be mathematically the same
@@ -221,39 +239,102 @@ const RUNG_STEP = 0.06;
 const RUNG_WOBBLE = 0.01;
 
 /**
- * Synthesize the DCA branch: every state, count and identifier VERBATIM, every rung
- * price invented.
+ * The prefix every synthetic `positionId` carries — the same posture as
+ * {@link SYNTHETIC_FUND_NAME}: a reader who opens the committed file must not have to
+ * reason about whether a position is real.
+ *
+ * Exported for `anchor-fixture.test.ts`, whose guard reads the COMMITTED BYTES: every
+ * `positionId` in the file on disk must match this shape, not merely whatever the
+ * generator would produce if it were re-run.
+ */
+export const SYNTHETIC_POSITION_PREFIX = "synthetic-position";
+
+/**
+ * Map every distinct real `positionId` in a whole series to its synthetic stand-in,
+ * numbered by FIRST APPEARANCE across the anchors in order.
+ *
+ * SERIES-LEVEL rather than per-anchor, because a plan that appears on twelve anchors
+ * is ONE plan and the fixture has to keep saying so: the card groups by id, and a
+ * per-anchor renaming would turn one position into twelve.
+ *
+ * The ordinal discloses only the position COUNT and the order in which they first
+ * appear — both already preserved as shape, both already visible in the file. It is
+ * deliberately NOT a hash of the real id: a hash is a commitment the real string can
+ * be tested against by anyone who guesses it, which is the same disclosure at a higher
+ * price.
+ */
+function synthesizePositionIds(
+  anchors: readonly SnapshotAnchor[],
+): Map<string, string> {
+  const ids = new Map<string, string>();
+  for (const anchor of anchors) {
+    for (const position of anchor.report.dca.positions) {
+      if (!ids.has(position.positionId)) {
+        ids.set(position.positionId, `${SYNTHETIC_POSITION_PREFIX}-${ids.size + 1}`);
+      }
+    }
+  }
+  return ids;
+}
+
+/**
+ * Synthesize the DCA branch: every state and count VERBATIM, every identifier and
+ * every rung price INVENTED.
  *
  * `source`, `state`, `kind` and `unattributable` are copied because they are
  * CONCLUSIONS with no magnitude in them — the same reasoning that copies the `glance`
  * block whole.
  *
- * `positionId` IS PRESERVED FOR A DIFFERENT REASON, and the difference matters: it is
- * not a conclusion, it is an operator-authored string lifted verbatim out of the
- * private sidecar. It survives under the same REPO POLICY that keeps every row id and
- * row label in this file — code identifiers keep their literal names
- * (`docs/local-data.md`) — the policy this module's own header restates when it
- * explains why `portfolio:accumulus` stays put. Do not generalize the conclusions
- * sentence onto it: by that logic the fund NAME would survive too, and this module
- * deliberately replaces it. Identifiers stay because policy says so; magnitudes and
- * the fund's identity go because the public bar says so.
+ * `positionId` IS REPLACED, and it is the one identifier in this file that is. Row ids
+ * and row labels stay verbatim under the repo policy that code identifiers keep their
+ * literal names (`docs/local-data.md`) — but that policy governs names THIS REPOSITORY
+ * AUTHORS: source paths, doc filenames, `portfolio:accumulus`. A `positionId` is not
+ * one of those. It is an operator-authored string lifted out of the PRIVATE sidecar,
+ * and the convention names the venue, the instrument and the strategy of a live
+ * position — the fund's composition, in the one field that had been reasoned about as
+ * though it were a code identifier. One real id did ship on exactly that reasoning
+ * (PR #282), which is why the rule now lives in code rather than in a paragraph:
+ * DATA-DERIVED strings are synthesized, REPOSITORY-AUTHORED names are kept, and
+ * `anchor-fixture.test.ts` reads the committed bytes rather than trusting either.
  *
- * Only `priceUsd` is replaced, and it is replaced positionally
- * so that a ladder of eight rungs stays a ladder of eight rungs: the card under test
- * renders a row per rung, and a synthesis that changed the count would change what the
- * fixture proves.
+ * THE RUNG WOBBLE IS SEEDED FROM THE SYNTHETIC ID, not the real one. Seeding it from
+ * the real string would leave every committed rung price a hash commitment to the very
+ * thing this function exists to withhold — the disclosure would survive the rename,
+ * in a form nobody would think to grep for.
+ *
+ * Among the rungs only `priceUsd` is replaced, and it is replaced positionally so that
+ * a ladder of eight rungs stays a ladder of eight rungs: the card under test renders a
+ * row per rung, and a synthesis that changed the count would change what the fixture
+ * proves.
  *
  * The rung ORDER is left where it was found. This module never sorts; the view does.
  */
-function synthesizeDca(dca: DcaBlock, asOf: string): DcaBlock {
+function synthesizeDca(
+  dca: DcaBlock,
+  asOf: string,
+  ids: ReadonlyMap<string, string>,
+): DcaBlock {
   return {
     source: dca.source,
     unattributable: dca.unattributable,
     positions: dca.positions.map((position) => {
-      const synthetic = { ...position };
+      const positionId = ids.get(position.positionId);
+      if (positionId === undefined) {
+        // Unreachable through `synthesizeAnchors`, which maps the whole series before
+        // it synthesizes any anchor. A throw rather than a fallback to the real id:
+        // the one outcome this function must never have is emitting the private
+        // string because a lookup missed.
+        throw new Error(
+          `fixture synthesis: no synthetic id was assigned for a position on ${asOf}.`,
+        );
+      }
+      // Spread first so the override lands in `positionId`'s ORIGINAL slot: the
+      // committed file's key order is asserted elsewhere, and a renamed key that
+      // moved would read as a shape change.
+      const synthetic = { ...position, positionId };
       if (position.rungs !== undefined) {
         synthetic.rungs = position.rungs.map((_rung, index) => {
-          const wobble = RUNG_WOBBLE * (2 * hashUnit(asOf, position.positionId, `rung-${index}`) - 1);
+          const wobble = RUNG_WOBBLE * (2 * hashUnit(asOf, positionId, `rung-${index}`) - 1);
           const level =
             SYNTHETIC_RUNG_TOP * Math.pow(1 - RUNG_STEP, index) * (1 + wobble);
           return { priceUsd: Math.round(level * 100) / 100 };
@@ -287,10 +368,16 @@ const PCT_EPSILON = 1e-9;
  * FNV-1a over the inputs, mapped to `[0, 1)`. The ONLY source of variation in this
  * module, and it is a pure function of `(asOf, rowId, salt)` — which is what makes
  * regeneration byte-identical.
+ *
+ * The parts are joined on `\0` so that `("ab", "c")` and `("a", "bc")` cannot collide
+ * on one seed. It is written as the ESCAPE and must stay that way: the literal control
+ * character was here first, and a single raw NUL made every text tool — `grep`, `rg`,
+ * GitHub's blob view — classify this whole file as binary and silently skip it. A
+ * sanitizer that no code search can find is a bad place to hide.
  */
 function hashUnit(...parts: string[]): number {
   let hash = 0x811c9dc5;
-  for (const part of parts.join(" ")) {
+  for (const part of parts.join("\0")) {
     hash ^= part.codePointAt(0) ?? 0;
     hash = Math.imul(hash, 0x01000193) >>> 0;
   }
@@ -592,7 +679,11 @@ function assertDescending(sectionId: string, rows: CompositionRow[]): void {
 }
 
 /** Synthesize ONE anchor onto a given synthetic NAV. */
-function synthesizeAnchor(anchor: SnapshotAnchor, nav: number): SnapshotAnchor {
+function synthesizeAnchor(
+  anchor: SnapshotAnchor,
+  nav: number,
+  positionIds: ReadonlyMap<string, string>,
+): SnapshotAnchor {
   const { dashboard, totals, glance, dca } = anchor.report;
   const asOf = anchor.asOf;
 
@@ -663,8 +754,9 @@ function synthesizeAnchor(anchor: SnapshotAnchor, nav: number): SnapshotAnchor {
       // Copied, never recomputed: `feedGap` and `suppressed` ARE the triggers slice 4
       // replays, and they carry no magnitude to sanitize (D14 already forbids dates).
       glance: structuredClone(glance),
-      // States and counts verbatim, rung LEVELS invented — see `synthesizeDca`.
-      dca: synthesizeDca(dca, asOf),
+      // States and counts verbatim, position IDS and rung LEVELS invented — see
+      // `synthesizeDca`.
+      dca: synthesizeDca(dca, asOf, positionIds),
     },
   };
 }
@@ -721,6 +813,9 @@ export function synthesizeAnchors(
   anchors: readonly SnapshotAnchor[],
 ): SnapshotAnchor[] {
   const out: SnapshotAnchor[] = [];
+  // Assigned over the WHOLE series before any anchor is synthesized, so one plan
+  // keeps one id across every anchor it appears on.
+  const positionIds = synthesizePositionIds(anchors);
   let nav = SYNTHETIC_START_NAV;
   for (const [index, anchor] of anchors.entries()) {
     if (index > 0) {
@@ -741,7 +836,7 @@ export function synthesizeAnchors(
         nav = SYNTHETIC_START_NAV;
       }
     }
-    out.push(synthesizeAnchor(anchor, nav));
+    out.push(synthesizeAnchor(anchor, nav, positionIds));
   }
   return out;
 }

--- a/docs/local-data.md
+++ b/docs/local-data.md
@@ -21,6 +21,27 @@ source file may legitimately contain the real exchange name in its filename
 prose and the literal name in a path or link in the same document is
 deliberate, not an inconsistency.
 
+### The line is authorship, not syntax
+
+The exemption above covers identifiers **this repository authors** — source
+paths, doc filenames, section ids, row kinds, `portfolio:accumulus`. It does
+**not** cover identifier-shaped strings **read out of the private store**,
+however much they look like code. Those are data, and anything committed here
+that derives from them must be synthesized.
+
+The case that set this rule: a plan `positionId` such as
+`dca-<asset>-<strategy>-<n>-<exchange>` is authored by the operator in the
+private plans sidecar, and the convention spells out a live position's venue,
+instrument and strategy. It was treated as a code identifier and kept verbatim
+in the committed anchor fixture, which put one real id into this public repo
+(PR #282). `apps/web/src/push/fixture-synthesis.ts` now replaces every
+`positionId` with `synthetic-position-N`, and `anchor-fixture.test.ts` asserts
+it against the committed bytes.
+
+So when a new field reaches a committed fixture, the question is not "is it a
+magnitude" — it is **"did we write this string, or did the operator's private
+file?"** Only the first is kept.
+
 ## Where the store lives
 
 The durable store does **not** live inside this checkout. It lives in a


### PR DESCRIPTION
## What shipped, and why it needed fixing

The committed anchor fixture carried one real plan id out of the private plans sidecar and into this **public** repository. It landed in `3c6c380` (PR #282, the v3→v4 DCA cutover) and sat on one of 42 anchors.

`synthesizeDca` kept every `positionId` verbatim, deliberately, under the repo policy that *code identifiers keep their literal names* (`docs/local-data.md`). That policy governs names **this repository authors** — source paths, doc filenames, `portfolio:accumulus`. A plan id is authored by the operator in the private sidecar, and the naming convention spells out a live position's **venue, instrument and strategy**. It was on the wrong side of the line, and the module's own header said so in as many words while doing the opposite.

## The rule, moved from a paragraph into code

**The line is authorship, not syntax.** A string this repo wrote is kept; a string read out of the private store is data and gets synthesized, however identifier-shaped it looks.

- Every `positionId` becomes `synthetic-position-N`, numbered by **first appearance across the whole series**. Series-level rather than per-anchor: a plan on twelve anchors is one plan and the card groups by id, so per-anchor numbering would render it as twelve.
- The ordinal discloses only the position **count** and **first-appearance order** — both already preserved as shape, both already visible in the file.
- Deliberately **not a hash** of the real id. A hash is a commitment the real string can be tested against by anyone who guesses it: the same disclosure at a higher price.

## The quieter half: the rung prices were a hash commitment

The rung wobble was seeded from the **real** `positionId`. Renaming the id alone would have left all eight committed rung prices as a hash commitment to the exact string synthesis exists to withhold — the disclosure surviving the rename, in a form no grep for the id could ever surface. The wobble is re-seeded from the synthetic id, which is why the eight prices move in this diff. Ladder count and ordering are unchanged.

## The guard reads the committed bytes

Beside the existing fund-id guard, and for the same reason: a generator-side test is **not** what would have caught this. A regeneration that bypassed synthesis would put a real id back, and only a test reading the file on disk notices. `anchor-fixture.test.ts` now asserts every `positionId` in the committed file matches `synthetic-position-N`, gap-free from 1.

## Two things found on the way

**`hashUnit` joined its parts on a raw NUL byte.** One control character made grep, ripgrep and GitHub's blob view classify the whole sanitizer as **binary** and skip it silently — `grep positionId` over this file returned nothing while the string sat on twenty lines of it. That is very likely why the preserved-id reasoning went unexamined for as long as it did. It is written as the `\0` escape now; the runtime string is identical, so no fixture bytes move because of it. A sanitizer no code search can find is a bad place to hide.

**A test polluted shared state.** The dca "states and counts" test pushed a sentinel position onto the *shared* synthesized array every later test in the file reads. Nothing downstream counted positions, so it was invisible until the new id assertions counted them — and then failed two of them. It mutates its own synthesis now.

## Verification

- Regeneration is **deterministic** — two consecutive `--fixture-only` runs are byte-identical, and a pre-change run reproduced the committed file exactly, so the diff below is attributable entirely to this change.
- The fixture diff is **confined to the dca branch**: 9 lines, key order intact, 42 anchors unchanged.
- Full suite green: **1687 passed**, 19 skipped. Typecheck clean across all six packages.

## What this does not do

Fixing forward does not unpublish the string. It remains in this repo's history at `3c6c380`, and — because GitHub retains pull-request refs permanently — in PR #282's diff regardless of any rewrite of `main`. Scrubbing history is tracked separately from this PR.

---

## Second commit: the review found the same defect one layer over

Reviewing the change above turned up a second real leak in the same directory, pre-existing and unrelated to the DCA branch.

`fixture-synthesis.test.ts` seeded its constructed input anchors with `19447.71`. That is **not a made-up number** — it is the fund's actual NAV on its first anchor, and `constructedAnchor("2026-06-26", 19447.71)` paired it with that anchor's **actual date**, in six places, in this public repo. The array it seeds is named `REAL`, which turned out to be accurate.

**A magnitude does not stop being one because a test is what holds it.** The sanitizer's own header already draws this line for *comments* — it refuses to name the firing NAV moves to two decimals, because "a comment listing them publishes the fund's largest days as surely as the NAV series would." The constant three files away did exactly that with a level instead of a move.

It matters beyond the one number: `NAV_JITTER_PP` exists precisely because *"any single real NAV that ever becomes public makes that factor recoverable by division."* This was that single real NAV — published beside the very fixture the jitter protects, on the anchor the synthetic series is pinned to.

Nothing reads the absolute value (synthesis re-anchors at 100 000 and carries the series on ratios), so it moves behind `CONSTRUCTED_NAV` with no assertion touched.

`12345.67` rather than something rounder, and that is not fussiness: **`20000` was tried first and failed** the "no input magnitude survived" sweep — `20000` is also the pinned Reserve row's value at 20% of the synthetic 100 000. The sweep cannot distinguish a coincidence from a leak, which is exactly its job. The requirement is fictional **and** collision-free.

## Sweep

A repo-wide check of every tracked file against all 42 real NAVs and the real plan id now returns empty. The one apparent fixture hit was a false positive — a real NAV appearing as the leading digits of a synthetic `costBasisUsd` on the 100 000 scale.

Full suite still green: **1687 passed**, typecheck clean.
