### PR TITLE
fix(tui): the module-graph walk reads code, not the prose around it

### DIFF
--- a/apps/tui/src/module-graph.test.ts
+++ b/apps/tui/src/module-graph.test.ts
@@ -15,10 +15,11 @@
  * a computed specifier that this walker cannot resolve shows up as an unresolved
  * import and fails the last assertion rather than passing silently.
  */
-import { readFileSync, readdirSync, existsSync } from "node:fs";
-import { dirname, join, relative, resolve } from "node:path";
+import { readFileSync, readdirSync, existsSync, mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { basename, dirname, join, relative, resolve } from "node:path";
 import { fileURLToPath } from "node:url";
-import { describe, expect, it } from "vitest";
+import { afterEach, describe, expect, it } from "vitest";
 
 const HERE = dirname(fileURLToPath(import.meta.url));
 // HERE = apps/tui/src → the repo root is three levels up.
@@ -81,6 +82,84 @@ function resolveSpecifier(specifier: string, fromFile: string): string | undefin
   return resolve(pkg.dir, target);
 }
 
+/**
+ * The same source with every comment removed — the walker's real input.
+ *
+ * WHY THE INPUT AND NOT THE MATCHER. The matcher below reads `from "…"` ANYWHERE in
+ * the text, so an ordinary English sentence in a doc comment — `a load failure is a
+ * different fact from "this position has no plan."` — was walked as an import of a
+ * package by that name and failed the graph as an unresolvable external (#273). The
+ * other candidate fix, anchoring the matcher to statement position, buys the same
+ * quiet by narrowing what counts as an import — and an import this walker stops
+ * seeing is exactly the edge the prototype hid. A comment cannot contain an import,
+ * so the comments go and the matcher stays as greedy as it was.
+ *
+ * STRING LITERALS ARE KEPT VERBATIM, since the specifier itself is one — and that is
+ * why `//` inside a string cannot start a comment here. Newlines survive so a removed
+ * comment cannot splice two statements together. A `'`/`"` string also ends at the
+ * newline: unterminated ones do not exist in source that compiles, and the bound
+ * keeps a stray quote inside a regex literal (`/["']/`) from swallowing the file.
+ */
+function stripComments(source: string): string {
+  let out = "";
+  let index = 0;
+  while (index < source.length) {
+    const char = source[index] as string;
+    const next = source[index + 1];
+    if (char === "/" && next === "/") {
+      while (index < source.length && source[index] !== "\n") {
+        index += 1;
+      }
+      continue;
+    }
+    if (char === "/" && next === "*") {
+      index += 2;
+      while (index < source.length && !(source[index] === "*" && source[index + 1] === "/")) {
+        if (source[index] === "\n") {
+          out += "\n";
+        }
+        index += 1;
+      }
+      index += 2;
+      continue;
+    }
+    if (char === '"' || char === "'" || char === "`") {
+      out += char;
+      index += 1;
+      while (index < source.length) {
+        const inner = source[index] as string;
+        if (inner === "\\") {
+          out += source.slice(index, index + 2);
+          index += 2;
+          continue;
+        }
+        out += inner;
+        index += 1;
+        if (inner === char || (inner === "\n" && char !== "`")) {
+          break;
+        }
+      }
+      continue;
+    }
+    out += char;
+    index += 1;
+  }
+  return out;
+}
+
+const STRIPPED = new Map<string, string>();
+
+/** A file's code with its comments gone — read once, stripped once. */
+function codeOf(file: string): string {
+  const cached = STRIPPED.get(file);
+  if (cached !== undefined) {
+    return cached;
+  }
+  const code = stripComments(readFileSync(file, "utf8"));
+  STRIPPED.set(file, code);
+  return code;
+}
+
 interface Graph {
   files: Set<string>;
   externals: Set<string>;
@@ -103,7 +182,7 @@ function walkGraph(entries: readonly string[]): Graph {
       continue;
     }
     graph.files.add(file);
-    const source = readFileSync(file, "utf8");
+    const source = codeOf(file);
     const specifiers = [
       ...[...source.matchAll(/from\s*["']([^"']+)["']/g)].map((m) => m[1] as string),
       ...[...source.matchAll(/import\s*\(\s*["']([^"']+)["']\s*\)/g)].map((m) => m[1] as string),
@@ -148,7 +227,9 @@ describe("the TUI's module graph", () => {
     // The assertion that would have failed on the prototype's bridge.
     expect([...GRAPH.externals].filter((name) => /^pg($|-)/.test(name))).toEqual([]);
     for (const file of GRAPH.files) {
-      expect(readFileSync(file, "utf8")).not.toMatch(/from\s*["']pg["']/);
+      // Stripped, like the walk: a comment PROMISING there is no `pg` import must
+      // not read as one (#273).
+      expect(codeOf(file)).not.toMatch(/from\s*["']pg["']/);
     }
   });
 
@@ -202,5 +283,117 @@ describe("the TUI's module graph", () => {
     expect(reached).toContain("packages/event-store/src/heartbeat.ts");
     expect(reached).toContain("packages/event-store/src/gap-report-io.ts");
     expect(GRAPH.files.size).toBeGreaterThan(20);
+  });
+});
+
+const fixtureDirs: string[] = [];
+
+afterEach(() => {
+  for (const dir of fixtureDirs) {
+    rmSync(dir, { recursive: true, force: true });
+  }
+  fixtureDirs.length = 0;
+});
+
+/** A throwaway module tree — `entry.ts` is the walk's entry point. */
+function walkFixture(files: Record<string, string>): Graph {
+  const dir = mkdtempSync(resolve(tmpdir(), "numisma-module-graph-"));
+  fixtureDirs.push(dir);
+  for (const [name, source] of Object.entries(files)) {
+    writeFileSync(join(dir, name), source, "utf8");
+  }
+  return walkGraph([join(dir, "entry.ts")]);
+}
+
+/** Just the file names the walk reached, so a temp directory does not leak in. */
+function reachedNames(graph: Graph): string[] {
+  return [...graph.files].map((file) => basename(file)).sort();
+}
+
+describe("the walker's input — what counts as an import specifier", () => {
+  it("reads no import out of a comment — English that says `from \"…\"` is English", () => {
+    // #273: a doc comment reading `… a different fact from "this position has no
+    // plan."` was walked as an import of a package by that name, and failed the
+    // graph as an unresolvable external. Twice in one increment, in files whose
+    // source was correct. Prose is prose in all three comment forms.
+    const graph = walkFixture({
+      "entry.ts": [
+        "/**",
+        ' * A load failure is a different fact from "this position has no plan."',
+        " */",
+        '// The TUI reads its rows from "the fold", never from "pg".',
+        '/* And a block comment, quoting a sentence from "somewhere else". */',
+        'import { thing } from "./thing.js";',
+        "export const used = thing;",
+      ].join("\n"),
+      "thing.ts": "export const thing = 1;\n",
+    });
+    expect([...graph.externals]).toEqual([]);
+    expect(graph.unresolved).toEqual([]);
+    // And the real import beside the prose was still followed.
+    expect(reachedNames(graph)).toEqual(["entry.ts", "thing.ts"]);
+  });
+
+  it("does not read `pg` out of a comment either — the same prose, the same file", () => {
+    // The other half of the `pg` assertion is a raw per-file match, so it carried
+    // the same false positive: a comment PROMISING there is no `pg` import read as
+    // one. It reads the same stripped source the walk does.
+    const graph = walkFixture({
+      "entry.ts": ['// Nothing in the TUI imports from "pg".', "export const ok = true;"].join("\n"),
+    });
+    const [entry] = [...graph.files];
+    expect(codeOf(entry as string)).not.toMatch(/from\s*["']pg["']/);
+  });
+
+  it("still fails on an import it cannot resolve — the guard is not merely quieter", () => {
+    // The fix must not buy silence with blindness. A missing relative file and a
+    // real external are both still seen, exactly as before.
+    const graph = walkFixture({
+      "entry.ts": ['import { gone } from "./missing.js";', 'import pg from "pg";', "export const x = [gone, pg];"].join(
+        "\n",
+      ),
+    });
+    expect(graph.unresolved).toEqual([expect.stringContaining("→ ./missing.js")]);
+    expect([...graph.externals]).toEqual(["pg"]);
+  });
+
+  it("follows imports that no statement-position matcher would find", () => {
+    // The other candidate fix — anchor the matcher to `^\s*import … from` — would
+    // pass the prose tests above while quietly dropping these three edges, and a
+    // dropped edge is how the prototype hid `pg` in the first place. So they are
+    // locked here: the walk's INPUT was narrowed, never its reach.
+    const graph = walkFixture({
+      "entry.ts": [
+        "import {",
+        "  a,",
+        "  b,",
+        '} from "./multi-line.js";',
+        'export { c } from "./re-exported.js";',
+        "export async function lazy() {",
+        '  return await import("./dynamic.js");',
+        "}",
+        "export const pair = [a, b];",
+      ].join("\n"),
+      "multi-line.ts": "export const a = 1;\nexport const b = 2;\n",
+      "re-exported.ts": "export const c = 3;\n",
+      "dynamic.ts": "export const d = 4;\n",
+    });
+    expect(graph.unresolved).toEqual([]);
+    expect(reachedNames(graph)).toEqual(["dynamic.ts", "entry.ts", "multi-line.ts", "re-exported.ts"]);
+  });
+
+  it("a `//` inside a string literal does not start a comment", () => {
+    // The cheap version of this fix — delete from `//` to end of line — eats the
+    // rest of any line holding a URL, and an import on that line goes with it.
+    const graph = walkFixture({
+      "entry.ts": [
+        'export const docs = "https://example.com/a//b";',
+        '/* A URL in a block comment: https://example.com/x */ import { thing } from "./thing.js";',
+        "export const used = thing;",
+      ].join("\n"),
+      "thing.ts": "export const thing = 1;\n",
+    });
+    expect(graph.unresolved).toEqual([]);
+    expect(reachedNames(graph)).toEqual(["entry.ts", "thing.ts"]);
   });
 });

--- a/apps/tui/src/module-graph.test.ts
+++ b/apps/tui/src/module-graph.test.ts
@@ -94,15 +94,68 @@ function resolveSpecifier(specifier: string, fromFile: string): string | undefin
  * seeing is exactly the edge the prototype hid. A comment cannot contain an import,
  * so the comments go and the matcher stays as greedy as it was.
  *
+ * THE THREE THINGS A `/` CAN MEAN are all handled, because getting one wrong is how
+ * this loses code rather than prose. `//` and `/*` open comments — neither can open a
+ * regex, since an empty regex is unwritable and `*` cannot begin one, so those two
+ * are read first and a literal's interior never reaches them. Otherwise a `/` in
+ * EXPRESSION POSITION opens a regex literal, consumed to its unescaped closing slash:
+ * without that state `/^\/*$/` opens a block comment that runs to EOF and the file
+ * yields NO imports at all, and `/https:\/\//` eats the rest of its line. A `/` after
+ * a value is division and is left alone, so a line comment after `a / b` is still a
+ * comment. Misjudging that last call is deliberately survivable in one direction
+ * only: a literal is emitted VERBATIM either way, so the cost is a comment left
+ * standing (loud — #273 returns), never a statement deleted (silent).
+ *
  * STRING LITERALS ARE KEPT VERBATIM, since the specifier itself is one — and that is
  * why `//` inside a string cannot start a comment here. Newlines survive so a removed
  * comment cannot splice two statements together. A `'`/`"` string also ends at the
  * newline: unterminated ones do not exist in source that compiles, and the bound
  * keeps a stray quote inside a regex literal (`/["']/`) from swallowing the file.
  */
+/** The words after which a `/` still opens a regex, not a division. */
+const REGEX_MAY_FOLLOW = new Set([
+  "await",
+  "case",
+  "delete",
+  "do",
+  "else",
+  "in",
+  "instanceof",
+  "new",
+  "of",
+  "return",
+  "throw",
+  "typeof",
+  "void",
+  "yield",
+]);
+
+/** Could a `/` arriving after `code` start a regex literal rather than divide? */
+function regexMayFollow(code: string): boolean {
+  const trimmed = code.replace(/\s+$/, "");
+  const last = trimmed.at(-1);
+  if (last === undefined) {
+    return true; // a file opening on a regex
+  }
+  if (last === ")" || last === "]") {
+    return false; // `(a + b) / 2`, `sizes[0] / 2`
+  }
+  if (/[\w$]/.test(last)) {
+    // An identifier or a number divides; a keyword does not.
+    return REGEX_MAY_FOLLOW.has(/[\w$]+$/.exec(trimmed)?.[0] ?? "");
+  }
+  return true; // `=`, `(`, `,`, `:`, `[`, `{`, `;`, `&&`, `!`, `?` …
+}
+
 function stripComments(source: string): string {
   let out = "";
+  // The last 32 characters of CODE (comments excluded), for `regexMayFollow`.
+  let tail = "";
   let index = 0;
+  const emit = (text: string): void => {
+    out += text;
+    tail = (tail + text).slice(-32);
+  };
   while (index < source.length) {
     const char = source[index] as string;
     const next = source[index + 1];
@@ -116,24 +169,47 @@ function stripComments(source: string): string {
       index += 2;
       while (index < source.length && !(source[index] === "*" && source[index + 1] === "/")) {
         if (source[index] === "\n") {
-          out += "\n";
+          out += "\n"; // a line the comment occupied, not code — `tail` is untouched
         }
         index += 1;
       }
       index += 2;
       continue;
     }
+    if (char === "/" && regexMayFollow(tail)) {
+      emit(char);
+      index += 1;
+      let inClass = false;
+      while (index < source.length) {
+        const inner = source[index] as string;
+        if (inner === "\\") {
+          emit(source.slice(index, index + 2));
+          index += 2;
+          continue;
+        }
+        emit(inner);
+        index += 1;
+        if (inner === "[") {
+          inClass = true; // an unescaped `/` inside `[…]` does not close the literal
+        } else if (inner === "]") {
+          inClass = false;
+        } else if ((inner === "/" && !inClass) || inner === "\n") {
+          break; // a literal cannot span a line: if one did, this was division
+        }
+      }
+      continue;
+    }
     if (char === '"' || char === "'" || char === "`") {
-      out += char;
+      emit(char);
       index += 1;
       while (index < source.length) {
         const inner = source[index] as string;
         if (inner === "\\") {
-          out += source.slice(index, index + 2);
+          emit(source.slice(index, index + 2));
           index += 2;
           continue;
         }
-        out += inner;
+        emit(inner);
         index += 1;
         if (inner === char || (inner === "\n" && char !== "`")) {
           break;
@@ -141,7 +217,7 @@ function stripComments(source: string): string {
       }
       continue;
     }
-    out += char;
+    emit(char);
     index += 1;
   }
   return out;
@@ -385,14 +461,52 @@ describe("the walker's input — what counts as an import specifier", () => {
   it("a `//` inside a string literal does not start a comment", () => {
     // The cheap version of this fix — delete from `//` to end of line — eats the
     // rest of any line holding a URL, and an import on that line goes with it.
+    // The import SHARES THE URL'S LINE deliberately: on its own line it survives a
+    // stripper with no string handling at all, and this test would lock nothing.
     const graph = walkFixture({
       "entry.ts": [
-        'export const docs = "https://example.com/a//b";',
-        '/* A URL in a block comment: https://example.com/x */ import { thing } from "./thing.js";',
+        'export const docs = "https://example.com/a//b"; import { thing } from "./thing.js";',
+        '/* A URL in a block comment: https://example.com/x */ export const used = [docs, thing];',
+      ].join("\n"),
+      "thing.ts": "export const thing = 1;\n",
+    });
+    expect(graph.unresolved).toEqual([]);
+    expect(reachedNames(graph)).toEqual(["entry.ts", "thing.ts"]);
+  });
+
+  it("a slash inside a regex literal does not open a comment", () => {
+    // The scanner's third state, and the one whose absence DELETES code rather
+    // than merely retaining it. `/^\/*$/` puts `/` next to `*` and would open a
+    // block comment that runs to EOF — the file yields no specifiers at all and
+    // its whole subtree drops out of the graph, which is a `pg` edge passing
+    // silently. `/https:\/\//` is the line-comment half of the same hole, so the
+    // import shares its line: everything after it would go.
+    const graph = walkFixture({
+      "entry.ts": [
+        "export const leading = /^\\/*$/;",
+        'export const https = /https:\\/\\//; import { thing } from "./thing.js";',
+        "export const used = [leading, https, thing];",
+      ].join("\n"),
+      "thing.ts": "export const thing = 1;\n",
+    });
+    expect(graph.unresolved).toEqual([]);
+    expect(reachedNames(graph)).toEqual(["entry.ts", "thing.ts"]);
+  });
+
+  it("division is not a regex literal — the third state cannot swallow a comment whole", () => {
+    // The other direction of the same judgement. Reading `/` after a value as the
+    // start of a regex would consume to the NEXT slash — here the `//` of a line
+    // comment — and hand the walk the prose inside it, putting #273 straight back.
+    const graph = walkFixture({
+      "entry.ts": [
+        "export const half = 10 / 2;",
+        'export const ratio = half / 5; // a ratio read from "prose", not a package',
+        'import { thing } from "./thing.js";',
         "export const used = thing;",
       ].join("\n"),
       "thing.ts": "export const thing = 1;\n",
     });
+    expect([...graph.externals]).toEqual([]);
     expect(graph.unresolved).toEqual([]);
     expect(reachedNames(graph)).toEqual(["entry.ts", "thing.ts"]);
   });

--- a/packages/engine/src/plans.ts
+++ b/packages/engine/src/plans.ts
@@ -300,7 +300,7 @@ export type LoadedNoPlanRecord = NoPlanRecord & { line: number };
  *     `endedBy` so the caller can name the date and the operator's reason.
  *   - **`unreadable`** — the newest in-window line for this position was SKIPPED, or
  *     the whole file failed to load. Never collapsed into `none`: "the file could not
- *     be read" is not the same fact as "this position has no plan."
+ *     be read" is a different fact from "this position has no plan."
  *
  * `skipped` carries the position's own in-window skips — the ones that were INPUTS
  * to this selection, in FILE ORDER. `unattributable` is FILE-GLOBAL: see


### PR DESCRIPTION
`apps/tui/src/module-graph.test.ts` walks the TUI's module graph by scraping import specifiers out of raw source text, and its matcher reads `from "…"` anywhere in the file. So an ordinary English sentence in a doc comment — `a load failure is a different fact from "this position has no plan."` — was walked as an import of a package literally named `this position has no plan.` and failed the build as an unresolvable external. It hit twice in one increment (#267), in unrelated files whose source was correct; both were worked around by rewording the sentence.

## What changed

**The input, not the matcher.** Comments are stripped before the walk; the `from "…"` matcher stays exactly as greedy as it was. The other candidate fix — anchoring to statement position (`^\s*(import|export)\b … from`) — buys the same quiet by narrowing what counts as an import, and an import this walker stops seeing is precisely the edge the prototype hid behind a computed specifier. Narrowing the input costs the guard nothing; narrowing the matcher costs it reach.

The stripper keeps string literals verbatim (the specifier is one — which is also why `//` inside a URL cannot start a comment), preserves newlines so a removed comment cannot splice two statements together, and ends a `'`/`"` string at the newline so a stray quote inside a regex literal like `/["']/` cannot swallow the rest of the file.

The `pg` half of the first assertion carried the same false positive — it matched raw source, so a comment *promising* there is no `pg` import read as one. It now reads the same stripped source the walk does.

## What holds it

Five fixture tests over a throwaway temp module tree, in both directions:

- prose saying `from "…"` in a line comment, a block comment and a JSDoc block is prose — and the real import sitting beside it is still followed;
- a comment mentioning `from "pg"` is not a `pg` import;
- an unresolvable relative import and a real external package are **both still reported** — the guard is not merely quieter;
- a multi-line import, a re-export and a dynamic `import()` inside a function body are all still followed, which is what a statement-position matcher would have dropped;
- a `//` inside a string literal does not start a comment.

Also, per the issue's third acceptance point, the engine's `PlanLookup` docstring goes back to its natural phrasing (`is a different fact from "this position has no plan."`) as the live regression fixture — verified to fail the old walker and pass the new one.

`pnpm typecheck` clean, `pnpm test` green (1692 passed).

What actually closes #273 is the stripped input plus the five fixtures that lock the guard's reach.

## Review round (a438ce9)

Two findings, both about the scanner rather than the walk, both fixed:

1. **The scanner had no regex-literal state**, so a `/` inside a regex could open a comment — which loses *code*, where the original bug only invented prose. `/^\/*$/` opens a block comment running to EOF, the file yields no imports at all, and its whole subtree drops out of the graph: a `pg` edge underneath would pass in silence. `/https:\/\//` is the line-comment half. Both shapes exist in the repo today (three test files), harmless only because no import shares those lines. The scanner now has the third state, and a wrong call is survivable in one direction only — a literal is emitted verbatim either way, so the cost is a comment left standing (loud) rather than a statement deleted (silent).
2. **The string-literal test passed with the string branch deleted** — the URL sat on a line holding no import. The import now shares that line, which is the only arrangement that locks the claim.

Two more fixture tests: the two regex shapes, and division staying division (`half / 5; // a ratio read from "prose"` must not swallow the comment and hand the walk its prose).

Checked against the TypeScript parser across all 266 TS/TSX files in the repo: every specifier `ts.preProcessFile` reports, the stripped walk still finds. `pnpm typecheck` clean, `pnpm test` green (1694 passed).
