### PR TITLE
docs: reconcile the ladder id and schema v5 after Fill Path landed

### DIFF
--- a/docs/hosted-cutover-runbook.md
+++ b/docs/hosted-cutover-runbook.md
@@ -508,7 +508,7 @@ all expected rather than faults:
 
 1. **Push-side (code half):** exit `0`, prints
    `[push] pushed snapshot fundId=<slug> asOf=<log's last event date>
-   schemaVersion=4 feedGap=<arrived>/<expected> reserveFloor=<pct|absent>
+   schemaVersion=5 feedGap=<arrived>/<expected> reserveFloor=<pct|absent>
    suppressed=[<keys>] dca=<loaded|unreadable>/<count>`; exactly one row for
    that `(fund_id, as_of)`; the `report` JSONB carries exactly `dashboard`,
    `dca`, `glance`, and `totals` — four keys, and the query sorts them, so
@@ -627,7 +627,7 @@ these connection strings rely on. On that upgrade, change them to
 | Seeded account password rotated — old rejected, new accepted | manual | PASS — both halves verified at the deployed URL | 2026-07-25 |
 | Rate-limit attack against the deployed URL (`auth:verify-limit`) | manual | PASS — 150 attempts, `403=14 429=136`, first 429 at #15, exit 0 | 2026-07-25 |
 | Rate-limit counter is DB-backed (D5), not per-instance memory | manual | PASS — 1 row, `has_signin_bucket=t`, `max_count=11` | 2026-07-25 |
-| First real push, push-side signal | manual | PASS — `fundId=<fund>-fund asOf=2026-07-24 schemaVersion=2` (v2 was current then; v4 today); 1 row; keys `{dashboard,totals}` | 2026-07-25 |
+| First real push, push-side signal | manual | PASS — `fundId=<fund>-fund asOf=2026-07-24 schemaVersion=2` (v2 was current then; v5 current now, reader accepts 4–5); 1 row; keys `{dashboard,totals}` | 2026-07-25 |
 | First real push, **gate-closing** signal (phone, away from desk) | manual | TODO | TODO |
 | Soak: one week spanning a weekend, four conditions hold | manual | TODO | TODO |
 

--- a/docs/plans-authoring-runbook.md
+++ b/docs/plans-authoring-runbook.md
@@ -74,19 +74,33 @@ authoring; the position is born later, when the first fill lands. Until then the
 renders that row `pending` — never `$0`. Zero is a measurement; pending is the absence of
 one.
 
-Identity is `positionId` + `effectiveAt`. There is no id field and no line number in the
-file: line numbers are read-side only, stamped by the loader so a diagnostic can tell you
-where to look.
+Identity for `dcaTime` and `noPlan` lines is `positionId` + `effectiveAt`; neither carries
+an `id` field, and there is no line number in the file for either — line numbers are
+read-side only, stamped by the loader so a diagnostic can tell you where to look.
+
+A `dcaLadder` line is the one exception: it also carries its own **required** `id`,
+covered in section 2.
 
 ## 2. The two kinds, worked
 
 **A ladder** — resting rungs declared as one plan, which is the fact the orders sidecar
-structurally cannot carry (it holds no `positionId` and no ladder id). `tierOrder` is the
-order capital is drawn down in; it is closed and strict (`c1`, `c2`, `c3`), non-empty, no
-repeats. Every rung needs a distinct `id` and a finite, positive `priceUsd` and `sizeUsd`.
+structurally cannot carry (it holds no `positionId` and no ladder id). Because that ladder
+id is what a fill later points back at, the line declaring the ladder must carry one
+itself: `id` is **required**, a UUID, non-empty, and unique across every `dcaLadder` line
+in the file — the loader refuses the line otherwise, and refuses a second line that
+repeats an id already claimed by an earlier, readable line. Generate one with `uuidgen`
+at the shell, or `crypto.randomUUID()` from a Node/Bun REPL — never author one by hand;
+it is a join key, not a label (see `packages/engine/src/plans.ts`'s note on why a UUID
+and not an authored slug). (Don't confuse this `id` with `planId`, which is the name of
+the *foreign* key that `OrderPlacedRecord` and `DcaPositionRow` use to point back at this
+ladder — the ladder's own identity field is `id`.)
+
+`tierOrder` is the order capital is drawn down in; it is closed and strict (`c1`, `c2`,
+`c3`), non-empty, no repeats. Every rung needs a distinct `id` and a finite, positive
+`priceUsd` and `sizeUsd`.
 
 ```json
-{"kind":"dcaLadder","positionId":"pos-demo-001","effectiveAt":"2026-08-10","tierOrder":["c1","c2"],"rungs":[{"id":"r1","priceUsd":90000,"sizeUsd":250},{"id":"r2","priceUsd":85000,"sizeUsd":250},{"id":"r3","priceUsd":80000,"sizeUsd":250},{"id":"r4","priceUsd":75000,"sizeUsd":250}]}
+{"kind":"dcaLadder","id":"3f1b7b9e-6c2a-4e3f-9d5a-2b7c8e1a4f60","positionId":"pos-demo-001","effectiveAt":"2026-08-10","tierOrder":["c1","c2"],"rungs":[{"id":"r1","priceUsd":90000,"sizeUsd":250},{"id":"r2","priceUsd":85000,"sizeUsd":250},{"id":"r3","priceUsd":80000,"sizeUsd":250},{"id":"r4","priceUsd":75000,"sizeUsd":250}]}
 ```
 
 **A time plan** — buy `amountUsd` every `cadence` (`daily`, `weekly`, `monthly`).


### PR DESCRIPTION
## Summary
Docs reconciliation sweep after the Fill Path increment (PR #291, issues #285-#290) landed. Fixes drift left behind by two changes: `DcaLadderPlanRecord.id` became a required field, and the projection's `schema_version` moved v4 -> v5.

- `docs/plans-authoring-runbook.md`: the worked `dcaLadder` example carried no `id`. Copying it as written would get the line refused at load (`packages/preferences/src/plans.ts` requires a non-empty, unique, renderable `id`). Added the id to the example, documented it as a required UUID (`uuidgen` / `crypto.randomUUID()`, never hand-authored), corrected the section-1 identity claim ("no id field" is no longer true for `dcaLadder`), and disambiguated it from `planId`, the foreign-key name on `OrderPlacedRecord`/`DcaPositionRow`.
- `docs/hosted-cutover-runbook.md`: the push-side success signal and the verification-record row both still quoted `schemaVersion=4`. Corrected both to 5, and noted the reader's accepted range (4-5) in the verification row.

## Checked, no change needed
- `docs/scripts.md` — verified against what slice 1 shipped; already accurate.
- `docs/web-deploy-runbook.md` — no schema-version or ladder-wire claims present; nothing stale.
- Rest of `docs/` swept for `sizeUsd`/`tornActs`/wire-shape claims — none found outside the one file below.

## Deliberately left alone (out of scope)
`context/adr/ADR-007`'s third amendment still says `sizeUsd` "stays off the wire" and rungs "ship as `priceUsd` alone" — both now false (per-rung `sizeUsd` crosses for the convexity caption). This is a known, recorded residual: amending ADR-007 was out of #290's scope, and `ADR-016-authentication-is-the-disclosure-ceiling.md` already documents the supersession and names it explicitly ("Recorded cost: ADR-007's third amendment now carries two sentences describing a narrower wire than exists... overtaken here rather than edited there"). No fourth amendment written.

## Test plan
- [x] `pnpm typecheck` green (docs-only change, ran to confirm no drift)
- [x] Manual read-through of both edited files for internal consistency