### PR TITLE
Fix phone login, and stop a hung price-feed run from eating the nightly window

### DIFF
--- a/apps/price-feed/src/schedule-window.test.ts
+++ b/apps/price-feed/src/schedule-window.test.ts
@@ -209,6 +209,38 @@ describe("the launchd fetch window", () => {
     expect(declared).toEqual(afterSpine);
   });
 
+  it("never rewrites LAST_STEP into a decorated value, which empties the landed-steps match", () => {
+    // The sibling test above pins WHICH names count as "the marks landed". This one
+    // pins that the variable those names are compared against still holds one of
+    // them. The comparison is an exact string match, so any assignment that turns
+    // `LAST_STEP` into a LABEL rather than a step name silently empties the whole
+    // predicate — every branch of the loop falls through and the run records itself
+    // as not having marked the day.
+    //
+    // That regression shipped once. The watchdog's TERM handler set
+    // `LAST_STEP="timeout:$LAST_STEP"`, so a run killed at `backfill` — after it had
+    // already appended, committed and VERIFIED the day's marks — stamped nothing,
+    // and the next morning claimed "nothing recorded for today" standing beside a
+    // true exit-124 line and a gap report that said the opposite. The `timeout:`
+    // label is still emitted; it is built at print time from a separate flag, which
+    // is what lets both facts be true at once.
+    //
+    // THE ANCHORED SCAN THE SIBLING USES CANNOT SEE THIS. That rewrite lived inside a
+    // single-quoted `trap` body on a `trap` line, so the `/^LAST_STEP="…"$/gm` list
+    // was still exactly the post-`spine` steps and the guard passed. This scan finds
+    // every assignment wherever it sits, and requires the two to agree — an
+    // assignment the anchored scan misses is itself the bug, because that scan is the
+    // oracle for `MARKS_LANDED_STEPS`.
+    const wrapper = readFileSync(WRAPPER_PATH, "utf8");
+    const everywhere = [...wrapper.matchAll(/\bLAST_STEP="([^"]*)"/g)].map((m) => m[1]!);
+    const anchored = [...wrapper.matchAll(/^LAST_STEP="([^"]+)"$/gm)].map((m) => m[1]!);
+    expect(everywhere).toEqual(anchored);
+    // A bare step name: no `$` (an expansion of itself), no `:` (a label prefix).
+    for (const value of everywhere) {
+      expect(value).toMatch(/^[a-z][a-z-]*$/);
+    }
+  });
+
   it("bounds a wedged run inside the gap between fires, so the next one is not skipped", () => {
     // THE ORACLE IS THE PLIST, WHICH IS WHY THIS LIVES HERE. The wrapper's watchdog
     // ceiling is only meaningful relative to how often launchd actually fires: the
@@ -244,5 +276,20 @@ describe("the launchd fetch window", () => {
       Math.min(...minutesOfDay.slice(1).map((m, i) => m - minutesOfDay[i]!)) * 60;
 
     expect(ceiling + grace).toBeLessThan(smallestGapSeconds);
+
+    // AND THE FLOOR, because the bound is two-sided and only the ceiling had a test.
+    // "Tighten it to be safe" is the single most plausible edit anyone will make to
+    // this number, and it is the one edit with the worst consequence: a ceiling at or
+    // below a healthy run's duration TERMs EVERY fire, not only the wedged ones. All
+    // six fires of an evening then die identically, the CDMX date rolls, and the day
+    // is unrecoverable — total loss, from an edit that looks like prudence and that
+    // the assertion above waves through (600 passes it cleanly).
+    //
+    // THE ORACLE IS THE WRAPPER'S OWN MEASURED RUN LENGTH, stated at the watchdog:
+    // "a healthy run takes ~15 minutes". Weaker than DEFAULT_CONFIG or the plist, and
+    // named as such — but it is a real observation of the thing being bounded, and
+    // 20 minutes is that figure with a third of itself as margin. This asserts the
+    // ceiling leaves room for a healthy run; it does not pin 2700.
+    expect(ceiling).toBeGreaterThan(20 * 60);
   });
 });

--- a/apps/price-feed/src/schedule-window.test.ts
+++ b/apps/price-feed/src/schedule-window.test.ts
@@ -208,4 +208,41 @@ describe("the launchd fetch window", () => {
     const declared = /^MARKS_LANDED_STEPS="([^"]+)"$/m.exec(wrapper)?.[1]?.split(" ");
     expect(declared).toEqual(afterSpine);
   });
+
+  it("bounds a wedged run inside the gap between fires, so the next one is not skipped", () => {
+    // THE ORACLE IS THE PLIST, WHICH IS WHY THIS LIVES HERE. The wrapper's watchdog
+    // ceiling is only meaningful relative to how often launchd actually fires: the
+    // whole point is that a hung run is dead and the job slot released BEFORE the
+    // next fire, so the hourly schedule's own retry still works.
+    //
+    // This is a real, observed failure, not a hypothetical. On 2026-08-11 the 22:01
+    // run wedged on a dead socket mid-backfill and was still alive twenty hours
+    // later; because launchd is a per-label singleton, it would have eaten the
+    // entire next evening's window too. Tightening the plist's intervals without
+    // tightening the ceiling silently restores that, and nothing else would catch it
+    // — the two files never reference each other.
+    const wrapper = readFileSync(WRAPPER_PATH, "utf8");
+    const ceiling = Number(
+      /^MAX_RUN_SECONDS="\$\{NUMISMA_PRICEFEED_MAX_RUN_SECONDS:-(\d+)\}"$/m.exec(wrapper)?.[1],
+    );
+    const grace = Number(
+      /^WATCHDOG_GRACE_SECONDS="\$\{NUMISMA_PRICEFEED_WATCHDOG_GRACE_SECONDS:-(\d+)\}"$/m.exec(
+        wrapper,
+      )?.[1],
+    );
+    expect(Number.isFinite(ceiling)).toBe(true);
+    expect(Number.isFinite(grace)).toBe(true);
+
+    // The SMALLEST gap between consecutive fires, not the nominal hour: if anyone
+    // ever adds a half-past interval, the tightest pair is what the ceiling has to
+    // clear. Sorted by minute-of-day; the day does not wrap because the schedule is
+    // pinned to a single 18:00-23:00 block by the assertions above.
+    const minutesOfDay = parseIntervals()
+      .map(({ Hour, Minute }) => Hour! * 60 + Minute!)
+      .sort((a, b) => a - b);
+    const smallestGapSeconds =
+      Math.min(...minutesOfDay.slice(1).map((m, i) => m - minutesOfDay[i]!)) * 60;
+
+    expect(ceiling + grace).toBeLessThan(smallestGapSeconds);
+  });
 });

--- a/apps/web/.env.example
+++ b/apps/web/.env.example
@@ -47,6 +47,14 @@ AUTH_DATABASE_URL=postgres://numisma_auth:changeme@localhost:5432/numisma_auth
 BETTER_AUTH_SECRET=dev-secret-change-me
 BETTER_AUTH_URL=http://localhost:3000
 
+# LOCAL DEV ONLY — extra origins allowed past Better Auth's CSRF origin check,
+# comma-separated. Needed to review the app on a phone: `vite dev --host` serves
+# the same server at your machine's LAN IP, but the Origin header no longer
+# matches BETTER_AUTH_URL, so sign-in fails with "Invalid origin". Set it to the
+# exact origin you type on the phone, scheme and port included. Ignored entirely
+# when NODE_ENV=production; never set it in the Vercel project.
+# DEV_TRUSTED_ORIGINS=http://192.168.100.60:3000
+
 # --- Single-tenant seed account (ADR-007) -----------------------------------
 # The product is single-tenant: open signup is DISABLED at the auth server. The
 # one account is established deterministically by `pnpm --filter @numisma/web

--- a/apps/web/README.md
+++ b/apps/web/README.md
@@ -145,6 +145,7 @@ See `apps/web/.env.example` for the authoritative, commented list. Summary:
 | `AUTH_DATABASE_URL` | Better Auth | Runtime — deployed app (Production only) |
 | `BETTER_AUTH_SECRET` | Better Auth | Runtime — deployed app (Production only) |
 | `BETTER_AUTH_URL` | Better Auth | Runtime — deployed app (Production only) |
+| `DEV_TRUSTED_ORIGINS` | Better Auth | Local dev only — comma-separated extra origins (e.g. the LAN IP you open on a phone); ignored when `NODE_ENV=production` |
 | `PROJECTION_WRITE_DATABASE_URL` | `push`, `backfill`, `db:init` | Local/operator only — never in the web project's env |
 | `PROJECTION_ADMIN_DATABASE_URL` | `db:provision` | One-shot, local/operator only |
 | `PROJECTION_WRITER_ROLE` / `PROJECTION_READER_ROLE` | `db:provision` | Optional, default `numisma_push` / `numisma_web` |

--- a/apps/web/src/lib/auth.ts
+++ b/apps/web/src/lib/auth.ts
@@ -22,12 +22,36 @@ import { betterAuth } from "better-auth";
 import { tanstackStartCookies } from "better-auth/tanstack-start";
 import { Pool } from "pg";
 
+/**
+ * LAN origins allowed during local development only (comma-separated in
+ * DEV_TRUSTED_ORIGINS, e.g. "http://192.168.100.60:3000").
+ *
+ * Better Auth CSRF-checks every /api/auth/* request by comparing the browser's
+ * Origin header against `baseURL` plus `trustedOrigins`. `baseURL` is a single
+ * fixed origin, so hitting `vite dev --host` from a phone at the machine's LAN
+ * IP fails with "Invalid origin" even though it is the same server — the host
+ * differs, and that is exactly what the check is for.
+ *
+ * The production gate is the point, not decoration: a LAN IP in the trusted set
+ * on a hosted deploy would widen the CSRF surface for no benefit, so the list is
+ * dropped whenever NODE_ENV === "production" (which Vercel sets at runtime).
+ * The var is also absent from Vercel's env, making this belt AND braces.
+ */
+const devTrustedOrigins =
+  process.env.NODE_ENV === "production"
+    ? []
+    : (process.env.DEV_TRUSTED_ORIGINS ?? "")
+        .split(",")
+        .map((origin) => origin.trim())
+        .filter(Boolean);
+
 export const auth = betterAuth({
   database: new Pool({
     connectionString: process.env.AUTH_DATABASE_URL,
   }),
   baseURL: process.env.BETTER_AUTH_URL,
   secret: process.env.BETTER_AUTH_SECRET,
+  trustedOrigins: devTrustedOrigins,
   emailAndPassword: {
     enabled: true,
     // Single-tenant invariant (ADR-007): the SERVER rejects new-account

--- a/apps/web/src/push/backfill-core.test.ts
+++ b/apps/web/src/push/backfill-core.test.ts
@@ -276,6 +276,42 @@ describe("runBackfill — a loop plus the existing upsert", () => {
     expect(results.map((r) => r.report)).toEqual(written.map((r) => r.report));
   });
 
+  /**
+   * WHAT MAKES THE POOL'S PER-QUERY CAP A BOUND ON THE WHOLE COMMAND. `query_timeout`
+   * bounds ONE query at 90s (projection-pool.ts). This loop issues one upsert per
+   * anchor — 43-44 of them, sequentially — so 90s per query only bounds the command
+   * because the FIRST rejection ends it. Nothing else in the system enforces that: it
+   * is a property of this loop having no per-anchor `catch`, which no test stated
+   * until this one.
+   *
+   * The tempting future edit is exactly the one that breaks it. `backfill` is
+   * idempotent and self-healing, so "keep going past one bad anchor" reads as an
+   * obvious robustness win — and it silently turns the command's worst case into
+   * ~43 x 90s = 65 minutes: past the wrapper's 2700s watchdog ceiling AND past the
+   * one-hour gap to the next scheduled fire, which is the hang this whole increment
+   * exists to make impossible. So the invariant is pinned where it lives, on
+   * behaviour: the loop stops, and it does not touch the next anchor.
+   */
+  it("ABORTS on the first failed upsert instead of continuing down the anchors", async () => {
+    await useStore(THREE_ANCHORS);
+    const queries: RecordedQuery[] = [];
+    const pool = {
+      query: async (sql: string, params: unknown[]) => {
+        queries.push({ sql, params });
+        // The shape the pool's client-side cap actually produces on a dead socket.
+        if (queries.length === 2) {
+          throw new Error("Query read timeout");
+        }
+        return { rows: [] };
+      },
+    } as unknown as Pool;
+
+    // Three anchors, so there IS a third one to reach if the loop swallowed the error.
+    await expect(runBackfill({ pool })).rejects.toThrow(/Query read timeout/);
+    expect(queries).toHaveLength(2);
+    expect(queries.map((q) => q.params[1])).toEqual(["2026-06-05", "2026-06-09"]);
+  });
+
   it("R6: re-running over an unchanged log derives identical payloads", async () => {
     await useStore(THREE_ANCHORS);
     const first = await runBackfill();

--- a/apps/web/src/push/backfill.ts
+++ b/apps/web/src/push/backfill.ts
@@ -29,6 +29,7 @@ import {
   runBackfill,
   writeAnchorFixture,
 } from "./backfill-core.ts";
+import { projectionPoolConfig } from "./projection-pool.ts";
 
 async function main(): Promise<void> {
   // `argv.slice(2)` drops the node binary and this script's own path; the parser and
@@ -44,8 +45,15 @@ async function main(): Promise<void> {
     throw new Error("PROJECTION_WRITE_DATABASE_URL is not set");
   }
 
+  // `projectionPoolConfig`, never a bare `{ connectionString }`: this command runs
+  // unattended under launchd, and a pool with no client-side query deadline wedged
+  // the 2026-08-11 22:01 run for twenty hours when the laptop slept mid-backfill.
+  // The full account, and why `query_timeout` is the only setting that covers it,
+  // is in projection-pool.ts.
   const pool =
-    fixtureOnly || !connectionString ? undefined : new Pool({ connectionString });
+    fixtureOnly || !connectionString
+      ? undefined
+      : new Pool(projectionPoolConfig(connectionString));
   try {
     const results = await runBackfill({
       pool,

--- a/apps/web/src/push/projection-pool.test.ts
+++ b/apps/web/src/push/projection-pool.test.ts
@@ -1,0 +1,75 @@
+import { describe, expect, it } from "vitest";
+import {
+  PROJECTION_QUERY_TIMEOUT_MS,
+  PROJECTION_STATEMENT_TIMEOUT_MS,
+  projectionPoolConfig,
+} from "./projection-pool.ts";
+
+/**
+ * These assertions are deliberately about PROPERTIES, not values. Pinning "30000 is
+ * 30000" would only restate the module's own bytes and would fail whenever someone
+ * retuned a number on purpose. What is asserted here is the small set of things
+ * that, if quietly dropped, would restore the 20-hour hang of 2026-08-11 — each of
+ * which has an oracle outside this file (the observed incident, and the launchd
+ * singleton the wrapper depends on).
+ */
+describe("projectionPoolConfig", () => {
+  const config = projectionPoolConfig("postgres://user@localhost:5432/db");
+
+  it("carries the connection string through untouched", () => {
+    expect(config.connectionString).toBe("postgres://user@localhost:5432/db");
+  });
+
+  /**
+   * THE REGRESSION TEST FOR THE INCIDENT. `query_timeout` is the only one of the
+   * four settings enforced client-side, so it is the only one that bounds a query
+   * whose socket has died silently. Everything else in this file is secondary to
+   * this one line: without it, a slept laptop wedges the nightly job indefinitely.
+   */
+  it("bounds every query client-side, so a dead socket cannot hang the run forever", () => {
+    expect(config.query_timeout).toBeGreaterThan(0);
+    expect(Number.isFinite(config.query_timeout)).toBe(true);
+  });
+
+  it("caps the connect phase as well as the query", () => {
+    expect(config.connectionTimeoutMillis).toBeGreaterThan(0);
+    expect(Number.isFinite(config.connectionTimeoutMillis)).toBe(true);
+  });
+
+  /**
+   * Order matters, and the reason is diagnostic quality rather than safety: the
+   * server must be the one to give up on a genuinely slow statement, so the failure
+   * arrives as a PG `query_canceled` naming the statement instead of an anonymous
+   * client-side timeout on a connection that was healthy all along.
+   */
+  it("lets the server's cap fire before the client's", () => {
+    expect(PROJECTION_STATEMENT_TIMEOUT_MS).toBeLessThan(PROJECTION_QUERY_TIMEOUT_MS);
+    expect(config.statement_timeout).toBe(PROJECTION_STATEMENT_TIMEOUT_MS);
+    expect(config.query_timeout).toBe(PROJECTION_QUERY_TIMEOUT_MS);
+  });
+
+  /**
+   * Keepalive is what lets the KERNEL notice the peer is gone rather than waiting
+   * out the full client cap. It does not replace `query_timeout` (its timing is an
+   * OS tunable), but with it off, every dead-socket query pays the maximum.
+   */
+  it("enables TCP keepalive with an explicit initial delay", () => {
+    expect(config.keepAlive).toBe(true);
+    expect(config.keepAliveInitialDelayMillis).toBeGreaterThan(0);
+  });
+
+  /**
+   * The wrapper's watchdog kills a wedged run so launchd's per-label singleton
+   * releases the job slot before the next hourly fire. That only helps if the pool
+   * gives up FIRST — otherwise the watchdog is the sole line of defence and the
+   * process dies by signal with no PG error to explain why. One hour is the
+   * interval the plist actually fires at; see schedule-window.test.ts, which pins
+   * the watchdog against the same oracle from the other side.
+   */
+  it("gives up well inside the one-hour gap between scheduled fires", () => {
+    const oneHourMs = 60 * 60 * 1000;
+    expect(config.connectionTimeoutMillis! + PROJECTION_QUERY_TIMEOUT_MS).toBeLessThan(
+      oneHourMs,
+    );
+  });
+});

--- a/apps/web/src/push/projection-pool.test.ts
+++ b/apps/web/src/push/projection-pool.test.ts
@@ -65,8 +65,16 @@ describe("projectionPoolConfig", () => {
    * process dies by signal with no PG error to explain why. One hour is the
    * interval the plist actually fires at; see schedule-window.test.ts, which pins
    * the watchdog against the same oracle from the other side.
+   *
+   * A BOUND ON ONE QUERY, NOT ON THE COMMAND, and the name says so because the
+   * distinction is load-bearing. This sum is one connect plus one query; `backfill`
+   * issues 43-44 upserts sequentially and NOTHING here scales with that count. What
+   * makes the command as a whole finite is that its loop aborts on the first
+   * rejection — a separate invariant, pinned separately in backfill-core.test.ts
+   * ("ABORTS on the first failed upsert"). Reading this assertion as a per-run bound
+   * is how a per-anchor `catch` could be added without a single test going red.
    */
-  it("gives up well inside the one-hour gap between scheduled fires", () => {
+  it("bounds ONE stalled connect-plus-query well inside the one-hour gap between fires", () => {
     const oneHourMs = 60 * 60 * 1000;
     expect(config.connectionTimeoutMillis! + PROJECTION_QUERY_TIMEOUT_MS).toBeLessThan(
       oneHourMs,

--- a/apps/web/src/push/projection-pool.ts
+++ b/apps/web/src/push/projection-pool.ts
@@ -1,0 +1,84 @@
+/**
+ * Pool configuration for the two UNATTENDED projection writers (`push.ts`,
+ * `backfill.ts`). It exists because of a specific, observed failure, and every
+ * value here is chosen against that failure rather than as generic hygiene.
+ *
+ * WHAT HAPPENED (2026-08-11 22:06 CDMX). The 22:01 scheduled run reached step 6,
+ * opened a pool against the Neon pooler, upserted 11 anchors, and then the laptop
+ * slept. The TCP connection died with it — but nothing on either end said so: the
+ * server never sent a FIN the client could see, and node-postgres imposes NO
+ * client-side deadline on a query by default. So `await pool.query(...)` for anchor
+ * 12/43 simply never settled. The run was still sitting there TWENTY HOURS later,
+ * having burned 0.49s of CPU.
+ *
+ * WHY A HANG IS WORSE THAN A CRASH HERE, and this is the part that makes it worth
+ * a file. A crashed run goes red, writes a heartbeat, and the next hourly fire
+ * heals it — `backfill` is idempotent precisely so that can work. A HUNG run does
+ * none of that. It never reaches the EXIT trap, so the heartbeat still describes
+ * the PREVIOUS run and reads perfectly healthy. And because launchd is a per-label
+ * singleton (see run-daily-fetch.sh's header, which says so explicitly), the wedged
+ * process holds the job slot: every remaining fire in the 18:00-23:00 window is
+ * skipped, and the following evening's window is skipped too. The plist's own
+ * header spells out the consequence — once the CDMX date rolls, `isFreshBar`
+ * refuses yesterday's bar and the day is unrecoverable. One dead socket therefore
+ * costs an unbounded number of days, silently.
+ *
+ * THE HANG-BREAKER IS `query_timeout`, NOT the other three. Be precise about this,
+ * because the obvious candidates do not cover the observed case:
+ *   - `connectionTimeoutMillis` caps only the CONNECT phase. The connection here
+ *     was already established and already working, so this would never have fired.
+ *   - `statement_timeout` is enforced by the SERVER. On a socket the server can no
+ *     longer reach, its verdict cannot get back to us, so it cannot end our wait.
+ *   - `keepAlive` lets the KERNEL discover the dead peer and error the socket. It
+ *     is the closest thing to a real fix, but its timing is an OS tunable we do not
+ *     set and should not depend on for an upper bound.
+ * Only `query_timeout` is enforced client-side, in-process, on a timer we own — so
+ * it is the only one that bounds this failure no matter what the network does. The
+ * others are kept because they each shorten a DIFFERENT failure, not as backup.
+ *
+ * `statement_timeout` IS DELIBERATELY THE SHORTER OF THE TWO. When a query is
+ * genuinely slow rather than orphaned, we want the server to abort it and return a
+ * real PG error (`57014 query_canceled`) naming the statement. Reversing the order
+ * would let the client give up first on a connection that was fine, leaving the
+ * server still working on a statement nobody will read, and reporting a generic
+ * client timeout in place of a diagnosable one.
+ */
+import type { PoolConfig } from "pg";
+
+/**
+ * Connect phase only. Generous because the Neon pooler cold-starts a compute on
+ * the first connection of the evening, and failing that is a real regression.
+ */
+export const PROJECTION_CONNECT_TIMEOUT_MS = 30_000;
+
+/**
+ * Server-side per-statement cap. Measured against reality, not guessed: a healthy
+ * backfill upserts all 43 anchors inside a single second (the `pushed_at` spread on
+ * 2026-08-12 was 03:28:08.098 → 03:28:08.632), so ~100ms per statement. 60s is
+ * three orders of magnitude of headroom and still bounded.
+ */
+export const PROJECTION_STATEMENT_TIMEOUT_MS = 60_000;
+
+/** Client-side per-query cap — the hang-breaker. Strictly above the server's cap. */
+export const PROJECTION_QUERY_TIMEOUT_MS = 90_000;
+
+/** How long an idle socket waits before the kernel starts probing the peer. */
+export const PROJECTION_KEEPALIVE_DELAY_MS = 10_000;
+
+/**
+ * Build the pool config for an unattended projection writer.
+ *
+ * Exported as a VALUE rather than applied inline at each `new Pool(...)` so the
+ * invariants above can be asserted by a test without standing up a database — the
+ * seam is the config object, and that is the whole point of it being one.
+ */
+export function projectionPoolConfig(connectionString: string): PoolConfig {
+  return {
+    connectionString,
+    connectionTimeoutMillis: PROJECTION_CONNECT_TIMEOUT_MS,
+    statement_timeout: PROJECTION_STATEMENT_TIMEOUT_MS,
+    query_timeout: PROJECTION_QUERY_TIMEOUT_MS,
+    keepAlive: true,
+    keepAliveInitialDelayMillis: PROJECTION_KEEPALIVE_DELAY_MS,
+  };
+}

--- a/apps/web/src/push/push.ts
+++ b/apps/web/src/push/push.ts
@@ -27,6 +27,7 @@
  * and recovery paths it is for.
  */
 import { Pool } from "pg";
+import { projectionPoolConfig } from "./projection-pool.ts";
 import { readSchemaDdl } from "../projection/provision.ts";
 import {
   buildDcaForAnchor,
@@ -81,7 +82,11 @@ async function main(): Promise<void> {
   const glance = fold ? await buildGlanceForAnchor(fold) : undefined;
   const dca = fold ? await buildDcaForAnchor(fold) : undefined;
 
-  const pool = new Pool({ connectionString });
+  // Same deadlines as `backfill`, and for the same reason — this command is the
+  // other unattended projection writer, so it is exposed to the identical dead-socket
+  // hang (projection-pool.ts). It was not the command that wedged on 2026-08-11 only
+  // because the wrapper calls `backfill`; nothing about `push` made it safe.
+  const pool = new Pool(projectionPoolConfig(connectionString));
   try {
     if (doInit) {
       await initSchema(pool);

--- a/apps/web/src/routes/login.tsx
+++ b/apps/web/src/routes/login.tsx
@@ -14,7 +14,19 @@ function LoginPage() {
 
   const signIn = useMutation({
     mutationFn: async () => {
-      const { error } = await authClient.signIn.email({ email, password });
+      // Normalized because phone keyboards and autofill are the reason this
+      // form fails where a desktop succeeds: iOS/Android suggestion bars append
+      // a trailing space, and some Android keyboards still capitalize the first
+      // letter even in a type="email" field. The stored account email is
+      // lowercase, so a capital or a stray space reads as "no such user".
+      //
+      // The PASSWORD is deliberately left untouched: whitespace and case are
+      // significant there, and silently trimming a password would reject a
+      // legitimate one.
+      const { error } = await authClient.signIn.email({
+        email: email.trim().toLowerCase(),
+        password,
+      });
       if (error) {
         throw new Error(error.message ?? "Sign in failed");
       }

--- a/ops/price-feed/run-daily-fetch.sh
+++ b/ops/price-feed/run-daily-fetch.sh
@@ -57,6 +57,12 @@ PATH_PREPEND="${NUMISMA_PATH_PREPEND:-$HOME/.asdf/shims:$HOME/Library/pnpm:/opt/
 # commit, because the heartbeat trap below must know where to write BEFORE the
 # exit-127 checks — which are the very failures the heartbeat exists to record.
 DATA_DIR="${NUMISMA_DATA_DIR:-$HOME/Dev/accumulus/data}"
+# Wall-clock ceiling on the WHOLE run, enforced by the watchdog below. Must stay
+# comfortably under the 3600s gap between scheduled fires; the reasoning and the
+# guard are at the watchdog itself. 0 disables it (manual debugging only).
+MAX_RUN_SECONDS="${NUMISMA_PRICEFEED_MAX_RUN_SECONDS:-2700}"
+# How long the watchdog waits after SIGTERM before escalating to SIGKILL.
+WATCHDOG_GRACE_SECONDS="${NUMISMA_PRICEFEED_WATCHDOG_GRACE_SECONDS:-30}"
 # ----------------------------------------------------------------------------
 
 # Give the scheduled (non-login) job a deterministic PATH that can find pnpm. This
@@ -141,9 +147,28 @@ if [[ -f "$HEARTBEAT_FILE" ]]; then
     's/.*"lastMarkWindowFinishedAt"[[:space:]]*:[[:space:]]*"\([^"]*\)".*/\1/p' \
     "$HEARTBEAT_FILE" 2>/dev/null | head -n1)" || CARRIED_MARK_WINDOW_AT=""
   # A schemaVersion-1 file predates this field, and every v1 run was treated as
-  # in-window — so its `finishedAt` IS the last in-window finish. Only fall back
-  # when the previous run did not explicitly declare itself out-of-window.
-  if [[ -z "$CARRIED_MARK_WINDOW_AT" ]] && ! grep -q '"markWindow"[[:space:]]*:[[:space:]]*false' "$HEARTBEAT_FILE" 2>/dev/null; then
+  # in-window — so its `finishedAt` IS the last in-window finish.
+  #
+  # GATED POSITIVELY ON v1, and the negative gate it replaces was a real bug. That
+  # version fell back whenever the file did not say `"markWindow": false`, which is
+  # true of a perfectly ordinary v2 file: an IN-WINDOW run that died before `spine`
+  # correctly omits `lastMarkWindowFinishedAt` (it marked nothing) while carrying
+  # `"markWindow": true`. The old condition read that omission as "v1" and promoted
+  # the failure's own `finishedAt` into a marked-day stamp — manufacturing evidence
+  # that the day was covered out of a run that covered nothing, and silencing the
+  # staleness warning on exactly the morning it was needed. That is the same failure
+  # the `MARKS_LANDED_STEPS` comment above is at pains to avoid, re-entered through
+  # the compatibility path.
+  #
+  # LATENT BEFORE, REACHABLE NOW. It needed an in-window run that failed before
+  # `spine` and left a v2 file — uncommon. The watchdog makes exactly that shape
+  # routine (a timed-out run is in-window and unmarked by construction), so it is
+  # fixed here rather than left for the fix to start tripping.
+  #
+  # Matching v1 EXPLICITLY rather than "not v2" keeps a future v3 on the correct
+  # side by default: an unrecognised newer file declines the fallback, which fails
+  # closed to an unset carry — the same direction every other guard here leans.
+  if [[ -z "$CARRIED_MARK_WINDOW_AT" ]] && grep -q '"schemaVersion"[[:space:]]*:[[:space:]]*1[[:space:]]*,' "$HEARTBEAT_FILE" 2>/dev/null; then
     CARRIED_MARK_WINDOW_AT="$(sed -n \
       's/.*"finishedAt"[[:space:]]*:[[:space:]]*"\([^"]*\)".*/\1/p' \
       "$HEARTBEAT_FILE" 2>/dev/null | head -n1)" || CARRIED_MARK_WINDOW_AT=""
@@ -184,6 +209,45 @@ fi
 # already run, so it can never dirty the tree it just verified.
 write_heartbeat() {
   HEARTBEAT_STATUS=$?
+  # Never let a dead stdout kill the writer. The EXIT path reaches here from the
+  # watchdog's TERM (where `tee` is already gone) as well as from a clean finish,
+  # and a SIGPIPE partway through would lose the whole breadcrumb. Set here TOO, not
+  # only in the TERM handler, because this trap also runs on paths that never passed
+  # through it. Cheap, idempotent, and the failure it prevents is silent.
+  trap '' PIPE
+  # CANCEL THE WATCHDOG FIRST — before the early `return 0` below, and before any
+  # work that could fail. A watchdog left sleeping is not a harmless stray: it sits
+  # in this run's process group, so launchd's per-label singleton still considers
+  # the job RUNNING and skips the next fire. That is precisely the failure the
+  # watchdog was added to prevent, re-created by the fix for it.
+  #
+  # SIGKILL, not SIGTERM, and it is not brutality: the watchdog holds `trap '' TERM`
+  # so it can outlive the group-TERM it sends, which also makes it deaf to a polite
+  # request from here. `:-` because the EXIT trap is installed BEFORE the watchdog is
+  # armed and must survive the exit-127 paths, where this variable does not exist yet.
+  #
+  # KILL THE SUBSHELL *AND ITS `sleep`*, because killing the subshell alone does not
+  # stop it. `sleep` is a separate child process, so a bare `kill $WATCHDOG_PID`
+  # reaps the subshell and leaves the timer orphaned to init — and that orphan is
+  # not inert. It stays in this run's process group (so launchd's per-label
+  # singleton still counts the job as RUNNING and skips the next fire) and it still
+  # holds the inherited write end of the log pipe (so `tee` never sees EOF and never
+  # exits, keeping yet another group member alive). Observed exactly that way: a
+  # HEALTHY run reported "complete", then sat there with a stray `sleep`, a live
+  # `tee`, and a held job slot — the very failure this watchdog was added to end,
+  # re-created by the watchdog itself.
+  #
+  # Children are enumerated BEFORE the parent dies, while `pgrep -P` can still see
+  # them; once orphaned they reparent to init and that link is gone.
+  if [[ -n "${WATCHDOG_PID:-}" ]]; then
+    WATCHDOG_KIDS="$(pgrep -P "$WATCHDOG_PID" 2>/dev/null | tr '\n' ' ')"
+    kill -KILL "$WATCHDOG_PID" 2>/dev/null || true
+    # Unquoted ON PURPOSE: this is a space-separated PID list that must word-split,
+    # and it is empty on the ordinary path where the subshell had no live child.
+    # shellcheck disable=SC2086
+    [[ -n "$WATCHDOG_KIDS" ]] && kill -KILL $WATCHDOG_KIDS 2>/dev/null
+  fi
+  true
   [[ -d "$DATA_DIR" ]] || return 0
   HEARTBEAT_FINISHED_AT="$(date -u +%Y-%m-%dT%H:%M:%SZ 2>/dev/null)" || HEARTBEAT_FINISHED_AT="$STARTED_AT"
   # A run stamps itself as the last in-window run only if it was in the window AND
@@ -230,9 +294,123 @@ mkdir -p "$LOG_DIR"
 LOG_FILE="$LOG_DIR/price-feed-$STAMP.log"
 
 # Everything from here is tee'd to the per-run log AND the scheduler's stdout.
-exec > >(tee -a "$LOG_FILE") 2>&1
+#
+# THE `trap '' TERM PIPE` INSIDE THE SUBSTITUTION IS NOT DECORATION — it is what
+# makes the watchdog's teardown survivable. This `tee` is an ordinary member of the
+# run's process group, so the watchdog's group-TERM would otherwise kill it FIRST,
+# leaving the shell writing into a dead pipe while it tries to run its EXIT trap.
+# Measured, not feared: with `tee` killable, the heartbeat was lost on 3 of 5
+# timeout runs (the shell died of SIGPIPE partway through `exit`, before the trap
+# body was even entered) — losing the one breadcrumb the whole watchdog exists to
+# leave. Deaf to TERM, `tee` outlives the group signal, the pipe stays open through
+# teardown, and it then exits on its own when the shell closes the pipe at exit.
+# PIPE is ignored for the same defensive reason on its far side.
+#
+# The SIGKILL escalation still takes it, which is correct: that path is the hard
+# stop for a run that ignored TERM, and by then there is no orderly teardown left
+# to protect.
+exec > >(trap '' TERM PIPE; tee -a "$LOG_FILE") 2>&1
 
 echo "[$STAMP] price-feed daily run starting (repo=$REPO_DIR)"
+
+# --- the watchdog (#308 follow-up) ------------------------------------------
+# A WEDGED RUN IS A WORSE FAILURE THAN A RED ONE, and until 2026-08-11 nothing here
+# bounded it. That evening the 22:01 run reached step 6, opened a pool against Neon,
+# upserted 11 of 43 anchors, and the laptop slept. The TCP connection died silently
+# and node-postgres had no client-side deadline, so the query never settled. The run
+# was still sitting there twenty hours later.
+#
+# THE COST IS NOT THE LOST RUN, IT IS EVERY RUN AFTER IT. Three separate mechanisms
+# in this file assume a run ENDS:
+#   - the EXIT trap never fires, so job-heartbeat.json still describes the PREVIOUS
+#     run and reads perfectly healthy — the staleness channel goes quiet exactly
+#     when it is needed;
+#   - launchd is a per-label singleton (see this file's header, which relies on that
+#     fact to justify having no lock), so the wedged process HOLDS THE JOB SLOT and
+#     every remaining fire in the 18:00-23:00 window is skipped;
+#   - and per the plist header, once the CDMX date rolls `isFreshBar` refuses
+#     yesterday's bar, so each skipped evening is unrecoverable.
+# One dead socket therefore costs an unbounded run of days, with no signal at all.
+#
+# The pool now gives up on its own (apps/web/src/push/projection-pool.ts), which
+# covers the observed cause. THIS COVERS THE CATEGORY: any step that can block
+# forever — a provider socket, a git credential prompt, an NFS stall — is bounded
+# here without this file having to enumerate them.
+#
+# WHY THE CEILING IS 2700s. It has to beat the next fire, not the end of the window:
+# the point is that launchd's slot is free at the top of the next hour, so the
+# schedule's own hourly retry still works. Fires are 3600s apart, a healthy run
+# takes ~15 minutes, and 2700 + 30s grace leaves ~14 minutes of margin.
+# apps/price-feed/src/schedule-window.test.ts pins this against the plist's actual
+# interval, so shortening the interval without shortening this fails a test.
+#
+# WHY A HAND-ROLLED WATCHDOG. macOS ships no `timeout(1)` (that is GNU coreutils),
+# and this file's whole design principle is to depend on nothing that could itself
+# be the missing thing. A subshell and `sleep` are always there.
+#
+# THE SELF-TERM IS THE SUBTLE PART. The watchdog signals the PROCESS GROUP, because
+# the thing to kill is usually not this script — it is the node process three levels
+# down holding the dead socket, and TERMing only the parent would orphan it and
+# leave the slot held. But the watchdog is itself in that group, so it would kill
+# itself before it could escalate to SIGKILL; `trap '' TERM` makes it immune to the
+# signal it sends. The parent must therefore use SIGKILL to cancel it (below).
+#
+# GROUP-KILL ONLY WHEN WE ARE THE GROUP LEADER. Under launchd this script is its own
+# process group leader, which is what makes `kill -- -$$` safe. Run some other way
+# (sourced, or without job control) it may share its parent's group, and signalling
+# that group would kill the caller's whole session. In that case the watchdog is
+# DISABLED AND SAYS SO, rather than silently becoming a hazard: the unattended path
+# is the one that needs it, and that path always qualifies.
+RUN_PGID="$(ps -o pgid= -p $$ 2>/dev/null | tr -d '[:space:]')" || RUN_PGID=""
+WATCHDOG_PID=""
+
+# Turn the watchdog's SIGTERM into an ordinary `exit`, so the EXIT trap still runs
+# and the heartbeat records the timeout instead of the run dying by signal with no
+# breadcrumb. `LAST_STEP` is rewritten first, so the file names the step that hung —
+# "timeout:backfill" is the whole diagnosis in one field. 124 is the exit code GNU
+# `timeout` uses for this, borrowed so the number means something to a reader.
+#
+# `trap '' PIPE` FIRST, AND IT IS LOAD-BEARING. Stdout here is a pipe into the `tee`
+# that writes the per-run log, and that `tee` is in the process group the watchdog
+# signals — so by the time this handler runs, the far end of our own stdout is
+# usually already dead. Without this, the next write earns SIGPIPE and the shell
+# dies by signal 13 with the EXIT trap half-run, losing the heartbeat: the run
+# vanishes exactly as silently as the hang it was killed for. Observed directly —
+# two identical runs during development exited 124 and -13 respectively, on nothing
+# but timing. Ignoring PIPE turns that write into a harmless EPIPE.
+#
+# Ignoring PIPE here is the SECOND half of a two-part fix and does not stand alone:
+# the first half is the `trap '' TERM` inside the logging `tee` above, which is what
+# actually keeps this shell's stdout alive through teardown. With `tee` killable,
+# ignoring PIPE was measurably not enough — the shell still died partway through
+# `exit`, before this trap's body ran, on 3 of 5 timeout runs. Keep both; this one
+# costs nothing and covers any writer the group signal reaches first.
+trap 'trap "" PIPE; LAST_STEP="timeout:$LAST_STEP"; exit 124' TERM
+
+if [[ "$MAX_RUN_SECONDS" -le 0 ]]; then
+  echo "[$STAMP] watchdog DISABLED (NUMISMA_PRICEFEED_MAX_RUN_SECONDS=$MAX_RUN_SECONDS)"
+elif [[ -z "$RUN_PGID" || "$RUN_PGID" != "$$" ]]; then
+  echo "[$STAMP] watchdog DISABLED (not a process-group leader: pgid=${RUN_PGID:-unknown} pid=$$)"
+else
+  (
+    # TERM so it survives the group signal it is about to send (see above); PIPE so
+    # its own progress lines cannot kill it. The second one is not cosmetic: these
+    # echoes go to the same `tee` the group-TERM just killed, so without it the
+    # watchdog dies of SIGPIPE on the "escalating" line and THE SIGKILL IS NEVER
+    # SENT — the escalation path would be dead in precisely the case that needs it,
+    # a child that ignored TERM.
+    trap '' TERM PIPE
+    sleep "$MAX_RUN_SECONDS"
+    echo "[$STAMP] WATCHDOG: run exceeded ${MAX_RUN_SECONDS}s — terminating process group $RUN_PGID"
+    kill -TERM -- "-$RUN_PGID" 2>/dev/null || true
+    sleep "$WATCHDOG_GRACE_SECONDS"
+    echo "[$STAMP] WATCHDOG: escalating to SIGKILL after ${WATCHDOG_GRACE_SECONDS}s grace"
+    kill -KILL -- "-$RUN_PGID" 2>/dev/null || true
+  ) &
+  WATCHDOG_PID=$!
+  echo "[$STAMP] watchdog armed: ${MAX_RUN_SECONDS}s ceiling (pid $WATCHDOG_PID, pgid $RUN_PGID)"
+fi
+# ----------------------------------------------------------------------------
 
 # Load provider tokens from the private file if it exists. Nothing secret lives in
 # the repo (transaction-data-is-private); the file is machine-local, chmod 600.

--- a/ops/price-feed/run-daily-fetch.sh
+++ b/ops/price-feed/run-daily-fetch.sh
@@ -77,6 +77,16 @@ STARTED_AT="$(date -u +%Y-%m-%dT%H:%M:%SZ)"
 # How far the run got. MAINTAINED, not guessed: each step below advances it, so a
 # heartbeat can say WHERE a run died and not merely that it did.
 LAST_STEP="startup"
+# Whether the WATCHDOG is what ended this run, carried as a SEPARATE FACT rather
+# than by rewriting `LAST_STEP`. An earlier version did rewrite it in place
+# ("timeout:backfill"), and that quietly broke the `MARKS_LANDED_STEPS` predicate
+# below: it is an exact-string match, so a decorated name matches nothing and a run
+# that HAD appended, committed and verified the day's marks recorded itself as not
+# having landed them — producing the "nothing recorded for today" cry-wolf the
+# comment at MARKS_LANDED_STEPS is written to prevent, standing right beside a true
+# exit-124 line. The step name now stays a bare step name everywhere; the timeout is
+# a flag, and the decoration happens once, at print time.
+TIMED_OUT=false
 HEARTBEAT_FILE="$DATA_DIR/job-heartbeat.json"
 
 # --- was this run even CAPABLE of marking? (#185 S2) -------------------------
@@ -216,7 +226,9 @@ write_heartbeat() {
   # through it. Cheap, idempotent, and the failure it prevents is silent.
   trap '' PIPE
   # CANCEL THE WATCHDOG FIRST — before the early `return 0` below, and before any
-  # work that could fail. A watchdog left sleeping is not a harmless stray: it sits
+  # work that could fail (except on the timeout path, where it is deliberately left
+  # running; the last paragraph of this comment is that case). A watchdog left
+  # sleeping on any OTHER path is not a harmless stray: it sits
   # in this run's process group, so launchd's per-label singleton still considers
   # the job RUNNING and skips the next fire. That is precisely the failure the
   # watchdog was added to prevent, re-created by the fix for it.
@@ -238,8 +250,30 @@ write_heartbeat() {
   # re-created by the watchdog itself.
   #
   # Children are enumerated BEFORE the parent dies, while `pgrep -P` can still see
-  # them; once orphaned they reparent to init and that link is gone.
-  if [[ -n "${WATCHDOG_PID:-}" ]]; then
+  # them; once orphaned they reparent to init and that link is gone. The `pgrep`/
+  # `kill` pair is still a race — the subshell can fork its next timer between the
+  # two lines, and in the ARMING window it may not have forked one at all yet — but
+  # it is now a BOUNDED one: the watchdog sleeps in poll-length increments, so the
+  # worst a lost child costs is one poll interval of stray `sleep`, not the whole
+  # 2700s ceiling it used to cost (a 45-minute held job slot).
+  #
+  # NOT ON THE TIMEOUT PATH, and this exclusion is the whole point of the watchdog's
+  # second half. If the shell reacts to the group TERM it arrives here within
+  # milliseconds and would SIGKILL the watchdog long before the grace expires — so
+  # the SIGKILL escalation could never fire in the one case it exists for, and any
+  # group member that IGNORED the TERM would survive the timeout. Reproduced exactly
+  # that way: a TERM-deaf grandchild lived on in the run's process group, and because
+  # it held the inherited write end of the log pipe, `tee` never saw EOF and stayed
+  # alive too — both still holding launchd's per-label slot. On this path the
+  # heartbeat below is already on disk by the time the shell leaves, so letting the
+  # watchdog finish its own grace and group-SIGKILL costs nothing and reaps the deaf
+  # descendant, `tee` and the watchdog's own timer in one signal.
+  #
+  # GATED ON THE FLAG, NOT ON `HEARTBEAT_STATUS -ne 124`: a step is free to exit 124
+  # on its own terms, and treating that as a timeout would leave a live watchdog
+  # sleeping out its full ceiling over an already-dead run — holding the slot for
+  # exactly as long as the hang would have.
+  if [[ -n "${WATCHDOG_PID:-}" && "$TIMED_OUT" != "true" ]]; then
     WATCHDOG_KIDS="$(pgrep -P "$WATCHDOG_PID" 2>/dev/null | tr '\n' ' ')"
     kill -KILL "$WATCHDOG_PID" 2>/dev/null || true
     # Unquoted ON PURPOSE: this is a space-separated PID list that must word-split,
@@ -273,14 +307,23 @@ write_heartbeat() {
       fi
     done
   fi
+  # DECORATE ONCE, HERE, AFTER THE PREDICATE ABOVE HAS ALREADY RUN. "timeout:backfill"
+  # is the whole diagnosis in one field and is worth keeping — but it is a LABEL, not
+  # a step name, and the loop above compares step names. Building it at print time is
+  # what lets both be true at once: the predicate sees `backfill` and stamps the day
+  # it really landed, the reader sees `timeout:backfill` and knows what killed it.
+  HEARTBEAT_LAST_STEP="$LAST_STEP"
+  if [[ "$TIMED_OUT" == "true" ]]; then
+    HEARTBEAT_LAST_STEP="timeout:$LAST_STEP"
+  fi
   if [[ -n "$HEARTBEAT_MARK_WINDOW_AT" ]]; then
     printf '{\n  "schemaVersion": 2,\n  "startedAt": "%s",\n  "finishedAt": "%s",\n  "exitCode": %d,\n  "lastStep": "%s",\n  "markWindow": %s,\n  "lastMarkWindowFinishedAt": "%s"\n}\n' \
-      "$STARTED_AT" "$HEARTBEAT_FINISHED_AT" "$HEARTBEAT_STATUS" "$LAST_STEP" \
+      "$STARTED_AT" "$HEARTBEAT_FINISHED_AT" "$HEARTBEAT_STATUS" "$HEARTBEAT_LAST_STEP" \
       "$MARK_WINDOW" "$HEARTBEAT_MARK_WINDOW_AT" \
       > "$HEARTBEAT_FILE" 2>/dev/null || true
   else
     printf '{\n  "schemaVersion": 2,\n  "startedAt": "%s",\n  "finishedAt": "%s",\n  "exitCode": %d,\n  "lastStep": "%s",\n  "markWindow": %s\n}\n' \
-      "$STARTED_AT" "$HEARTBEAT_FINISHED_AT" "$HEARTBEAT_STATUS" "$LAST_STEP" "$MARK_WINDOW" \
+      "$STARTED_AT" "$HEARTBEAT_FINISHED_AT" "$HEARTBEAT_STATUS" "$HEARTBEAT_LAST_STEP" "$MARK_WINDOW" \
       > "$HEARTBEAT_FILE" 2>/dev/null || true
   fi
   return 0
@@ -292,6 +335,12 @@ trap write_heartbeat EXIT
 
 mkdir -p "$LOG_DIR"
 LOG_FILE="$LOG_DIR/price-feed-$STAMP.log"
+# The watchdog's calling card. It is touched by the watchdog immediately BEFORE it
+# signals the group, and it is the only way the TERM handler can tell the watchdog's
+# signal from anybody else's — `launchctl stop`/`unload` (the documented reinstall
+# step), a logout, or a shutdown all deliver the same bare SIGTERM. Per-run name, so
+# it can never be a stale flag from an earlier run.
+WATCHDOG_FIRED_FILE="$LOG_FILE.watchdog-fired"
 
 # Everything from here is tee'd to the per-run log AND the scheduler's stdout.
 #
@@ -364,11 +413,29 @@ echo "[$STAMP] price-feed daily run starting (repo=$REPO_DIR)"
 RUN_PGID="$(ps -o pgid= -p $$ 2>/dev/null | tr -d '[:space:]')" || RUN_PGID=""
 WATCHDOG_PID=""
 
-# Turn the watchdog's SIGTERM into an ordinary `exit`, so the EXIT trap still runs
-# and the heartbeat records the timeout instead of the run dying by signal with no
-# breadcrumb. `LAST_STEP` is rewritten first, so the file names the step that hung —
-# "timeout:backfill" is the whole diagnosis in one field. 124 is the exit code GNU
-# `timeout` uses for this, borrowed so the number means something to a reader.
+# Turn a SIGTERM into an ordinary `exit`, so the EXIT trap still runs and the
+# heartbeat records what happened instead of the run dying by signal with no
+# breadcrumb at all. 124 is the exit code GNU `timeout` uses, borrowed so the number
+# means something to a reader; the step that hung is named by the `timeout:` label
+# the heartbeat writer builds from `TIMED_OUT`.
+#
+# IT ASKS WHO SENT THE SIGNAL, because this handler is installed unconditionally and
+# a bare SIGTERM has more than one sender. `launchctl stop`, `launchctl unload` (the
+# documented reinstall step in docs/launchagent-reinstall.md), a logout and a system
+# shutdown all land here, and labelling those a timeout is a lie with a cost: the
+# next TUI startup reports "FAILED — exit 124 at step 'timeout:prices-fetch'" for a
+# run that was stopped by hand four minutes in with 2400s of ceiling left. This
+# breadcrumb is the only channel that reaches a human, so a spurious FAILED line
+# spends exactly the credibility it exists to hold. The watchdog leaves its calling
+# card before it signals; anything without that card is an EXTERNAL stop and is
+# recorded as one — plain step name, exit 143 (128+SIGTERM), which reads as "someone
+# stopped this" rather than "this hung".
+#
+# THE HEARTBEAT IS STILL WRITTEN ON THAT PATH, unlike before the watchdog existed
+# (where the shell died by signal and the EXIT trap never ran). That is deliberate:
+# a run TERMed at shutdown AFTER `spine` really did land the day's marks, and only a
+# heartbeat can say so. Going silent there would leave the next morning claiming
+# nothing was recorded for a day the log plainly holds.
 #
 # `trap '' PIPE` FIRST, AND IT IS LOAD-BEARING. Stdout here is a pipe into the `tee`
 # that writes the per-run log, and that `tee` is in the process group the watchdog
@@ -385,13 +452,27 @@ WATCHDOG_PID=""
 # ignoring PIPE was measurably not enough — the shell still died partway through
 # `exit`, before this trap's body ran, on 3 of 5 timeout runs. Keep both; this one
 # costs nothing and covers any writer the group signal reaches first.
-trap 'trap "" PIPE; LAST_STEP="timeout:$LAST_STEP"; exit 124' TERM
+trap 'trap "" PIPE; if [[ -e "$WATCHDOG_FIRED_FILE" ]]; then TIMED_OUT=true; exit 124; fi; exit 143' TERM
 
 if [[ "$MAX_RUN_SECONDS" -le 0 ]]; then
   echo "[$STAMP] watchdog DISABLED (NUMISMA_PRICEFEED_MAX_RUN_SECONDS=$MAX_RUN_SECONDS)"
 elif [[ -z "$RUN_PGID" || "$RUN_PGID" != "$$" ]]; then
   echo "[$STAMP] watchdog DISABLED (not a process-group leader: pgid=${RUN_PGID:-unknown} pid=$$)"
 else
+  # HOW LONG A SINGLE `sleep` MAY BE, which is the same question as "how long can a
+  # stray timer outlive the run". The parent cancels this watchdog by SIGKILLing the
+  # subshell and whatever `pgrep -P` could see at that instant, and that pair is
+  # inherently racy — the subshell can fork its next timer in between, and during the
+  # ARMING window (between `$!` and the first fork) there is no child to find at all.
+  # With one 2700s `sleep` that race orphaned a 45-MINUTE timer into the run's
+  # process group, holding launchd's per-label slot through the next fire — the exact
+  # failure the watchdog exists to prevent. Waiting in short hops does not close the
+  # race, it makes losing it cheap: the stray exits within one hop. Clamped so a small
+  # ceiling (manual debugging, tests) is still honoured rather than rounded up.
+  WATCHDOG_POLL_SECONDS=5
+  if [[ "$MAX_RUN_SECONDS" -lt "$WATCHDOG_POLL_SECONDS" ]]; then
+    WATCHDOG_POLL_SECONDS="$MAX_RUN_SECONDS"
+  fi
   (
     # TERM so it survives the group signal it is about to send (see above); PIPE so
     # its own progress lines cannot kill it. The second one is not cosmetic: these
@@ -400,8 +481,19 @@ else
     # SENT — the escalation path would be dead in precisely the case that needs it,
     # a child that ignored TERM.
     trap '' TERM PIPE
-    sleep "$MAX_RUN_SECONDS"
+    # `SECONDS` is wall-clock since this assignment, so the ceiling stays honest no
+    # matter how the hops round: the loop overshoots by less than one hop, never
+    # accumulating drift the way counting iterations would.
+    SECONDS=0
+    while [[ $SECONDS -lt $MAX_RUN_SECONDS ]]; do
+      sleep "$WATCHDOG_POLL_SECONDS"
+    done
     echo "[$STAMP] WATCHDOG: run exceeded ${MAX_RUN_SECONDS}s — terminating process group $RUN_PGID"
+    # Leave the calling card BEFORE the signal, so the TERM handler can tell this
+    # signal from an operator's or the system's and does not report a `launchctl
+    # unload` as a timeout. Guarded: a failure to write it costs a mislabel, never
+    # the kill itself.
+    : > "$WATCHDOG_FIRED_FILE" 2>/dev/null || true
     kill -TERM -- "-$RUN_PGID" 2>/dev/null || true
     sleep "$WATCHDOG_GRACE_SECONDS"
     echo "[$STAMP] WATCHDOG: escalating to SIGKILL after ${WATCHDOG_GRACE_SECONDS}s grace"


### PR DESCRIPTION
Two independent pieces of work that happened to be in flight together: the phone-login fixes, and the price-feed hang found while investigating a stale dashboard. They share no code — separate commits, reviewable separately.

Closes #309

## 1. Login from a phone — `feat(auth)`

Two distinct reasons sign-in failed on mobile while working on the desktop:

- **Origin.** Better Auth CSRF-checks every `/api/auth/*` request against `baseURL`, a single fixed origin — so `vite dev --host` reached at the machine's LAN IP is rejected as "Invalid origin" even though it is the same server. Adds an opt-in `DEV_TRUSTED_ORIGINS` list, dropped entirely when `NODE_ENV=production` so a LAN IP can never widen the CSRF surface on a hosted deploy.
- **Credentials.** Past that, the form still failed: phone keyboards and autofill append a trailing space and can capitalize the first letter even in a `type="email"` field, and the stored account email is lowercase. The email is now trimmed and lowercased — **the password deliberately is not**, since whitespace and case are significant there and silently trimming one would reject a legitimate credential.

## 2. The nightly price feed could hang forever — `fix(price-feed)`

Full incident write-up in #309. In short: on 2026-08-11 the 22:01 run upserted 11 of 43 anchors and the laptop slept. The socket died silently, `node-postgres` applies no client-side query deadline, and the run was still alive **20 hours later**.

**It hung rather than failed, and that distinction is the entire bug.** A crash is harmless here — red exit, heartbeat, next hourly fire heals it, `backfill` is idempotent precisely so that works. A hang defeats all three mechanisms at once: the EXIT trap never runs (so the heartbeat still describes the *previous* run and reads healthy), and launchd's per-label singleton — which this wrapper's header relies on to justify having no lock — keeps the job slot held. Since `isFreshBar` refuses yesterday's bar once the CDMX date rolls, every skipped evening is unrecoverable. One dead socket costs an unbounded run of days, with no signal.

### What changed

- **`apps/web/src/push/projection-pool.ts` (new).** Shared deadlines for both unattended writers. `query_timeout` is the hang-breaker and the only setting that covers this case — `connectionTimeoutMillis` caps a connect phase that had already succeeded, `statement_timeout` is the server's verdict on a socket it can no longer reach, and `keepAlive` depends on an OS tunable we do not set. All four are kept, each shortening a different failure; the server's cap sits below the client's so a genuinely slow query returns a diagnosable `query_canceled`.
- **Wrapper watchdog.** Bounds the whole run at 2700s → TERM the process group → SIGKILL after grace, converting the signal into `exit 124`. The ceiling beats the **next fire**, not the end of the window — the slot must be free at the top of the hour for the schedule's own retry to work — and is pinned against the plist's real interval by a test, since the two files never reference each other.
- **Two SIGTERM senders, told apart.** The watchdog is not the only thing that sends this process a bare TERM: `launchctl stop`, `launchctl unload` (the documented reinstall step), a logout and a shutdown all land in the same handler. The watchdog leaves a per-run calling card immediately before it signals, so a timeout records `exit 124` with a `"lastStep": "timeout:<step>"` label, while an **external** stop records `exit 143` (128+SIGTERM) with a plain step name — "someone stopped this" rather than "this hung". The heartbeat is written on both paths, which is new: before the watchdog existed an external TERM killed the shell by signal and the EXIT trap never ran. Deliberate, because a run stopped *after* `spine` really did land the day's marks and only a heartbeat can say so.

### Two defects found by testing the watchdog, not by reading it

Both would have defeated it in production, and both are the reason this diff is larger than "add a timeout":

- **Teardown lost the heartbeat on 3 of 5 runs.** The group-TERM also killed the `tee` behind the script's stdout, so the shell died of SIGPIPE partway through `exit`, before the EXIT trap body ran — the watchdog would have killed the run and left no breadcrumb, which is exactly the failure it exists to prevent. The logging `tee` is now deaf to TERM so the pipe outlives teardown.
- **The watchdog leaked and re-created the original bug.** Killing the subshell does not kill its `sleep` child; the orphan stayed in the process group *and* held the inherited write end of the log pipe, so `tee` never saw EOF either. Observed on a **healthy** run: it reported "complete", then sat there with a stray `sleep`, a live `tee`, and a held job slot. Children are now enumerated before the parent dies and reaped with it.

### Plus a latent heartbeat bug this makes reachable

The `schemaVersion`-1 fallback fired for any file not saying `"markWindow": false` — also true of an ordinary v2 file from an in-window run that died before `spine`. It promoted that failure's own `finishedAt` into a marked-day stamp, **manufacturing evidence that the day was covered**, silencing the staleness warning on exactly the morning it was needed. Latent before; a timed-out run is precisely that shape, so the watchdog would have started tripping it. Now gated positively on v1, so an unrecognised future version fails closed.

## Review round — two more defects, again found by running it

Reviewed in a fresh context so the session that authored the change did not review its own work. Six findings; the two that mattered were both in the watchdog, and both were reproduced before being fixed. Commits `69b909d`, `e05baa0`, `c3a45a9`.

- **The timeout label broke the "did this run land the marks?" predicate.** The TERM handler rewrote `LAST_STEP` to `timeout:<step>` in place, and `MARKS_LANDED_STEPS` is an **exact-string** match — so a run the watchdog killed at `backfill`, the literal 08-11 shape, had already appended, committed and verified the day's marks yet recorded itself as not having landed them. `lastMarkWindowFinishedAt` fell back to the previous evening and the next morning read *"nothing recorded for today"* beside a true exit-124 line: the cry-wolf that the comment above `MARKS_LANDED_STEPS` exists to prevent. Fixed by carrying the timeout as a separate `TIMED_OUT` flag and building the `timeout:` label once, at print time, **after** the predicate has run — so the predicate sees a bare step name and the reader still gets the diagnosis in one field.
- **Cancelling the watchdog made its own SIGKILL escalation dead code.** The reap in `write_heartbeat` ran within milliseconds of the group TERM, killing the watchdog long before its grace expired — so the escalation could never fire in the one case it exists for, and any group member that *ignored* the TERM survived. Reproduced exactly that way: a TERM-deaf grandchild lived on in the run's pgid and, holding the inherited write end of the log pipe, kept `tee` alive with it — both still holding launchd's slot. The reap is now skipped on the timeout path so the watchdog finishes its own grace and group-SIGKILL. Gated on `TIMED_OUT` rather than on `exitCode == 124`, since a step is free to exit 124 on its own terms and treating that as a timeout would leave a live watchdog sleeping out the full ceiling over an already-dead run.
- **The watchdog now waits in 5s hops instead of one `sleep 2700`.** The `pgrep -P` / `kill` cancel is inherently racy and the arming window — before the first timer is forked — is not covered by the original "it is always asleep for the full ceiling" argument. Short hops do not close the race, they make losing it cheap: a lost child orphans a 5-second timer rather than a 45-minute held job slot. `SECONDS` is wall-clock, so the ceiling stays honest however the hops round.
- **Two test-only guards.** The exact-string predicate is now pinned against the `timeout:` decoration, and the pool test's "gives up well inside the one-hour gap" claim — which sums one connect + one query against a backfill that issues 43-44 sequential upserts — now rests on a stated, pinned invariant (`runBackfill` aborts on first error) rather than an unstated one. The watchdog-ceiling guard also gained a floor: `MAX_RUN_SECONDS=600` used to pass green while TERMing every healthy ~15-minute run.

## Verification

- **Timeout path:** 6/6 consecutive runs with a reactive child and 6/6 with a `trap "" TERM` grandchild — exit 124, `lastStep=timeout:<step>`, the day stamped to *this* run's `finishedAt`, **zero leaked processes** in the pgid.
- **External stop:** 6/6 `killpg` mid-`prices-fetch` — exit 143, undecorated step name, zero leaked.
- **Early failure:** 12/12 `exit 127` under a 300s ceiling — zero leaked.
- **Healthy path:** exit 0, heartbeat `"complete"`, zero leaked.
- **Negative control against the pre-review commit:** 3/3 timeouts carried yesterday's stamp forward, left **4 processes** in the pgid (deaf grandchild, its `sleep`, the `tee` subshell, `tee`), and 3/3 external TERMs mislabelled themselves `124 / timeout:prices-fetch`. Both new vitest guards confirmed red against their regressions before being restored.
- **Heartbeat carry:** v2-unmarked no longer invents a stamp; genuine v1 still carries its `finishedAt`.
- **Real run via `launchctl start`:** watchdog armed, completed in 76s, exit 0, 44 anchors through `2026-08-12` — the day the wedged process had already eaten was recovered before the date rolled.
- `/bin/bash -n` clean under 3.2.57 (what launchd runs). `shellcheck` unavailable on this machine.
- `pnpm typecheck` clean; `pnpm test` **1925 passed / 19 skipped**.

## Reviewer notes / known gaps

Three residuals are filed as follow-ups rather than fixed here — none of them blocks this merge, and all three are tracked:

- **No committed test harness for the wrapper** — issue #313. Two rounds, four signal-handling defects, every one of them found by *running* the script and none by reading it; both harnesses were thrown away. This remains the weakest part of the change and the most likely place for a regression to hide. It is a real increment, not a tidy-up.
- **The `pgrep` cancel race is bounded, not closed** — issue #311. Cost reduced from a 45-minute held job slot to a 5-second stray timer. Keeping the mitigation and closing that issue is a legitimate outcome.
- **The external-stop path has only been exercised synthetically** — issue #312. `killpg` is not `launchctl unload`, a logout, or a shutdown, and the exit-143 path writes a heartbeat where the pre-watchdog code wrote nothing.

Two more, unchanged from the original write-up:

- `apps/web/src/projection/snapshot-reader.ts` builds its own pool without these deadlines. Different lifecycle (request-scoped, behind a platform function timeout) so it is out of scope here, but it is the same hazard class.
- The local dev projection DB is only ever written by hand — the nightly job writes to the hosted DB — so a local dashboard drifts stale by design. Not addressed here; worth deciding separately.
