### PR TITLE
test(engine,tui): four test setups now assert what their titles claim

### DIFF
--- a/apps/tui/src/spine-args.test.ts
+++ b/apps/tui/src/spine-args.test.ts
@@ -29,11 +29,15 @@ describe("parseAsOfArg — the windowed-fold flag, fail-loud on a bad value", ()
   });
 
   it("fails loud on a malformed value", () => {
-    expect(() => parseAsOfArg(["node", "spine", "--as-of", "nope"])).toThrow(/--as-of/);
+    expect(() => parseAsOfArg(["node", "spine", "--as-of", "nope"])).toThrow(
+      "Missing or invalid value for --as-of (expected YYYY-MM-DD).",
+    );
   });
 
   it("fails loud on a missing value", () => {
-    expect(() => parseAsOfArg(["node", "spine", "--as-of"])).toThrow(/--as-of/);
+    expect(() => parseAsOfArg(["node", "spine", "--as-of"])).toThrow(
+      "Missing or invalid value for --as-of (expected YYYY-MM-DD).",
+    );
   });
 });
 

--- a/apps/tui/src/startup.test.ts
+++ b/apps/tui/src/startup.test.ts
@@ -171,7 +171,7 @@ describe("prepareStartup — ingests, surfaces the report, and wires the fold lo
           throw new Error("ingest should not run when --as-of is invalid");
         },
       }),
-    ).rejects.toThrow(/--as-of/);
+    ).rejects.toThrow("Missing or invalid value for --as-of (expected YYYY-MM-DD).");
     expect(emitted).toEqual([]);
   });
 

--- a/packages/engine/src/cash-settlement-scenarios.test.ts
+++ b/packages/engine/src/cash-settlement-scenarios.test.ts
@@ -74,7 +74,11 @@ describe("durable-log versioning — a legacy open/close fails loud with a migra
   });
 
   it("parseEvent refuses a record tagged newer than this build supports", () => {
-    const future = { ...legacyClose, schemaVersion: EVENT_SCHEMA_VERSION + 1, settlement: { reserveId: "tiered", proceeds: 360 } };
+    // Proceeds 600: the same gate-legal figure the migration test below uses (alt-pos
+    // expects 20 × last close 40 = 800; 600 is −25%, inside ±50%). parseEvent never
+    // consults the cross-ref gate, but a fixture that only the SHAPE gate would admit
+    // would be asserting about a record the ingest path could never hold.
+    const future = { ...legacyClose, schemaVersion: EVENT_SCHEMA_VERSION + 1, settlement: { reserveId: "tiered", proceeds: 600 } };
     const result = parseEvent(future);
     expect(result.kind).toBe("event-error");
     if (result.kind === "event-error") {
@@ -84,7 +88,8 @@ describe("durable-log versioning — a legacy open/close fails loud with a migra
   });
 
   it("accepts a current-version record carrying the schemaVersion marker", () => {
-    const v2 = { ...legacyClose, schemaVersion: EVENT_SCHEMA_VERSION, settlement: { reserveId: "tiered", proceeds: 360 } };
+    // Same gate-legal 600 as above, for the same reason.
+    const v2 = { ...legacyClose, schemaVersion: EVENT_SCHEMA_VERSION, settlement: { reserveId: "tiered", proceeds: 600 } };
     expect(parseEvent(v2).kind).toBe("ok");
   });
 

--- a/packages/engine/src/cash-settlement.test.ts
+++ b/packages/engine/src/cash-settlement.test.ts
@@ -105,24 +105,31 @@ describe("cash leg — Open debits the funding reserve, tiered by the lots' own 
 });
 
 describe("cash leg — Close credits the settlement reserve, proceeds tiered proportionally", () => {
-  it("splits proceeds by the closed position's cost-basis tier mix; loss falls per Tier", () => {
-    // alt-pos cost basis: c1 100 + c2 300 = 400. Proceeds 360 = a realized loss.
-    // c1 weight 25% → 90 (lost 10), c2 weight 75% → 270 (lost 30). Lineage shrinks
-    // honestly on the same Tier it was risked on.
+  it("splits proceeds by the closed position's cost-basis tier mix; the gain lands per Tier", () => {
+    // alt-pos cost basis: c1 100 + c2 300 = 400. Proceeds 600 = a realized gain of 200.
+    // c1 weight 25% → 150 (gained 50), c2 weight 75% → 450 (gained 150). Lineage grows
+    // on the same Tier it was risked on.
+    //
+    // 600 is a GATE-LEGAL fill, which is why it is not a loss: the settlement-magnitude
+    // gate expects 20 units × last close 40 = 800 and admits ±50%, so the legal band is
+    // 400–1200 — and 400 is this position's exact cost basis. No admissible close of
+    // alt-pos can realize a loss at all; the loss-absorption path is locked on the
+    // real-shaped gram fixture in cash-settlement-scenarios.test.ts (108 against a basis
+    // of 120), where a loss IS reachable.
     const close: PortfolioEvent = {
       id: "close-alt",
       asOf: "2026-06-03",
       type: "PositionClosed",
       positionId: "alt-pos",
-      settlement: { reserveId: "tiered", proceeds: 360 },
+      settlement: { reserveId: "tiered", proceeds: 600 },
     };
 
     const data = foldEvents(genesis(), [close]);
     const reserve = reserveById(data, "tiered");
 
-    expect(reserve.amount).toBe(1860); // 1500 + 360
-    expect(tierQty(reserve, "c1")).toBeCloseTo(1090, 6); // 1000 + 90
-    expect(tierQty(reserve, "c2")).toBeCloseTo(770, 6); // 500 + 270
+    expect(reserve.amount).toBe(2100); // 1500 + 600
+    expect(tierQty(reserve, "c1")).toBeCloseTo(1150, 6); // 1000 + 150
+    expect(tierQty(reserve, "c2")).toBeCloseTo(950, 6); // 500 + 450
     expect(data.positions.some((position) => position.id === "alt-pos")).toBe(false);
   });
 

--- a/packages/engine/src/cash-settlement.test.ts
+++ b/packages/engine/src/cash-settlement.test.ts
@@ -105,31 +105,45 @@ describe("cash leg — Open debits the funding reserve, tiered by the lots' own 
 });
 
 describe("cash leg — Close credits the settlement reserve, proceeds tiered proportionally", () => {
-  it("splits proceeds by the closed position's cost-basis tier mix; the gain lands per Tier", () => {
-    // alt-pos cost basis: c1 100 + c2 300 = 400. Proceeds 600 = a realized gain of 200.
-    // c1 weight 25% → 150 (gained 50), c2 weight 75% → 450 (gained 150). Lineage grows
-    // on the same Tier it was risked on.
+  it("splits proceeds by the closed position's cost-basis tier mix; loss falls per Tier", () => {
+    // alt-pos cost basis: c1 100 + c2 300 = 400. Proceeds 360 = a realized loss.
+    // c1 weight 25% → 90 (lost 10), c2 weight 75% → 270 (lost 30). Lineage shrinks
+    // honestly on the same Tier it was risked on.
     //
-    // 600 is a GATE-LEGAL fill, which is why it is not a loss: the settlement-magnitude
-    // gate expects 20 units × last close 40 = 800 and admits ±50%, so the legal band is
-    // 400–1200 — and 400 is this position's exact cost basis. No admissible close of
-    // alt-pos can realize a loss at all; the loss-absorption path is locked on the
-    // real-shaped gram fixture in cash-settlement-scenarios.test.ts (108 against a basis
-    // of 120), where a loss IS reachable.
+    // The loss is GATE-LEGAL, and the mark is what makes it so. The settlement-magnitude
+    // gate sizes the close against `quantity × last close`, and last close moves with
+    // every PriceMarked: walking alt-usd from the genesis anchor 40 down to 25 (−37.5%,
+    // inside the ±50% mark band) resets expected to 20 × 25 = 500, so 360 is −28% —
+    // in-band. Both legs are run through `crossReferenceEvent` below rather than
+    // asserted in prose, so the fixture cannot drift back into an unreachable world.
+    const mark: PortfolioEvent = {
+      id: "mark-alt",
+      asOf: "2026-06-02",
+      type: "PriceMarked",
+      instrumentId: "alt-usd",
+      price: 25,
+    };
     const close: PortfolioEvent = {
       id: "close-alt",
       asOf: "2026-06-03",
       type: "PositionClosed",
       positionId: "alt-pos",
-      settlement: { reserveId: "tiered", proceeds: 600 },
+      settlement: { reserveId: "tiered", proceeds: 360 },
     };
 
-    const data = foldEvents(genesis(), [close]);
+    const seed = genesis();
+    expect(crossReferenceEvent(mark, buildEventReference(seed, [])).kind).toBe("ok");
+    expect(crossReferenceEvent(close, buildEventReference(seed, [mark])).kind).toBe("ok");
+    // …and the mark is load-bearing: against the genesis anchor of 40 the same close
+    // is a 55% deviation and the gate refuses it.
+    expect(crossReferenceEvent(close, buildEventReference(seed, [])).kind).toBe("event-error");
+
+    const data = foldEvents(seed, [mark, close]);
     const reserve = reserveById(data, "tiered");
 
-    expect(reserve.amount).toBe(2100); // 1500 + 600
-    expect(tierQty(reserve, "c1")).toBeCloseTo(1150, 6); // 1000 + 150
-    expect(tierQty(reserve, "c2")).toBeCloseTo(950, 6); // 500 + 450
+    expect(reserve.amount).toBe(1860); // 1500 + 360
+    expect(tierQty(reserve, "c1")).toBeCloseTo(1090, 6); // 1000 + 90
+    expect(tierQty(reserve, "c2")).toBeCloseTo(770, 6); // 500 + 270
     expect(data.positions.some((position) => position.id === "alt-pos")).toBe(false);
   });
 

--- a/packages/engine/src/fold.test.ts
+++ b/packages/engine/src/fold.test.ts
@@ -11,6 +11,8 @@ import {
   crossReferenceEvent,
   foldEvents,
   parseFundReview,
+  reserveDeltasForClose,
+  reserveDeltasForOpen,
   type FundReviewData,
   type PortfolioEvent,
   type PositionDecision,
@@ -826,5 +828,59 @@ describe("foldEvents — the seed is never mutated (defensive clone)", () => {
     expect(genesis.instruments[0]!.symbol).toBe("AAPL");
     expect(genesis.reserves[0]!.amount).toBe(1000);
     expect(genesis.positions[0]!.markPrice).toBe(150);
+  });
+});
+
+describe("tier-weighted deltas — the zero-cost degenerate fallback (pinned, not endorsed)", () => {
+  // PIN OF A DEGENERATE FALLBACK. `tierWeightedDeltas` normally splits a cash
+  // delta across the lots' Tiers by cost-basis weight, but when the lots carry no
+  // cost at all (`totalCost === 0`) there is no weight to split by, and it
+  // attributes the WHOLE delta to `lots[0].tier` — the FIRST LOT'S tier, not the
+  // first Tier in c1/c2/c3 order, and not a split. Coverage rationale §5 names
+  // this arm (`events/fold.ts:47-48`) as an open, reachable branch.
+  //
+  // These tests record what the code does today so the behavior cannot change
+  // silently; they are not an argument that attributing everything to one lot's
+  // Tier is the right answer.
+
+  it("attributes the whole close credit to the FIRST lot's Tier when every lot has zero cost", () => {
+    // Zero-cost lots across two Tiers, deliberately ordered c3-then-c1 so the
+    // answer distinguishes "the first lot's tier" (c3) from "the first Tier
+    // present in c1/c2/c3 order" (c1) — and from any proportional split, which
+    // would have to divide by a zero total cost.
+    const zeroCostLots: PositionLot[] = [
+      { quantity: 4, cost: 0, tier: "c3" },
+      { quantity: 6, cost: 0, tier: "c1" },
+    ];
+
+    const deltas = reserveDeltasForClose(zeroCostLots, 250);
+
+    expect(deltas).toEqual([{ tier: "c3", amount: 250 }]);
+  });
+
+  it("debits the same single Tier on the open leg, sign-flipped", () => {
+    const zeroCostLots: PositionLot[] = [
+      { quantity: 1, cost: 0, tier: "c2" },
+      { quantity: 1, cost: 0, tier: "c1" },
+    ];
+
+    expect(reserveDeltasForOpen(zeroCostLots, 80)).toEqual([{ tier: "c2", amount: -80 }]);
+  });
+
+  it("splits proportionally the moment ANY lot carries cost — the fallback is the exception", () => {
+    // Same Tier mix and lot order as the first case, but with real cost basis, so
+    // the normal path runs: two deltas, weighted 40/60, in c1/c2/c3 Tier order
+    // rather than lot order. Deleting the degenerate arm would have to make the
+    // first case look like this one (or NaN) — this is the contrast that gives
+    // the pin its teeth.
+    const costedLots: PositionLot[] = [
+      { quantity: 4, cost: 10, tier: "c3" },
+      { quantity: 6, cost: 10, tier: "c1" },
+    ];
+
+    expect(reserveDeltasForClose(costedLots, 250)).toEqual([
+      { tier: "c1", amount: 150 },
+      { tier: "c3", amount: 100 },
+    ]);
   });
 });

--- a/packages/engine/src/orders/detection-basis.test.ts
+++ b/packages/engine/src/orders/detection-basis.test.ts
@@ -151,13 +151,22 @@ describe("detectChangedClaims compares against the LATEST observation (#181)", (
 
   it("ignores `orderFilled` and `orderCancelled` — they are not observations", () => {
     // What the FUND booked is not what the VENUE showed. A fill line moves `consumed`,
-    // which is the partition's business downstream, and must not move the figure the
-    // export is compared against.
+    // and a cancellation retires the rung — both are the partition's business downstream,
+    // and neither must move the figure the export is compared against.
     const stream: OrderRecord[] = [
       placed("2026-01-01T10:00:00", 10, 6),
       { id: RUNG, observedAt: "2026-01-02T09:00:00", kind: "orderFilled", currency: "USD", filledQuantity: 4 },
+      { id: RUNG, observedAt: "2026-01-03T09:00:00", kind: "orderCancelled", currency: "USD" },
     ];
     expect(detectChangedClaims(stream, [exported(10, 6)])).toEqual([]);
+
+    // BOTH DIRECTIONS, so neither line can go unread. The `[]` above stays `[]` whether
+    // the cancellation is ignored (correct) or swallows the rung entirely (wrong), so it
+    // alone cannot tell the two apart: the placement line must still be the basis AFTER a
+    // cancellation, and a venue figure past it must still be reported.
+    expect(detectChangedClaims(stream, [exported(10, 9)])).toEqual([
+      { id: RUNG, differences: [{ field: "observedFilledQuantity", known: 6, observed: 9 }] },
+    ]);
   });
 });
 

--- a/packages/engine/src/realized-pnl.test.ts
+++ b/packages/engine/src/realized-pnl.test.ts
@@ -17,9 +17,16 @@ const CLOSE_ALT: PortfolioEvent = {
   asOf: "2026-06-05",
   type: "PositionClosed",
   positionId: "alt-pos",
-  // Cost basis is 400 USD (c1 100 + c2 300); proceeds 360 → realized −40, a loss
+  // Cost basis is 400 USD (c1 100 + c2 300); proceeds 600 → realized +200, a gain
   // that falls per Tier on the same 25% / 75% mix it was risked on.
-  settlement: { reserveId: "tiered", proceeds: 360 },
+  //
+  // 600 is a fill the ingest gates would actually admit: the settlement-magnitude gate
+  // (crossReferenceClose) expects 20 units × alt-pos' last close 40 = 800 and allows
+  // ±50%, so the legal band is 400–1200 — whose floor IS the 400 cost basis. A closing
+  // LOSS on this position is therefore unreachable through ingest; the loss-absorption
+  // behavior is locked instead on the real-shaped gram fixture in
+  // cash-settlement-scenarios.test.ts, where proceeds 108 against a basis of 120 is legal.
+  settlement: { reserveId: "tiered", proceeds: 600 },
 };
 
 describe("realized P&L — closed book", () => {
@@ -35,8 +42,8 @@ describe("realized P&L — closed book", () => {
     expect(row.tempo).toBe("Pulse");
     expect(row.closedAsOf).toBe("2026-06-05");
     expect(row.costBasisUsd).toBeCloseTo(400, 6);
-    expect(row.proceedsUsd).toBeCloseTo(360, 6);
-    expect(row.realizedPnlUsd).toBeCloseTo(-40, 6);
+    expect(row.proceedsUsd).toBeCloseTo(600, 6);
+    expect(row.realizedPnlUsd).toBeCloseTo(200, 6);
   });
 
   it("attributes realized per Tier on the closed position's cost-basis mix", () => {
@@ -44,16 +51,16 @@ describe("realized P&L — closed book", () => {
     const byTier = new Map(
       data.closedPositions![0]!.tierAttribution.map((t) => [t.tier, t]),
     );
-    // 25% / 75% split: c1 gets 90 proceeds vs 100 cost (−10); c2 gets 270 vs 300 (−30).
-    expect(byTier.get("c1")!.realizedPnlUsd).toBeCloseTo(-10, 6);
-    expect(byTier.get("c2")!.realizedPnlUsd).toBeCloseTo(-30, 6);
+    // 25% / 75% split: c1 gets 150 proceeds vs 100 cost (+50); c2 gets 450 vs 300 (+150).
+    expect(byTier.get("c1")!.realizedPnlUsd).toBeCloseTo(50, 6);
+    expect(byTier.get("c2")!.realizedPnlUsd).toBeCloseTo(150, 6);
   });
 
   it("rolls realized up by Tempo and by Tier in the report blotter", () => {
     const report = buildCompositionReport(foldEvents(genesis(), [CLOSE_ALT]));
-    expect(report.closedBook.totalRealizedPnlUsd).toBeCloseTo(-40, 6);
-    expect(report.closedBook.byTempo.find((r) => r.key === "Pulse")!.realizedPnlUsd).toBeCloseTo(-40, 6);
-    expect(report.closedBook.byTier.find((r) => r.key === "c1")!.realizedPnlUsd).toBeCloseTo(-10, 6);
+    expect(report.closedBook.totalRealizedPnlUsd).toBeCloseTo(200, 6);
+    expect(report.closedBook.byTempo.find((r) => r.key === "Pulse")!.realizedPnlUsd).toBeCloseTo(200, 6);
+    expect(report.closedBook.byTier.find((r) => r.key === "c1")!.realizedPnlUsd).toBeCloseTo(50, 6);
   });
 
   it("is descriptive only: realized is NOT added to NAV", () => {
@@ -144,8 +151,8 @@ describe("closed book — as-of replay (fold invariant)", () => {
     expect(data.closedPositions![0]!.positionId).toBe("alt-pos");
     expect(data.positions.find((p) => p.id === "beta-pos")).toBeUndefined();
     const report = buildCompositionReport(data);
-    expect(report.closedBook.totalRealizedPnlUsd).toBeCloseTo(-40, 6);
-    expect(report.closedBook.byTempo.find((r) => r.key === "Pulse")!.realizedPnlUsd).toBeCloseTo(-40, 6);
+    expect(report.closedBook.totalRealizedPnlUsd).toBeCloseTo(200, 6);
+    expect(report.closedBook.byTempo.find((r) => r.key === "Pulse")!.realizedPnlUsd).toBeCloseTo(200, 6);
   });
 
   it("shows beta-pos still open (not yet on the blotter) mid-timeline", () => {
@@ -157,14 +164,14 @@ describe("closed book — as-of replay (fold invariant)", () => {
 
   it("reproduces the full two-row blotter as-of the second close, matching a live fold", () => {
     const asOf = foldEvents(genesis(), log, "2026-06-15");
-    // Both closes have landed by 06-15: alt-pos (−40) + beta-pos (+50) = +10 total.
+    // Both closes have landed by 06-15: alt-pos (+200) + beta-pos (+50) = +250 total.
     expect(asOf.closedPositions).toHaveLength(2);
-    expect(buildCompositionReport(asOf).closedBook.totalRealizedPnlUsd).toBeCloseTo(10, 6);
+    expect(buildCompositionReport(asOf).closedBook.totalRealizedPnlUsd).toBeCloseTo(250, 6);
 
     // Replay invariant: folding the whole log with NO as-of (current state) must
     // equal folding as-of the last event date — the blotter is stable once closed.
     const live = foldEvents(genesis(), log);
-    expect(buildCompositionReport(live).closedBook.totalRealizedPnlUsd).toBeCloseTo(10, 6);
+    expect(buildCompositionReport(live).closedBook.totalRealizedPnlUsd).toBeCloseTo(250, 6);
     expect(live.closedPositions!.map((r) => r.positionId).sort()).toEqual(
       asOf.closedPositions!.map((r) => r.positionId).sort(),
     );

--- a/packages/engine/src/realized-pnl.test.ts
+++ b/packages/engine/src/realized-pnl.test.ts
@@ -6,32 +6,70 @@
 import { describe, expect, it } from "vitest";
 import {
   buildCompositionReport,
+  buildEventReference,
+  crossReferenceEvent,
   foldEvents,
   type FundReviewData,
   type PortfolioEvent,
 } from "./index.js";
 import { DECISION, genesis } from "./cash-settlement.fixtures.js";
 
+// The settlement-magnitude gate sizes a close against `quantity × the instrument's
+// LAST CLOSE` — and last close is not frozen at the genesis anchor of 40, it MOVES
+// with every `PriceMarked`. This mark walks alt-usd down to 25 (−37.5%, inside the
+// ±50% PriceMarked band), which resets the close's expected value to 20 × 25 = 500.
+// That is what makes the loss below a fill ingest would really admit: a losing close
+// on this position is reachable, it just needs the mark that makes it plausible.
+// Both legs are proven against the real gate in the first describe block.
+const MARK_ALT: PortfolioEvent = {
+  id: "mark-alt",
+  asOf: "2026-06-04",
+  type: "PriceMarked",
+  instrumentId: "alt-usd",
+  price: 25,
+};
+
 const CLOSE_ALT: PortfolioEvent = {
   id: "close-alt",
   asOf: "2026-06-05",
   type: "PositionClosed",
   positionId: "alt-pos",
-  // Cost basis is 400 USD (c1 100 + c2 300); proceeds 600 → realized +200, a gain
-  // that falls per Tier on the same 25% / 75% mix it was risked on.
-  //
-  // 600 is a fill the ingest gates would actually admit: the settlement-magnitude gate
-  // (crossReferenceClose) expects 20 units × alt-pos' last close 40 = 800 and allows
-  // ±50%, so the legal band is 400–1200 — whose floor IS the 400 cost basis. A closing
-  // LOSS on this position is therefore unreachable through ingest; the loss-absorption
-  // behavior is locked instead on the real-shaped gram fixture in
-  // cash-settlement-scenarios.test.ts, where proceeds 108 against a basis of 120 is legal.
-  settlement: { reserveId: "tiered", proceeds: 600 },
+  // Cost basis is 400 USD (c1 100 + c2 300); proceeds 360 → realized −40, a loss
+  // that falls per Tier on the same 25% / 75% mix it was risked on. Against the
+  // marked-down expected 500 this is a −28% deviation, inside the ±50% settlement
+  // band. This is the repo's only fold-driven NEGATIVE realized figure: it is what
+  // keeps a clamp-at-zero on per-Tier realized, or an absolute-value blotter sum,
+  // from shipping unnoticed. Do not move it to a gain to satisfy the gate.
+  settlement: { reserveId: "tiered", proceeds: 360 },
 };
+
+/** The mark that legalizes the close, then the close. Order matters. */
+const ALT_LOG: PortfolioEvent[] = [MARK_ALT, CLOSE_ALT];
+
+describe("the losing close is admissible — proven at the real ingest gate", () => {
+  it("accepts the mark, then accepts the loss-making close behind it", () => {
+    const seed = genesis();
+    expect(crossReferenceEvent(MARK_ALT, buildEventReference(seed, [])).kind).toBe("ok");
+    expect(crossReferenceEvent(CLOSE_ALT, buildEventReference(seed, [MARK_ALT])).kind).toBe(
+      "ok",
+    );
+  });
+
+  it("would refuse the same close WITHOUT the mark — the mark is load-bearing, not decoration", () => {
+    // Against the genesis anchor of 40 the expected value is 20 × 40 = 800 and 360 is
+    // a 55% deviation. If this ever goes green, the mark above has stopped mattering
+    // and the fixture is no longer proving what it claims.
+    const refused = crossReferenceEvent(CLOSE_ALT, buildEventReference(genesis(), []));
+    expect(refused.kind).toBe("event-error");
+    if (refused.kind === "event-error") {
+      expect(refused.path).toBe("settlement.proceeds");
+    }
+  });
+});
 
 describe("realized P&L — closed book", () => {
   it("keeps the closed position as a blotter row with realized = proceeds − cost basis", () => {
-    const data = foldEvents(genesis(), [CLOSE_ALT]);
+    const data = foldEvents(genesis(), ALT_LOG);
 
     // The open position is retired…
     expect(data.positions.find((p) => p.id === "alt-pos")).toBeUndefined();
@@ -42,29 +80,32 @@ describe("realized P&L — closed book", () => {
     expect(row.tempo).toBe("Pulse");
     expect(row.closedAsOf).toBe("2026-06-05");
     expect(row.costBasisUsd).toBeCloseTo(400, 6);
-    expect(row.proceedsUsd).toBeCloseTo(600, 6);
-    expect(row.realizedPnlUsd).toBeCloseTo(200, 6);
+    expect(row.proceedsUsd).toBeCloseTo(360, 6);
+    expect(row.realizedPnlUsd).toBeCloseTo(-40, 6);
   });
 
   it("attributes realized per Tier on the closed position's cost-basis mix", () => {
-    const data = foldEvents(genesis(), [CLOSE_ALT]);
+    const data = foldEvents(genesis(), ALT_LOG);
     const byTier = new Map(
       data.closedPositions![0]!.tierAttribution.map((t) => [t.tier, t]),
     );
-    // 25% / 75% split: c1 gets 150 proceeds vs 100 cost (+50); c2 gets 450 vs 300 (+150).
-    expect(byTier.get("c1")!.realizedPnlUsd).toBeCloseTo(50, 6);
-    expect(byTier.get("c2")!.realizedPnlUsd).toBeCloseTo(150, 6);
+    // 25% / 75% split: c1 gets 90 proceeds vs 100 cost (−10); c2 gets 270 vs 300 (−30).
+    // Negative on BOTH tiers on purpose — per-Tier realized is computed independently
+    // of the row total (events/fold.ts, tierProceeds − tierCost), so a clamp at zero
+    // there is invisible to every other tierAttribution assertion in the suite.
+    expect(byTier.get("c1")!.realizedPnlUsd).toBeCloseTo(-10, 6);
+    expect(byTier.get("c2")!.realizedPnlUsd).toBeCloseTo(-30, 6);
   });
 
   it("rolls realized up by Tempo and by Tier in the report blotter", () => {
-    const report = buildCompositionReport(foldEvents(genesis(), [CLOSE_ALT]));
-    expect(report.closedBook.totalRealizedPnlUsd).toBeCloseTo(200, 6);
-    expect(report.closedBook.byTempo.find((r) => r.key === "Pulse")!.realizedPnlUsd).toBeCloseTo(200, 6);
-    expect(report.closedBook.byTier.find((r) => r.key === "c1")!.realizedPnlUsd).toBeCloseTo(50, 6);
+    const report = buildCompositionReport(foldEvents(genesis(), ALT_LOG));
+    expect(report.closedBook.totalRealizedPnlUsd).toBeCloseTo(-40, 6);
+    expect(report.closedBook.byTempo.find((r) => r.key === "Pulse")!.realizedPnlUsd).toBeCloseTo(-40, 6);
+    expect(report.closedBook.byTier.find((r) => r.key === "c1")!.realizedPnlUsd).toBeCloseTo(-10, 6);
   });
 
   it("is descriptive only: realized is NOT added to NAV", () => {
-    const data = foldEvents(genesis(), [CLOSE_ALT]);
+    const data = foldEvents(genesis(), ALT_LOG);
     const withBook = buildCompositionReport(data).totals.fundValueUsd;
     // Blanking the closed book must not change fund value — it never fed NAV.
     const withoutBook = buildCompositionReport({ ...data, closedPositions: [] }).totals.fundValueUsd;
@@ -134,8 +175,8 @@ describe("closed book — as-of replay (fold invariant)", () => {
     // Proceeds 150 → realized +50, a gain.
     settlement: { reserveId: "tiered", proceeds: 150 },
   };
-  // Log order is close-alt (06-05), open-beta (06-10), close-beta (06-15).
-  const log: PortfolioEvent[] = [CLOSE_ALT, OPEN_BETA, CLOSE_BETA];
+  // Log order is mark-alt (06-04), close-alt (06-05), open-beta (06-10), close-beta (06-15).
+  const log: PortfolioEvent[] = [...ALT_LOG, OPEN_BETA, CLOSE_BETA];
 
   it("yields an empty blotter as-of before the first close", () => {
     const data = foldEvents(genesis(), log, "2026-06-04");
@@ -151,8 +192,8 @@ describe("closed book — as-of replay (fold invariant)", () => {
     expect(data.closedPositions![0]!.positionId).toBe("alt-pos");
     expect(data.positions.find((p) => p.id === "beta-pos")).toBeUndefined();
     const report = buildCompositionReport(data);
-    expect(report.closedBook.totalRealizedPnlUsd).toBeCloseTo(200, 6);
-    expect(report.closedBook.byTempo.find((r) => r.key === "Pulse")!.realizedPnlUsd).toBeCloseTo(200, 6);
+    expect(report.closedBook.totalRealizedPnlUsd).toBeCloseTo(-40, 6);
+    expect(report.closedBook.byTempo.find((r) => r.key === "Pulse")!.realizedPnlUsd).toBeCloseTo(-40, 6);
   });
 
   it("shows beta-pos still open (not yet on the blotter) mid-timeline", () => {
@@ -164,14 +205,16 @@ describe("closed book — as-of replay (fold invariant)", () => {
 
   it("reproduces the full two-row blotter as-of the second close, matching a live fold", () => {
     const asOf = foldEvents(genesis(), log, "2026-06-15");
-    // Both closes have landed by 06-15: alt-pos (+200) + beta-pos (+50) = +250 total.
+    // Both closes have landed by 06-15: alt-pos (−40) + beta-pos (+50) = +10 total.
+    // A loss NETTED against a gain — the one place in the suite where the blotter
+    // total can tell a signed sum from an absolute-value one.
     expect(asOf.closedPositions).toHaveLength(2);
-    expect(buildCompositionReport(asOf).closedBook.totalRealizedPnlUsd).toBeCloseTo(250, 6);
+    expect(buildCompositionReport(asOf).closedBook.totalRealizedPnlUsd).toBeCloseTo(10, 6);
 
     // Replay invariant: folding the whole log with NO as-of (current state) must
     // equal folding as-of the last event date — the blotter is stable once closed.
     const live = foldEvents(genesis(), log);
-    expect(buildCompositionReport(live).closedBook.totalRealizedPnlUsd).toBeCloseTo(250, 6);
+    expect(buildCompositionReport(live).closedBook.totalRealizedPnlUsd).toBeCloseTo(10, 6);
     expect(live.closedPositions!.map((r) => r.positionId).sort()).toEqual(
       asOf.closedPositions!.map((r) => r.positionId).sort(),
     );


### PR DESCRIPTION
Four test setups asserted less than their titles claimed. Individually small; together a class — assertions that pass for reasons other than the one they name. This is a test-only pass: **no non-test source file is touched.**

Closes #299.

## What changed, and why each one mattered

**1. A test named a verb it never streamed** — `packages/engine/src/orders/detection-basis.test.ts`

The title claimed it ignores `orderFilled` *and* `orderCancelled`; the stream carried one `orderFilled` line and no `orderCancelled` line at all. The missing line is now in the stream.

It also needed a **second assertion**. The original `toEqual([])` cannot verify the cancellation on its own: it stays `[]` both when the cancellation is correctly ignored *and* when a regression drops the rung from `placedById` (the detector `continue`s on an unknown id, also yielding `[]`). The added case pins the other direction — with the cancellation on file, an export at filled `9` must still report `known: 6, observed: 9`.

No production defect: `detectChangedClaims` handles `orderCancelled` in an explicit joint arm with `orderFilled` behind a `never` latch. The gap was fixture-only.

**2. Fixtures that could never gate-legally exist** — `cash-settlement.test.ts`, `realized-pnl.test.ts`, `cash-settlement-scenarios.test.ts` (×2)

`proceeds: 360` on an alt-position closing at a realized loss. The refusing gate is the settlement-magnitude check at `crossref.ts:986-1003`, dialled by `SETTLEMENT_MAGNITUDE_THRESHOLD = 0.5` (`crossref.ts:59`): against `alt-pos`' genesis anchor the expectation is 20 units × last close 40 = **800**, so 360 is a 55% deviation and would be rejected on ingest.

**The fix is to supply the missing `PriceMarked`, not to move the close to a gain.** The gate sizes a close against `quantity × LAST CLOSE`, and last close is not frozen at the genesis anchor — it moves with every `PriceMarked`. A legal `PriceMarked{alt-usd, 25}` (−37.5%, inside the ±50% mark band) resets expected to 20 × 25 = **500**, which makes `proceeds: 360` a −28% deviation, comfortably in-band. So the two `alt-pos` sites keep their loss and their original expectations verbatim (`−40` realized, `−10` c1 / `−30` c2, `+10` on the two-row blotter) and become admissible by gaining the mark that makes them plausible.

An earlier revision of this PR moved all four sites to `600` on the premise that *no admissible close of `alt-pos` can realize a loss at all*. **That premise was false** — it holds only if the mark never moves — and acting on it deleted the repo's only fold-driven negative-realized coverage: `tierAttribution[].realizedPnlUsd` (computed independently at `events/fold.ts:595` as `tierProceeds − tierCost`) and the `buildClosedBook` roll-up that nets a loss against a gain (`compose/report.ts:168`). With every realized figure positive, a clamp-at-zero on per-Tier realized and an absolute-value blotter sum both shipped green. That is reverted; the coverage is back.

Three things worth a reviewer's attention:

- **The issue named three sites; there are four.** `cash-settlement-scenarios.test.ts` carries it at both `:77` and `:87`. Those two are shape assertions with no expectation riding on the sign, and they keep the re-derived `600`. The two `alt-pos` sites that *did* carry sign-bearing expectations — `realized-pnl.test.ts` and `cash-settlement.test.ts` — keep the loss and take the mark instead.
- **Admissibility is proven, not asserted.** Both legs run through `crossReferenceEvent` in-suite, the way `position-trimmed-reliable.test.ts` does. Each site also carries a probe asserting the gate **refuses** the same close *without* the mark — so if the mark ever stops being load-bearing, a test says so rather than the fixture quietly drifting back into an unreachable world.
- **Mutation-checked.** The two regressions the loss exists to catch — `events/fold.ts:595` → `Math.max(0, tierProceeds − tierCost)`, and `compose/report.ts:168` → `sum + Math.abs(row.realizedPnlUsd)` — were each applied and each goes **red** (2 tests and 3 tests respectively). Both were reverted; no production file is touched.
- Separately: `cash-settlement-scenarios.test.ts`'s gram close pins loss-absorption on the **reserve credit split** at `:162-165` (proceeds 108 vs basis 120, 8 on c1 and 4 on c2). That is *different* coverage from the `tierAttribution` assertions above, and it is not a substitute for them. (`:179-191` is the fee-residual T5 test, not this one.)

A fifth `proceeds: 360` at `position-trimmed-reliable.test.ts:116` is **deliberately untouched** — different seed, already gate-legal (4 c2 units at mark 100 → expected 400, so −10%), and routed through `crossReferenceEvent`, so it is demonstrably admissible.

**3. Matchers loose enough to pass on the wrong error** — `apps/tui/src/spine-args.test.ts` (`:32`, `:36`), `apps/tui/src/startup.test.ts:174`

`toThrow(/--as-of/)` is satisfied by any error mentioning the flag. All three now assert the exact message thrown at `apps/tui/src/spine-args.ts:35`.

The `startup.test.ts` one was the genuinely dangerous case: that test's own spy throws `"ingest should not run when --as-of is invalid"`, which itself matches `/--as-of/` — so the old matcher would have gone **green on precisely the regression the test exists to catch**.

Two further loose matchers were found and **left alone** as outside this issue's scope: `startup.test.ts:250` on `/cross-reference/`, and the `--magnitude-threshold` set in `spine-args.test.ts`.

**4. An uncovered degenerate branch** — `packages/engine/src/fold.test.ts`

A three-test pin on the zero-cost tier-attribution fallback at `packages/engine/src/events/fold.ts:45-48`, named in `coverage-rationale` §5. The lot order in the fixture is deliberately `c3`-then-`c1` so the result separates "first *lot's* tier" from "first tier in canonical order" from any split; a contrast case with non-zero cost pins the normal proportional path so deleting the fallback cannot pass silently. The pin was red-checked (perturb the fallback → 2 of 3 go red) and the perturbation reverted.

## Two deliberate consequences to carry forward

**This pin lands in a file #293 is about to rewrite. That is the point** — it is a guard for that rewrite, landed ahead of it on purpose, not an accident of ordering.

**The pin freezes behavior it does not endorse.** Pinning the branch surfaced a real defect, filed as **#329** rather than fixed here, under this issue's own scope discipline: the fallback returns `lots[0].tier` — array insertion order — while every other path in the file emits Tiers in canonical `TIERS` order, and the `present.length === 0` arm is reachable only with empty `lots`, where `lots[0]?.tier ?? "c1"` invents a full-magnitude `c1` attribution for a delta with no provenance. **#329 is out of scope for this run and stays open and unbuilt.** The pin here will go red when #329 is fixed; whoever fixes it updates the pin in the same change.

## Merge order

**This PR is the bottom of lane A's stack and merges first.** Base is `main`.

    A1 #299 (this PR)  →  A2 #300  →  A3 #293/#323 (+#324–#328)  →  A4 #297

Each later lane-A PR targets its predecessor's branch, so this one must land before A2's can retarget to `main`. They queue on `crossref.ts` and `fold.ts` by construction; nothing here can be merged out of order.

## Verification

`pnpm verify` green — typecheck clean, **133 files / 1957 tests passed** (21 skipped), startup smoke exit 0.

