### PR TITLE
fix(tui): a unique temp path per write, so concurrent log writers stop silently losing whole images

### DIFF
--- a/apps/tui/src/event-store-write-failure.test.ts
+++ b/apps/tui/src/event-store-write-failure.test.ts
@@ -1,0 +1,130 @@
+/**
+ * THE FAILING LOG-IMAGE WRITE — the one path on which `writeLogImage` can leave litter
+ * behind, and the reason it needs a test file of its own.
+ *
+ * `writeLogImage` writes a unique temp sibling (`<log>.<pid>.<tick>.tmp`) and `rename`s
+ * it over the log. On the happy path the rename CONSUMES the temp, so every passing
+ * success case — including the four-writer concurrency case in `event-store.test.ts`,
+ * where every writer succeeds — proves exactly nothing about the `catch { rm }`. Delete
+ * the whole try/catch and those tests stay green.
+ *
+ * The window is between `writeFile` and `rename`, and no arrangement of real files opens
+ * it: every candidate (a directory at the target, a read-only parent) fails BEFORE a temp
+ * file exists, so the test would pass vacuously. So `rename` is mocked, and only
+ * `rename`: everything else is the real filesystem in a real temp directory. This file is
+ * separate because that mock is module-wide and has no business near the ingest tests.
+ *
+ * What it locks: a failed image write leaves NOTHING beside the log, and the caller sees
+ * the TRUE cause. Without the first, `events.jsonl.<pid>.<n>.tmp` accumulates one
+ * multi-megabyte orphan per failed attempt, forever and invisibly — accumulus ignores
+ * `/data/*.tmp`, so nothing on the durability path would ever surface it. Without the
+ * second, a cleanup that throws in turn (the dir went read-only, which is often WHY the
+ * write failed) replaces "the log image failed to publish" with an `unlink` error naming
+ * a temp file the operator has never heard of.
+ *
+ * Every fixture here is authored filler — no real event, price or balance.
+ */
+import { mkdtemp, readdir, readFile, rm } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join, resolve } from "node:path";
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+/** Flipped by a test to make the next `rename` fail the way a full volume would. */
+let renameFails = false;
+/**
+ * Flipped to make the CLEANUP fail too. Real-file arrangements cannot stage this
+ * reliably — making the dir read-only mid-flight races the `writeFile` — and the
+ * masking bug it targets is exactly a two-failure sequence, so both failures are
+ * injected rather than provoked.
+ */
+let cleanupFails = false;
+
+vi.mock("node:fs/promises", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("node:fs/promises")>();
+  return {
+    ...actual,
+    rename: async (from: string, to: string) => {
+      if (renameFails) {
+        throw Object.assign(new Error("ENOSPC: no space left on device, rename"), {
+          code: "ENOSPC",
+        });
+      }
+      return actual.rename(from, to);
+    },
+    rm: async (path: string, options?: Parameters<typeof actual.rm>[1]) => {
+      if (cleanupFails) {
+        throw Object.assign(new Error(`EACCES: permission denied, unlink '${path}'`), {
+          code: "EACCES",
+        });
+      }
+      return actual.rm(path, options);
+    },
+  };
+});
+
+const { writeLogImage } = await import("./event-store.js");
+
+const PRIOR_IMAGE = '{"kind":"synthetic","n":1}\n';
+const NEXT_IMAGE = '{"kind":"synthetic","n":1}\n{"kind":"synthetic","n":2}\n';
+
+const createdDirs: string[] = [];
+
+afterEach(async () => {
+  renameFails = false;
+  cleanupFails = false;
+  for (const dir of createdDirs) {
+    await rm(dir, { recursive: true, force: true });
+  }
+  createdDirs.length = 0;
+});
+
+async function tempDir(): Promise<string> {
+  const dir = await mkdtemp(resolve(tmpdir(), "numisma-log-image-"));
+  createdDirs.push(dir);
+  return dir;
+}
+
+describe("writeLogImage cleans up after ITSELF when the write cannot land", () => {
+  it("leaves no temp sibling behind, and does not create the log", async () => {
+    const dir = await tempDir();
+    const logPath = join(dir, "events.jsonl");
+    renameFails = true;
+
+    await expect(writeLogImage(logPath, NEXT_IMAGE)).rejects.toThrow(/ENOSPC/);
+
+    // The whole directory, not a guess at the temp's name: anything at all left here is
+    // litter, including a name a future revision of the scheme might choose instead.
+    expect(await readdir(dir)).toEqual([]);
+  });
+
+  it("leaves the PRIOR image untouched — a failed write loses no committed line", async () => {
+    const dir = await tempDir();
+    const logPath = join(dir, "events.jsonl");
+    await writeLogImage(logPath, PRIOR_IMAGE);
+
+    renameFails = true;
+    await expect(writeLogImage(logPath, NEXT_IMAGE)).rejects.toThrow(/ENOSPC/);
+
+    // Crash-atomicity is the entire warrant for writing through a temp, so the cleanup
+    // must not have cost it: the log still holds exactly what it held before.
+    expect(await readdir(dir)).toEqual(["events.jsonl"]);
+    expect(await readFile(logPath, "utf8")).toBe(PRIOR_IMAGE);
+  });
+
+  it("reports the WRITE's failure even when the cleanup cannot run either", async () => {
+    // The masking scenario, as seen on a data dir that goes read-only mid-flight: the
+    // rename fails, and the `rm` of the orphaned temp then fails EACCES in turn. `force:
+    // true` swallows only ENOENT, so without a `.catch` the caller is handed
+    // "EACCES: permission denied, unlink '…events.jsonl.<pid>.<n>.tmp'" and the true
+    // cause — the durable log image failed to publish — is gone. On a spine contracted
+    // to fail loud WITH the true cause, that is the operator pointed at the wrong file.
+    const dir = await tempDir();
+    const logPath = join(dir, "events.jsonl");
+    renameFails = true;
+    cleanupFails = true;
+
+    await expect(writeLogImage(logPath, NEXT_IMAGE)).rejects.toThrow(/ENOSPC/);
+    // And specifically NOT the cleanup's error wearing the failure's place.
+    await expect(writeLogImage(logPath, NEXT_IMAGE)).rejects.not.toThrow(/EACCES/);
+  });
+});

--- a/apps/tui/src/event-store.test.ts
+++ b/apps/tui/src/event-store.test.ts
@@ -177,6 +177,20 @@ async function exists(path: string): Promise<boolean> {
   }
 }
 
+/**
+ * Every `.tmp` entry sitting in a file's OWN directory.
+ *
+ * Over the directory, not over one guessed name: `writeLogImage` names its temp
+ * uniquely per write (`<log>.<pid>.<tick>.tmp`), so asserting the absence of a single
+ * `${path}.tmp` passes vacuously while a whole generation of temps piles up beside the
+ * durable log — and nothing on the durability path would surface them, because
+ * accumulus ignores `/data/*.tmp`.
+ */
+async function tempLitter(path: string): Promise<string[]> {
+  const entries = await readdir(dirname(path));
+  return entries.filter((entry) => entry.endsWith(".tmp"));
+}
+
 async function readOrUndefined(path: string): Promise<string | undefined> {
   try {
     return await readFile(path, "utf8");
@@ -371,7 +385,7 @@ describe("appendEvents — atomic append (temp + rename)", () => {
       expect(() => JSON.parse(line)).not.toThrow();
     }
     // The temp image is renamed away, never left behind.
-    expect(await exists(`${paths.log}.tmp`)).toBe(false);
+    expect(await tempLitter(paths.log)).toEqual([]);
   });
 });
 
@@ -380,13 +394,23 @@ describe("writeLogImage — concurrent writers cannot corrupt each other", () =>
     const paths = await makeStore({});
     const dir = dirname(paths.log);
 
-    // Multi-megabyte images on purpose: with a tiny payload the write completes inside
-    // one turn and the writers never really overlap. At this size the open/write/rename
-    // steps genuinely interleave, so a SHARED temp name loses the race deterministically
-    // — one writer truncating another's half-written temp, or renaming it out from under
-    // it. Every byte here is authored filler: a distinct marker line per writer, repeated.
+    // Multi-megabyte images on purpose, but NOT because small ones fail to overlap —
+    // measured against a faithful copy of the pre-fix shared-temp implementation, the
+    // `rejected` assertion below is red 10/10 at ONE line (67 bytes) just as it is here.
+    // `fs/promises.writeFile` always yields, so all four writers open the shared temp
+    // before any rename fires and three then hit ENOENT at any size: the LOST-IMAGE mode
+    // reproduces for free.
+    //
+    // What the size buys is the OTHER mode — a BLENDED image, one writer's bytes
+    // interleaved into another's, which survives the rename and fails only byte-identity.
+    // That one needs the write to span many turns: 4/10 runs at 60_000 lines against the
+    // old code, 0/10 small. So the payload is sized for `distinctLines` and the
+    // byte-identity check, not for the rejection check. The whole case runs in ~38ms and
+    // is 10/10 clean under the fix — do not shrink it to save a cost that isn't there.
+    //
+    // Every byte here is authored filler: a distinct marker line per writer, repeated.
     const WRITERS = 4;
-    const LINES = 60_000; // ~4 MB per image at 68 bytes/line.
+    const LINES = 60_000; // ~4 MB per image at 67 bytes/line (66 + "\n").
     const images = Array.from(
       { length: WRITERS },
       (_, index) => `${`writer-${index}`.padEnd(66, String.fromCharCode(97 + index))}\n`.repeat(LINES),
@@ -596,7 +620,7 @@ describe("durable-log migration — legacy-shape events fail loud, then migrate 
     await migrateLegacyLog(paths, cashLegs);
 
     // The temp image is renamed away, never left behind (the writeLogImage contract).
-    expect(await exists(`${paths.log}.tmp`)).toBe(false);
+    expect(await tempLitter(paths.log)).toEqual([]);
 
     // And structurally: the migration holds no writer of its own. `writeLogImage` is
     // documented as "the only way the log is written" — any hardening landed there

--- a/apps/tui/src/event-store.test.ts
+++ b/apps/tui/src/event-store.test.ts
@@ -16,7 +16,7 @@ import {
   resolveEventStorePaths,
   type EventStorePaths,
 } from "@numisma/event-store";
-import { ingestInbox, migrateLegacyLog } from "./event-store.js";
+import { ingestInbox, migrateLegacyLog, writeLogImage } from "./event-store.js";
 import type { SuppliedCashLeg } from "@numisma/engine";
 import { afterEach, describe, expect, it, vi } from "vitest";
 
@@ -372,6 +372,45 @@ describe("appendEvents — atomic append (temp + rename)", () => {
     }
     // The temp image is renamed away, never left behind.
     expect(await exists(`${paths.log}.tmp`)).toBe(false);
+  });
+});
+
+describe("writeLogImage — concurrent writers cannot corrupt each other", () => {
+  it("leaves the log byte-identical to exactly one writer's image, never a blend", async () => {
+    const paths = await makeStore({});
+    const dir = dirname(paths.log);
+
+    // Multi-megabyte images on purpose: with a tiny payload the write completes inside
+    // one turn and the writers never really overlap. At this size the open/write/rename
+    // steps genuinely interleave, so a SHARED temp name loses the race deterministically
+    // — one writer truncating another's half-written temp, or renaming it out from under
+    // it. Every byte here is authored filler: a distinct marker line per writer, repeated.
+    const WRITERS = 4;
+    const LINES = 60_000; // ~4 MB per image at 68 bytes/line.
+    const images = Array.from(
+      { length: WRITERS },
+      (_, index) => `${`writer-${index}`.padEnd(66, String.fromCharCode(97 + index))}\n`.repeat(LINES),
+    );
+
+    const results = await Promise.allSettled(images.map((image) => writeLogImage(paths.log, image)));
+    // Every writer must SUCCEED: a rejection here is the shared-temp collision itself
+    // (the sibling renamed the source away), not an incidental failure.
+    const rejected = results.filter((result) => result.status === "rejected");
+    expect(rejected.map((result) => String((result as PromiseRejectedResult).reason))).toEqual([]);
+
+    const content = await readFile(paths.log, "utf8");
+
+    // No blend: a surviving image is one writer's marker line, repeated — nothing else.
+    const distinctLines = new Set(content.split("\n").filter((line) => line.length > 0));
+    expect([...distinctLines]).toHaveLength(1);
+    // No truncation: full length, and byte-identical to one of the inputs. Compared as a
+    // boolean so a failure reports a flag rather than dumping megabytes of diff.
+    expect(content.length).toBe(images[0]!.length);
+    expect(images.some((image) => image === content)).toBe(true);
+
+    // And no litter: every temp image was renamed away or cleaned up.
+    const leftovers = (await readdir(dir)).filter((name) => name.includes(".tmp"));
+    expect(leftovers).toEqual([]);
   });
 });
 

--- a/apps/tui/src/event-store.ts
+++ b/apps/tui/src/event-store.ts
@@ -355,7 +355,17 @@ let tempImageTick = 0;
  * because rename(2) is only atomic within one filesystem; a temp in `os.tmpdir()` would
  * degrade to a copy that can tear.
  *
+ * The suffix stays `.tmp` — that is policy, not decoration. Accumulus's `/data/*.tmp`
+ * ignore rule (ADR-006) is the only thing stopping a multi-megabyte staged image from
+ * becoming committable into the private data repo, so any rename of this scheme must
+ * keep the `.tmp` ending. `packages/preferences/src/sidecar-io.ts` carries the same
+ * constraint on its own copy; both must hold it.
+ *
  * A failed write removes its own temp file, so a doomed write leaves no litter behind.
+ * The cleanup is best-effort BY DESIGN: if the removal itself fails (the directory went
+ * read-only, which is often why the write failed in the first place) its error is
+ * dropped, because the caller must be told the log image failed to publish — not handed
+ * an `unlink` error naming a temp file it has never heard of.
  */
 export async function writeLogImage(logPath: string, contents: string): Promise<void> {
   await mkdir(dirname(logPath), { recursive: true });
@@ -365,7 +375,7 @@ export async function writeLogImage(logPath: string, contents: string): Promise<
     await writeFile(tempPath, contents, "utf8");
     await rename(tempPath, logPath);
   } catch (error) {
-    await rm(tempPath, { force: true });
+    await rm(tempPath, { force: true }).catch(() => {});
     throw error;
   }
 }

--- a/apps/tui/src/event-store.ts
+++ b/apps/tui/src/event-store.ts
@@ -337,12 +337,37 @@ export function nextLogImage(prior: string | undefined, events: PortfolioEvent[]
   return `${prior ?? ""}${prefix}${lines}\n`;
 }
 
-/** Write a full image of the log via temp + rename. The only way the log is written. */
+/**
+ * Per-process counter behind the temp name. Two writes from the SAME process can
+ * be in flight at once (the pid alone would collide), so the name carries a tick
+ * as well; across processes the pid separates them.
+ */
+let tempImageTick = 0;
+
+/**
+ * Write a full image of the log via temp + rename. The only way the log is written.
+ *
+ * The temp file's name is unique per write — `<log>.<pid>.<tick>.tmp` — and lives in the
+ * SAME directory as the log. Unique because a shared `<log>.tmp` is a shared mutable file:
+ * two concurrent writers open it at once, one truncates what the other is still writing,
+ * and the rename — atomic in itself — then publishes a blended or truncated image, or
+ * fails outright because the sibling already renamed the source away. Same directory
+ * because rename(2) is only atomic within one filesystem; a temp in `os.tmpdir()` would
+ * degrade to a copy that can tear.
+ *
+ * A failed write removes its own temp file, so a doomed write leaves no litter behind.
+ */
 export async function writeLogImage(logPath: string, contents: string): Promise<void> {
   await mkdir(dirname(logPath), { recursive: true });
-  const tempPath = `${logPath}.tmp`;
-  await writeFile(tempPath, contents, "utf8");
-  await rename(tempPath, logPath);
+  tempImageTick += 1;
+  const tempPath = `${logPath}.${process.pid}.${tempImageTick}.tmp`;
+  try {
+    await writeFile(tempPath, contents, "utf8");
+    await rename(tempPath, logPath);
+  } catch (error) {
+    await rm(tempPath, { force: true });
+    throw error;
+  }
 }
 
 /**

--- a/apps/tui/src/record-fill-reliable.test.ts
+++ b/apps/tui/src/record-fill-reliable.test.ts
@@ -13,8 +13,8 @@
 //
 // Every fixture is a SYNTHETIC ladder (`O7`). Invented ids, round decade prices, round
 // balances — no real price, quantity, balance or rung enters this repository.
-import { chmod, mkdir, mkdtemp, readFile, rm, stat, writeFile } from "node:fs/promises";
-import { resolve } from "node:path";
+import { chmod, mkdir, mkdtemp, readdir, readFile, rm, stat, writeFile } from "node:fs/promises";
+import { dirname, resolve } from "node:path";
 import { tmpdir } from "node:os";
 import {
   foldEvents,
@@ -203,6 +203,20 @@ async function exists(path: string): Promise<boolean> {
   }
 }
 
+/**
+ * Every `.tmp` entry left in a file's OWN directory — the litter guard for BOTH writers.
+ *
+ * Over the directory rather than over one guessed name: both `writeLogImage` and
+ * `appendOrders` now name their temp uniquely per call (`<path>.<pid>.<n>.tmp`), so
+ * asserting the absence of a single `${path}.tmp` passes vacuously — the name it probes
+ * is one neither writer can ever produce. The events log and the orders sidecar share
+ * one data dir, so a single sweep covers both halves of the fill act.
+ */
+async function tempLitter(path: string): Promise<string[]> {
+  const entries = await readdir(dirname(path));
+  return entries.filter((entry) => entry.endsWith(".tmp"));
+}
+
 describe("`O2` on a real filesystem — the rollback restores real bytes", () => {
   it("guards against a vacuous pass: a clean act really writes BOTH files", async () => {
     // Without this, every rollback case below could be passing because the flow never
@@ -219,9 +233,9 @@ describe("`O2` on a real filesystem — the rollback restores real bytes", () =>
     expect(log.startsWith(PRIOR_LOG_LINE)).toBe(true);
     expect(log).toContain("fill:rung-400@2026-01-05T12:00:00");
     expect(await readFile(ordersPath, "utf8")).toContain(`"kind":"orderFilled"`);
-    // The temp files both writers rename FROM are gone, not left behind.
-    expect(await exists(`${eventsPath}.tmp`)).toBe(false);
-    expect(await exists(`${ordersPath}.tmp`)).toBe(false);
+    // The temp files both writers rename FROM are gone, not left behind — one sweep of
+    // the shared data dir catches either writer's litter, whatever it named it.
+    expect(await tempLitter(eventsPath)).toEqual([]);
   });
 
   it("restores a PRE-EXISTING log BYTE-FOR-BYTE when the sidecar write fails", async () => {
@@ -249,7 +263,7 @@ describe("`O2` on a real filesystem — the rollback restores real bytes", () =>
     // rewriting every line of the durable record of fact.
     expect(await readFile(eventsPath, "utf8")).toBe(PRIOR_LOG_LINE);
     expect(await readFile(ordersPath, "utf8")).toBe(ordersImage);
-    expect(await exists(`${eventsPath}.tmp`)).toBe(false);
+    expect(await tempLitter(eventsPath)).toEqual([]);
   });
 
   it("restores a log that had a TORN final line byte-for-byte, terminator and all", async () => {


### PR DESCRIPTION
`writeLogImage` built its temp path by appending a fixed suffix to the log path, so every writer against a given log shared `${logPath}.tmp`. Two concurrent writers interleaved on that one file, and because each builds a **complete next image** and renames it over the log, the loser's entire image vanished silently — no torn file to notice afterwards, just a staged image that never landed.

Closes #296.

## What changed

`apps/tui/src/event-store.ts` — the temp name is now `${logPath}.${process.pid}.${tick}.tmp`, where `tick` is a module-level counter incremented per call.

Pid alone is not sufficient. The observed corruption is two in-flight writes from **one** process (`Promise.all` over callers), so the counter is the part that actually separates them; the pid covers the cross-process case. The temp file stays a **sibling of the log**, so the rename remains same-filesystem and therefore still atomic — that directory constraint is the whole reason this is not simply "stage into `os.tmpdir()`".

Cleanup is a `try`/`catch` around write+rename that `rm`s its own temp and rethrows. No shared state, no directory scanning, nothing to reconcile.

The three real callers — `appendEvents`, `migrateLegacyLog`, `restoreLogImage` — plus the `record-fill` injection point are untouched. Note that `restoreLogImage`, the rollback half of the two-file fill act, routes through the same function, so the fix covers rollback as well as append.

## The test, and why it is large on purpose

Extended the house file `apps/tui/src/event-store.test.ts` with `writeLogImage — concurrent writers cannot corrupt each other`. Four writers, each a distinct ~4 MB image built from an authored marker line repeated 60,000 times. It asserts that every write resolves, that the surviving image contains exactly one distinct line, its full length, that it is byte-identical to one of the four inputs, and that no `.tmp` files are left in the directory.

**Verified red before the fix.** Against the pre-fix code the concurrency assertion fails with three `ENOENT … rename '…/events.jsonl.tmp' -> '…/events.jsonl'` errors: three of four writers lost their staged image entirely because a sibling renamed the shared temp out from under them. That is the defect itself, not an assertion on an implementation detail.

**The payload size is load-bearing.** With a small payload the whole write completes inside one turn, the writers never overlap, and the test passes against broken code. The multi-megabyte payload is what makes the race deterministic. This is stated in a comment in the test so nobody "optimizes" it back into green-on-broken.

Every byte of test input is authored — generated filler, nothing read from any log or data directory.

## Note for a future increment: should concurrent writers be *prevented*?

Issue #296 asks whether concurrent writers to one log should be prevented outright rather than merely made safe. **Deliberately not answered here, and deliberately not built.** The TUI is single-operator, so today the collision needs two processes; a lock would say that explicitly instead of leaving it to the temp-name scheme. This PR makes the existing concurrency safe and records the question rather than growing into a locking increment.

`event-store.test.ts:551` ("migrateLegacyLog writes through writeLogImage") already anticipated this fix — its comment names "a distinct temp name" as hardening that must land in `writeLogImage` because it is the one writer of the whole log. That structural assertion still holds.

## Verification

- `pnpm typecheck` — clean across all six packages.
- Test suite scoped to this tree — 137 files, 1953 passed, 21 skipped, 0 failed.

One caveat for reviewers: a bare `pnpm test` from a worktree root is contaminated while sibling worktrees exist, because `.claude/` is a symlink into the main checkout's worktree directory and vitest follows it (822 files collected, failures belonging to other lanes). This is an artifact of concurrent worktrees, not of this change, and the vitest config was **not** modified to paper over it. CI is unaffected — `.claude/` is gitignored.

## Merge order

**Base branch: `main`.** This is the first PR of the lane C stack:

1. **this PR** — `feature/unique-log-temp-path` → `main`
2. #294 — `feature/cli-shell-tests` → `feature/unique-log-temp-path`
3. #298 — `feature/r6-r7-single-owner` → `feature/cli-shell-tests`

Merge in that order. GitHub retargets each stacked PR to `main` automatically when its base is deleted on merge. Nothing on this board merges before the end-of-workflow batch-merge session.
