### PR TITLE
test(tui): give the three untested CLI shells a contract of their own

### DIFF
--- a/apps/tui/src/cancel-order-cli.test.ts
+++ b/apps/tui/src/cancel-order-cli.test.ts
@@ -20,7 +20,10 @@
  *
  * EVERY FIXTURE IS SYNTHETIC — invented rung ids, round decade prices, round quantities.
  * No real order, price or balance appears here, and the real accumulus data dir is never
- * reachable: `NUMISMA_DATA_DIR` points at a throwaway `mkdtemp` directory in every case.
+ * reachable: the runner's `dataDir` is REQUIRED and becomes `NUMISMA_DATA_DIR` verbatim,
+ * so every case names a throwaway `mkdtemp` directory (or, in the one relative-path case,
+ * the relative string under test). There is no default — an empty string would resolve to
+ * the real ledger, so omitting the dir has to be, and is, a type error.
  */
 import { spawnSync } from "node:child_process";
 import { mkdtemp, readFile, readdir, rm, writeFile } from "node:fs/promises";
@@ -55,8 +58,9 @@ function ladderRecords(): OrderRecord[] {
   }));
 }
 
-interface Run {
+interface ShellRun {
   status: number | null;
+  signal: NodeJS.Signals | null;
   stdout: string;
   stderr: string;
 }
@@ -90,24 +94,56 @@ describe("cancel-order-cli — the shell's argv, env and exit-code contract", ()
     return join(dataDir, "orders.jsonl");
   }
 
-  /** Run the real `cancel-order-cli.ts` under tsx, stdin CLOSED and stdio piped. */
+  /**
+   * Run the real `cancel-order-cli.ts` under tsx, stdin CLOSED and stdio piped.
+   *
+   * `dataDir` is REQUIRED and is the LITERAL `NUMISMA_DATA_DIR` value — a case that wants
+   * to exercise the relative-path refusal passes the relative string here. There is
+   * deliberately no default: `resolveDataDir` treats `""` exactly like an unset var
+   * (`packages/engine/src/data-dir.ts:47` gates on `fromEnv.trim() !== ""`) and falls back
+   * to the REAL accumulus ledger, so a runner that let the value be omitted would put a
+   * live write one forgotten argument away. Omitting it is a type error, not a fallback.
+   */
   function runCancel(
-    args: string[],
-    options: { dataDir?: string; dataDirEnv?: string; cwd?: string } = {},
-  ): Run {
+    args: readonly string[],
+    options: { dataDir: string; cwd?: string },
+  ): ShellRun {
     const script = join(REPO_ROOT, "apps", "tui", "src", "cancel-order-cli.ts");
     const tsx = join(REPO_ROOT, "node_modules", ".bin", "tsx");
-    const env = {
-      ...process.env,
-      NUMISMA_DATA_DIR: options.dataDirEnv ?? options.dataDir ?? "",
-    };
+    const env = { ...process.env, NUMISMA_DATA_DIR: options.dataDir };
     const result = spawnSync(tsx, [script, ...args], {
       encoding: "utf8",
       env,
       input: "",
+      // A shell that blocked on a read would hang this worker outright: `spawnSync` is not
+      // preemptible by vitest's own testTimeout, which is a timer on the same thread. The
+      // timeout turns a hang into a KILLED process, which `expectExited` reads as failure.
+      timeout: 20_000,
       ...(options.cwd === undefined ? {} : { cwd: options.cwd }),
     });
-    return { status: result.status, stdout: result.stdout ?? "", stderr: result.stderr ?? "" };
+    return {
+      status: result.status,
+      signal: result.signal,
+      stdout: result.stdout ?? "",
+      stderr: result.stderr ?? "",
+    };
+  }
+
+  /**
+   * Asserted on EVERY path: the process ended on its own rather than being killed by the
+   * runner's timeout. This shell claims to need no TTY (`cancel-order-cli.ts:11-13`), so a
+   * path that started waiting on a prompt must surface here as a signal, not as a hang.
+   */
+  function expectExited(run: ShellRun): void {
+    expect(run.signal).toBeNull();
+    expect(typeof run.status).toBe("number");
+  }
+
+  /** Every `.tmp`/`.lock` entry in a directory — the staging name is UNIQUE per write. */
+  async function litter(dir: string): Promise<string[]> {
+    return (await readdir(dir)).filter(
+      (entry) => entry.endsWith(".tmp") || entry.endsWith(".lock"),
+    );
   }
 
   async function readOrders(dataDir: string): Promise<string> {
@@ -128,6 +164,7 @@ describe("cancel-order-cli — the shell's argv, env and exit-code contract", ()
 
     const result = runCancel(["rung-300", "2026-01-03T10:00:00"], { dataDir: dir });
 
+    expectExited(result);
     expect(result.status).toBe(0);
     expect(result.stdout).toContain("Cancelled rung-300");
     expect(result.stderr).toBe("");
@@ -147,6 +184,7 @@ describe("cancel-order-cli — the shell's argv, env and exit-code contract", ()
 
     const result = runCancel([], { dataDir: dir });
 
+    expectExited(result);
     expect(result.status).toBe(1);
     // Exact, and on the ERROR channel — a usage line on stdout would pollute a pipeline.
     expect(result.stderr).toBe(USAGE);
@@ -164,6 +202,7 @@ describe("cancel-order-cli — the shell's argv, env and exit-code contract", ()
     // `!orderId` is one falsiness check covering both `undefined` and `""`.
     const result = runCancel([""], { dataDir: dir });
 
+    expectExited(result);
     expect(result.status).toBe(1);
     expect(result.stderr).toBe(USAGE);
     expect(result.stdout).toBe("");
@@ -184,27 +223,23 @@ describe("cancel-order-cli — the shell's argv, env and exit-code contract", ()
       // path, while an operator who passed nothing at all sees a usage line. Same
       // mistake, two code paths, two messages — pinned here so neither drifts silently.
       const result = runCancel([" "], { dataDir: dir });
+      const absent = runCancel([], { dataDir: dir });
 
+      expectExited(result);
+      expectExited(absent);
       expect(result.status).toBe(1);
       expect(result.stderr).toContain("REFUSED — no order id was given");
       // NOT the usage sentence — that is the whole point of this case.
       expect(result.stderr).not.toContain(USAGE.trim());
       expect(result.stdout).toBe("");
       expect(await readOrders(dir)).toBe(before);
+
+      // The divergence made explicit against the other branch: SAME exit code, so a
+      // calling script cannot tell the two mistakes apart — only the text can.
+      expect(absent.status).toBe(result.status);
+      expect(absent.stderr).toBe(USAGE);
     },
   );
-
-  it("the two 'no id' messages are genuinely different text", async () => {
-    const dir = await syntheticDataDir();
-
-    const absent = runCancel([], { dataDir: dir });
-    const blank = runCancel([" "], { dataDir: dir });
-
-    // Same exit code, same operator intent, different sentences. Both exit 1, so a
-    // script cannot tell them apart; only the text can.
-    expect(absent.status).toBe(blank.status);
-    expect(absent.stderr).not.toBe(blank.stderr);
-  });
 
   // ── The positional mapping. ───────────────────────────────────────────────────────
   it("maps argv[3] to observedAt: the supplied stamp lands VERBATIM in the appended line", async () => {
@@ -212,6 +247,7 @@ describe("cancel-order-cli — the shell's argv, env and exit-code contract", ()
 
     const result = runCancel(["rung-200", "2026-03-04T05:06:07"], { dataDir: dir });
 
+    expectExited(result);
     expect(result.status).toBe(0);
     // Verbatim, not re-formatted, not re-stamped — this is what proves argv[3] is the
     // stamp positional rather than something the shell reorders or ignores.
@@ -226,6 +262,7 @@ describe("cancel-order-cli — the shell's argv, env and exit-code contract", ()
     const result = runCancel(["rung-200"], { dataDir: dir });
     const after = formatObservedAt(new Date());
 
+    expectExited(result);
     expect(result.status).toBe(0);
     // `YYYY-MM-DDTHH:MM:SS` sorts lexicographically, so bracketing the spawn is a real
     // bound on `io.now()` (`cancel-order.ts:122`) without freezing global time.
@@ -243,6 +280,7 @@ describe("cancel-order-cli — the shell's argv, env and exit-code contract", ()
 
     // A shell that grew flags would either consume or reject these; this one reads two
     // positionals and stops.
+    expectExited(result);
     expect(result.status).toBe(0);
     expect(lastRecord(await readOrders(dir)).observedAt).toBe("2026-03-04T05:06:07");
   });
@@ -257,6 +295,7 @@ describe("cancel-order-cli — the shell's argv, env and exit-code contract", ()
     // the path the parent's env produced in the CHILD process.
     const result = runCancel(["rung-does-not-exist"], { dataDir: dir });
 
+    expectExited(result);
     expect(result.status).toBe(1);
     expect(result.stderr).toContain(ordersPath(dir));
     expect(result.stderr).toContain(`Nothing was written to ${ordersPath(dir)}.`);
@@ -272,10 +311,11 @@ describe("cancel-order-cli — the shell's argv, env and exit-code contract", ()
       // this very `orders.jsonl` and the cancellation would SUCCEED. The byte-identical
       // assertion below is therefore load-bearing, not vacuous.
       const result = runCancel(["rung-300", "2026-01-03T10:00:00"], {
-        dataDirEnv: relative,
+        dataDir: relative,
         cwd: dir,
       });
 
+      expectExited(result);
       expect(result.status).toBe(1);
       expect(result.stderr).toContain("split-brain ledger");
       expect(result.stderr).toContain("NUMISMA_DATA_DIR must be an absolute path");
@@ -288,10 +328,15 @@ describe("cancel-order-cli — the shell's argv, env and exit-code contract", ()
   it("maps all three outcomes: usage → 1, rejected → 1, cancelled → 0", async () => {
     const dir = await syntheticDataDir();
 
-    expect(runCancel([], { dataDir: dir }).status).toBe(1);
+    const usage = runCancel([], { dataDir: dir });
+    expectExited(usage);
+    expect(usage.status).toBe(1);
     // `not-resting`: the rung is retired by the first call, so the second is refused.
-    expect(runCancel(["rung-300", "2026-01-03T10:00:00"], { dataDir: dir }).status).toBe(0);
+    const cancelled = runCancel(["rung-300", "2026-01-03T10:00:00"], { dataDir: dir });
+    expectExited(cancelled);
+    expect(cancelled.status).toBe(0);
     const again = runCancel(["rung-300", "2026-01-04T10:00:00"], { dataDir: dir });
+    expectExited(again);
     expect(again.status).toBe(1);
     expect(again.stderr).toContain("REFUSED —");
   });
@@ -299,13 +344,12 @@ describe("cancel-order-cli — the shell's argv, env and exit-code contract", ()
   it("leaves no temp or lock litter beside the sidecar after a successful append", async () => {
     const dir = await syntheticDataDir();
 
-    expect(runCancel(["rung-200", "2026-01-03T10:00:00"], { dataDir: dir }).status).toBe(0);
+    const result = runCancel(["rung-200", "2026-01-03T10:00:00"], { dataDir: dir });
+    expectExited(result);
+    expect(result.status).toBe(0);
 
     // Over the DIRECTORY, not a guessed `${path}.tmp`: the staging name is unique per
     // write, so probing one literal name would pass vacuously.
-    const leftovers = (await readdir(dir)).filter(
-      (entry) => entry.endsWith(".tmp") || entry.endsWith(".lock"),
-    );
-    expect(leftovers).toEqual([]);
+    expect(await litter(dir)).toEqual([]);
   });
 });

--- a/apps/tui/src/cancel-order-cli.test.ts
+++ b/apps/tui/src/cancel-order-cli.test.ts
@@ -1,0 +1,311 @@
+/**
+ * THE CANCEL SHELL'S OWN CONTRACT — argv, env and exit codes, not the flow.
+ *
+ * `cancel-order-cli.ts` is 43 lines of wiring with a top-level `if`/`else`, a top-level
+ * `await` and no exports: importing it RUNS THE ACT, so spawning it is the only door.
+ * `cancelOrder` itself — all seven rejection reasons — is already covered in
+ * `apps/tui/src/cancel-order.test.ts` through an injected IO bag, and nothing here
+ * re-tests those. What is covered here is only what the injected-bag suite structurally
+ * cannot see:
+ *
+ *   - the `!orderId` usage branch, which returns BEFORE `cancelOrder` and before
+ *     `resolveOrdersPath()` is ever called;
+ *   - the positional mapping — that `argv[3]` really is the stamp and reaches the domain,
+ *     and that its absence means "now";
+ *   - `NUMISMA_DATA_DIR` → `resolveOrdersPath()` plumbing across the process boundary;
+ *   - the exit-code mapping (usage → 1, rejected → 1, cancelled → 0);
+ *   - the header's stated NO-TTY contract (`cancel-order-cli.ts:11-13`): "the whole
+ *     assertion is in argv, so this is scriptable and does not need a TTY". Nothing
+ *     pinned that, so every case runs with stdin CLOSED (`input: ""`) and stdio piped.
+ *
+ * EVERY FIXTURE IS SYNTHETIC — invented rung ids, round decade prices, round quantities.
+ * No real order, price or balance appears here, and the real accumulus data dir is never
+ * reachable: `NUMISMA_DATA_DIR` points at a throwaway `mkdtemp` directory in every case.
+ */
+import { spawnSync } from "node:child_process";
+import { mkdtemp, readFile, readdir, rm, writeFile } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { dirname, join, resolve } from "node:path";
+import { fileURLToPath } from "node:url";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { formatObservedAt, serializeOrderRecord, type OrderRecord } from "@numisma/engine";
+
+// Spawning `tsx` costs a cold TypeScript start; give it headroom under load.
+vi.setConfig({ testTimeout: 30_000 });
+
+const HERE = dirname(fileURLToPath(import.meta.url));
+// HERE = apps/tui/src → the repo root is three levels up.
+const REPO_ROOT = resolve(HERE, "../../..");
+
+/** The exact sentence the usage branch prints — pinned character-for-character. */
+const USAGE = "usage: pnpm orders:cancel <orderId> [YYYY-MM-DDTHH:MM:SS]\n";
+
+/** A synthetic descending ladder of two resting rungs. */
+function ladderRecords(): OrderRecord[] {
+  return [300, 200].map((price) => ({
+    id: `rung-${price}`,
+    observedAt: "2026-01-02T09:00:00",
+    kind: "orderPlaced" as const,
+    currency: "USD" as const,
+    symbol: "TEST/USD",
+    side: "buy" as const,
+    price,
+    quantity: 10,
+    fundingReserveId: "reserve-synthetic",
+  }));
+}
+
+interface Run {
+  status: number | null;
+  stdout: string;
+  stderr: string;
+}
+
+describe("cancel-order-cli — the shell's argv, env and exit-code contract", () => {
+  const createdDirs: string[] = [];
+
+  afterEach(async () => {
+    await Promise.all(createdDirs.map((dir) => rm(dir, { recursive: true, force: true })));
+    createdDirs.length = 0;
+  });
+
+  /**
+   * A throwaway data dir holding ONLY `orders.jsonl` — this act reads nothing else: no
+   * genesis, no event log, no plans, no fold.
+   */
+  async function syntheticDataDir(): Promise<string> {
+    const dir = await mkdtemp(resolve(tmpdir(), "numisma-cancel-cli-"));
+    createdDirs.push(dir);
+    await writeFile(
+      join(dir, "orders.jsonl"),
+      ladderRecords()
+        .map((record) => `${serializeOrderRecord(record)}\n`)
+        .join(""),
+      "utf8",
+    );
+    return dir;
+  }
+
+  function ordersPath(dataDir: string): string {
+    return join(dataDir, "orders.jsonl");
+  }
+
+  /** Run the real `cancel-order-cli.ts` under tsx, stdin CLOSED and stdio piped. */
+  function runCancel(
+    args: string[],
+    options: { dataDir?: string; dataDirEnv?: string; cwd?: string } = {},
+  ): Run {
+    const script = join(REPO_ROOT, "apps", "tui", "src", "cancel-order-cli.ts");
+    const tsx = join(REPO_ROOT, "node_modules", ".bin", "tsx");
+    const env = {
+      ...process.env,
+      NUMISMA_DATA_DIR: options.dataDirEnv ?? options.dataDir ?? "",
+    };
+    const result = spawnSync(tsx, [script, ...args], {
+      encoding: "utf8",
+      env,
+      input: "",
+      ...(options.cwd === undefined ? {} : { cwd: options.cwd }),
+    });
+    return { status: result.status, stdout: result.stdout ?? "", stderr: result.stderr ?? "" };
+  }
+
+  async function readOrders(dataDir: string): Promise<string> {
+    return readFile(ordersPath(dataDir), "utf8");
+  }
+
+  /** The appended line's parsed record — the LAST non-blank line of the sidecar. */
+  function lastRecord(raw: string): Record<string, unknown> {
+    const lines = raw.split("\n").filter((line) => line.trim() !== "");
+    return JSON.parse(lines[lines.length - 1] as string) as Record<string, unknown>;
+  }
+
+  // ── The control: the refusals below are the SHELL talking, not a shell that cannot
+  // start at all. ───────────────────────────────────────────────────────────────────
+  it("cancels a resting rung: exit 0, one appended line, and NO TTY anywhere", async () => {
+    const dir = await syntheticDataDir();
+    const before = await readOrders(dir);
+
+    const result = runCancel(["rung-300", "2026-01-03T10:00:00"], { dataDir: dir });
+
+    expect(result.status).toBe(0);
+    expect(result.stdout).toContain("Cancelled rung-300");
+    expect(result.stderr).toBe("");
+
+    // The header's claim (`:11-13`) made mechanical: stdin was CLOSED and stdout/stderr
+    // were pipes, not a terminal, and the act still completed. Nothing waits on a prompt.
+    const after = await readOrders(dir);
+    expect(after.startsWith(before)).toBe(true);
+    const appended = lastRecord(after);
+    expect(appended).toMatchObject({ id: "rung-300", kind: "orderCancelled", currency: "USD" });
+  });
+
+  // ── The usage branch: it returns before the domain and before path resolution. ─────
+  it("prints the usage sentence to STDERR and exits 1 when orderId is absent", async () => {
+    const dir = await syntheticDataDir();
+    const before = await readOrders(dir);
+
+    const result = runCancel([], { dataDir: dir });
+
+    expect(result.status).toBe(1);
+    // Exact, and on the ERROR channel — a usage line on stdout would pollute a pipeline.
+    expect(result.stderr).toBe(USAGE);
+    expect(result.stdout).toBe("");
+    // `resolveOrdersPath()` is INSIDE the else-branch, so a usage refusal never names a
+    // path — the absence of the temp dir in stderr is what proves the early return.
+    expect(result.stderr).not.toContain(dir);
+    expect(await readOrders(dir)).toBe(before);
+  });
+
+  it("treats an EMPTY-STRING orderId as absent — same usage sentence, same exit 1", async () => {
+    const dir = await syntheticDataDir();
+    const before = await readOrders(dir);
+
+    // `!orderId` is one falsiness check covering both `undefined` and `""`.
+    const result = runCancel([""], { dataDir: dir });
+
+    expect(result.status).toBe(1);
+    expect(result.stderr).toBe(USAGE);
+    expect(result.stdout).toBe("");
+    expect(await readOrders(dir)).toBe(before);
+  });
+
+  // ── THE DIVERGENCE. ───────────────────────────────────────────────────────────────
+  it(
+    "DIVERGES on a whitespace-only orderId: it clears the shell's truthiness check and is " +
+      "refused by the DOMAIN instead — a different sentence for the same operator mistake",
+    async () => {
+      const dir = await syntheticDataDir();
+      const before = await readOrders(dir);
+
+      // `" "` is truthy, so the shell's `!orderId` guard passes it through; `cancelOrder`
+      // TRIMS (`cancel-order.ts:103-105`) and rejects with `no-order-id`. An operator
+      // whose shell expanded an unset variable to a space sees a REFUSED banner naming a
+      // path, while an operator who passed nothing at all sees a usage line. Same
+      // mistake, two code paths, two messages — pinned here so neither drifts silently.
+      const result = runCancel([" "], { dataDir: dir });
+
+      expect(result.status).toBe(1);
+      expect(result.stderr).toContain("REFUSED — no order id was given");
+      // NOT the usage sentence — that is the whole point of this case.
+      expect(result.stderr).not.toContain(USAGE.trim());
+      expect(result.stdout).toBe("");
+      expect(await readOrders(dir)).toBe(before);
+    },
+  );
+
+  it("the two 'no id' messages are genuinely different text", async () => {
+    const dir = await syntheticDataDir();
+
+    const absent = runCancel([], { dataDir: dir });
+    const blank = runCancel([" "], { dataDir: dir });
+
+    // Same exit code, same operator intent, different sentences. Both exit 1, so a
+    // script cannot tell them apart; only the text can.
+    expect(absent.status).toBe(blank.status);
+    expect(absent.stderr).not.toBe(blank.stderr);
+  });
+
+  // ── The positional mapping. ───────────────────────────────────────────────────────
+  it("maps argv[3] to observedAt: the supplied stamp lands VERBATIM in the appended line", async () => {
+    const dir = await syntheticDataDir();
+
+    const result = runCancel(["rung-200", "2026-03-04T05:06:07"], { dataDir: dir });
+
+    expect(result.status).toBe(0);
+    // Verbatim, not re-formatted, not re-stamped — this is what proves argv[3] is the
+    // stamp positional rather than something the shell reorders or ignores.
+    expect(lastRecord(await readOrders(dir)).observedAt).toBe("2026-03-04T05:06:07");
+    expect(result.stdout).toContain("retired 2026-03-04T05:06:07");
+  });
+
+  it("omitting argv[3] stamps NOW, inside the window the test itself brackets", async () => {
+    const dir = await syntheticDataDir();
+
+    const before = formatObservedAt(new Date());
+    const result = runCancel(["rung-200"], { dataDir: dir });
+    const after = formatObservedAt(new Date());
+
+    expect(result.status).toBe(0);
+    // `YYYY-MM-DDTHH:MM:SS` sorts lexicographically, so bracketing the spawn is a real
+    // bound on `io.now()` (`cancel-order.ts:122`) without freezing global time.
+    const stamped = lastRecord(await readOrders(dir)).observedAt as string;
+    expect(stamped >= before).toBe(true);
+    expect(stamped <= after).toBe(true);
+  });
+
+  it("ignores argv[4] and beyond — there is no flag parsing in this shell", async () => {
+    const dir = await syntheticDataDir();
+
+    const result = runCancel(["rung-300", "2026-03-04T05:06:07", "--force", "extra"], {
+      dataDir: dir,
+    });
+
+    // A shell that grew flags would either consume or reject these; this one reads two
+    // positionals and stops.
+    expect(result.status).toBe(0);
+    expect(lastRecord(await readOrders(dir)).observedAt).toBe("2026-03-04T05:06:07");
+  });
+
+  // ── The env plumbing. ─────────────────────────────────────────────────────────────
+  it("routes NUMISMA_DATA_DIR through resolveOrdersPath — stderr names the resolved path", async () => {
+    const dir = await syntheticDataDir();
+    const before = await readOrders(dir);
+
+    // Every domain refusal goes through one `reject()` helper that prints "Nothing was
+    // written to <ordersPath>" (`cancel-order.ts:84-91`), so ANY refusal is a probe of
+    // the path the parent's env produced in the CHILD process.
+    const result = runCancel(["rung-does-not-exist"], { dataDir: dir });
+
+    expect(result.status).toBe(1);
+    expect(result.stderr).toContain(ordersPath(dir));
+    expect(result.stderr).toContain(`Nothing was written to ${ordersPath(dir)}.`);
+    expect(await readOrders(dir)).toBe(before);
+  });
+
+  it("refuses a RELATIVE NUMISMA_DATA_DIR (exit 1) rather than splitting the ledger", async () => {
+    const dir = await syntheticDataDir();
+    const before = await readOrders(dir);
+
+    for (const relative of ["data", "."]) {
+      // `.` is the sharp one: with cwd = the fixture dir, ACCEPTING it would resolve to
+      // this very `orders.jsonl` and the cancellation would SUCCEED. The byte-identical
+      // assertion below is therefore load-bearing, not vacuous.
+      const result = runCancel(["rung-300", "2026-01-03T10:00:00"], {
+        dataDirEnv: relative,
+        cwd: dir,
+      });
+
+      expect(result.status).toBe(1);
+      expect(result.stderr).toContain("split-brain ledger");
+      expect(result.stderr).toContain("NUMISMA_DATA_DIR must be an absolute path");
+      expect(result.stdout).toBe("");
+      expect(await readOrders(dir)).toBe(before);
+    }
+  });
+
+  // ── The exit-code mapping, and the write-nothing posture. ─────────────────────────
+  it("maps all three outcomes: usage → 1, rejected → 1, cancelled → 0", async () => {
+    const dir = await syntheticDataDir();
+
+    expect(runCancel([], { dataDir: dir }).status).toBe(1);
+    // `not-resting`: the rung is retired by the first call, so the second is refused.
+    expect(runCancel(["rung-300", "2026-01-03T10:00:00"], { dataDir: dir }).status).toBe(0);
+    const again = runCancel(["rung-300", "2026-01-04T10:00:00"], { dataDir: dir });
+    expect(again.status).toBe(1);
+    expect(again.stderr).toContain("REFUSED —");
+  });
+
+  it("leaves no temp or lock litter beside the sidecar after a successful append", async () => {
+    const dir = await syntheticDataDir();
+
+    expect(runCancel(["rung-200", "2026-01-03T10:00:00"], { dataDir: dir }).status).toBe(0);
+
+    // Over the DIRECTORY, not a guessed `${path}.tmp`: the staging name is unique per
+    // write, so probing one literal name would pass vacuously.
+    const leftovers = (await readdir(dir)).filter(
+      (entry) => entry.endsWith(".tmp") || entry.endsWith(".lock"),
+    );
+    expect(leftovers).toEqual([]);
+  });
+});

--- a/apps/tui/src/event-store-write-failure.test.ts
+++ b/apps/tui/src/event-store-write-failure.test.ts
@@ -1,0 +1,130 @@
+/**
+ * THE FAILING LOG-IMAGE WRITE — the one path on which `writeLogImage` can leave litter
+ * behind, and the reason it needs a test file of its own.
+ *
+ * `writeLogImage` writes a unique temp sibling (`<log>.<pid>.<tick>.tmp`) and `rename`s
+ * it over the log. On the happy path the rename CONSUMES the temp, so every passing
+ * success case — including the four-writer concurrency case in `event-store.test.ts`,
+ * where every writer succeeds — proves exactly nothing about the `catch { rm }`. Delete
+ * the whole try/catch and those tests stay green.
+ *
+ * The window is between `writeFile` and `rename`, and no arrangement of real files opens
+ * it: every candidate (a directory at the target, a read-only parent) fails BEFORE a temp
+ * file exists, so the test would pass vacuously. So `rename` is mocked, and only
+ * `rename`: everything else is the real filesystem in a real temp directory. This file is
+ * separate because that mock is module-wide and has no business near the ingest tests.
+ *
+ * What it locks: a failed image write leaves NOTHING beside the log, and the caller sees
+ * the TRUE cause. Without the first, `events.jsonl.<pid>.<n>.tmp` accumulates one
+ * multi-megabyte orphan per failed attempt, forever and invisibly — accumulus ignores
+ * `/data/*.tmp`, so nothing on the durability path would ever surface it. Without the
+ * second, a cleanup that throws in turn (the dir went read-only, which is often WHY the
+ * write failed) replaces "the log image failed to publish" with an `unlink` error naming
+ * a temp file the operator has never heard of.
+ *
+ * Every fixture here is authored filler — no real event, price or balance.
+ */
+import { mkdtemp, readdir, readFile, rm } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join, resolve } from "node:path";
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+/** Flipped by a test to make the next `rename` fail the way a full volume would. */
+let renameFails = false;
+/**
+ * Flipped to make the CLEANUP fail too. Real-file arrangements cannot stage this
+ * reliably — making the dir read-only mid-flight races the `writeFile` — and the
+ * masking bug it targets is exactly a two-failure sequence, so both failures are
+ * injected rather than provoked.
+ */
+let cleanupFails = false;
+
+vi.mock("node:fs/promises", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("node:fs/promises")>();
+  return {
+    ...actual,
+    rename: async (from: string, to: string) => {
+      if (renameFails) {
+        throw Object.assign(new Error("ENOSPC: no space left on device, rename"), {
+          code: "ENOSPC",
+        });
+      }
+      return actual.rename(from, to);
+    },
+    rm: async (path: string, options?: Parameters<typeof actual.rm>[1]) => {
+      if (cleanupFails) {
+        throw Object.assign(new Error(`EACCES: permission denied, unlink '${path}'`), {
+          code: "EACCES",
+        });
+      }
+      return actual.rm(path, options);
+    },
+  };
+});
+
+const { writeLogImage } = await import("./event-store.js");
+
+const PRIOR_IMAGE = '{"kind":"synthetic","n":1}\n';
+const NEXT_IMAGE = '{"kind":"synthetic","n":1}\n{"kind":"synthetic","n":2}\n';
+
+const createdDirs: string[] = [];
+
+afterEach(async () => {
+  renameFails = false;
+  cleanupFails = false;
+  for (const dir of createdDirs) {
+    await rm(dir, { recursive: true, force: true });
+  }
+  createdDirs.length = 0;
+});
+
+async function tempDir(): Promise<string> {
+  const dir = await mkdtemp(resolve(tmpdir(), "numisma-log-image-"));
+  createdDirs.push(dir);
+  return dir;
+}
+
+describe("writeLogImage cleans up after ITSELF when the write cannot land", () => {
+  it("leaves no temp sibling behind, and does not create the log", async () => {
+    const dir = await tempDir();
+    const logPath = join(dir, "events.jsonl");
+    renameFails = true;
+
+    await expect(writeLogImage(logPath, NEXT_IMAGE)).rejects.toThrow(/ENOSPC/);
+
+    // The whole directory, not a guess at the temp's name: anything at all left here is
+    // litter, including a name a future revision of the scheme might choose instead.
+    expect(await readdir(dir)).toEqual([]);
+  });
+
+  it("leaves the PRIOR image untouched — a failed write loses no committed line", async () => {
+    const dir = await tempDir();
+    const logPath = join(dir, "events.jsonl");
+    await writeLogImage(logPath, PRIOR_IMAGE);
+
+    renameFails = true;
+    await expect(writeLogImage(logPath, NEXT_IMAGE)).rejects.toThrow(/ENOSPC/);
+
+    // Crash-atomicity is the entire warrant for writing through a temp, so the cleanup
+    // must not have cost it: the log still holds exactly what it held before.
+    expect(await readdir(dir)).toEqual(["events.jsonl"]);
+    expect(await readFile(logPath, "utf8")).toBe(PRIOR_IMAGE);
+  });
+
+  it("reports the WRITE's failure even when the cleanup cannot run either", async () => {
+    // The masking scenario, as seen on a data dir that goes read-only mid-flight: the
+    // rename fails, and the `rm` of the orphaned temp then fails EACCES in turn. `force:
+    // true` swallows only ENOENT, so without a `.catch` the caller is handed
+    // "EACCES: permission denied, unlink '…events.jsonl.<pid>.<n>.tmp'" and the true
+    // cause — the durable log image failed to publish — is gone. On a spine contracted
+    // to fail loud WITH the true cause, that is the operator pointed at the wrong file.
+    const dir = await tempDir();
+    const logPath = join(dir, "events.jsonl");
+    renameFails = true;
+    cleanupFails = true;
+
+    await expect(writeLogImage(logPath, NEXT_IMAGE)).rejects.toThrow(/ENOSPC/);
+    // And specifically NOT the cleanup's error wearing the failure's place.
+    await expect(writeLogImage(logPath, NEXT_IMAGE)).rejects.not.toThrow(/EACCES/);
+  });
+});

--- a/apps/tui/src/event-store.test.ts
+++ b/apps/tui/src/event-store.test.ts
@@ -177,6 +177,20 @@ async function exists(path: string): Promise<boolean> {
   }
 }
 
+/**
+ * Every `.tmp` entry sitting in a file's OWN directory.
+ *
+ * Over the directory, not over one guessed name: `writeLogImage` names its temp
+ * uniquely per write (`<log>.<pid>.<tick>.tmp`), so asserting the absence of a single
+ * `${path}.tmp` passes vacuously while a whole generation of temps piles up beside the
+ * durable log — and nothing on the durability path would surface them, because
+ * accumulus ignores `/data/*.tmp`.
+ */
+async function tempLitter(path: string): Promise<string[]> {
+  const entries = await readdir(dirname(path));
+  return entries.filter((entry) => entry.endsWith(".tmp"));
+}
+
 async function readOrUndefined(path: string): Promise<string | undefined> {
   try {
     return await readFile(path, "utf8");
@@ -371,7 +385,7 @@ describe("appendEvents — atomic append (temp + rename)", () => {
       expect(() => JSON.parse(line)).not.toThrow();
     }
     // The temp image is renamed away, never left behind.
-    expect(await exists(`${paths.log}.tmp`)).toBe(false);
+    expect(await tempLitter(paths.log)).toEqual([]);
   });
 });
 
@@ -380,13 +394,23 @@ describe("writeLogImage — concurrent writers cannot corrupt each other", () =>
     const paths = await makeStore({});
     const dir = dirname(paths.log);
 
-    // Multi-megabyte images on purpose: with a tiny payload the write completes inside
-    // one turn and the writers never really overlap. At this size the open/write/rename
-    // steps genuinely interleave, so a SHARED temp name loses the race deterministically
-    // — one writer truncating another's half-written temp, or renaming it out from under
-    // it. Every byte here is authored filler: a distinct marker line per writer, repeated.
+    // Multi-megabyte images on purpose, but NOT because small ones fail to overlap —
+    // measured against a faithful copy of the pre-fix shared-temp implementation, the
+    // `rejected` assertion below is red 10/10 at ONE line (67 bytes) just as it is here.
+    // `fs/promises.writeFile` always yields, so all four writers open the shared temp
+    // before any rename fires and three then hit ENOENT at any size: the LOST-IMAGE mode
+    // reproduces for free.
+    //
+    // What the size buys is the OTHER mode — a BLENDED image, one writer's bytes
+    // interleaved into another's, which survives the rename and fails only byte-identity.
+    // That one needs the write to span many turns: 4/10 runs at 60_000 lines against the
+    // old code, 0/10 small. So the payload is sized for `distinctLines` and the
+    // byte-identity check, not for the rejection check. The whole case runs in ~38ms and
+    // is 10/10 clean under the fix — do not shrink it to save a cost that isn't there.
+    //
+    // Every byte here is authored filler: a distinct marker line per writer, repeated.
     const WRITERS = 4;
-    const LINES = 60_000; // ~4 MB per image at 68 bytes/line.
+    const LINES = 60_000; // ~4 MB per image at 67 bytes/line (66 + "\n").
     const images = Array.from(
       { length: WRITERS },
       (_, index) => `${`writer-${index}`.padEnd(66, String.fromCharCode(97 + index))}\n`.repeat(LINES),
@@ -596,7 +620,7 @@ describe("durable-log migration — legacy-shape events fail loud, then migrate 
     await migrateLegacyLog(paths, cashLegs);
 
     // The temp image is renamed away, never left behind (the writeLogImage contract).
-    expect(await exists(`${paths.log}.tmp`)).toBe(false);
+    expect(await tempLitter(paths.log)).toEqual([]);
 
     // And structurally: the migration holds no writer of its own. `writeLogImage` is
     // documented as "the only way the log is written" — any hardening landed there

--- a/apps/tui/src/event-store.test.ts
+++ b/apps/tui/src/event-store.test.ts
@@ -16,7 +16,7 @@ import {
   resolveEventStorePaths,
   type EventStorePaths,
 } from "@numisma/event-store";
-import { ingestInbox, migrateLegacyLog } from "./event-store.js";
+import { ingestInbox, migrateLegacyLog, writeLogImage } from "./event-store.js";
 import type { SuppliedCashLeg } from "@numisma/engine";
 import { afterEach, describe, expect, it, vi } from "vitest";
 
@@ -372,6 +372,45 @@ describe("appendEvents — atomic append (temp + rename)", () => {
     }
     // The temp image is renamed away, never left behind.
     expect(await exists(`${paths.log}.tmp`)).toBe(false);
+  });
+});
+
+describe("writeLogImage — concurrent writers cannot corrupt each other", () => {
+  it("leaves the log byte-identical to exactly one writer's image, never a blend", async () => {
+    const paths = await makeStore({});
+    const dir = dirname(paths.log);
+
+    // Multi-megabyte images on purpose: with a tiny payload the write completes inside
+    // one turn and the writers never really overlap. At this size the open/write/rename
+    // steps genuinely interleave, so a SHARED temp name loses the race deterministically
+    // — one writer truncating another's half-written temp, or renaming it out from under
+    // it. Every byte here is authored filler: a distinct marker line per writer, repeated.
+    const WRITERS = 4;
+    const LINES = 60_000; // ~4 MB per image at 68 bytes/line.
+    const images = Array.from(
+      { length: WRITERS },
+      (_, index) => `${`writer-${index}`.padEnd(66, String.fromCharCode(97 + index))}\n`.repeat(LINES),
+    );
+
+    const results = await Promise.allSettled(images.map((image) => writeLogImage(paths.log, image)));
+    // Every writer must SUCCEED: a rejection here is the shared-temp collision itself
+    // (the sibling renamed the source away), not an incidental failure.
+    const rejected = results.filter((result) => result.status === "rejected");
+    expect(rejected.map((result) => String((result as PromiseRejectedResult).reason))).toEqual([]);
+
+    const content = await readFile(paths.log, "utf8");
+
+    // No blend: a surviving image is one writer's marker line, repeated — nothing else.
+    const distinctLines = new Set(content.split("\n").filter((line) => line.length > 0));
+    expect([...distinctLines]).toHaveLength(1);
+    // No truncation: full length, and byte-identical to one of the inputs. Compared as a
+    // boolean so a failure reports a flag rather than dumping megabytes of diff.
+    expect(content.length).toBe(images[0]!.length);
+    expect(images.some((image) => image === content)).toBe(true);
+
+    // And no litter: every temp image was renamed away or cleaned up.
+    const leftovers = (await readdir(dir)).filter((name) => name.includes(".tmp"));
+    expect(leftovers).toEqual([]);
   });
 });
 

--- a/apps/tui/src/event-store.ts
+++ b/apps/tui/src/event-store.ts
@@ -355,7 +355,17 @@ let tempImageTick = 0;
  * because rename(2) is only atomic within one filesystem; a temp in `os.tmpdir()` would
  * degrade to a copy that can tear.
  *
+ * The suffix stays `.tmp` — that is policy, not decoration. Accumulus's `/data/*.tmp`
+ * ignore rule (ADR-006) is the only thing stopping a multi-megabyte staged image from
+ * becoming committable into the private data repo, so any rename of this scheme must
+ * keep the `.tmp` ending. `packages/preferences/src/sidecar-io.ts` carries the same
+ * constraint on its own copy; both must hold it.
+ *
  * A failed write removes its own temp file, so a doomed write leaves no litter behind.
+ * The cleanup is best-effort BY DESIGN: if the removal itself fails (the directory went
+ * read-only, which is often why the write failed in the first place) its error is
+ * dropped, because the caller must be told the log image failed to publish — not handed
+ * an `unlink` error naming a temp file it has never heard of.
  */
 export async function writeLogImage(logPath: string, contents: string): Promise<void> {
   await mkdir(dirname(logPath), { recursive: true });
@@ -365,7 +375,7 @@ export async function writeLogImage(logPath: string, contents: string): Promise<
     await writeFile(tempPath, contents, "utf8");
     await rename(tempPath, logPath);
   } catch (error) {
-    await rm(tempPath, { force: true });
+    await rm(tempPath, { force: true }).catch(() => {});
     throw error;
   }
 }

--- a/apps/tui/src/event-store.ts
+++ b/apps/tui/src/event-store.ts
@@ -337,12 +337,37 @@ export function nextLogImage(prior: string | undefined, events: PortfolioEvent[]
   return `${prior ?? ""}${prefix}${lines}\n`;
 }
 
-/** Write a full image of the log via temp + rename. The only way the log is written. */
+/**
+ * Per-process counter behind the temp name. Two writes from the SAME process can
+ * be in flight at once (the pid alone would collide), so the name carries a tick
+ * as well; across processes the pid separates them.
+ */
+let tempImageTick = 0;
+
+/**
+ * Write a full image of the log via temp + rename. The only way the log is written.
+ *
+ * The temp file's name is unique per write — `<log>.<pid>.<tick>.tmp` — and lives in the
+ * SAME directory as the log. Unique because a shared `<log>.tmp` is a shared mutable file:
+ * two concurrent writers open it at once, one truncates what the other is still writing,
+ * and the rename — atomic in itself — then publishes a blended or truncated image, or
+ * fails outright because the sibling already renamed the source away. Same directory
+ * because rename(2) is only atomic within one filesystem; a temp in `os.tmpdir()` would
+ * degrade to a copy that can tear.
+ *
+ * A failed write removes its own temp file, so a doomed write leaves no litter behind.
+ */
 export async function writeLogImage(logPath: string, contents: string): Promise<void> {
   await mkdir(dirname(logPath), { recursive: true });
-  const tempPath = `${logPath}.tmp`;
-  await writeFile(tempPath, contents, "utf8");
-  await rename(tempPath, logPath);
+  tempImageTick += 1;
+  const tempPath = `${logPath}.${process.pid}.${tempImageTick}.tmp`;
+  try {
+    await writeFile(tempPath, contents, "utf8");
+    await rename(tempPath, logPath);
+  } catch (error) {
+    await rm(tempPath, { force: true });
+    throw error;
+  }
 }
 
 /**

--- a/apps/tui/src/import-orders-cli.test.ts
+++ b/apps/tui/src/import-orders-cli.test.ts
@@ -1,0 +1,408 @@
+/**
+ * THE IMPORT SHELL'S OWN CONTRACT — argv, exit codes, env plumbing, readline lifecycle.
+ *
+ * `import-orders-cli.ts` is wiring, and every one of its own decisions was untested: the
+ * usage branch, the THREE-WAY exit-code mapping it performs over the flow's outcome, the
+ * one env var it resolves three independent paths from, and the `finally` that closes the
+ * prompt. The flow it delegates to — `importBitgetOpenOrders` and its twelve refusal
+ * reasons — is covered by eight sibling suites (`import-orders.test.ts` and friends), and
+ * NOTHING HERE RE-TESTS THAT TAXONOMY. Where a refusal appears below it is being used as a
+ * probe for the shell's wiring: which PATH the message names, which CHANNEL it went to,
+ * which exit code the shell chose for it.
+ *
+ * THE MOST IMPORTANT LINE IN THIS FILE is the `imported-partial` case. That branch exits
+ * ZERO deliberately, under a fifteen-line rationale citing ADR-014 and #183 — nothing was
+ * REFUSED, so exiting 1 would tell a caller the run failed when it did not — and it names
+ * its own re-trigger: if the import is ever automated or piped, the exit code becomes the
+ * only surface left and the branch must be revisited BEFORE that lands. A documented,
+ * deliberate, fragile decision with no test under it is one refactor away from silently
+ * becoming a 1, so it is pinned here by a test whose name says why the code is 0.
+ *
+ * WHY IT SPAWNS. The shell is top-level `if`/`else` with top-level `await` — no `main`, no
+ * exports — so importing it RUNS THE IMPORT. Spawning `tsx` against the source is the only
+ * door, the same shape `record-fill-cli.test.ts` uses. `input` is always supplied so the
+ * readline prompt gets EOF or an authored answer instead of hanging, and every runner call
+ * carries a `timeout` so a shell that failed to close its prompt surfaces as a KILLED
+ * process rather than as a stuck suite.
+ *
+ * EVERY FIXTURE IS AUTHORED — invented ids, an invented instrument, round decade prices,
+ * round balances. Nothing is seeded from, or shaped by, a real export, a real ladder or a
+ * real ledger, and the real data dir is unreachable: `NUMISMA_DATA_DIR` is set explicitly
+ * on EVERY run, always to a throwaway `mkdtemp` directory.
+ */
+import { spawnSync } from "node:child_process";
+import { mkdtemp, readFile, readdir, rm, writeFile } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { dirname, join, resolve } from "node:path";
+import { fileURLToPath } from "node:url";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import {
+  BITGET_OPEN_ORDERS_HEADER,
+  canonicalDecimal,
+  serializeOrderRecord,
+  synthesizeOrderId,
+  type OrderRecord,
+} from "@numisma/engine";
+
+// Spawning `tsx` costs a cold TypeScript start; give it headroom under load.
+vi.setConfig({ testTimeout: 30_000 });
+
+const HERE = dirname(fileURLToPath(import.meta.url));
+// HERE = apps/tui/src → the repo root is three levels up.
+const REPO_ROOT = resolve(HERE, "../../..");
+
+/** A synthetic fund: one portfolio, one account, one instrument, one live reserve. */
+const GENESIS_SEED = {
+  fund: { id: "fund-authored", name: "Authored", baseCurrency: "USD" },
+  review: { asOf: "2026-01-01", usdMxn: 20 },
+  portfolios: [{ id: "portfolio-authored", name: "Authored" }],
+  accounts: [
+    { id: "account-authored", name: "Authored Venue", platform: "SYNTH", currency: "USD" },
+  ],
+  instruments: [
+    { id: "instrument-authored", name: "Authored Asset", symbol: "TEST", currency: "USD" },
+  ],
+  reserves: [
+    {
+      id: "reserve-authored",
+      portfolioId: "portfolio-authored",
+      tempo: "Capital",
+      executionMode: "live",
+      accountId: "account-authored",
+      currency: "USD",
+      amount: 10000,
+      lots: [{ quantity: 10000, tier: "c1" }],
+    },
+  ],
+  positions: [],
+};
+
+const HEADER = BITGET_OPEN_ORDERS_HEADER.join(",");
+
+/** One export row, authored column by column in the venue's own order. */
+function exportRow(cells: {
+  timestamp: string;
+  price: string;
+  quantity: string;
+  filled: string;
+  status: string;
+}): string {
+  return [
+    cells.timestamp,
+    "TEST/USDT",
+    "GTC",
+    "Limit",
+    "Buy",
+    cells.price,
+    cells.quantity,
+    "-- / --",
+    "4000",
+    cells.filled,
+    cells.quantity,
+    "0%",
+    cells.status,
+    "Cancel",
+  ].join(",");
+}
+
+/** The id the parser will synthesize for a row — computed the way the parser computes it. */
+function authoredId(price: string, observedAt: string): string {
+  return synthesizeOrderId({
+    venue: "bitget",
+    symbol: "TESTUSDT",
+    side: "buy",
+    // `canonicalDecimal` is total; these are authored, well-formed decimals.
+    price: canonicalDecimal(price) ?? price,
+    observedAt,
+  });
+}
+
+/** A rung the venue shows 4 of 10 filled — an id already on file, further filled since. */
+const RESTATED_STAMP = "2026-01-02T09:00:00";
+const RESTATED_ROW = exportRow({
+  timestamp: "2026-01-02 09:00:00",
+  price: "400",
+  quantity: "10",
+  filled: "4",
+  status: "Partially Filled",
+});
+const RESTATED_ID = authoredId("400", RESTATED_STAMP);
+
+/** A row nobody can read — an unreadable PRICE, which `leavesRungUnweighed` counts. */
+const UNREADABLE_ROW = exportRow({
+  timestamp: "2026-01-02 09:30:00",
+  price: "not-a-price",
+  quantity: "10",
+  filled: "0",
+  status: "unfilled",
+});
+
+/** A rung the file has never seen — the one shape that reaches the funding interview. */
+const FRESH_ROW = exportRow({
+  timestamp: "2026-01-02 10:00:00",
+  price: "300",
+  quantity: "10",
+  filled: "0",
+  status: "unfilled",
+});
+
+/** The placement line `RESTATED_ROW` restates: same size, a SMALLER observed partial. */
+function placementOnFile(): OrderRecord {
+  return {
+    id: RESTATED_ID,
+    observedAt: RESTATED_STAMP,
+    kind: "orderPlaced",
+    currency: "USD",
+    symbol: "TESTUSDT",
+    side: "buy",
+    price: 400,
+    quantity: 10,
+    observedFilledQuantity: 2,
+    fundingReserveId: "reserve-authored",
+  };
+}
+
+interface ShellRun {
+  status: number | null;
+  signal: NodeJS.Signals | null;
+  stdout: string;
+  stderr: string;
+}
+
+describe("import-orders-cli — the shell's own contract (argv, exit codes, env, readline)", () => {
+  const createdDirs: string[] = [];
+
+  afterEach(async () => {
+    await Promise.all(createdDirs.map((dir) => rm(dir, { recursive: true, force: true })));
+    createdDirs.length = 0;
+  });
+
+  /** A throwaway data dir. `files` is written verbatim, so a case can plant a bad one. */
+  async function dataDir(files: Record<string, string> = {}): Promise<string> {
+    const dir = await mkdtemp(resolve(tmpdir(), "numisma-import-cli-"));
+    createdDirs.push(dir);
+    await writeFile(join(dir, "genesis.json"), JSON.stringify(GENESIS_SEED), "utf8");
+    await writeFile(join(dir, "events.jsonl"), "", "utf8");
+    for (const [name, content] of Object.entries(files)) {
+      await writeFile(join(dir, name), content, "utf8");
+    }
+    return dir;
+  }
+
+  /** Write an export beside the data dir and return its path. */
+  async function exportFile(dir: string, rows: readonly string[]): Promise<string> {
+    const path = join(dir, "open-orders-export.csv");
+    await writeFile(path, [HEADER, ...rows].join("\n") + "\n", "utf8");
+    return path;
+  }
+
+  /**
+   * Run the real `import-orders-cli.ts` under tsx. `dataDir` is REQUIRED — the real
+   * accumulus dir must never be reachable from here, so the env var is always set.
+   */
+  function runImport(
+    args: readonly string[],
+    options: { dataDir: string; input?: string },
+  ): ShellRun {
+    const script = join(REPO_ROOT, "apps", "tui", "src", "import-orders-cli.ts");
+    const tsx = join(REPO_ROOT, "node_modules", ".bin", "tsx");
+    const env = { ...process.env, NUMISMA_DATA_DIR: options.dataDir };
+    const result = spawnSync(tsx, [script, ...args], {
+      encoding: "utf8",
+      env,
+      input: options.input ?? "",
+      // A shell that never closed its readline would block here forever; the timeout
+      // turns that into a KILLED process, which `expectExited` reads as a failure.
+      timeout: 20_000,
+    });
+    return {
+      status: result.status,
+      signal: result.signal,
+      stdout: result.stdout ?? "",
+      stderr: result.stderr ?? "",
+    };
+  }
+
+  /**
+   * The readline lifecycle assertion, made on EVERY path: the process ended on its own.
+   * `rl.close()` lives in a `finally`, so a path that lost it would leave stdin open and
+   * the process alive until the runner's timeout killed it — which is a signal, not a
+   * status.
+   */
+  function expectExited(run: ShellRun): void {
+    expect(run.signal).toBeNull();
+    expect(typeof run.status).toBe("number");
+  }
+
+  it("prints usage to STDERR and exits 1 with no argument, touching no data dir", async () => {
+    const dir = await dataDir();
+    const before = (await readdir(dir)).sort();
+
+    const run = runImport([], { dataDir: dir });
+
+    expectExited(run);
+    expect(run.status).toBe(1);
+    // The channel is the assertion: usage is a refusal to run, not output.
+    expect(run.stderr).toBe("usage: pnpm orders:import <path/to/open-orders-export.csv>\n");
+    expect(run.stdout).toBe("");
+    // No readline is constructed on this branch and the data dir is never resolved, let
+    // alone written — no sidecar appears, and no temp sibling of one either.
+    expect((await readdir(dir)).sort()).toEqual(before);
+  });
+
+  it("treats an EMPTY first argument as no argument at all", async () => {
+    const dir = await dataDir();
+
+    // `!csvPath` covers both shapes; a truthiness test is the reason `""` is not a path
+    // this shell then tries to read.
+    const run = runImport([""], { dataDir: dir });
+
+    expectExited(run);
+    expect(run.status).toBe(1);
+    expect(run.stderr).toContain("usage: pnpm orders:import");
+    expect(run.stdout).toBe("");
+  });
+
+  it("exits 0 on imported-partial because NOTHING WAS REFUSED, not 1 (ADR-014, #183)", async () => {
+    // THE PIN ON THE SHELL'S MOST DELIBERATE DECISION. `imported-partial` is a SUCCESS
+    // carrying a qualification — one row nobody could read — and the branch exits 0 under
+    // a rationale that says so at length. A caller reading the exit code is told the run
+    // did not fail, because it did not. If this ever has to become 1 (the rationale names
+    // the trigger: an automated or piped import, where the code is the only surface left),
+    // that is a decision to be made deliberately — this test is what makes it deliberate.
+    const dir = await dataDir({
+      "orders.jsonl": `${serializeOrderRecord(placementOnFile())}\n`,
+    });
+    const csv = await exportFile(dir, [UNREADABLE_ROW, RESTATED_ROW]);
+
+    const run = runImport([csv], { dataDir: dir });
+
+    expectExited(run);
+    expect(run.status).toBe(0);
+    // The qualification is real and reported — this is not a clean run mislabelled.
+    expect(run.stdout).toMatch(/INCOMPLETE — 1 row\(s\)/);
+    expect(run.stdout).toMatch(/1 observation\(s\) recorded/);
+    // And the unreadable row was reported on the error channel, where per-row problems go.
+    expect(run.stderr).toContain(`${csv}:2 skipped`);
+    // The operator was never taken into the interview: every readable rung was already on
+    // file, so there was nothing to attribute. The funding prompt's own text is the proof.
+    expect(run.stdout).not.toMatch(/Funding reserve for this batch/);
+  });
+
+  it("exits 0 on imported, leaves no temp sibling, and never writes the plans sidecar", async () => {
+    const plans = "this line is authored, and this import must not touch it\n";
+    const dir = await dataDir({
+      "orders.jsonl": `${serializeOrderRecord(placementOnFile())}\n`,
+      "plans.jsonl": plans,
+    });
+    const csv = await exportFile(dir, [RESTATED_ROW]);
+
+    const run = runImport([csv], { dataDir: dir });
+
+    expectExited(run);
+    expect(run.status).toBe(0);
+    // The same run WITHOUT the unreadable row: nothing qualified, so no notice.
+    expect(run.stdout).not.toMatch(/INCOMPLETE/);
+    expect(run.stdout).toMatch(/Imported .*: 0 order\(s\) appended/);
+    // The restatement landed as its own line — the shell bound a real filesystem, so the
+    // sidecar on disk is the evidence the wiring was end-to-end.
+    expect(await readFile(join(dir, "orders.jsonl"), "utf8")).toContain("orderFillObserved");
+    // Over the DIRECTORY, never a guessed `${path}.tmp`: the staging sibling is uniquely
+    // named per write, so probing one literal name would pass vacuously.
+    const leftovers = (await readdir(dir)).filter(
+      (entry) => entry.endsWith(".tmp") || entry.endsWith(".lock"),
+    );
+    expect(leftovers).toEqual([]);
+    // THE PLANS SIDECAR IS READ-ONLY on this path (#286): the import proposes a rung
+    // against the ladders in force and never writes a plan line. The bytes are unchanged,
+    // and no plans temp sibling appeared in the sweep above either.
+    expect(await readFile(join(dir, "plans.jsonl"), "utf8")).toBe(plans);
+  });
+
+  it("exits 1 when the flow refuses, and the refusal names the resolved orders path", async () => {
+    const dir = await dataDir();
+    const missing = join(dir, "never-exported.csv");
+
+    const run = runImport([missing], { dataDir: dir });
+
+    expectExited(run);
+    // The third arm of the mapping: rejected → 1, against imported / imported-partial → 0.
+    expect(run.status).toBe(1);
+    expect(run.stderr).toContain(`REFUSED — could not read ${missing}`);
+    // THE WIRING, not the taxonomy: the sentence names the orders path THIS shell
+    // resolved, so a refusal cannot be reported about some other file than the one the
+    // run would have written.
+    expect(run.stderr).toContain(`Nothing was written to ${join(dir, "orders.jsonl")}.`);
+    expect(run.stdout).toBe("");
+  });
+
+  it("refuses a RELATIVE NUMISMA_DATA_DIR through the shell's outer catch, exit 1", async () => {
+    const dir = await dataDir();
+    const csv = await exportFile(dir, [FRESH_ROW]);
+
+    // `resolveOrdersPath()` throws inside the try, AFTER the readline was constructed —
+    // so this path exercises both the catch (message to stderr, exit 1) and the `finally`
+    // that must still close the prompt.
+    const run = runImport([csv], { dataDir: "data" });
+
+    expectExited(run);
+    expect(run.status).toBe(1);
+    expect(run.stderr).toMatch(/split-brain ledger/);
+    expect(run.stdout).toBe("");
+  });
+
+  it("moves the resolved data-dir paths with NUMISMA_DATA_DIR, never the default root", async () => {
+    // TWO DIRS, ONE KNOB. The refusal sentence names the ORDERS path this shell resolved,
+    // so running the same refusal under two different values shows the resolution
+    // FOLLOWING the env var rather than merely happening to sit somewhere plausible.
+    //
+    // THE OTHER TWO RESOLVERS SIT BEHIND THE PROMPT and cannot be reached from a spawned
+    // run — see the interview-wall case below for why — so what is pinned here is the
+    // reachable one plus the negative that matters: no run of this shell falls back to the
+    // real accumulus root. `resolvePlansPath` and `resolveEventStorePaths` share
+    // `resolveDataDir` with `resolveOrdersPath`, and that agreement is pinned at the
+    // resolver (`packages/preferences/src/plans-reliable.test.ts`, the data-dir drift
+    // test) rather than re-derived here through an interview this harness cannot answer.
+    const first = await dataDir();
+    const second = await dataDir();
+
+    const one = runImport([join(first, "never-exported.csv")], { dataDir: first });
+    const two = runImport([join(second, "never-exported.csv")], { dataDir: second });
+
+    expectExited(one);
+    expectExited(two);
+    expect(one.stderr).toContain(`Nothing was written to ${join(first, "orders.jsonl")}.`);
+    expect(two.stderr).toContain(`Nothing was written to ${join(second, "orders.jsonl")}.`);
+    expect(one.stderr).not.toContain(second);
+    expect(one.stderr).not.toMatch(/accumulus/);
+    expect(two.stderr).not.toMatch(/accumulus/);
+  });
+
+  it("reaches the funding prompt on good inputs and still exits, closing the readline", async () => {
+    // THE CONTROL CASE, and a finding in its own right. A fresh rung has nothing on file
+    // to compare against, so the flow runs the export read, the header parse, the sidecar
+    // load and the changed-claim partition and then ASKS — and the shell's own readline,
+    // constructed over a PIPE that carries no terminal, has already seen end-of-input by
+    // the time the question is put. The prompt rejects, the outer catch reports it, and
+    // the run exits 1 through the same `finally` every other path uses.
+    //
+    // What that buys the assertions above: this run proves the shell STARTS and gets all
+    // the way through the reads on good inputs, so a refusal elsewhere in this file is the
+    // shell's own decision rather than a process that could not run at all. What it also
+    // records is the wall: the interactive half of this flow — the funding declaration,
+    // the rung picks, the plans read and the fold behind them — is not exercisable from a
+    // non-interactive spawn, and the `no-reserve-declared` refusal is unreachable here.
+    const dir = await dataDir();
+    const csv = await exportFile(dir, [FRESH_ROW]);
+
+    const run = runImport([csv], { dataDir: dir });
+
+    expectExited(run);
+    expect(run.status).toBe(1);
+    // It did NOT fail on any of the reads before the prompt — no refusal was raised.
+    expect(run.stderr).not.toMatch(/REFUSED/);
+    expect(run.stderr).toMatch(/readline was closed/);
+    // Nothing was written on the way to the prompt: the sidecar is still absent.
+    expect(await readdir(dir)).not.toContain("orders.jsonl");
+  });
+});

--- a/apps/tui/src/import-orders-cli.test.ts
+++ b/apps/tui/src/import-orders-cli.test.ts
@@ -369,9 +369,9 @@ describe("import-orders-cli — the shell's own contract (argv, exit codes, env,
     // FOLLOWING the env var rather than merely happening to sit somewhere plausible.
     //
     // THE OTHER TWO RESOLVERS SIT BEHIND THE PROMPT and cannot be reached from a spawned
-    // run — see the interview-wall case below for why — so what is pinned here is the
-    // reachable one plus the negative that matters: no run of this shell falls back to the
-    // real accumulus root. `resolvePlansPath` and `resolveEventStorePaths` share
+    // run — see the interview-wall case below, and #346, for why — so what is pinned here
+    // is the reachable one plus the negative that matters: no run of this shell falls back
+    // to the real accumulus root. `resolvePlansPath` and `resolveEventStorePaths` share
     // `resolveDataDir` with `resolveOrdersPath`, and that agreement is pinned at the
     // resolver (`packages/preferences/src/plans-reliable.test.ts`, the data-dir drift
     // test) rather than re-derived here through an interview this harness cannot answer.
@@ -404,6 +404,12 @@ describe("import-orders-cli — the shell's own contract (argv, exit codes, env,
     // records is the wall: the interactive half of this flow — the funding declaration,
     // the rung picks, the plans read and the fold behind them — is not exercisable from a
     // non-interactive spawn, and the `no-reserve-declared` refusal is unreachable here.
+    //
+    // FILED AS #346: `createInterface` is constructed at `import-orders-cli.ts:28` and
+    // eagerly consumes stdin, so by the time the first `ask` runs a piped stdin has already
+    // ended and `rl.question` rejects — which is why piping answers to `pnpm orders:import`
+    // cannot work, and why `no-reserve-declared` at `import-orders.ts:588` is unreachable
+    // without a TTY.
     const dir = await dataDir();
     const csv = await exportFile(dir, [FRESH_ROW]);
 

--- a/apps/tui/src/import-orders-cli.test.ts
+++ b/apps/tui/src/import-orders-cli.test.ts
@@ -234,6 +234,13 @@ describe("import-orders-cli — the shell's own contract (argv, exit codes, env,
     expect(typeof run.status).toBe("number");
   }
 
+  /** Every `.tmp`/`.lock` entry in a directory — the staging name is UNIQUE per write. */
+  async function litter(dir: string): Promise<string[]> {
+    return (await readdir(dir)).filter(
+      (entry) => entry.endsWith(".tmp") || entry.endsWith(".lock"),
+    );
+  }
+
   it("prints usage to STDERR and exits 1 with no argument, touching no data dir", async () => {
     const dir = await dataDir();
     const before = (await readdir(dir)).sort();
@@ -289,7 +296,7 @@ describe("import-orders-cli — the shell's own contract (argv, exit codes, env,
     expect(run.stdout).not.toMatch(/Funding reserve for this batch/);
   });
 
-  it("exits 0 on imported, leaves no temp sibling, and never writes the plans sidecar", async () => {
+  it("exits 0 on imported and leaves no temp sibling beside the sidecar it wrote", async () => {
     const plans = "this line is authored, and this import must not touch it\n";
     const dir = await dataDir({
       "orders.jsonl": `${serializeOrderRecord(placementOnFile())}\n`,
@@ -309,13 +316,18 @@ describe("import-orders-cli — the shell's own contract (argv, exit codes, env,
     expect(await readFile(join(dir, "orders.jsonl"), "utf8")).toContain("orderFillObserved");
     // Over the DIRECTORY, never a guessed `${path}.tmp`: the staging sibling is uniquely
     // named per write, so probing one literal name would pass vacuously.
-    const leftovers = (await readdir(dir)).filter(
-      (entry) => entry.endsWith(".tmp") || entry.endsWith(".lock"),
-    );
-    expect(leftovers).toEqual([]);
-    // THE PLANS SIDECAR IS READ-ONLY on this path (#286): the import proposes a rung
-    // against the ladders in force and never writes a plan line. The bytes are unchanged,
-    // and no plans temp sibling appeared in the sweep above either.
+    expect(await litter(dir)).toEqual([]);
+    // A WEAK GUARD, KEPT AND LABELLED AS ONE. The plans sidecar is read-only on this path
+    // (#286), but this comparison is not what proves it: `loadInForceLadders` has exactly
+    // one call site (`import-orders.ts:596`), inside `if (admitted.length > 0)` and AFTER
+    // `declareFunding` — i.e. behind the interview wall a non-interactive spawn cannot get
+    // past. This case admits nothing, so `plans.jsonl` is never OPENED, and an unread file
+    // cannot fail a byte-comparison. (The proof: the fixture below is not JSON, yet stderr
+    // on this run is empty — a read would have printed `:1 skipped (invalid)`.)
+    //
+    // It is kept only as a cheap tripwire for a write on some OTHER path that this run
+    // does reach. It would NOT catch the natural #286 follow-on — writing the accepted
+    // rung pick back after `:596` — which needs a test that can answer the interview.
     expect(await readFile(join(dir, "plans.jsonl"), "utf8")).toBe(plans);
   });
 
@@ -401,6 +413,12 @@ describe("import-orders-cli — the shell's own contract (argv, exit codes, env,
     expect(run.status).toBe(1);
     // It did NOT fail on any of the reads before the prompt — no refusal was raised.
     expect(run.stderr).not.toMatch(/REFUSED/);
+    // DELIBERATELY A NODE-INTERNAL STRING, not a contract of ours. `ERR_USE_AFTER_CLOSE`
+    // is the most precise available probe for "the prompt was actually put": no message of
+    // ours is emitted between the last read and the question. The tradeoff is owned here —
+    // a Node release that rewords it breaks this case, and the fix is to re-derive the new
+    // wording rather than to weaken the probe, because a looser match would stop
+    // distinguishing "reached the prompt" from "died earlier for some other reason".
     expect(run.stderr).toMatch(/readline was closed/);
     // Nothing was written on the way to the prompt: the sidecar is still absent.
     expect(await readdir(dir)).not.toContain("orders.jsonl");

--- a/apps/tui/src/migrate-legacy-log.test.ts
+++ b/apps/tui/src/migrate-legacy-log.test.ts
@@ -17,7 +17,9 @@
  * `main()` with a trailing `.catch`. Importing it RUNS THE MIGRATION against whatever
  * data dir the test process inherits. Spawning is the only door, and it is the same
  * `spawnSync(tsx, …)` shape `record-fill-cli.test.ts` and `durable-log-guards.test.ts`
- * already use. `input: ""` closes stdin so a shell can never hang on a read.
+ * already use. `input: ""` closes stdin so a shell can never hang on a read, and every
+ * spawn carries an explicit `timeout` — vitest's `testTimeout` cannot preempt a blocking
+ * `spawnSync`, so without it a shell that waited would hang the worker rather than fail.
  *
  * THE CWD/ENV SPLIT THIS FILE EXISTS TO NAME. The log is read from
  * `$NUMISMA_DATA_DIR/events.jsonl`, but `MAPPING_PATH` is the CWD-relative literal
@@ -28,8 +30,10 @@
  *
  * EVERY FIXTURE IS AUTHORED HERE — invented ids, an invented instrument, round decade
  * prices and round balances. Nothing is copied or seeded from real log output, and the
- * real ledger is unreachable: `NUMISMA_DATA_DIR` is a throwaway `mkdtemp` dir in every
- * single run.
+ * real ledger is unreachable: the runner's `dataDir` is REQUIRED and becomes
+ * `NUMISMA_DATA_DIR` verbatim, so every run names a throwaway `mkdtemp` dir (or, in the
+ * one relative-path case, the relative string under test). There is no default — an empty
+ * value would resolve to the real accumulus ledger.
  */
 import { spawnSync } from "node:child_process";
 import { mkdir, mkdtemp, readdir, readFile, rm, stat, writeFile } from "node:fs/promises";
@@ -101,8 +105,9 @@ const CASH_LEGS_MAPPING = JSON.stringify({
   [LEGACY_CLOSE_ID]: { settlement: { reserveId: "reserve-vault", proceeds: 1000 } },
 });
 
-interface RunResult {
+interface ShellRun {
   status: number | null;
+  signal: NodeJS.Signals | null;
   stdout: string;
   stderr: string;
 }
@@ -151,10 +156,15 @@ describe("migrate-legacy-log — the shell around the one-shot durable-log rewri
 
   /**
    * Run the real `migrate-legacy-log.ts` under tsx, with stdin closed. Both knobs are
-   * explicit and independent: `dataDir` becomes `NUMISMA_DATA_DIR` (where the log is),
-   * `cwd` is where the CWD-relative mapping is looked up.
+   * explicit and independent: `dataDir` becomes `NUMISMA_DATA_DIR` VERBATIM (where the log
+   * is, or the relative string a case is putting under test), `cwd` is where the
+   * CWD-relative mapping is looked up. Both are REQUIRED — there is no default, because an
+   * empty `NUMISMA_DATA_DIR` resolves to the real accumulus ledger.
+   *
+   * EVERY spawn in this file goes through here, including the relative-path case, so the
+   * timeout below covers all of them.
    */
-  function runMigrate(options: { dataDir: string; cwd: string }): RunResult {
+  function runMigrate(options: { dataDir: string; cwd: string }): ShellRun {
     const script = join(REPO_ROOT, "apps", "tui", "src", "migrate-legacy-log.ts");
     const tsx = join(REPO_ROOT, "node_modules", ".bin", "tsx");
     const env = { ...process.env, NUMISMA_DATA_DIR: options.dataDir };
@@ -163,14 +173,35 @@ describe("migrate-legacy-log — the shell around the one-shot durable-log rewri
       env,
       cwd: options.cwd,
       input: "",
+      // `vi.setConfig({ testTimeout })` cannot cover a blocking `spawnSync`: it is a timer
+      // on the same thread and cannot preempt the call. Without this, a shell that grew a
+      // confirmation prompt — the obvious next change to the one tool that rewrites the
+      // durable log — would block the worker indefinitely with no diagnostic instead of
+      // failing. The timeout turns that into a KILLED process, which `expectExited` reads.
+      timeout: 20_000,
     });
-    return { status: result.status, stdout: result.stdout ?? "", stderr: result.stderr ?? "" };
+    return {
+      status: result.status,
+      signal: result.signal,
+      stdout: result.stdout ?? "",
+      stderr: result.stderr ?? "",
+    };
   }
 
-  /** Every `.tmp` entry in the log's own directory — the scheme stages under a UNIQUE name. */
-  async function tempLitter(logPath: string): Promise<string[]> {
-    const entries = await readdir(dirname(logPath));
-    return entries.filter((entry) => entry.endsWith(".tmp"));
+  /**
+   * Asserted on EVERY path: the process ended on its own rather than being killed by the
+   * runner's timeout. `migrate:log` reads no input, so a run that waits is already a bug.
+   */
+  function expectExited(run: ShellRun): void {
+    expect(run.signal).toBeNull();
+    expect(typeof run.status).toBe("number");
+  }
+
+  /** Every `.tmp`/`.lock` entry in a directory — the scheme stages under a UNIQUE name. */
+  async function litter(dir: string): Promise<string[]> {
+    return (await readdir(dir)).filter(
+      (entry) => entry.endsWith(".tmp") || entry.endsWith(".lock"),
+    );
   }
 
   async function exists(path: string): Promise<boolean> {
@@ -189,6 +220,7 @@ describe("migrate-legacy-log — the shell around the one-shot durable-log rewri
 
       const result = runMigrate({ dataDir: dir, cwd: await workingDir() });
 
+      expectExited(result);
       expect(result.status).toBe(0);
       expect(result.stdout).toBe(
         `Migration complete: 0 legacy record(s) migrated, 2 unchanged. Log rewritten at ${logPath}.\n`,
@@ -199,7 +231,7 @@ describe("migrate-legacy-log — the shell around the one-shot durable-log rewri
       const rewritten = (await readFile(logPath, "utf8")).trim().split("\n");
       expect(rewritten).toHaveLength(2);
       expect(rewritten.every((line) => JSON.parse(line).schemaVersion === 2)).toBe(true);
-      expect(await tempLitter(logPath)).toEqual([]);
+      expect(await litter(dir)).toEqual([]);
     });
 
     it("counts a migrated legacy record separately from the unchanged ones (exit 0)", async () => {
@@ -207,6 +239,7 @@ describe("migrate-legacy-log — the shell around the one-shot durable-log rewri
 
       const result = runMigrate({ dataDir: dir, cwd: await workingDir(CASH_LEGS_MAPPING) });
 
+      expectExited(result);
       expect(result.status).toBe(0);
       expect(result.stdout).toBe(
         `Migration complete: 1 legacy record(s) migrated, 1 unchanged. Log rewritten at ${logPath}.\n`,
@@ -217,7 +250,7 @@ describe("migrate-legacy-log — the shell around the one-shot durable-log rewri
       const lines = (await readFile(logPath, "utf8")).trim().split("\n");
       const closed = lines.map((line) => JSON.parse(line)).find((event) => event.id === LEGACY_CLOSE_ID);
       expect(closed.settlement).toEqual({ reserveId: "reserve-vault", proceeds: 1000 });
-      expect(await tempLitter(logPath)).toEqual([]);
+      expect(await litter(dir)).toEqual([]);
     });
 
     it("says 'No durable log to migrate' and writes nothing when the log is absent (exit 0)", async () => {
@@ -225,6 +258,7 @@ describe("migrate-legacy-log — the shell around the one-shot durable-log rewri
 
       const result = runMigrate({ dataDir: dir, cwd: await workingDir(CASH_LEGS_MAPPING) });
 
+      expectExited(result);
       expect(result.status).toBe(0);
       expect(result.stdout).toBe(`No durable log to migrate at ${logPath}.\n`);
       expect(result.stderr).toBe("");
@@ -234,7 +268,12 @@ describe("migrate-legacy-log — the shell around the one-shot durable-log rewri
     });
 
     /**
-     * KNOWN DEFECT — CHARACTERIZED HERE, NOT BLESSED. A FOLLOW-UP ISSUE IS OWED.
+     * KNOWN DEFECT — CHARACTERIZED HERE, NOT BLESSED.
+     *
+     * NO TRACKER ISSUE EXISTS FOR THIS YET, and this comment deliberately cites none
+     * rather than a number that would not resolve. One is owed: the fix is a behavior
+     * change, so filing it is the next step, and whoever files it should put the number
+     * here and on the sibling case below.
      *
      * This test asserts what the tool OBSERVABLY DOES today, and what it does is wrong:
      * it reports "No durable log to migrate" about a log it has just OVERWRITTEN.
@@ -252,26 +291,30 @@ describe("migrate-legacy-log — the shell around the one-shot durable-log rewri
      * one tool in the repo that rewrites the durable log, and the same `undefined`-only
      * ENOENT check is what stands between "empty" and "unreadable". Fixing it is a
      * behavior change and this increment is tests only; the fix belongs in its own
-     * increment, with this test inverted to assert the log is left untouched.
+     * increment (see the follow-up owed above), with this test INVERTED to assert the log
+     * is left untouched.
      */
     it("KNOWN DEFECT: rewrites an EMPTY log to a single newline while reporting 'No durable log'", async () => {
       const { dir, logPath } = await syntheticDataDir("");
 
       const result = runMigrate({ dataDir: dir, cwd: await workingDir() });
 
+      expectExited(result);
       expect(result.status).toBe(0);
       // What the operator is told:
       expect(result.stdout).toBe(`No durable log to migrate at ${logPath}.\n`);
       // What actually happened to the file it just told them it did not migrate:
       expect(await readFile(logPath, "utf8")).toBe("\n");
-      expect(await tempLitter(logPath)).toEqual([]);
+      expect(await litter(dir)).toEqual([]);
     });
 
+    // KNOWN DEFECT, same seam and the same unfiled follow-up as the case above.
     it("KNOWN DEFECT (same seam): a blank-lines-only log is collapsed to a single newline", async () => {
       const { dir, logPath } = await syntheticDataDir("\n\n\n");
 
       const result = runMigrate({ dataDir: dir, cwd: await workingDir() });
 
+      expectExited(result);
       expect(result.status).toBe(0);
       expect(result.stdout).toBe(`No durable log to migrate at ${logPath}.\n`);
       // Blank lines are records to neither half, so the loop yields nothing and the
@@ -299,6 +342,7 @@ describe("migrate-legacy-log — the shell around the one-shot durable-log rewri
       // Wrong CWD: the mapping exists on disk, but not under THIS process's CWD.
       const lost = await syntheticDataDir(`${LEGACY_CLOSE}\n`);
       const lostRun = runMigrate({ dataDir: lost.dir, cwd: barrenCwd });
+      expectExited(lostRun);
       expect(lostRun.status).toBe(1);
       expect(lostRun.stderr).toMatch(/no supplied cash leg/i);
       expect(lostRun.stdout).toBe("");
@@ -308,6 +352,7 @@ describe("migrate-legacy-log — the shell around the one-shot durable-log rewri
       // the refusal above could be a shell that never starts at all.
       const found = await syntheticDataDir(`${LEGACY_CLOSE}\n`);
       const foundRun = runMigrate({ dataDir: found.dir, cwd: mappingCwd });
+      expectExited(foundRun);
       expect(foundRun.status).toBe(0);
       expect(foundRun.stdout).toMatch(/1 legacy record\(s\) migrated/);
     });
@@ -322,6 +367,7 @@ describe("migrate-legacy-log — the shell around the one-shot durable-log rewri
       // ENOENT is deliberately swallowed into an empty Map: the shell does not invent a
       // "mapping file missing" error, it delegates the better message — which ids need a
       // leg — to `migrateLegacyLog`.
+      expectExited(result);
       expect(result.status).toBe(1);
       expect(result.stderr).toMatch(/Migration aborted: 1 legacy record\(s\) have no supplied cash leg/);
       expect(result.stderr).toContain(LEGACY_CLOSE_ID);
@@ -330,7 +376,7 @@ describe("migrate-legacy-log — the shell around the one-shot durable-log rewri
       expect(result.stdout).toBe("");
       // Byte-identical: a refusal writes nothing at all.
       expect(await readFile(logPath, "utf8")).toBe(`${LEGACY_CLOSE}\n`);
-      expect(await tempLitter(logPath)).toEqual([]);
+      expect(await litter(dir)).toEqual([]);
     });
 
     it("surfaces malformed mapping JSON as the RAW SyntaxError — no wrapper, no filename", async () => {
@@ -339,6 +385,7 @@ describe("migrate-legacy-log — the shell around the one-shot durable-log rewri
 
       const result = runMigrate({ dataDir: dir, cwd: await workingDir("{ not json") });
 
+      expectExited(result);
       expect(result.status).toBe(1);
       // `JSON.parse` throws and the trailing `.catch` prints `error.message` verbatim.
       expect(result.stderr).toMatch(/JSON/);
@@ -350,7 +397,7 @@ describe("migrate-legacy-log — the shell around the one-shot durable-log rewri
       expect(result.stdout).toBe("");
       // It throws BEFORE the log is touched, so the log is byte-identical.
       expect(await readFile(logPath, "utf8")).toBe(log);
-      expect(await tempLitter(logPath)).toEqual([]);
+      expect(await litter(dir)).toEqual([]);
     });
 
     it("does not validate a well-formed-but-wrong mapping at all — garbage flows downstream", async () => {
@@ -366,6 +413,7 @@ describe("migrate-legacy-log — the shell around the one-shot durable-log rewri
         // No complaint about the mapping; the run completes as if none were supplied.
         // (`"x"` even becomes the entry `"0" -> "x"`, and `{"id": 42}` the entry
         // `"id" -> 42` — a number where a cash leg belongs — with nobody looking.)
+        expectExited(result);
         expect(result.status).toBe(0);
         expect(result.stdout).toBe(
           `Migration complete: 0 legacy record(s) migrated, 1 unchanged. Log rewritten at ${logPath}.\n`,
@@ -383,6 +431,7 @@ describe("migrate-legacy-log — the shell around the one-shot durable-log rewri
       // The refusal that arrives is the DOWNSTREAM one about a missing leg, not a shell
       // "your mapping is malformed" — because the shell never checks. A mapping with a
       // typo'd key is indistinguishable here from no mapping at all.
+      expectExited(result);
       expect(result.status).toBe(1);
       expect(result.stderr).toMatch(/no supplied cash leg/i);
       expect(await readFile(logPath, "utf8")).toBe(`${LEGACY_CLOSE}\n`);
@@ -391,28 +440,27 @@ describe("migrate-legacy-log — the shell around the one-shot durable-log rewri
 
   describe("NUMISMA_DATA_DIR plumbing and the exit-code mapping", () => {
     it("rejects a RELATIVE NUMISMA_DATA_DIR as a split-brain ledger (exit 1)", async () => {
-      const log = `${markZzz(200)}\n`;
-      const { logPath } = await syntheticDataDir(log);
+      // `$CWD/data` really exists here and holds the mapping, so the relative value names
+      // a directory the tool could plausibly have used.
       const cwd = await workingDir(CASH_LEGS_MAPPING);
 
-      const script = join(REPO_ROOT, "apps", "tui", "src", "migrate-legacy-log.ts");
-      const tsx = join(REPO_ROOT, "node_modules", ".bin", "tsx");
-      const result = spawnSync(tsx, [script], {
-        encoding: "utf8",
-        env: { ...process.env, NUMISMA_DATA_DIR: "data" },
-        cwd,
-        input: "",
-      });
+      // Through the file's own runner — `dataDir` is the LITERAL env value, so the
+      // relative string goes in here rather than being hand-rolled around the helper and
+      // silently missing its timeout.
+      const result = runMigrate({ dataDir: "data", cwd });
 
+      expectExited(result);
       expect(result.status).toBe(1);
       expect(result.stderr).toMatch(/split-brain ledger/i);
       expect(result.stderr).toMatch(/must be an absolute path/i);
       expect(result.stdout).toBe("");
-      // It refuses at resolution time, so neither the ledger it would have guessed at
-      // (`$CWD/data`, which really exists here and holds the mapping) nor the real
-      // fixture log is touched.
-      expect(await exists(join(cwd, "data", "events.jsonl"))).toBe(false);
-      expect(await readFile(logPath, "utf8")).toBe(log);
+      // The refusal at resolution time IS the whole assertion, and there is deliberately
+      // no "and nothing was written" check beside it: none is available here. If the
+      // relative value WERE accepted, `$CWD/data` holds no `events.jsonl`, so
+      // `readOptional` returns undefined and `migrateLegacyLog` early-returns at
+      // `event-store.ts:209-211` — nothing is written anywhere. An absent-file probe or a
+      // byte-comparison against a fixture log would therefore both pass under the very
+      // mutation they read as guarding. `status === 1` is what actually catches it.
     });
 
     it("exits 1 with the abort message on stderr when the migration itself refuses", async () => {
@@ -429,13 +477,14 @@ describe("migrate-legacy-log — the shell around the one-shot durable-log rewri
 
       const result = runMigrate({ dataDir: dir, cwd: await workingDir() });
 
+      expectExited(result);
       expect(result.status).toBe(1);
       expect(result.stderr).toMatch(/Migration aborted: 2 legacy record\(s\) have no supplied cash leg/);
       expect(result.stderr).toContain("line 1");
       expect(result.stderr).toContain("line 2");
       expect(result.stdout).toBe("");
       expect(await readFile(logPath, "utf8")).toBe(log);
-      expect(await tempLitter(logPath)).toEqual([]);
+      expect(await litter(dir)).toEqual([]);
     });
 
     it("exits 1 on an unparseable log line, leaving the log byte-identical", async () => {
@@ -444,11 +493,12 @@ describe("migrate-legacy-log — the shell around the one-shot durable-log rewri
 
       const result = runMigrate({ dataDir: dir, cwd: await workingDir(CASH_LEGS_MAPPING) });
 
+      expectExited(result);
       expect(result.status).toBe(1);
       expect(result.stderr).toMatch(/line 2 is not valid JSON/);
       expect(result.stdout).toBe("");
       expect(await readFile(logPath, "utf8")).toBe(log);
-      expect(await tempLitter(logPath)).toEqual([]);
+      expect(await litter(dir)).toEqual([]);
     });
 
     it("exits 1 when the data dir has no genesis to migrate against", async () => {
@@ -461,6 +511,7 @@ describe("migrate-legacy-log — the shell around the one-shot durable-log rewri
 
       // `loadGenesis` reads AFTER the log read, so this is the shell's `.catch` carrying
       // an fs error through the same one exit path — not a bespoke branch.
+      expectExited(result);
       expect(result.status).toBe(1);
       expect(result.stderr).toMatch(/genesis\.json/);
       expect(result.stdout).toBe("");

--- a/apps/tui/src/migrate-legacy-log.test.ts
+++ b/apps/tui/src/migrate-legacy-log.test.ts
@@ -1,0 +1,470 @@
+/**
+ * THE MIGRATION SHELL'S OWN CONTRACT (`pnpm migrate:log`).
+ *
+ * `migrate-legacy-log.ts` is the only tool in the repo that REWRITES the whole durable
+ * log, and until now nothing tested it. Its delegate `migrateLegacyLog` is well covered
+ * in `event-store.test.ts` (line numbering, the writeLogImage route, the loud refusals),
+ * so this file deliberately stays off the domain and pins only what the SHELL owns:
+ *
+ *   - the operator-authored mapping read (`data/migration-cash-legs.json`) — ENOENT
+ *     tolerance, the unwrapped `JSON.parse` failure, and the total absence of any
+ *     structural validation on a well-formed-but-wrong mapping;
+ *   - the two stdout sentences and the `touched === 0` boundary between them;
+ *   - the exit-code mapping (0 on resolve, 1 on any throw, message on stderr);
+ *   - `NUMISMA_DATA_DIR` plumbing, including the relative-path rejection.
+ *
+ * WHY THIS TEST SPAWNS A SUBPROCESS. Nothing is exported: the module is a self-executing
+ * `main()` with a trailing `.catch`. Importing it RUNS THE MIGRATION against whatever
+ * data dir the test process inherits. Spawning is the only door, and it is the same
+ * `spawnSync(tsx, …)` shape `record-fill-cli.test.ts` and `durable-log-guards.test.ts`
+ * already use. `input: ""` closes stdin so a shell can never hang on a read.
+ *
+ * THE CWD/ENV SPLIT THIS FILE EXISTS TO NAME. The log is read from
+ * `$NUMISMA_DATA_DIR/events.jsonl`, but `MAPPING_PATH` is the CWD-relative literal
+ * `"data/migration-cash-legs.json"` — it does NOT follow `NUMISMA_DATA_DIR`. So every
+ * run here controls BOTH `env.NUMISMA_DATA_DIR` and `spawnSync`'s `cwd`, and the two
+ * point at DIFFERENT throwaway directories on purpose, so no case can pass by accident
+ * of them coinciding.
+ *
+ * EVERY FIXTURE IS AUTHORED HERE — invented ids, an invented instrument, round decade
+ * prices and round balances. Nothing is copied or seeded from real log output, and the
+ * real ledger is unreachable: `NUMISMA_DATA_DIR` is a throwaway `mkdtemp` dir in every
+ * single run.
+ */
+import { spawnSync } from "node:child_process";
+import { mkdir, mkdtemp, readdir, readFile, rm, stat, writeFile } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { dirname, join, resolve } from "node:path";
+import { fileURLToPath } from "node:url";
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+// Spawning `tsx` costs a cold TypeScript start; give it headroom under load.
+vi.setConfig({ testTimeout: 30_000 });
+
+const HERE = dirname(fileURLToPath(import.meta.url));
+// HERE = apps/tui/src → the repo root is three levels up.
+const REPO_ROOT = resolve(HERE, "../../..");
+
+/** Where the shell looks for the operator's mapping — CWD-relative, by design of the code. */
+const MAPPING_RELATIVE_PATH = join("data", "migration-cash-legs.json");
+
+/** A synthetic fund: one portfolio, one account, one invented instrument, one open position. */
+const GENESIS_SEED = {
+  fund: { id: "fund-migrate", name: "Migration Fixture", baseCurrency: "USD" },
+  review: { asOf: "2026-03-01", usdMxn: 20 },
+  portfolios: [{ id: "vault", name: "Vault" }],
+  accounts: [{ id: "synth-usd", name: "Synthetic Venue", platform: "SYNTH", currency: "USD" }],
+  instruments: [{ id: "zzz-usd", name: "Synthetic Asset", symbol: "ZZZ", currency: "USD" }],
+  reserves: [
+    {
+      id: "reserve-vault",
+      portfolioId: "vault",
+      tempo: "Reserve",
+      executionMode: "live",
+      accountId: "synth-usd",
+      currency: "USD",
+      amount: 5000,
+    },
+  ],
+  positions: [
+    {
+      id: "zzz-vault",
+      portfolioId: "vault",
+      tempo: "Capital",
+      executionMode: "live",
+      accountId: "synth-usd",
+      instrumentId: "zzz-usd",
+      direction: "long",
+      markPrice: 200,
+      currency: "USD",
+      lots: [{ quantity: 5, cost: 100, tier: "c1" }],
+    },
+  ],
+};
+
+/** A loadable v2 record: a price mark on the invented instrument. */
+function markZzz(price: number, id = "mark-zzz"): string {
+  return JSON.stringify({ id, asOf: "2026-03-02", type: "PriceMarked", instrumentId: "zzz-usd", price });
+}
+
+/** A v1-shape close of the genesis position: no settlement cash leg, so unloadable. */
+const LEGACY_CLOSE_ID = "legacy-close-zzz";
+const LEGACY_CLOSE = JSON.stringify({
+  id: LEGACY_CLOSE_ID,
+  asOf: "2026-03-03",
+  type: "PositionClosed",
+  positionId: "zzz-vault",
+});
+
+/** The leg only the operator could hold: 5 × 200 marked → 1000 proceeds back to the reserve. */
+const CASH_LEGS_MAPPING = JSON.stringify({
+  [LEGACY_CLOSE_ID]: { settlement: { reserveId: "reserve-vault", proceeds: 1000 } },
+});
+
+interface RunResult {
+  status: number | null;
+  stdout: string;
+  stderr: string;
+}
+
+describe("migrate-legacy-log — the shell around the one-shot durable-log rewrite", () => {
+  const createdDirs: string[] = [];
+
+  afterEach(async () => {
+    await Promise.all(createdDirs.map((dir) => rm(dir, { recursive: true, force: true })));
+    createdDirs.length = 0;
+  });
+
+  async function tempDir(): Promise<string> {
+    const dir = await mkdtemp(resolve(tmpdir(), "numisma-migrate-"));
+    createdDirs.push(dir);
+    return dir;
+  }
+
+  /**
+   * A throwaway data dir holding a valid genesis and, when given, the durable-log bytes
+   * VERBATIM (so a case can plant an empty log, or one the reader cannot load).
+   */
+  async function syntheticDataDir(log?: string): Promise<{ dir: string; logPath: string }> {
+    const dir = await tempDir();
+    await writeFile(join(dir, "genesis.json"), JSON.stringify(GENESIS_SEED), "utf8");
+    const logPath = join(dir, "events.jsonl");
+    if (log !== undefined) {
+      await writeFile(logPath, log, "utf8");
+    }
+    return { dir, logPath };
+  }
+
+  /**
+   * A throwaway working directory with a `data/` subdir — where the shell will look for
+   * the mapping. `mapping` is written raw (not JSON.stringify'd) so a case can plant
+   * bytes that are not JSON at all. Omit it to leave the mapping absent (ENOENT).
+   */
+  async function workingDir(mapping?: string): Promise<string> {
+    const dir = await tempDir();
+    await mkdir(join(dir, "data"), { recursive: true });
+    if (mapping !== undefined) {
+      await writeFile(join(dir, MAPPING_RELATIVE_PATH), mapping, "utf8");
+    }
+    return dir;
+  }
+
+  /**
+   * Run the real `migrate-legacy-log.ts` under tsx, with stdin closed. Both knobs are
+   * explicit and independent: `dataDir` becomes `NUMISMA_DATA_DIR` (where the log is),
+   * `cwd` is where the CWD-relative mapping is looked up.
+   */
+  function runMigrate(options: { dataDir: string; cwd: string }): RunResult {
+    const script = join(REPO_ROOT, "apps", "tui", "src", "migrate-legacy-log.ts");
+    const tsx = join(REPO_ROOT, "node_modules", ".bin", "tsx");
+    const env = { ...process.env, NUMISMA_DATA_DIR: options.dataDir };
+    const result = spawnSync(tsx, [script], {
+      encoding: "utf8",
+      env,
+      cwd: options.cwd,
+      input: "",
+    });
+    return { status: result.status, stdout: result.stdout ?? "", stderr: result.stderr ?? "" };
+  }
+
+  /** Every `.tmp` entry in the log's own directory — the scheme stages under a UNIQUE name. */
+  async function tempLitter(logPath: string): Promise<string[]> {
+    const entries = await readdir(dirname(logPath));
+    return entries.filter((entry) => entry.endsWith(".tmp"));
+  }
+
+  async function exists(path: string): Promise<boolean> {
+    try {
+      await stat(path);
+      return true;
+    } catch {
+      return false;
+    }
+  }
+
+  describe("the two stdout sentences and the touched === 0 boundary", () => {
+    it("reports the rewrite of a clean log as 0 migrated, N unchanged (exit 0)", async () => {
+      const log = `${markZzz(200)}\n${markZzz(210, "mark-zzz-2")}\n`;
+      const { dir, logPath } = await syntheticDataDir(log);
+
+      const result = runMigrate({ dataDir: dir, cwd: await workingDir() });
+
+      expect(result.status).toBe(0);
+      expect(result.stdout).toBe(
+        `Migration complete: 0 legacy record(s) migrated, 2 unchanged. Log rewritten at ${logPath}.\n`,
+      );
+      // Nothing goes to stderr on a success path.
+      expect(result.stderr).toBe("");
+      // The rewrite really happened: both lines came back schemaVersion-stamped.
+      const rewritten = (await readFile(logPath, "utf8")).trim().split("\n");
+      expect(rewritten).toHaveLength(2);
+      expect(rewritten.every((line) => JSON.parse(line).schemaVersion === 2)).toBe(true);
+      expect(await tempLitter(logPath)).toEqual([]);
+    });
+
+    it("counts a migrated legacy record separately from the unchanged ones (exit 0)", async () => {
+      const { dir, logPath } = await syntheticDataDir(`${markZzz(200)}\n${LEGACY_CLOSE}\n`);
+
+      const result = runMigrate({ dataDir: dir, cwd: await workingDir(CASH_LEGS_MAPPING) });
+
+      expect(result.status).toBe(0);
+      expect(result.stdout).toBe(
+        `Migration complete: 1 legacy record(s) migrated, 1 unchanged. Log rewritten at ${logPath}.\n`,
+      );
+      expect(result.stderr).toBe("");
+      // The operator's supplied leg is what landed on disk — the shell really read the
+      // mapping and really handed it down.
+      const lines = (await readFile(logPath, "utf8")).trim().split("\n");
+      const closed = lines.map((line) => JSON.parse(line)).find((event) => event.id === LEGACY_CLOSE_ID);
+      expect(closed.settlement).toEqual({ reserveId: "reserve-vault", proceeds: 1000 });
+      expect(await tempLitter(logPath)).toEqual([]);
+    });
+
+    it("says 'No durable log to migrate' and writes nothing when the log is absent (exit 0)", async () => {
+      const { dir, logPath } = await syntheticDataDir();
+
+      const result = runMigrate({ dataDir: dir, cwd: await workingDir(CASH_LEGS_MAPPING) });
+
+      expect(result.status).toBe(0);
+      expect(result.stdout).toBe(`No durable log to migrate at ${logPath}.\n`);
+      expect(result.stderr).toBe("");
+      // The `touched === 0` branch on the honest side of the boundary: no log existed
+      // before and none was conjured.
+      expect(await exists(logPath)).toBe(false);
+    });
+
+    /**
+     * KNOWN DEFECT — CHARACTERIZED HERE, NOT BLESSED. A FOLLOW-UP ISSUE IS OWED.
+     *
+     * This test asserts what the tool OBSERVABLY DOES today, and what it does is wrong:
+     * it reports "No durable log to migrate" about a log it has just OVERWRITTEN.
+     *
+     * The mechanism: `readOptional` returns `undefined` only on ENOENT, so an existing
+     * but empty (or blank-lines-only) `events.jsonl` reads back as `""` and the early
+     * return at `event-store.ts:209-211` is NOT taken. `loadGenesis` runs, the line loop
+     * produces no events, and `writeLogImage` is still called — with `"\n"`. The log is
+     * replaced by a single newline byte, while `migratedCount + unchangedCount === 0`
+     * sends the shell down the `touched === 0` branch and it prints the reassuring
+     * "no log" sentence and exits 0.
+     *
+     * Nothing of value is lost from a log that was already empty, so this is not a live
+     * data-loss incident — but the report is a lie about a write that happened, on the
+     * one tool in the repo that rewrites the durable log, and the same `undefined`-only
+     * ENOENT check is what stands between "empty" and "unreadable". Fixing it is a
+     * behavior change and this increment is tests only; the fix belongs in its own
+     * increment, with this test inverted to assert the log is left untouched.
+     */
+    it("KNOWN DEFECT: rewrites an EMPTY log to a single newline while reporting 'No durable log'", async () => {
+      const { dir, logPath } = await syntheticDataDir("");
+
+      const result = runMigrate({ dataDir: dir, cwd: await workingDir() });
+
+      expect(result.status).toBe(0);
+      // What the operator is told:
+      expect(result.stdout).toBe(`No durable log to migrate at ${logPath}.\n`);
+      // What actually happened to the file it just told them it did not migrate:
+      expect(await readFile(logPath, "utf8")).toBe("\n");
+      expect(await tempLitter(logPath)).toEqual([]);
+    });
+
+    it("KNOWN DEFECT (same seam): a blank-lines-only log is collapsed to a single newline", async () => {
+      const { dir, logPath } = await syntheticDataDir("\n\n\n");
+
+      const result = runMigrate({ dataDir: dir, cwd: await workingDir() });
+
+      expect(result.status).toBe(0);
+      expect(result.stdout).toBe(`No durable log to migrate at ${logPath}.\n`);
+      // Blank lines are records to neither half, so the loop yields nothing and the
+      // three-byte image is replaced by a one-byte one — again reported as "no log".
+      expect(await readFile(logPath, "utf8")).toBe("\n");
+    });
+  });
+
+  describe("the mapping is read from the CWD, NOT from NUMISMA_DATA_DIR", () => {
+    /**
+     * The divergence, asserted both ways in one case so neither half can drift: the very
+     * same data dir and the very same mapping bytes succeed from a CWD that has
+     * `data/migration-cash-legs.json` and fail from one that does not. `MAPPING_PATH` is
+     * a CWD-relative literal (`migrate-legacy-log.ts:29`), so running `pnpm migrate:log`
+     * from a package directory instead of the repo root makes the operator's mapping
+     * silently vanish and degrades the run to the "no mapping" path. That is arguably a
+     * latent bug — the tool is not self-locating — but it fails LOUD (the refusal below),
+     * so it destroys nothing; it just wastes the operator's time with a refusal that names
+     * ids they already supplied.
+     */
+    it("finds the mapping from a CWD that has data/, and loses it from one that does not", async () => {
+      const mappingCwd = await workingDir(CASH_LEGS_MAPPING);
+      const barrenCwd = await workingDir();
+
+      // Wrong CWD: the mapping exists on disk, but not under THIS process's CWD.
+      const lost = await syntheticDataDir(`${LEGACY_CLOSE}\n`);
+      const lostRun = runMigrate({ dataDir: lost.dir, cwd: barrenCwd });
+      expect(lostRun.status).toBe(1);
+      expect(lostRun.stderr).toMatch(/no supplied cash leg/i);
+      expect(lostRun.stdout).toBe("");
+      expect(await readFile(lost.logPath, "utf8")).toBe(`${LEGACY_CLOSE}\n`);
+
+      // CONTROL — the same env and the same bytes, only the CWD differs. Without this
+      // the refusal above could be a shell that never starts at all.
+      const found = await syntheticDataDir(`${LEGACY_CLOSE}\n`);
+      const foundRun = runMigrate({ dataDir: found.dir, cwd: mappingCwd });
+      expect(foundRun.status).toBe(0);
+      expect(foundRun.stdout).toMatch(/1 legacy record\(s\) migrated/);
+    });
+  });
+
+  describe("mapping-file handling — pure shell logic", () => {
+    it("tolerates an absent mapping (ENOENT) and lets the refusal come from downstream", async () => {
+      const { dir, logPath } = await syntheticDataDir(`${LEGACY_CLOSE}\n`);
+
+      const result = runMigrate({ dataDir: dir, cwd: await workingDir() });
+
+      // ENOENT is deliberately swallowed into an empty Map: the shell does not invent a
+      // "mapping file missing" error, it delegates the better message — which ids need a
+      // leg — to `migrateLegacyLog`.
+      expect(result.status).toBe(1);
+      expect(result.stderr).toMatch(/Migration aborted: 1 legacy record\(s\) have no supplied cash leg/);
+      expect(result.stderr).toContain(LEGACY_CLOSE_ID);
+      expect(result.stderr).toMatch(/supply a settlement leg/);
+      expect(result.stderr.endsWith("\n")).toBe(true);
+      expect(result.stdout).toBe("");
+      // Byte-identical: a refusal writes nothing at all.
+      expect(await readFile(logPath, "utf8")).toBe(`${LEGACY_CLOSE}\n`);
+      expect(await tempLitter(logPath)).toEqual([]);
+    });
+
+    it("surfaces malformed mapping JSON as the RAW SyntaxError — no wrapper, no filename", async () => {
+      const log = `${markZzz(200)}\n`;
+      const { dir, logPath } = await syntheticDataDir(log);
+
+      const result = runMigrate({ dataDir: dir, cwd: await workingDir("{ not json") });
+
+      expect(result.status).toBe(1);
+      // `JSON.parse` throws and the trailing `.catch` prints `error.message` verbatim.
+      expect(result.stderr).toMatch(/JSON/);
+      // Asserting what it ACTUALLY does, not what would be kind: the operator is never
+      // told WHICH file failed to parse, and there is no "could not read the mapping"
+      // sentence anywhere. Worth improving; pinned here so a change is a deliberate one.
+      expect(result.stderr).not.toContain("migration-cash-legs.json");
+      expect(result.stderr).not.toMatch(/mapping/i);
+      expect(result.stdout).toBe("");
+      // It throws BEFORE the log is touched, so the log is byte-identical.
+      expect(await readFile(logPath, "utf8")).toBe(log);
+      expect(await tempLitter(logPath)).toEqual([]);
+    });
+
+    it("does not validate a well-formed-but-wrong mapping at all — garbage flows downstream", async () => {
+      // `Object.entries` is applied to whatever parsed, behind an unchecked
+      // `as Record<string, SuppliedCashLeg>`. None of these are a mapping; the shell has
+      // no opinion about any of them.
+      const log = `${markZzz(200)}\n`;
+      for (const mapping of ["[]", '"x"', '{"id": 42}']) {
+        const { dir, logPath } = await syntheticDataDir(log);
+
+        const result = runMigrate({ dataDir: dir, cwd: await workingDir(mapping) });
+
+        // No complaint about the mapping; the run completes as if none were supplied.
+        // (`"x"` even becomes the entry `"0" -> "x"`, and `{"id": 42}` the entry
+        // `"id" -> 42` — a number where a cash leg belongs — with nobody looking.)
+        expect(result.status).toBe(0);
+        expect(result.stdout).toBe(
+          `Migration complete: 0 legacy record(s) migrated, 1 unchanged. Log rewritten at ${logPath}.\n`,
+        );
+        expect(result.stderr).toBe("");
+      }
+    });
+
+    it("a wrong-shaped mapping cannot rescue a legacy record — it just is not the leg", async () => {
+      const { dir, logPath } = await syntheticDataDir(`${LEGACY_CLOSE}\n`);
+
+      // Structurally valid JSON, keyed by something that is not this event's id.
+      const result = runMigrate({ dataDir: dir, cwd: await workingDir('{"id": 42}') });
+
+      // The refusal that arrives is the DOWNSTREAM one about a missing leg, not a shell
+      // "your mapping is malformed" — because the shell never checks. A mapping with a
+      // typo'd key is indistinguishable here from no mapping at all.
+      expect(result.status).toBe(1);
+      expect(result.stderr).toMatch(/no supplied cash leg/i);
+      expect(await readFile(logPath, "utf8")).toBe(`${LEGACY_CLOSE}\n`);
+    });
+  });
+
+  describe("NUMISMA_DATA_DIR plumbing and the exit-code mapping", () => {
+    it("rejects a RELATIVE NUMISMA_DATA_DIR as a split-brain ledger (exit 1)", async () => {
+      const log = `${markZzz(200)}\n`;
+      const { logPath } = await syntheticDataDir(log);
+      const cwd = await workingDir(CASH_LEGS_MAPPING);
+
+      const script = join(REPO_ROOT, "apps", "tui", "src", "migrate-legacy-log.ts");
+      const tsx = join(REPO_ROOT, "node_modules", ".bin", "tsx");
+      const result = spawnSync(tsx, [script], {
+        encoding: "utf8",
+        env: { ...process.env, NUMISMA_DATA_DIR: "data" },
+        cwd,
+        input: "",
+      });
+
+      expect(result.status).toBe(1);
+      expect(result.stderr).toMatch(/split-brain ledger/i);
+      expect(result.stderr).toMatch(/must be an absolute path/i);
+      expect(result.stdout).toBe("");
+      // It refuses at resolution time, so neither the ledger it would have guessed at
+      // (`$CWD/data`, which really exists here and holds the mapping) nor the real
+      // fixture log is touched.
+      expect(await exists(join(cwd, "data", "events.jsonl"))).toBe(false);
+      expect(await readFile(logPath, "utf8")).toBe(log);
+    });
+
+    it("exits 1 with the abort message on stderr when the migration itself refuses", async () => {
+      // A second legacy record with no leg, to pin that the shell surfaces the delegate's
+      // ACCUMULATED refusal (both ids in one message) rather than the first failure only.
+      const secondLegacy = JSON.stringify({
+        id: "legacy-close-zzz-2",
+        asOf: "2026-03-04",
+        type: "PositionClosed",
+        positionId: "zzz-vault",
+      });
+      const log = `${LEGACY_CLOSE}\n${secondLegacy}\n`;
+      const { dir, logPath } = await syntheticDataDir(log);
+
+      const result = runMigrate({ dataDir: dir, cwd: await workingDir() });
+
+      expect(result.status).toBe(1);
+      expect(result.stderr).toMatch(/Migration aborted: 2 legacy record\(s\) have no supplied cash leg/);
+      expect(result.stderr).toContain("line 1");
+      expect(result.stderr).toContain("line 2");
+      expect(result.stdout).toBe("");
+      expect(await readFile(logPath, "utf8")).toBe(log);
+      expect(await tempLitter(logPath)).toEqual([]);
+    });
+
+    it("exits 1 on an unparseable log line, leaving the log byte-identical", async () => {
+      const log = `${markZzz(200)}\nthis is not JSON\n`;
+      const { dir, logPath } = await syntheticDataDir(log);
+
+      const result = runMigrate({ dataDir: dir, cwd: await workingDir(CASH_LEGS_MAPPING) });
+
+      expect(result.status).toBe(1);
+      expect(result.stderr).toMatch(/line 2 is not valid JSON/);
+      expect(result.stdout).toBe("");
+      expect(await readFile(logPath, "utf8")).toBe(log);
+      expect(await tempLitter(logPath)).toEqual([]);
+    });
+
+    it("exits 1 when the data dir has no genesis to migrate against", async () => {
+      const dir = await tempDir();
+      const logPath = join(dir, "events.jsonl");
+      const log = `${markZzz(200)}\n`;
+      await writeFile(logPath, log, "utf8");
+
+      const result = runMigrate({ dataDir: dir, cwd: await workingDir() });
+
+      // `loadGenesis` reads AFTER the log read, so this is the shell's `.catch` carrying
+      // an fs error through the same one exit path — not a bespoke branch.
+      expect(result.status).toBe(1);
+      expect(result.stderr).toMatch(/genesis\.json/);
+      expect(result.stdout).toBe("");
+      expect(await readFile(logPath, "utf8")).toBe(log);
+    });
+  });
+});

--- a/apps/tui/src/migrate-legacy-log.test.ts
+++ b/apps/tui/src/migrate-legacy-log.test.ts
@@ -270,10 +270,9 @@ describe("migrate-legacy-log — the shell around the one-shot durable-log rewri
     /**
      * KNOWN DEFECT — CHARACTERIZED HERE, NOT BLESSED.
      *
-     * NO TRACKER ISSUE EXISTS FOR THIS YET, and this comment deliberately cites none
-     * rather than a number that would not resolve. One is owed: the fix is a behavior
-     * change, so filing it is the next step, and whoever files it should put the number
-     * here and on the sibling case below.
+     * FILED AS #345, which covers this case and the sibling case below. The fix is a
+     * behavior change, so it belongs in its own increment rather than in this tests-only
+     * one.
      *
      * This test asserts what the tool OBSERVABLY DOES today, and what it does is wrong:
      * it reports "No durable log to migrate" about a log it has just OVERWRITTEN.
@@ -291,8 +290,8 @@ describe("migrate-legacy-log — the shell around the one-shot durable-log rewri
      * one tool in the repo that rewrites the durable log, and the same `undefined`-only
      * ENOENT check is what stands between "empty" and "unreadable". Fixing it is a
      * behavior change and this increment is tests only; the fix belongs in its own
-     * increment (see the follow-up owed above), with this test INVERTED to assert the log
-     * is left untouched.
+     * increment (#345, cited above), with this test INVERTED to assert the log is left
+     * untouched.
      */
     it("KNOWN DEFECT: rewrites an EMPTY log to a single newline while reporting 'No durable log'", async () => {
       const { dir, logPath } = await syntheticDataDir("");
@@ -308,7 +307,8 @@ describe("migrate-legacy-log — the shell around the one-shot durable-log rewri
       expect(await litter(dir)).toEqual([]);
     });
 
-    // KNOWN DEFECT, same seam and the same unfiled follow-up as the case above.
+    // KNOWN DEFECT, same seam and the same follow-up (#345) as the case above: INVERT this
+    // case too when the fix lands, to assert the log is left untouched.
     it("KNOWN DEFECT (same seam): a blank-lines-only log is collapsed to a single newline", async () => {
       const { dir, logPath } = await syntheticDataDir("\n\n\n");
 

--- a/apps/tui/src/record-fill-reliable.test.ts
+++ b/apps/tui/src/record-fill-reliable.test.ts
@@ -13,8 +13,8 @@
 //
 // Every fixture is a SYNTHETIC ladder (`O7`). Invented ids, round decade prices, round
 // balances — no real price, quantity, balance or rung enters this repository.
-import { chmod, mkdir, mkdtemp, readFile, rm, stat, writeFile } from "node:fs/promises";
-import { resolve } from "node:path";
+import { chmod, mkdir, mkdtemp, readdir, readFile, rm, stat, writeFile } from "node:fs/promises";
+import { dirname, resolve } from "node:path";
 import { tmpdir } from "node:os";
 import {
   foldEvents,
@@ -203,6 +203,20 @@ async function exists(path: string): Promise<boolean> {
   }
 }
 
+/**
+ * Every `.tmp` entry left in a file's OWN directory — the litter guard for BOTH writers.
+ *
+ * Over the directory rather than over one guessed name: both `writeLogImage` and
+ * `appendOrders` now name their temp uniquely per call (`<path>.<pid>.<n>.tmp`), so
+ * asserting the absence of a single `${path}.tmp` passes vacuously — the name it probes
+ * is one neither writer can ever produce. The events log and the orders sidecar share
+ * one data dir, so a single sweep covers both halves of the fill act.
+ */
+async function tempLitter(path: string): Promise<string[]> {
+  const entries = await readdir(dirname(path));
+  return entries.filter((entry) => entry.endsWith(".tmp"));
+}
+
 describe("`O2` on a real filesystem — the rollback restores real bytes", () => {
   it("guards against a vacuous pass: a clean act really writes BOTH files", async () => {
     // Without this, every rollback case below could be passing because the flow never
@@ -219,9 +233,9 @@ describe("`O2` on a real filesystem — the rollback restores real bytes", () =>
     expect(log.startsWith(PRIOR_LOG_LINE)).toBe(true);
     expect(log).toContain("fill:rung-400@2026-01-05T12:00:00");
     expect(await readFile(ordersPath, "utf8")).toContain(`"kind":"orderFilled"`);
-    // The temp files both writers rename FROM are gone, not left behind.
-    expect(await exists(`${eventsPath}.tmp`)).toBe(false);
-    expect(await exists(`${ordersPath}.tmp`)).toBe(false);
+    // The temp files both writers rename FROM are gone, not left behind — one sweep of
+    // the shared data dir catches either writer's litter, whatever it named it.
+    expect(await tempLitter(eventsPath)).toEqual([]);
   });
 
   it("restores a PRE-EXISTING log BYTE-FOR-BYTE when the sidecar write fails", async () => {
@@ -249,7 +263,7 @@ describe("`O2` on a real filesystem — the rollback restores real bytes", () =>
     // rewriting every line of the durable record of fact.
     expect(await readFile(eventsPath, "utf8")).toBe(PRIOR_LOG_LINE);
     expect(await readFile(ordersPath, "utf8")).toBe(ordersImage);
-    expect(await exists(`${eventsPath}.tmp`)).toBe(false);
+    expect(await tempLitter(eventsPath)).toEqual([]);
   });
 
   it("restores a log that had a TORN final line byte-for-byte, terminator and all", async () => {


### PR DESCRIPTION
`apps/tui/src/import-orders-cli.ts`, `apps/tui/src/cancel-order-cli.ts` and `apps/tui/src/migrate-legacy-log.ts` had no test file of any kind. `migrate-legacy-log.ts` rewrites the durable event log — the least-tested code in the repo touching the most consequential file.

Three new spawn-test files, 34 cases, one per shell. Each asserts **the shell's own contract**: argument parsing, the refusal paths, the exit code. The domain logic each shell delegates to is already well covered, and none of it is re-tested here.

Closes #294.

## A correction to the issue body

**#294 names `apps/tui/src/record-fill-reliable.test.ts` as the proven spawn-test pattern to copy. That file is not a spawn test.** It is in-process — it imports `recordFill` directly and injects a `RecordFillIo` bag wired to real files (`record-fill-reliable.test.ts:135-195`), and it never spawns anything. It covers the *domain* module, not the shell.

The actual template is **`apps/tui/src/record-fill-cli.test.ts`**, which spawns the shell under `tsx` via `spawnSync`. Its own header says why. A second, older instance of the same pattern lives at `apps/tui/src/durable-log-guards.test.ts:69-98`. All three new files follow `record-fill-cli.test.ts`. #294's body is worth correcting so the next reader is not sent to the wrong file.

## `migrate-legacy-log.test.ts` — 14 cases, first and deepest

The only one of the three whose failure mode is a corrupted durable log rather than a bad exit code, so it got the most.

Covered: both stdout sentences and the `touched === 0` boundary; the exit-code mapping including the accumulated `no supplied cash leg` abort, an unparseable log line and a missing genesis; `NUMISMA_DATA_DIR` plumbing including the relative-path refusal; and all four mapping-file handling paths.

**The CWD/env split is the divergence from the template.** `MAPPING_PATH` is `"data/migration-cash-legs.json"` (`migrate-legacy-log.ts:29`) — CWD-relative, and it does **not** follow `NUMISMA_DATA_DIR`. The log is read from `$NUMISMA_DATA_DIR/events.jsonl` while the mapping comes from `$PWD/data/migration-cash-legs.json`. The spawn helper therefore drives `dataDir` and `cwd` as two independent knobs pointing at two different `mkdtemp` dirs, so no case can pass by them coinciding. One case proves both directions with identical inputs: barren CWD → exit 1 `no supplied cash leg` with the log byte-identical; mapping CWD → exit 0, `1 legacy record(s) migrated`.

**Every exit-1 case asserts the log is byte-identical afterwards** — `readFile` compared against the fixture string, not merely an exit code. That is house style (`cancel-order.test.ts:175` names a whole describe block after it).

### A known defect, characterized rather than blessed

Two cases are named `KNOWN DEFECT`. `readOptional` returns `undefined` only on ENOENT, so an **existing but empty** (or blank-lines-only) `events.jsonl` returns `""` and the early return at `apps/tui/src/event-store.ts:209-211` is skipped: `loadGenesis` runs, the loop produces nothing, and `writeLogImage` is still called with `"\n"`. **The log is rewritten to a single newline byte** while `migratedCount + unchangedCount === 0` makes the shell print `No durable log to migrate at <path>` and exit 0.

It reports "no log" about a log it just overwrote. The tests assert `stdout === "No durable log to migrate at <path>.\n"` under the comment *"What the operator is told:"* and `readFile === "\n"` under *"What actually happened to the file it just told them it did not migrate:"*. The doc comment traces the mechanism, states plainly that what it does is wrong, and records that these tests should be **inverted** when the fix lands. **The fix is out of scope here — #294 is tests only.** It is filed as **#345**, which both cases now cite; whoever fixes it must invert them to assert the log is left untouched.

Two further rough edges pinned as-is: the mapping's `JSON.parse` failure surfaces a raw `SyntaxError` with **no filename and no wrapper** (asserted via the *absence* of help), and the mapping gets **zero structural validation** — `[]`, `"x"` and `{"id": 42}` all run to exit 0 without complaint.

## `import-orders-cli.test.ts` — 8 cases

The flagship is **`imported-partial` → exit 0**. That decision carries a fifteen-line rationale (`import-orders-cli.ts:62-76`) citing ADR-014 and issue #183, names the condition under which it must be revisited, and had nothing pinning it. The case also asserts the `INCOMPLETE — 1 row(s)` and `1 observation(s) recorded` lines, so a clean run mislabelled as partial cannot pass it.

Also pinned: the usage branch writes to **stderr** and touches no data dir (no readline constructed, nothing resolved); the empty-string argv takes the same branch; a rejected import names the temp `orders.jsonl` *this run* resolved; a relative `NUMISMA_DATA_DIR` is refused with a readline already open; two different temp dirs each name their own path and neither leaks the other nor mentions `accumulus`; and the plans sidecar is byte-identical afterwards.

Every run goes through a helper asserting the process **exited rather than was killed** (`signal === null`, numeric status), so a lost `rl.close()` surfaces as a failure on every case instead of a hung suite.

### Finding — the funding interview is unreachable without a TTY (filed as #346)

`createInterface` is constructed at `import-orders-cli.ts:28` and eagerly consumes stdin. By the time the first `ask` runs — after the export read and the sidecar load — a piped stdin has already ended and the interface is closed, so `rl.question` **rejects with `readline was closed`**. The outer catch prints that string verbatim to stderr and exits 1.

Consequences: piping answers to `pnpm orders:import` cannot work; the `no-reserve-declared` refusal at `import-orders.ts:588` is unreachable without a TTY; and an operator who redirects stdin gets an internal readline message instead of a refusal sentence. Harmless interactively.

This is also why the three data-dir paths are not pinned moving together end-to-end: `resolvePlansPath` and `resolveEventStorePaths` are both consumed *behind* that prompt. The reachable resolver is pinned along with the negative (no fallback to the accumulus root), and the wall is recorded in the test's comment rather than over-claimed. Pinning the rest needs a PTY-driven runner — a separate decision, deliberately not smuggled in here.

## `cancel-order-cli.test.ts` — 12 cases

The simplest shell and the only one needing no TTY, which its header claims (`cancel-order-cli.ts:11-13`) and the control case now proves mechanically.

Pinned: the usage sentence byte-exact on stderr with stdout empty; `argv[3]` landing **verbatim** as `observedAt` in the appended line; omitting it stamping now, bracketed by `formatObservedAt` before and after the spawn rather than freezing a global clock; `argv[4]+` silently ignored, which pins the absence of flag parsing; env plumbing proved by an `unknown-order` refusal naming the full resolved temp path; and all three outcomes mapping to their exit codes.

Two assertions are deliberately shaped to avoid being vacuous:

- The usage case asserts the temp dir path does **not** appear in stderr. `resolveOrdersPath()` lives inside the else-branch, so a usage refusal can never name a path — that is what actually pins the early return.
- The relative-`NUMISMA_DATA_DIR` case loops `"data"` and `"."`, running the `"."` leg with `cwd` set to the fixture dir. Had the relative path been accepted it would have resolved to that very `orders.jsonl` and succeeded, which makes the byte-identical assertion load-bearing rather than trivially true.

Also recorded: an absent `orderId` and a whitespace-only one refuse with **different text but identical exit codes**, so a calling script cannot distinguish them. `" "` clears the shell's truthiness check, reaches the domain, and is trimmed and refused as `no-order-id`. Assessed as a UX inconsistency, not a defect — both paths refuse and write nothing. If it is ever fixed, the honest move is trimming in the shell before the `!orderId` check so both mistakes take one path.

## Test data

**Every fixture is authored** — invented fund, reserve and instrument ids, `TEST/USD` and `TEST/USDT`, round decade prices, round balances. Nothing is seeded or copied from real log output, and `NUMISMA_DATA_DIR` always points at a throwaway `mkdtemp` dir so the real ledger is unreachable. Fresh `mkdtemp` prefixes (`numisma-migrate-`, `numisma-import-cli-`, `numisma-cancel-cli-`) avoid collisions with the existing suites.

Where a `.tmp` litter sweep is asserted, it is a `readdir` over the directory rather than a probe of a literal `*.tmp` name — the log-image staging scheme on this branch's base uses a unique temp name per write, so a hardcoded probe would be unfalsifiable.

## Coverage note

All three shells are in the coverage `exclude` list (`vitest.config.ts:41-44`) and a spawn test does not change that — v8 cannot instrument a subprocess. The coverage number will not move. This is expected and already documented at `docs/coverage-rationale.md:56-63`, which named this exact gap as "a real, open gap". That prose is now stale in the good direction and is worth updating when convenient.

## Verification

`pnpm typecheck` clean across all six packages. Full suite: **141 files, 1990 passed, 21 skipped, 0 failed.**

## Merge order

**Base branch: `feature/unique-log-temp-path` (PR #339), not `main`.** This is the second PR of the lane C stack:

1. #296 — `feature/unique-log-temp-path` → `main` ([#339](https://github.com/AmetAlvirde/numisma/pull/339))
2. **this PR** — `feature/cli-shell-tests` → `feature/unique-log-temp-path`
3. #298 — `feature/r6-r7-single-owner` → `feature/cli-shell-tests`

Merge in that order. GitHub retargets each stacked PR to `main` automatically when its base is deleted on merge. Nothing on this board merges before the end-of-workflow batch-merge session.

## ⚠️ For whoever runs the batch merge: the closing reference is not live yet

`gh pr view 340 --json closingIssuesReferences` returns **empty** right now, and that is expected, not a defect in this body. **GitHub only registers a PR's closing references when the PR targets the repository's default branch.** This PR targets `feature/unique-log-temp-path`, so the `Closes #294.` above is inert until GitHub retargets this PR to `main` — which it does automatically when the base branch is deleted on merge.

**Consequence: do not treat an empty `closingIssuesReferences` on a stacked PR as a missing keyword.** Re-verify it *after* the base merges and this PR retargets, and before merging this one. If #294 has not attached by then, the keyword needs fixing — but it cannot attach any earlier. The same applies to lane C's third PR and to every other stacked PR on this board.
