### PR TITLE
feat(engine): a close is the position's last dated event — ADR-017

### DIFF
--- a/packages/engine/src/events/crossref.ts
+++ b/packages/engine/src/events/crossref.ts
@@ -513,6 +513,32 @@ export function buildEventReference(
     });
   }
 
+  // ADR-017's as-of world, LAZY AND MEMOISED BY DATE. Nothing folds until a guard asks,
+  // and today the only caller is a trim aimed at an already-retired position — so every
+  // trim, mark and close on an OPEN position pays exactly one closure allocation and no
+  // fold. The memo is keyed by date, not by event, because that is the whole of the
+  // question: two backdated verbs sharing a date share a world.
+  //
+  // The prefix is STRICTLY BEFORE `asOf`, mirroring the fold's own placement of a
+  // backdated verb: everything dated earlier is already in the world it lands in, and
+  // its same-dated siblings are not (the fold's (`asOf`, then log index) order settles
+  // those, and a gate that pre-applied them would judge against a world the fold has not
+  // built yet). Recursion is not a hazard: the returned reference is built by this same
+  // constructor and its own `worldAsOf` is equally lazy.
+  const worldsAsOf = new Map<string, EventReference>();
+  const worldAsOf = (asOf: string): EventReference => {
+    const memoised = worldsAsOf.get(asOf);
+    if (memoised !== undefined) {
+      return memoised;
+    }
+    const world = buildEventReference(
+      genesis,
+      priorEvents.filter((event) => event.asOf < asOf),
+    );
+    worldsAsOf.set(asOf, world);
+    return world;
+  };
+
   return {
     positionIds,
     reserveIds: new Set(folded.reserves.map((reserve) => reserve.id)),
@@ -532,6 +558,7 @@ export function buildEventReference(
         { instrumentId: position.instrumentId, lots: position.lots },
       ]),
     ),
+    worldAsOf,
   };
 }
 
@@ -1096,12 +1123,34 @@ function crossReferenceTrim(
   if (bornBy) {
     return { ...bornBy, message: `PositionTrimmed ${bornBy.message}` };
   }
-  if (reference.closedPositionIds.has(event.positionId)) {
+  // ADR-017, THE TRIM HALF: "a close is the position's last dated event" is a rule about
+  // DATES, so this refusal must be too. A trim dated STRICTLY BEFORE the close that
+  // retired the position is a correctly-dated trim reported late, and the fold places it
+  // where its date says. `>=` matches the seal rule's strictness in the other direction:
+  // the two rules meet on the close date itself and must not disagree there.
+  const retiredAsOf = reference.closedPositionAsOf.get(event.positionId);
+  if (retiredAsOf !== undefined && event.asOf >= retiredAsOf) {
     return eventError(
       "positionId",
       `PositionTrimmed targets position id '${event.positionId}', which is already closed.`,
     );
   }
+  // AND THE COMPARISON IS NOT THE WORK. Reaching here with `retiredAsOf` set means the
+  // trim is BACKDATED and its target is retired in `reference` — so `positionLots` has no
+  // entry for it. Judged against that world the sufficiency gate below would see
+  // `available = 0` and refuse every backdated trim with a message that misdescribes the
+  // fund's own history; worse, the settlement-magnitude gate is guarded on
+  // `if (held && last !== undefined)` and would SILENTLY STOP FIRING — no error, no
+  // warning, nothing red — leaving the backdated trim the one class of trim admitted with
+  // no proceeds sanity check at all.
+  //
+  // So the remaining gates judge against the world AS OF THE TRIM'S OWN DATE (ADR-015's
+  // doctrine one level deeper: the gate judges against the fold, and for a backdated verb
+  // the relevant fold is the one at the verb's date). `held` comes back as a SIDE EFFECT
+  // of that, which is why the magnitude hole is closed structurally here rather than by
+  // patching its conditional. For an ordinary trim this is `reference` itself — no fold,
+  // no allocation, no change in behavior.
+  const world = retiredAsOf === undefined ? reference : reference.worldAsOf(event.asOf);
   const trimSettlesInto = requireReserveBornBy(
     reference,
     event.settlement.reserveId,
@@ -1111,7 +1160,7 @@ function crossReferenceTrim(
   if (trimSettlesInto.kind === "event-error") {
     return { ...trimSettlesInto.error, message: `PositionTrimmed ${trimSettlesInto.error.message}` };
   }
-  const held = reference.positionLots.get(event.positionId);
+  const held = world.positionLots.get(event.positionId);
   const availableByTier = new Map<CapitalTier, number>();
   for (const lot of held?.lots ?? []) {
     availableByTier.set(lot.tier, (availableByTier.get(lot.tier) ?? 0) + lot.quantity);
@@ -1154,7 +1203,7 @@ function crossReferenceTrim(
   }
   // Settlement-magnitude gate on the removed subset: expected ≈ Σ removed quantity ×
   // the instrument's last close; a gross deviation is a fat-finger, rejected loud.
-  const last = held ? reference.lastClose.get(held.instrumentId) : undefined;
+  const last = held ? world.lastClose.get(held.instrumentId) : undefined;
   if (held && last !== undefined) {
     const removedQuantity = event.removals.reduce((sum, removal) => sum + removal.quantity, 0);
     const expected = removedQuantity * last.price;

--- a/packages/engine/src/events/crossref.ts
+++ b/packages/engine/src/events/crossref.ts
@@ -254,7 +254,7 @@ export interface EventReference {
    */
   positionLots: Map<string, { instrumentId: string; lots: PositionLot[] }>;
   /**
-   * THE SAME REFERENCE, REBUILT FROM THE EVENTS DATED STRICTLY BEFORE `asOf` — the world
+   * THE SAME REFERENCE, REBUILT FROM THE EVENTS DATED ON OR BEFORE `asOf` — the world
    * the fold will actually place a backdated verb in, rather than the world as it stands
    * after everything the log has accepted. ADR-015's doctrine one level deeper: the gate
    * judges against the fold, and for a BACKDATED verb the relevant fold is the one at
@@ -274,11 +274,18 @@ export interface EventReference {
    *      check at all. Restoring `held` from the as-of world fixes this structurally,
    *      which is why the fix belongs here and not in a patched conditional.
    *
-   * LAZY AND MEMOISED BY DATE: nothing is folded until a guard asks, and today only a
-   * trim aimed at an already-retired position asks. The ordinary path — every trim, mark
-   * and close on an open position — costs exactly nothing. When it does fire it is one
-   * additional `foldEvents` over a strict prefix of the log, on top of the one this
-   * reference was built from; see this function's own cost note.
+   * THE PREFIX IS INCLUSIVE OF `asOf` because the fold orders by (`asOf`, then LOG
+   * INDEX) and every event in this reference was logged BEFORE the one being checked —
+   * so a same-dated prior really is applied first, and belongs in the world the verb
+   * lands in. The event under check is never in its own prefix. The exclusive boundary
+   * lives on the other side, in the guards' `>=`: a verb dated ON its target's close is
+   * refused before this is ever called, so the retiring close can never enter the world.
+   *
+   * LAZY: nothing is folded until a guard asks, and today only a trim aimed at an
+   * already-retired position asks. The ordinary path — every trim, mark and close on an
+   * open position — costs exactly nothing. When it does fire it is one additional
+   * `foldEvents` over a prefix of the log, on top of the one this reference was built
+   * from; see this function's own cost note.
    *
    * The returned reference is a FULL {@link EventReference}, not a fragment, so a future
    * as-of question (reserve balances at a date — the follow-up ADR-017 names) has the
@@ -513,31 +520,32 @@ export function buildEventReference(
     });
   }
 
-  // ADR-017's as-of world, LAZY AND MEMOISED BY DATE. Nothing folds until a guard asks,
-  // and today the only caller is a trim aimed at an already-retired position — so every
-  // trim, mark and close on an OPEN position pays exactly one closure allocation and no
-  // fold. The memo is keyed by date, not by event, because that is the whole of the
-  // question: two backdated verbs sharing a date share a world.
+  // ADR-017's as-of world, LAZY. Nothing folds until a guard asks, and today the only
+  // caller is a trim aimed at an already-retired position — so every trim, mark and
+  // close on an OPEN position pays exactly one closure allocation and no fold.
   //
-  // The prefix is STRICTLY BEFORE `asOf`, mirroring the fold's own placement of a
-  // backdated verb: everything dated earlier is already in the world it lands in, and
-  // its same-dated siblings are not (the fold's (`asOf`, then log index) order settles
-  // those, and a gate that pre-applied them would judge against a world the fold has not
-  // built yet). Recursion is not a hazard: the returned reference is built by this same
-  // constructor and its own `worldAsOf` is equally lazy.
-  const worldsAsOf = new Map<string, EventReference>();
-  const worldAsOf = (asOf: string): EventReference => {
-    const memoised = worldsAsOf.get(asOf);
-    if (memoised !== undefined) {
-      return memoised;
-    }
-    const world = buildEventReference(
+  // THE PREFIX IS `<=`, INCLUSIVE OF SAME-DATED SIBLINGS, because that is the world the
+  // fold will actually build under the backdated verb. `foldEvents` orders by (`asOf`,
+  // THEN LOG INDEX), and every event in `priorEvents` has a LOWER log index than the
+  // event being cross-referenced — the walk rebuilds this reference from
+  // `[...priorEvents, ...accepted]` and the candidate joins `accepted` only after it is
+  // admitted, so it is never in its own prefix and `<=` cannot make a trim judge against
+  // itself. A same-dated prior is therefore applied BEFORE the verb under check, and a
+  // strict `<` would hide it: it judged against a world the fold does not build, which
+  // both let same-dated siblings oversell a position (each seeing the others' lots
+  // intact) and falsely refused a trim that a same-dated add had made room for — and
+  // refused a trim dated on its position's own OPEN date with the `holds only 0` message
+  // this ADR exists to eliminate. `<=` here and the guard's `>=` above are one boundary
+  // read from its two ends: reaching this call means `event.asOf < retiredAsOf` strictly,
+  // so no prefix dated `<= event.asOf` can ever pull the retiring close into the world.
+  //
+  // Recursion is not a hazard: the returned reference is built by this same constructor
+  // and its own `worldAsOf` is equally lazy.
+  const worldAsOf = (asOf: string): EventReference =>
+    buildEventReference(
       genesis,
-      priorEvents.filter((event) => event.asOf < asOf),
+      priorEvents.filter((event) => event.asOf <= asOf),
     );
-    worldsAsOf.set(asOf, world);
-    return world;
-  };
 
   return {
     positionIds,
@@ -1132,7 +1140,11 @@ function crossReferenceTrim(
   if (retiredAsOf !== undefined && event.asOf >= retiredAsOf) {
     return eventError(
       "positionId",
-      `PositionTrimmed targets position id '${event.positionId}', which is already closed.`,
+      `PositionTrimmed targets position id '${event.positionId}', which is already closed ` +
+        `as of ${retiredAsOf} — and this trim is dated ${event.asOf}. The fold applies events ` +
+        `in date order, so this one would land on a position the close has already ` +
+        `consumed and its removal would vanish silently. A trim dated BEFORE ${retiredAsOf} ` +
+        `is accepted; redate it if the sale really happened while the position was open.`,
     );
   }
   // AND THE COMPARISON IS NOT THE WORK. Reaching here with `retiredAsOf` set means the

--- a/packages/engine/src/events/crossref.ts
+++ b/packages/engine/src/events/crossref.ts
@@ -245,11 +245,46 @@ export interface EventReference {
    * expected proceeds (quantity × last close) and the Tier mix proceeds inherit.
    * Mirrors `lastClose` existing solely to feed the PriceMarked guard.
    *
-   * The fold's surviving `positions`, and only those: a retired id is caught by
-   * {@link closedPositionIds} before either magnitude gate reaches this map, so the
-   * lots of a closed position are never needed and are not carried.
+   * The fold's surviving `positions`, and only those: a retired id has NO ENTRY HERE.
+   * For every verb but one that is harmless — a retired id is caught by
+   * {@link closedPositionIds} before either magnitude gate reaches this map. The
+   * exception is ADR-017's backdated trim, which is now admitted against a position the
+   * fold has retired; it reads {@link worldAsOf}'s map instead of this one, for the two
+   * reasons that field records.
    */
   positionLots: Map<string, { instrumentId: string; lots: PositionLot[] }>;
+  /**
+   * THE SAME REFERENCE, REBUILT FROM THE EVENTS DATED STRICTLY BEFORE `asOf` — the world
+   * the fold will actually place a backdated verb in, rather than the world as it stands
+   * after everything the log has accepted. ADR-015's doctrine one level deeper: the gate
+   * judges against the fold, and for a BACKDATED verb the relevant fold is the one at
+   * the verb's own date.
+   *
+   * ADR-017 needs this, and needs it for TWO reasons, only the first of which is
+   * visible. {@link crossReferenceTrim} now admits a trim dated before its target's
+   * close, and that target is RETIRED in this reference, so:
+   *
+   *   1. {@link positionLots} has no entry for it and the position-lot-sufficiency gate
+   *      would see `available = 0` — refusing every backdated trim anyway, with a
+   *      message ("holds only 0") that misdescribes the fund's own history; and
+   *   2. THE SETTLEMENT-MAGNITUDE GATE WOULD SILENTLY STOP FIRING. It is guarded on
+   *      `if (held && last !== undefined)`, so an absent `held` does not weaken the
+   *      check — it DELETES it, with no error, no warning and nothing going red. A
+   *      backdated trim would be the one class of trim admitted with no proceeds sanity
+   *      check at all. Restoring `held` from the as-of world fixes this structurally,
+   *      which is why the fix belongs here and not in a patched conditional.
+   *
+   * LAZY AND MEMOISED BY DATE: nothing is folded until a guard asks, and today only a
+   * trim aimed at an already-retired position asks. The ordinary path — every trim, mark
+   * and close on an open position — costs exactly nothing. When it does fire it is one
+   * additional `foldEvents` over a strict prefix of the log, on top of the one this
+   * reference was built from; see this function's own cost note.
+   *
+   * The returned reference is a FULL {@link EventReference}, not a fragment, so a future
+   * as-of question (reserve balances at a date — the follow-up ADR-017 names) has the
+   * whole world to ask rather than needing this shape widened.
+   */
+  worldAsOf: (asOf: string) => EventReference;
 }
 
 /**

--- a/packages/engine/src/events/crossref.ts
+++ b/packages/engine/src/events/crossref.ts
@@ -141,8 +141,37 @@ export interface EventReference {
    * `foldEvents(...).closedPositions` — so "retired" means exactly what the fold
    * means by it. A partial (trim) row is excluded: a trim always leaves the position
    * open, and the fold keeps it in `positions`.
+   *
+   * SINCE ADR-017 THIS IS THE KEY SET OF {@link closedPositionAsOf} and nothing else —
+   * one derivation, so the membership answer and the dated answer cannot drift apart.
+   * It remains the right question for the two verbs whose refusal is date-INSENSITIVE
+   * (`PositionClosed`, `InvalidationMarked`); the two date-SENSITIVE verbs ask the map.
    */
   closedPositionIds: Set<string>;
+  /**
+   * Every retired position id → the date its `PositionClosed` retired it. What makes
+   * "is this position closed" answerable AS OF A DATE, and the carrier ADR-017's guards
+   * read: reject when `event.asOf >= closedAsOf`, admit when `event.asOf < closedAsOf`.
+   *
+   * THE COMPARISON IS `>=`, matching {@link requirePositionUntouchedAfter}'s own
+   * strictness (which accepts EQUAL, because trim-then-close on one day is ordinary and
+   * the fold's (`asOf`, THEN LOG INDEX) order applies the earlier-logged verb first).
+   * The two rules meet on the close date and must not disagree there — otherwise a
+   * batch's verdict would depend on which of the pair arrived first.
+   *
+   * Read today by {@link crossReferenceAddedTo} only; {@link crossReferenceTrim} joins
+   * it when ADR-017's second half lands, which additionally needs the world as of the
+   * trim's own date because it reads {@link positionLots}.
+   *
+   * KEY SET: exactly {@link closedPositionIds}, which is built FROM this map. The
+   * EARLIEST close wins if a position somehow carries two full-close rows — the fold
+   * applies events in (`asOf`, then log) order, so the first-sorting close is the one
+   * that actually retires the id and every later verb must be judged against it. The
+   * ingest gate refuses a second close outright, so nothing reaching here through the
+   * ingest path can hold two; `buildEventReference` is pure and takes the safe reading
+   * anyway.
+   */
+  closedPositionAsOf: Map<string, string>;
   /**
    * Every known position id → the date it came into existence: `genesis.review.asOf`
    * for a genesis-held position, the `PositionOpened`'s own `asOf` for a log-born
@@ -338,14 +367,23 @@ export function buildEventReference(
   // a retired id stays known (it existed; close-and-reopen mints a fresh id), and the
   // full-close rows are precisely the retired set. A partial row is a trim, whose
   // position is still open above.
+  //
+  // Each retired id is DATED as it is collected (ADR-017): the membership set below is
+  // the map's key set, so "closed" and "closed as of" are one derivation and cannot
+  // disagree. Earliest close wins — the fold applies events in (`asOf`, then log) order,
+  // so a first-sorting close is the one that actually retires the id.
   const positionIds = new Set(folded.positions.map((position) => position.id));
-  const closedPositionIds = new Set<string>();
+  const closedPositionAsOf = new Map<string, string>();
   for (const row of folded.closedPositions ?? []) {
     positionIds.add(row.positionId);
     if (!row.partial) {
-      closedPositionIds.add(row.positionId);
+      const retiredAsOf = closedPositionAsOf.get(row.positionId);
+      if (retiredAsOf === undefined || row.closedAsOf < retiredAsOf) {
+        closedPositionAsOf.set(row.positionId, row.closedAsOf);
+      }
     }
   }
+  const closedPositionIds = new Set(closedPositionAsOf.keys());
 
   // Each known position's BIRTH DATE. A LOG-BORN position's is read off the folded
   // book and only off it: unlike a Reserve's, that date IS carried by the folded
@@ -448,6 +486,7 @@ export function buildEventReference(
     instrumentIds: new Set(folded.instruments.map((instrument) => instrument.id)),
     genesisAsOf,
     closedPositionIds,
+    closedPositionAsOf,
     positionBornAsOf,
     positionLastVerbAsOf,
     lastClose,
@@ -1101,10 +1140,30 @@ function crossReferenceTrim(
 }
 
 /**
- * Cross-reference a `PositionAddedTo`: the position must exist and be open, and the
- * funding Reserve
- * must exist and hold enough (per tier) to cover the debit — so an add cannot drive
- * a Reserve silently negative. Pure.
+ * Cross-reference a `PositionAddedTo`: the position must exist and must not already be
+ * closed AS OF THIS EVENT'S DATE, and the funding Reserve must exist and hold enough
+ * (per tier) to cover the debit — so an add cannot drive a Reserve silently negative.
+ * Pure.
+ *
+ * ADR-017, THE FIRST OF ITS TWO SITES. The closed check compares dates rather than
+ * asking a date-blind `closedPositionIds.has(id)`: an add dated STRICTLY BEFORE the
+ * close is admitted, because the fold's (`asOf`, then log) ordering lands it ahead of
+ * the close and it folds perfectly correctly — the lots it appends are lots the close
+ * then consumes. Refusing it made the closed book report a position smaller than the
+ * fund actually held, and the operator's only remedy was hand-editing the durable log.
+ *
+ * THIS HALF NEEDS ONLY THE COMPARISON, and that is why it lands before the trim's.
+ * Nothing below reads {@link EventReference.positionLots} — the checks are the funding
+ * Reserve's birth and its per-tier debit sufficiency, neither of which is a fact about
+ * the position's holdings. `crossReferenceTrim` does read the lots, and a closed
+ * position has NO entry there (the map is the fold's survivors), so relaxing its
+ * comparison alone would refuse the trim again one gate later and silently disable its
+ * settlement-magnitude check; it needs the world as of the trim's own date instead.
+ *
+ * THE RESERVE IS STILL SIZED AT ITS BALANCE NOW, not at the add's date — `checkDebit`
+ * reads `reserveBalances`, the fold of everything accepted. Pre-existing for every
+ * backdated verb the gate admits; ADR-017 widens the population it applies to without
+ * changing its shape, and names it as a follow-up rather than a hole opened here.
  */
 function crossReferenceAddedTo(
   event: PositionAddedToEvent,
@@ -1114,10 +1173,20 @@ function crossReferenceAddedTo(
   if (bornBy) {
     return { ...bornBy, message: `PositionAddedTo ${bornBy.message}` };
   }
-  if (reference.closedPositionIds.has(event.positionId)) {
+  // `>=`, deliberately: EQUAL IS REFUSED here, where `requirePositionUntouchedAfter`
+  // accepts it. The two rules are the same sentence read from its two ends — a close may
+  // not be dated behind an accepted verb, and a verb may not be dated ON OR AFTER an
+  // accepted close — and on the close date itself only one of them can say yes, or the
+  // batch's verdict would turn on which of the pair the log happened to receive first.
+  const retiredAsOf = reference.closedPositionAsOf.get(event.positionId);
+  if (retiredAsOf !== undefined && event.asOf >= retiredAsOf) {
     return eventError(
       "positionId",
-      `PositionAddedTo targets position id '${event.positionId}', which is already closed.`,
+      `PositionAddedTo targets position id '${event.positionId}', which is already closed ` +
+        `as of ${retiredAsOf} — and this add is dated ${event.asOf}. The fold applies events ` +
+        `in date order, so this one would land on a position the close has already ` +
+        `consumed and its lot would vanish silently. An add dated BEFORE ${retiredAsOf} is ` +
+        `accepted; redate it if the fill really happened while the position was open.`,
     );
   }
   const addFundedBy = requireReserveBornBy(

--- a/packages/engine/src/position-backdated-add-to.test.ts
+++ b/packages/engine/src/position-backdated-add-to.test.ts
@@ -247,10 +247,14 @@ describe("ADR-017 — the pair reads in both directions", () => {
   });
 });
 
-// THE OTHER THREE CALL SITES DO NOT MOVE. Two of them never will (ADR-017 rules them
-// date-INSENSITIVE on the merits); the third is ADR-017's second slice and is pinned
-// here only so this slice cannot reach it by accident through the shared carrier.
-describe("ADR-017 — the sites this slice leaves alone", () => {
+// THE OTHER TWO CALL SITES DO NOT MOVE, AND NEVER WILL — ADR-017 rules both of them
+// date-INSENSITIVE on the merits. The third site, `PositionTrimmed`, was pinned here as
+// unmoved while it was still ADR-017's second slice; that slice has since landed, so its
+// pin now reads the other way up and lives with the rest of the trim rule in
+// `position-backdated-trim.test.ts`. What survives here is the boundary this file cares
+// about: relaxing BOTH verbs through the shared `closedPositionAsOf` carrier must still
+// leave these two flat refusals alone.
+describe("ADR-017 — the sites that stay date-blind", () => {
   it("a backdated SECOND close is still refused flat: whichever sorts first retires the id", () => {
     const result = ingestBatch([
       openLate(),
@@ -273,15 +277,24 @@ describe("ADR-017 — the sites this slice leaves alone", () => {
     expect(result.rejection?.message).toContain("already closed");
   });
 
-  it("a backdated PositionTrimmed is still refused — that relaxation is ADR-017's second slice", () => {
+  it("but a backdated PositionTrimmed is now admitted — the second slice landed", () => {
+    // The exact batch this block used to pin as refused. Kept because it is the one
+    // assertion proving the two relaxations share a carrier and not a copy: the same
+    // `closedPositionAsOf` answers "closed as of when" for the add-to above and for the
+    // trim here. The trim rule's own boundary, magnitude and fold coverage is in
+    // `position-backdated-trim.test.ts`.
     const result = ingestBatch([
       openLate(),
       closePayload("evt-close", CLOSED_AS_OF),
       trimPayload("evt-trim", "2026-06-08"),
     ]);
 
-    expect(result.rejection?.message).toContain("PositionTrimmed");
-    expect(result.rejection?.message).toContain("already closed");
+    expect(result.rejection).toBeNull();
+    expect(result.committed.map((event) => event.id)).toEqual([
+      "evt-open-late",
+      "evt-close",
+      "evt-trim",
+    ]);
   });
 });
 

--- a/packages/engine/src/position-backdated-add-to.test.ts
+++ b/packages/engine/src/position-backdated-add-to.test.ts
@@ -1,0 +1,320 @@
+// ADR-017, THE ADD-TO HALF. "A close is the position's last dated event" — one
+// sentence the gate enforces from two directions, and until this file only one of them
+// compared dates. `requirePositionUntouchedAfter` (the seal rule) already refuses a
+// close dated behind an accepted verb; the other direction asked
+// `closedPositionIds.has(id)`, a membership test with no date in it, and so refused a
+// correctly-dated verb along with the genuinely-late ones.
+//
+// SCOPE, DELIBERATELY NARROW. Exactly two of the four `closedPositionIds` call sites
+// move under ADR-017, and this is the FIRST of them. `crossReferenceAddedTo` never
+// reads `positionLots` — it checks the funding Reserve's per-tier debit sufficiency and
+// nothing about the position's holdings — so the add-to half needs only the comparison,
+// while the trim half additionally needs the world AS OF the trim's own date. That
+// asymmetry is why this lands alone. `PositionClosed` and `InvalidationMarked` keep the
+// flat, date-insensitive refusal, and their pins are below: at those two sites the
+// refusal is not over-strict, because a backdated verb could not fold correctly either.
+//
+// Fixtures mirror `position-seal.test.ts` (same genesis seed, same `openLate`, same
+// `ingestBatch` harness) so the two files describe the same rule from its two ends.
+import {
+  buildEventReference,
+  crossReferenceEvent,
+  foldEvents,
+  parseEvent,
+  type FundReviewData,
+  type PortfolioEvent,
+} from "./index.js";
+import { describe, expect, it } from "vitest";
+
+const GENESIS_AS_OF = "2026-06-01";
+const OPENED_AS_OF = "2026-06-05";
+/** The date `btc-late` is retired on in every batch below. */
+const CLOSED_AS_OF = "2026-06-10";
+
+function genesis(): FundReviewData {
+  return {
+    fund: { id: "fund-1", name: "Accumulus", baseCurrency: "USD" },
+    review: { asOf: GENESIS_AS_OF, usdMxn: 20 },
+    portfolios: [{ id: "core", name: "Core" }],
+    accounts: [{ id: "bitget-usd", name: "Bitget", platform: "BITGET", currency: "USD" }],
+    instruments: [{ id: "btc-usd", name: "Bitcoin", symbol: "BTC", currency: "USD" }],
+    reserves: [
+      {
+        id: "pulse-cash",
+        portfolioId: "core",
+        tempo: "Pulse",
+        executionMode: "live",
+        accountId: "bitget-usd",
+        currency: "USD",
+        amount: 1000,
+        lots: [
+          { quantity: 600, tier: "c1" },
+          { quantity: 400, tier: "c2" },
+        ],
+      },
+    ],
+    positions: [
+      {
+        id: "btc-core",
+        portfolioId: "core",
+        tempo: "Capital",
+        executionMode: "live",
+        accountId: "bitget-usd",
+        instrumentId: "btc-usd",
+        direction: "long",
+        markPrice: 100,
+        currency: "USD",
+        lots: [{ quantity: 2, cost: 100, tier: "c1" }],
+      },
+    ],
+  };
+}
+
+/** The LOG-BORN position: `btc-late`, born 2026-06-05, one lot of 1 @ 100. */
+function openLate(): Record<string, unknown> {
+  return {
+    id: "evt-open-late",
+    asOf: OPENED_AS_OF,
+    type: "PositionOpened",
+    position: {
+      id: "btc-late",
+      portfolioId: "core",
+      tempo: "Capital",
+      executionMode: "live",
+      accountId: "bitget-usd",
+      instrumentId: "btc-usd",
+      direction: "long",
+      currency: "USD",
+      lots: [{ quantity: 1, cost: 100, tier: "c1" }],
+    },
+    decision: {
+      entryThesis: "thesis",
+      invalidationCondition: "invalidation",
+      riskBudget: "1R",
+      plannedHoldingHorizon: "weeks",
+      strategy: "trend",
+    },
+    funding: { reserveId: "pulse-cash", amount: 100 },
+  };
+}
+
+const addToPayload = (id: string, asOf: string): Record<string, unknown> => ({
+  id,
+  asOf,
+  type: "PositionAddedTo",
+  positionId: "btc-late",
+  lot: { quantity: 1, cost: 100, tier: "c1" },
+  funding: { reserveId: "pulse-cash", amount: 100 },
+});
+
+const closePayload = (id: string, asOf: string, proceeds = 100): Record<string, unknown> => ({
+  id,
+  asOf,
+  type: "PositionClosed",
+  positionId: "btc-late",
+  settlement: { reserveId: "pulse-cash", proceeds },
+});
+
+const invalidatePayload = (id: string, asOf: string): Record<string, unknown> => ({
+  id,
+  asOf,
+  type: "InvalidationMarked",
+  positionId: "btc-late",
+  price: 80,
+  direction: "below",
+});
+
+const trimPayload = (id: string, asOf: string): Record<string, unknown> => ({
+  id,
+  asOf,
+  type: "PositionTrimmed",
+  positionId: "btc-late",
+  removals: [{ quantity: 0.5, tier: "c1" }],
+  settlement: { reserveId: "pulse-cash", proceeds: 50 },
+});
+
+function accepted(input: Record<string, unknown>): PortfolioEvent {
+  const result = parseEvent(input);
+  if (result.kind !== "ok") {
+    throw new Error(`expected parse to accept: ${result.path}: ${result.message}`);
+  }
+  return result.value;
+}
+
+/** The ingest contract in miniature: parse then cross-reference in LOG order against
+ * genesis + everything committed so far (ADR-015), aborting the batch on the first
+ * rejection. All-or-nothing, so `committed` is evidence and not a partial log. */
+function ingestBatch(inputs: Record<string, unknown>[]): {
+  committed: PortfolioEvent[];
+  rejection: { path: string; message: string } | null;
+} {
+  const committed: PortfolioEvent[] = [];
+  for (const input of inputs) {
+    const parsed = parseEvent(input);
+    if (parsed.kind !== "ok") {
+      return { committed: [], rejection: { path: parsed.path, message: parsed.message } };
+    }
+    const checked = crossReferenceEvent(parsed.value, buildEventReference(genesis(), committed));
+    if (checked.kind !== "ok") {
+      return { committed: [], rejection: { path: checked.path, message: checked.message } };
+    }
+    committed.push(parsed.value);
+  }
+  return { committed, rejection: null };
+}
+
+/** `[Opened 06-05, Closed 06-10, PositionAddedTo <asOf>]` — the close arrives FIRST,
+ * which is the arrival order the date-blind guard could not judge. */
+const closeThenAdd = (asOf: string): Record<string, unknown>[] => [
+  openLate(),
+  closePayload("evt-close", CLOSED_AS_OF),
+  addToPayload("evt-add", asOf),
+];
+
+describe("ADR-017 — a PositionAddedTo dated STRICTLY BEFORE its target's close", () => {
+  it("is admitted, where the date-blind guard refused it", () => {
+    const result = ingestBatch(closeThenAdd("2026-06-08"));
+
+    expect(result.rejection).toBeNull();
+    expect(result.committed.map((event) => event.id)).toEqual([
+      "evt-open-late",
+      "evt-close",
+      "evt-add",
+    ]);
+  });
+
+  it("and the fold really does place it ahead of the close, at the size it implies", () => {
+    // The point of admitting it: the closed book must report the position the fund
+    // actually held. The add lands 06-08 on lots the 06-10 close then consumes, so the
+    // single closed row carries BOTH lots — cost basis 200, not the 100 the refusal
+    // would have booked.
+    const folded = foldEvents(genesis(), ingestBatch(closeThenAdd("2026-06-08")).committed);
+    const rows = (folded.closedPositions ?? []).filter((row) => row.positionId === "btc-late");
+
+    expect(rows).toHaveLength(1);
+    expect(rows[0]).toMatchObject({ closedAsOf: CLOSED_AS_OF, costBasisUsd: 200 });
+  });
+});
+
+// THE BOUNDARY IS `>=`, MATCHING THE SEAL RULE'S OWN STRICTNESS AT `crossref.ts:819`.
+// The two rules meet on the close date itself and must not disagree there: the seal
+// rule accepts a verb dated EQUAL to a close (trim-then-close on one day is ordinary,
+// and the fold's (asOf, THEN LOG INDEX) order applies the earlier-logged verb first),
+// so this direction — where the close is already in the log — must REFUSE equality.
+// Anything else would let a batch's verdict depend on which of the two arrived first.
+describe("ADR-017 — the boundary", () => {
+  it("refuses an add-to dated ON the close date", () => {
+    const result = ingestBatch(closeThenAdd(CLOSED_AS_OF));
+
+    expect(result.rejection?.path).toBe("positionId");
+    expect(result.rejection?.message).toContain("PositionAddedTo");
+    expect(result.rejection?.message).toContain("already closed");
+    expect(result.committed).toEqual([]);
+  });
+
+  it("still refuses one dated after it", () => {
+    const result = ingestBatch(closeThenAdd("2026-06-11"));
+
+    expect(result.rejection?.path).toBe("positionId");
+    expect(result.rejection?.message).toContain("already closed");
+    expect(result.committed).toEqual([]);
+  });
+
+  it("admits the day before and refuses the day of — the same batch, one day apart", () => {
+    // The pair, side by side: nothing else in these two batches differs.
+    expect(ingestBatch(closeThenAdd("2026-06-09")).rejection).toBeNull();
+    expect(ingestBatch(closeThenAdd(CLOSED_AS_OF)).rejection).not.toBeNull();
+  });
+});
+
+// BOTH HALVES OF THE INVARIANT, ASSERTED TOGETHER. Neither sentence is complete without
+// the other, and relaxing this direction must not quiet the other one.
+describe("ADR-017 — the pair reads in both directions", () => {
+  it("a close may not be dated behind an already-accepted add-to", () => {
+    const result = ingestBatch([
+      openLate(),
+      addToPayload("evt-add", "2026-06-18"),
+      closePayload("evt-close", CLOSED_AS_OF, 200),
+    ]);
+
+    expect(result.rejection?.path).toBe("positionId");
+    expect(result.rejection?.message).toContain("has already been accepted for it");
+    expect(result.committed).toEqual([]);
+  });
+
+  it("and an add-to may not be dated on or after an already-accepted close", () => {
+    expect(ingestBatch(closeThenAdd(CLOSED_AS_OF)).rejection?.message).toContain("already closed");
+  });
+});
+
+// THE OTHER THREE CALL SITES DO NOT MOVE. Two of them never will (ADR-017 rules them
+// date-INSENSITIVE on the merits); the third is ADR-017's second slice and is pinned
+// here only so this slice cannot reach it by accident through the shared carrier.
+describe("ADR-017 — the sites this slice leaves alone", () => {
+  it("a backdated SECOND close is still refused flat: whichever sorts first retires the id", () => {
+    const result = ingestBatch([
+      openLate(),
+      closePayload("evt-close", CLOSED_AS_OF),
+      closePayload("evt-close-again", "2026-06-08"),
+    ]);
+
+    expect(result.rejection?.message).toContain("PositionClosed");
+    expect(result.rejection?.message).toContain("already closed");
+  });
+
+  it("a backdated InvalidationMarked is still refused flat: breach is derived per OPEN position", () => {
+    const result = ingestBatch([
+      openLate(),
+      closePayload("evt-close", CLOSED_AS_OF),
+      invalidatePayload("evt-invalidate", "2026-06-08"),
+    ]);
+
+    expect(result.rejection?.message).toContain("InvalidationMarked");
+    expect(result.rejection?.message).toContain("already closed");
+  });
+
+  it("a backdated PositionTrimmed is still refused — that relaxation is ADR-017's second slice", () => {
+    const result = ingestBatch([
+      openLate(),
+      closePayload("evt-close", CLOSED_AS_OF),
+      trimPayload("evt-trim", "2026-06-08"),
+    ]);
+
+    expect(result.rejection?.message).toContain("PositionTrimmed");
+    expect(result.rejection?.message).toContain("already closed");
+  });
+});
+
+// THE CARRIER, structurally. `closedPositionAsOf` is what makes "closed" answerable AS
+// OF A DATE, and `closedPositionIds` is derived from its key set rather than built
+// alongside it — one derivation, so the two cannot drift apart the way a shadow did.
+// Slice 2 reads the same map for `PositionTrimmed`.
+describe("EventReference.closedPositionAsOf", () => {
+  it("dates each retired position with the close that retired it", () => {
+    const reference = buildEventReference(genesis(), [
+      accepted(openLate()),
+      accepted(closePayload("evt-close", CLOSED_AS_OF)),
+    ]);
+
+    expect(reference.closedPositionAsOf.get("btc-late")).toBe(CLOSED_AS_OF);
+    expect(reference.closedPositionAsOf.has("btc-core")).toBe(false);
+  });
+
+  it("carries exactly the ids `closedPositionIds` carries", () => {
+    const reference = buildEventReference(genesis(), [
+      accepted(openLate()),
+      accepted(closePayload("evt-close", CLOSED_AS_OF)),
+    ]);
+
+    expect([...reference.closedPositionAsOf.keys()]).toEqual([...reference.closedPositionIds]);
+  });
+
+  it("has no entry for a position only TRIMMED — a trim always leaves it open", () => {
+    const reference = buildEventReference(genesis(), [
+      accepted(openLate()),
+      accepted(trimPayload("evt-trim", "2026-06-08")),
+    ]);
+
+    expect(reference.closedPositionAsOf.has("btc-late")).toBe(false);
+  });
+});

--- a/packages/engine/src/position-backdated-trim.test.ts
+++ b/packages/engine/src/position-backdated-trim.test.ts
@@ -1,0 +1,323 @@
+// ADR-017, THE TRIM HALF — the second and last of its two sites. "A close is the
+// position's last dated event" is one sentence the gate enforces from two directions:
+// `requirePositionUntouchedAfter` refuses a close dated behind an accepted verb, and
+// this direction must refuse a verb dated ON OR AFTER an accepted close — no more than
+// that. Until this file it asked `closedPositionIds.has(id)`, a membership test with no
+// date in it, and so refused a correctly-dated trim along with the genuinely-late ones.
+//
+// THE COMPARISON IS NOT THE WORK, and that is why this half lands after the add-to's.
+// `EventReference.positionLots` is the fold's SURVIVORS, so a retired position has no
+// entry at all. Relax only the membership test and two things follow:
+//
+//   1. the position-lot-sufficiency gate sees `available = 0` and refuses the trim
+//      anyway, now with a WORSE message ("removes 0.5 … which holds only 0");
+//   2. the settlement-magnitude gate SILENTLY STOPS FIRING — it is guarded on
+//      `if (held && last !== undefined)`, and with `held` undefined a backdated trim
+//      would be admitted with no proceeds sanity check at all, while every other trim
+//      keeps one. Nothing would go red. Nothing would complain.
+//
+// So the trim is judged against the world AS OF ITS OWN DATE — ADR-015's doctrine one
+// level deeper: the gate judges against the fold, and for a backdated verb the relevant
+// fold is the one at the verb's own date. `held` comes back as a side effect, which is
+// why (2) is fixed structurally rather than by a separate patch. THE ABSURD-PROCEEDS
+// TEST BELOW IS THIS FILE'S LOAD-BEARING ONE: without it, (2) ships unnoticed.
+//
+// Fixtures mirror `position-seal.test.ts` and `position-backdated-add-to.test.ts` (same
+// genesis seed, same `openLate`, same `ingestBatch` harness) so all three files describe
+// one rule from its several ends.
+import {
+  buildEventReference,
+  crossReferenceEvent,
+  foldEvents,
+  parseEvent,
+  type FundReviewData,
+  type PortfolioEvent,
+} from "./index.js";
+import { describe, expect, it } from "vitest";
+
+const GENESIS_AS_OF = "2026-06-01";
+const OPENED_AS_OF = "2026-06-05";
+/** The date `btc-late` is retired on in every batch below. */
+const CLOSED_AS_OF = "2026-06-10";
+/** Two days behind the close — the ADR's own worked case. */
+const BACKDATED_AS_OF = "2026-06-08";
+
+function genesis(): FundReviewData {
+  return {
+    fund: { id: "fund-1", name: "Accumulus", baseCurrency: "USD" },
+    review: { asOf: GENESIS_AS_OF, usdMxn: 20 },
+    portfolios: [{ id: "core", name: "Core" }],
+    accounts: [{ id: "bitget-usd", name: "Bitget", platform: "BITGET", currency: "USD" }],
+    instruments: [{ id: "btc-usd", name: "Bitcoin", symbol: "BTC", currency: "USD" }],
+    reserves: [
+      {
+        id: "pulse-cash",
+        portfolioId: "core",
+        tempo: "Pulse",
+        executionMode: "live",
+        accountId: "bitget-usd",
+        currency: "USD",
+        amount: 1000,
+        lots: [
+          { quantity: 600, tier: "c1" },
+          { quantity: 400, tier: "c2" },
+        ],
+      },
+    ],
+    positions: [
+      {
+        id: "btc-core",
+        portfolioId: "core",
+        tempo: "Capital",
+        executionMode: "live",
+        accountId: "bitget-usd",
+        instrumentId: "btc-usd",
+        direction: "long",
+        markPrice: 100,
+        currency: "USD",
+        lots: [{ quantity: 2, cost: 100, tier: "c1" }],
+      },
+    ],
+  };
+}
+
+/** The LOG-BORN position: `btc-late`, born 2026-06-05, one lot of 1 @ 100. */
+function openLate(): Record<string, unknown> {
+  return {
+    id: "evt-open-late",
+    asOf: OPENED_AS_OF,
+    type: "PositionOpened",
+    position: {
+      id: "btc-late",
+      portfolioId: "core",
+      tempo: "Capital",
+      executionMode: "live",
+      accountId: "bitget-usd",
+      instrumentId: "btc-usd",
+      direction: "long",
+      currency: "USD",
+      lots: [{ quantity: 1, cost: 100, tier: "c1" }],
+    },
+    decision: {
+      entryThesis: "thesis",
+      invalidationCondition: "invalidation",
+      riskBudget: "1R",
+      plannedHoldingHorizon: "weeks",
+      strategy: "trend",
+    },
+    funding: { reserveId: "pulse-cash", amount: 100 },
+  };
+}
+
+const trimPayload = (
+  id: string,
+  asOf: string,
+  quantity = 0.5,
+  proceeds = 50,
+): Record<string, unknown> => ({
+  id,
+  asOf,
+  type: "PositionTrimmed",
+  positionId: "btc-late",
+  removals: [{ quantity, tier: "c1" }],
+  settlement: { reserveId: "pulse-cash", proceeds },
+});
+
+const closePayload = (id: string, asOf: string, proceeds = 100): Record<string, unknown> => ({
+  id,
+  asOf,
+  type: "PositionClosed",
+  positionId: "btc-late",
+  settlement: { reserveId: "pulse-cash", proceeds },
+});
+
+function accepted(input: Record<string, unknown>): PortfolioEvent {
+  const result = parseEvent(input);
+  if (result.kind !== "ok") {
+    throw new Error(`expected parse to accept: ${result.path}: ${result.message}`);
+  }
+  return result.value;
+}
+
+/** The ingest contract in miniature: parse then cross-reference in LOG order against
+ * genesis + everything committed so far (ADR-015), aborting the batch on the first
+ * rejection. All-or-nothing, so `committed` is evidence and not a partial log. */
+function ingestBatch(inputs: Record<string, unknown>[]): {
+  committed: PortfolioEvent[];
+  rejection: { path: string; message: string } | null;
+} {
+  const committed: PortfolioEvent[] = [];
+  for (const input of inputs) {
+    const parsed = parseEvent(input);
+    if (parsed.kind !== "ok") {
+      return { committed: [], rejection: { path: parsed.path, message: parsed.message } };
+    }
+    const checked = crossReferenceEvent(parsed.value, buildEventReference(genesis(), committed));
+    if (checked.kind !== "ok") {
+      return { committed: [], rejection: { path: checked.path, message: checked.message } };
+    }
+    committed.push(parsed.value);
+  }
+  return { committed, rejection: null };
+}
+
+/** `[Opened 06-05, Closed 06-10, Trimmed <asOf>]` — the close arrives FIRST, which is
+ * the arrival order the date-blind guard could not judge. */
+const closeThenTrim = (
+  asOf: string,
+  quantity = 0.5,
+  proceeds = 50,
+): Record<string, unknown>[] => [
+  openLate(),
+  closePayload("evt-close", CLOSED_AS_OF),
+  trimPayload("evt-trim", asOf, quantity, proceeds),
+];
+
+describe("ADR-017 — a PositionTrimmed dated STRICTLY BEFORE its target's close", () => {
+  it("is admitted, where the date-blind guard refused it", () => {
+    const result = ingestBatch(closeThenTrim(BACKDATED_AS_OF));
+
+    expect(result.rejection).toBeNull();
+    expect(result.committed.map((event) => event.id)).toEqual([
+      "evt-open-late",
+      "evt-close",
+      "evt-trim",
+    ]);
+  });
+
+  it("and the book then reports the fifty the fund actually made, not zero", () => {
+    // The ADR's own worked case, in the book's own numbers. The trim removes half the
+    // basis on 06-08, so the 06-10 close books 100 against the 50 that remained.
+    // REFUSED, the trim never enters the log and the close books 100 against the full
+    // 100 — one row, at full size, realized 0 on a position that made 50.
+    const folded = foldEvents(genesis(), ingestBatch(closeThenTrim(BACKDATED_AS_OF)).committed);
+    const rows = (folded.closedPositions ?? []).filter((row) => row.positionId === "btc-late");
+
+    expect(rows.map((row) => row.closedAsOf)).toEqual([BACKDATED_AS_OF, CLOSED_AS_OF]);
+    expect(rows[1]).toMatchObject({ costBasisUsd: 50, proceedsUsd: 100, realizedPnlUsd: 50 });
+    expect(rows.reduce((sum, row) => sum + (row.realizedPnlUsd ?? 0), 0)).toBe(50);
+
+    // The counterfactual, joined rather than asserted beside: what the refusal booked.
+    const refused = foldEvents(genesis(), [accepted(openLate()), accepted(closePayload("c", CLOSED_AS_OF))]);
+    const refusedRows = (refused.closedPositions ?? []).filter((row) => row.positionId === "btc-late");
+    expect(refusedRows).toHaveLength(1);
+    expect(refusedRows[0]).toMatchObject({ costBasisUsd: 100, realizedPnlUsd: 0 });
+  });
+});
+
+// THE LOAD-BEARING TEST OF THIS SLICE. The settlement-magnitude gate is guarded on
+// `if (held && last !== undefined)`, and `held` comes from `positionLots` — the fold's
+// SURVIVORS, which a retired position is not among. A naive relaxation therefore admits
+// a backdated trim with NO proceeds sanity check and says nothing about it: no error, no
+// warning, no failing test anywhere else in the suite. This is the only thing standing
+// between that hole and the durable log.
+describe("ADR-017 — the settlement-magnitude gate still fires on a backdated trim", () => {
+  it("rejects absurd proceeds on a trim dated behind the close", () => {
+    const result = ingestBatch(closeThenTrim(BACKDATED_AS_OF, 0.5, 5000));
+
+    expect(result.rejection?.path).toBe("settlement.proceeds");
+    expect(result.rejection?.message).toContain("PositionTrimmed proceeds 5000");
+    expect(result.rejection?.message).toContain("settlement sanity threshold");
+    expect(result.committed).toEqual([]);
+  });
+
+  it("computes the expectation from the lots the position held AS OF that date", () => {
+    // Not merely "it was rejected": the expected figure must be 0.5 × the last close of
+    // 100 = 50.00, which is only computable if the as-of world restored `held`. A gate
+    // reading the survivors map would have had no quantity and no instrument to name.
+    const result = ingestBatch(closeThenTrim(BACKDATED_AS_OF, 0.5, 5000));
+
+    expect(result.rejection?.message).toContain("expected 50.00");
+    expect(result.rejection?.message).toContain("0.5 × last close 100");
+    expect(result.rejection?.message).toContain("btc-usd");
+  });
+
+  it("and treats a backdated trim exactly as it treats an ordinary one", () => {
+    // Same absurd proceeds, same instrument, same size — only the close's presence
+    // differs. The two messages must be the same sentence, or the gate has two minds.
+    const backdated = ingestBatch(closeThenTrim(BACKDATED_AS_OF, 0.5, 5000)).rejection;
+    const ordinary = ingestBatch([openLate(), trimPayload("evt-trim", BACKDATED_AS_OF, 0.5, 5000)])
+      .rejection;
+
+    expect(ordinary?.path).toBe("settlement.proceeds");
+    expect(backdated?.message).toBe(ordinary?.message);
+  });
+
+  it("still admits proceeds that are merely close to the expectation", () => {
+    // The gate firing must not become a gate refusing everything: a plausible fill goes
+    // through, so the test above is evidence about the THRESHOLD and not about `held`
+    // being permanently absent.
+    expect(ingestBatch(closeThenTrim(BACKDATED_AS_OF, 0.5, 52)).rejection).toBeNull();
+  });
+});
+
+// THE OTHER CONSEQUENCE OF READING THE SURVIVORS MAP: the sufficiency gate would see
+// `available = 0` for a retired position and refuse every backdated trim with a message
+// that describes a position holding nothing — misleading about the fund's own history.
+// Judged as of the trim's date, the lots are real and the gate answers about them.
+describe("ADR-017 — the position-lot-sufficiency gate judges the lots as of the date", () => {
+  it("refuses a backdated trim larger than the position ever held, naming the real size", () => {
+    const result = ingestBatch(closeThenTrim(BACKDATED_AS_OF, 5, 500));
+
+    expect(result.rejection?.path).toBe("removals");
+    expect(result.rejection?.message).toContain("removes 5");
+    expect(result.rejection?.message).toContain("which holds only 1");
+    expect(result.rejection?.message).not.toContain("holds only 0");
+  });
+
+  it("still refuses a backdated trim that would empty the position — a trim is not a close", () => {
+    const result = ingestBatch(closeThenTrim(BACKDATED_AS_OF, 1, 100));
+
+    expect(result.rejection?.path).toBe("removals");
+    expect(result.rejection?.message).toContain("full retirement");
+  });
+});
+
+// THE BOUNDARY IS `>=`, MATCHING THE SEAL RULE'S OWN STRICTNESS AT `crossref.ts:819`.
+// The two rules meet on the close date itself and must not disagree there: the seal rule
+// ACCEPTS a verb dated EQUAL to a close (trim-then-close on one day is ordinary, and the
+// fold's (asOf, THEN LOG INDEX) order applies the earlier-logged verb first), so this
+// direction — where the close is already in the log — must REFUSE equality.
+describe("ADR-017 — the trim boundary", () => {
+  it("refuses a trim dated ON the close date", () => {
+    const result = ingestBatch(closeThenTrim(CLOSED_AS_OF));
+
+    expect(result.rejection?.path).toBe("positionId");
+    expect(result.rejection?.message).toContain("PositionTrimmed");
+    expect(result.rejection?.message).toContain("already closed");
+    expect(result.committed).toEqual([]);
+  });
+
+  it("still refuses one dated after it", () => {
+    const result = ingestBatch(closeThenTrim("2026-06-11"));
+
+    expect(result.rejection?.path).toBe("positionId");
+    expect(result.rejection?.message).toContain("already closed");
+    expect(result.committed).toEqual([]);
+  });
+
+  it("admits the day before and refuses the day of — the same batch, one day apart", () => {
+    expect(ingestBatch(closeThenTrim("2026-06-09")).rejection).toBeNull();
+    expect(ingestBatch(closeThenTrim(CLOSED_AS_OF)).rejection).not.toBeNull();
+  });
+});
+
+// BOTH HALVES OF THE INVARIANT, ASSERTED TOGETHER. Neither sentence is complete without
+// the other, and relaxing this direction must not quiet the other one.
+describe("ADR-017 — the pair reads in both directions, for the trim too", () => {
+  it("a close may not be dated behind an already-accepted trim", () => {
+    const result = ingestBatch([
+      openLate(),
+      trimPayload("evt-trim", "2026-06-18", 0.5, 50),
+      closePayload("evt-close", CLOSED_AS_OF, 50),
+    ]);
+
+    expect(result.rejection?.path).toBe("positionId");
+    expect(result.rejection?.message).toContain("has already been accepted for it");
+    expect(result.committed).toEqual([]);
+  });
+
+  it("and a trim may not be dated on or after an already-accepted close", () => {
+    expect(ingestBatch(closeThenTrim(CLOSED_AS_OF)).rejection?.message).toContain("already closed");
+  });
+});

--- a/packages/engine/src/position-backdated-trim.test.ts
+++ b/packages/engine/src/position-backdated-trim.test.ts
@@ -123,6 +123,20 @@ const trimPayload = (
   settlement: { reserveId: "pulse-cash", proceeds },
 });
 
+const addToPayload = (
+  id: string,
+  asOf: string,
+  quantity = 1,
+  cost = 100,
+): Record<string, unknown> => ({
+  id,
+  asOf,
+  type: "PositionAddedTo",
+  positionId: "btc-late",
+  lot: { quantity, cost, tier: "c1" },
+  funding: { reserveId: "pulse-cash", amount: cost },
+});
+
 const closePayload = (id: string, asOf: string, proceeds = 100): Record<string, unknown> => ({
   id,
   asOf,
@@ -299,6 +313,91 @@ describe("ADR-017 — the trim boundary", () => {
   it("admits the day before and refuses the day of — the same batch, one day apart", () => {
     expect(ingestBatch(closeThenTrim("2026-06-09")).rejection).toBeNull();
     expect(ingestBatch(closeThenTrim(CLOSED_AS_OF)).rejection).not.toBeNull();
+  });
+});
+
+// THE PREFIX BOUNDARY IS `<=`, NOT `<` — the four cases a strict prefix got wrong.
+//
+// `worldAsOf(d)` folds the events the fold will have applied BEFORE the backdated verb.
+// The fold orders by (`asOf`, THEN LOG INDEX) (`fold.ts:250`), and every event in the
+// reference has a LOWER log index than the event under check — `ingest-walk.ts:191`
+// rebuilds the reference from `[...priorEvents, ...accepted]` and the candidate joins
+// `accepted` only once it is admitted. So a same-dated prior is applied BEFORE the trim
+// and belongs in its world; a strict `<` prefix judges against a world the fold will
+// never build. The guard's `>=` keeps `<=` safe from the close itself: reaching the
+// world means `event.asOf < retiredAsOf` strictly, so no prefix dated `<= event.asOf`
+// can ever contain the retiring close.
+//
+// THE FIRST TEST BELOW MUST FAIL LOUDLY if the strict `<` ever returns: under it, each
+// same-dated sibling sees the untrimmed position and 1.2 units are sold out of 1.
+describe("ADR-017 — the as-of world contains the trim's same-dated siblings", () => {
+  it("refuses the third of three same-dated trims that would together oversell the position", () => {
+    // 3 × 0.4 out of 1 unit held. Under a strict `<` prefix all three are COMMITTED —
+    // each sees the whole unit — and the fold books 1.2 units sold out of 1.
+    const result = ingestBatch([
+      openLate(),
+      closePayload("evt-close", CLOSED_AS_OF),
+      trimPayload("evt-trim-1", BACKDATED_AS_OF, 0.4, 40),
+      trimPayload("evt-trim-2", BACKDATED_AS_OF, 0.4, 40),
+      trimPayload("evt-trim-3", BACKDATED_AS_OF, 0.4, 40),
+    ]);
+
+    expect(result.rejection?.path).toBe("removals");
+    expect(result.rejection?.message).toContain("removes 0.4");
+    expect(result.rejection?.message).toContain("holds only 0.19999999999999996");
+    expect(result.committed).toEqual([]);
+  });
+
+  it("and the full-retirement refusal is not bypassed by splitting it across siblings", () => {
+    // 0.5 + 0.5 empties the position. The rule the reject exists for — "the position
+    // ALWAYS survives a trim" — must hold across same-dated siblings, not just within
+    // one event's removals.
+    const result = ingestBatch([
+      openLate(),
+      closePayload("evt-close", CLOSED_AS_OF),
+      trimPayload("evt-trim-1", BACKDATED_AS_OF, 0.5, 50),
+      trimPayload("evt-trim-2", BACKDATED_AS_OF, 0.5, 50),
+    ]);
+
+    expect(result.rejection?.path).toBe("removals");
+    expect(result.rejection?.message).toContain("full retirement");
+    expect(result.committed).toEqual([]);
+  });
+
+  it("admits a trim that only fits because a same-dated add is already accepted", () => {
+    // The false-reject direction: the add lands first (lower log index, same date), so
+    // the position really holds 2 at that instant and 1.5 fits. A strict `<` prefix
+    // drops the add and refuses with "holds only 1".
+    const result = ingestBatch([
+      openLate(),
+      closePayload("evt-close", CLOSED_AS_OF),
+      addToPayload("evt-add", BACKDATED_AS_OF),
+      trimPayload("evt-trim", BACKDATED_AS_OF, 1.5, 150),
+    ]);
+
+    expect(result.rejection).toBeNull();
+    expect(result.committed.map((event) => event.id)).toEqual([
+      "evt-open-late",
+      "evt-close",
+      "evt-add",
+      "evt-trim",
+    ]);
+  });
+
+  it("admits a trim dated on the position's own open date, without the 'holds only 0' message", () => {
+    // `requirePositionBornBy` accepts a verb dated ON the birth date, so the open is a
+    // same-dated sibling of this trim. Under a strict `<` prefix its world is empty and
+    // the refusal reads `which holds only 0` — the exact message ADR-017 exists to
+    // eliminate. The identical trim without the close was always accepted.
+    const result = ingestBatch(closeThenTrim(OPENED_AS_OF));
+
+    expect(result.rejection).toBeNull();
+    expect(result.committed.map((event) => event.id)).toEqual([
+      "evt-open-late",
+      "evt-close",
+      "evt-trim",
+    ]);
+    expect(ingestBatch([openLate(), trimPayload("evt-trim", OPENED_AS_OF)]).rejection).toBeNull();
   });
 });
 

--- a/packages/engine/src/position-seal.test.ts
+++ b/packages/engine/src/position-seal.test.ts
@@ -741,35 +741,37 @@ it("names the LAST-logged verb when two share the latest date", () => {
   );
 });
 
-// CASE C — A DELIBERATE OVER-REJECTION, PINNED SO THAT CHANGING IT IS A DECISION.
+// CASE C — THE OVER-REJECTION ADR-017 RESOLVED, NOW PINNED THE OTHER WAY UP.
 // `[Opened 06-05, Closed 06-10, Trimmed 06-08]`: the trim sorts BEFORE the close and
-// would fold perfectly correctly, so refusing it is stricter than the fold requires.
-// It stays refused on purpose — relaxing it means admitting retroactive edits to a
-// closed position's history, which is a policy question about the book, not a gate bug.
-// Filed as ledger item 21. This test exists so that a future relaxation is deliberate
-// rather than drift, and it is equally a pin on the SEAL rule's reach: the seal check
-// guards closes only, so the trim must still be refused by the already-closed guard and
-// must NOT report the seal message.
-describe("case C stays refused as already-closed, deliberately (ledger 21)", () => {
+// folds perfectly correctly, so refusing it was stricter than the fold required. It was
+// pinned as refused (ledger item 21) so that relaxing it would be a decision rather than
+// drift; ADR-017 took that decision, and the pin is inverted here rather than deleted —
+// the batch is the same, only the expected answer moved. It remains a pin on the SEAL
+// rule's reach in the bargain: the seal check guards closes only, and admitting this trim
+// must not make it start reporting on trims. The refusal boundary and the settlement-
+// magnitude gate that survives the relaxation live in `position-backdated-trim.test.ts`.
+describe("case C is admitted, the backdated trim ADR-017 relaxed", () => {
   const caseC = () => [
     openLate(),
     closePayload("evt-close", "2026-06-10"),
     trimPayload("evt-trim", "2026-06-08", 0.5, 50),
   ];
 
-  it("rejects the backdated trim with the already-closed message, not the seal one", () => {
+  it("admits the backdated trim, reporting neither the already-closed nor the seal message", () => {
     const result = ingestBatch(caseC());
 
-    expect(result.rejection?.path).toBe("positionId");
-    expect(result.rejection?.message).toContain("PositionTrimmed");
-    expect(result.rejection?.message).toContain("already closed");
-    expect(result.rejection?.message).not.toContain("has already been accepted for it");
-    expect(result.committed).toEqual([]);
+    expect(result.rejection).toBeNull();
+    expect(result.committed.map((event) => event.id)).toEqual([
+      "evt-open-late",
+      "evt-close",
+      "evt-trim",
+    ]);
   });
 
-  // What today's refusal costs, stated so the ledger-21 decision can be weighed on
-  // evidence rather than intuition: these events WOULD have folded correctly.
-  it("although that trim would have folded correctly — which is why 21 is open", () => {
+  // Unchanged from when it was the EVIDENCE for ledger 21: the same fold, the same two
+  // rows, the same realized 50. It was the argument for the relaxation and is now the
+  // expectation of it — which is the point of stating the cost in the book's own numbers.
+  it("and the book it folds to is the one that argued for admitting it", () => {
     const folded = foldEvents(genesis(), caseC().map(accepted));
     const rows = folded.closedPositions ?? [];
 


### PR DESCRIPTION
Implements **ADR-017** (`context/adr/ADR-017-a-close-is-the-positions-last-dated-event.md`), which resolves remediation-ledger item 21.

A `PositionTrimmed` or `PositionAddedTo` dated **strictly before** its target position's close date is now **admitted**. The guard stops asking the date-blind `closedPositionIds.has(id)` and asks `asOf >= closedAsOf`.

Closes #300.

## What it was costing

On the pin's own `caseC` — `[Opened 06-05 @ 1 × 100 in c1, Closed 06-10 @ 100, Trimmed 06-08 0.5 @ 50]`:

| | closed rows | realized |
| --- | --- | --- |
| refused (before) | one, at full size | **0** |
| admitted (after) | two, `closedAsOf` `["2026-06-08","2026-06-10"]`, final `{costBasisUsd: 50, proceedsUsd: 100, realizedPnlUsd: 50}` | **50** |

Zero realized profit reported on a position that made fifty, and one whole position closed where half had been sold two days earlier. The operator's only remedy was editing the durable log by hand.

## Exactly two of the four call sites move

All four verified present in `packages/engine/src/events/crossref.ts`. The other two are **not** over-strict and are deliberately untouched:

| line | verb | moves? | why |
| --- | --- | --- | --- |
| `:625` | `InvalidationMarked` | no | breach is derived per OPEN position only, so a mark on a retired position can never be watched whatever its date |
| `:939` | `PositionClosed` | no | whichever close sorts first retires the id; the other hits `if (closing)` and drops |
| `:1025` | `PositionTrimmed` | **yes** | slice 2 |
| `:1117` | `PositionAddedTo` | **yes** | slice 1 |

## Slice 1 — `PositionAddedTo` (`f0abba0`)

`crossReferenceAddedTo` never reads `positionLots` — it checks the funding Reserve's per-tier debit sufficiency and nothing about the position's holdings. **This half needs only the comparison.**

It introduces the carrier both halves share: `EventReference.closedPositionAsOf: Map<string, string>` — retired position id → the `closedAsOf` of the full-close row that retired it (partial rows skipped, earliest close wins). `closedPositionIds` is now derived as `new Set(closedPositionAsOf.keys())`, so **membership and date cannot diverge**, and the two flat sites plus every existing test that spreads or `.has()`es the set are untouched.

## Slice 2 — `PositionTrimmed` (`4704495` red checkpoint, `57031d6` green)

**The work is not the comparison.** `EventReference.positionLots` is built from `folded.positions` (`crossref.ts:459`) — the fold's **survivors** — so a closed position has no entry at all. Two things follow:

1. Relax only the membership test and a backdated trim falls through to the lot-sufficiency gate (`crossref.ts:1054-1063`) with `available = 0`, refused anyway with a *worse* message ("holds only 0") that misdescribes the fund's own history.
2. **The settlement-magnitude gate silently stops firing on exactly this class of event.** `crossref.ts:1083-1084` resolves `last` through `held ? reference.lastClose.get(held.instrumentId) : undefined` and guards on `if (held && last !== undefined)`. An absent `held` does not weaken that check — it **deletes** it, with no error, no warning and nothing going red. A backdated trim would be the one class of trim admitted with **no proceeds sanity check at all**.

The fix is to judge the trim against the world **at its own date**, ADR-015's doctrine one level deeper:

    foldEvents(genesis, accepted.filter((e) => e.asOf <= trim.asOf))

wrapped as `EventReference.worldAsOf(asOf)` — a lazy closure over `genesis` and `priorEvents`, recursing into `buildEventReference` and returning a **full** `EventReference`, not a fragment. `crossReferenceTrim` binds `const world = retiredAsOf === undefined ? reference : reference.worldAsOf(event.asOf)` and reads `positionLots` / `lastClose` off `world`.

This restores `held` **as a side effect**, which is why the magnitude gate keeps firing structurally rather than by a patched conditional. **Ordinary path cost is zero folds** — one closure allocation per reference build; only a trim aimed at an already-retired position ever folds.

## The non-negotiable test, and the proof it is load-bearing

**A backdated trim with absurd proceeds is still rejected.** Without it, consequence (2) ships unnoticed.

Proving it required care, and the first attempt would have fooled us. Stubbing the whole trim path back to naive relaxation turns 9 of 13 red — but the absurd-proceeds case fails via the **sufficiency** gate's "holds only 0", which *masks* the real hole. The sharper isolation — sufficiency reading the as-of world, magnitude alone reading `reference.positionLots` — fails exactly 3 tests with **`rejection` null for 5000 proceeds against an expectation of 50**: the silent admission, with nothing else in the repo complaining. Both stubs were reverted; `git status` is clean.

## The pin inverts, and its two halves part company

`packages/engine/src/position-seal.test.ts:753` — the first test asserted the behavior this reverses and is rewritten to assert acceptance (`rejection` null, all three ids committed). The describe comment is repointed from ledger item 21 to **ADR-017**. The second test at `:772` has a **byte-untouched body** — only its title and comment change, from evidence-for-a-complaint to the positive expectation.

One fixture flipped, inside this lane: `position-backdated-add-to.test.ts:277`, slice 1's own "sites this slice leaves alone" block, which pinned the backdated trim as still refused. That arm is inverted and the block renamed; the second-close and `InvalidationMarked` arms are untouched. Nothing outside `packages/engine` moved.

## Held to the ADR's exclusions

- **No bounded-retroactivity window.** Rejected by name in the ADR — it puts a clock inside a pure fold and makes the same batch admissible on Tuesday and refused on Friday.
- **`EVENT_SCHEMA_VERSION` stays `2`.** No verb added, no record reshaped, no line of `events.jsonl` migrated.
- The refusal message keeps **`already closed`** as a literal substring — `event-ingest.test.ts`, `position-born-by.test.ts`, `position-seal.test.ts` and two TUI suites key off it.

## Carried forward, deliberately not fixed here

**A closed-book row can now move with nothing announcing it.** Today's flat refusal incidentally prevented this; after this lands it is live. Accepted deliberately in the ADR — a book that becomes *right* silently beats one that stays *wrong* silently — and it is exactly what makes **#293** this change's natural companion, the next item in this lane. The first thing a fold diagnostics channel should report is an append that landed behind a close.

## Where a reviewer should look hardest

1. **The `<=` prefix in `worldAsOf` — corrected by review, and the reason matters.** This PR originally shipped a **strict `<`**, argued here as deliberate. That argument was wrong, and the review caught it. Same-dated siblings must be **included**: `foldEvents` orders by `(asOf, then log index)`, and every event in the reference was logged *before* the one under check — `ingest-walk.ts:191` rebuilds from `[...priorEvents, ...accepted]` and the candidate joins `accepted` only once admitted. So a same-dated prior really is applied **first**, and a strict prefix judged against a world the fold never builds. It cost correctness in both directions: three `Trimmed 06-08 0.4` behind a `Closed 06-10` on a 1-unit position were **all committed** (1.2 units sold out of 1, the full-retirement refusal bypassed by splitting the sale); a backdated `AddedTo 06-08` followed by `Trimmed 06-08 1.5` was **falsely refused**; and a trim dated on its position's own open date was refused with exactly the `holds only 0` message this ADR exists to eliminate. `<=` and the guard's `>=` are one boundary read from its two ends — reaching the world means `event.asOf < retiredAsOf` **strictly**, so no prefix can pull the retiring close in, and the event is never in its own prefix. Four regression tests pin the four scenarios; the oversell one goes red on the strict `<`, verified by reverting.
2. **The trim's already-closed refusal now mirrors the add-to's** — same rule, one operator experience, naming both dates and the remedy. `already closed` is kept as a literal substring, so the five suites keying off it are unaffected.

## Merge order — this PR is stacked

**Base is `feature/tighten-four-test-setups` (A1 / #299), not `main`.**

    A1 #299  →  A2 #300 (this PR)  →  A3 #293/#323  →  A4 #297

A1 must merge first; GitHub retargets this PR to `main` automatically when its base branch is deleted on merge.

**`closingIssuesReferences` is expected to come back empty on this PR.** GitHub only registers closing references against the default branch, so the link stays inert until the retarget above happens — at which point the `Closes #300` prose takes effect. This is not a defect and does not need chasing.

## Verification

`pnpm verify` fully green — typecheck clean, **1983 passed / 21 skipped** (the standing Postgres-integration skips), openTUI startup smoke completed.

