### PR TITLE
test(web): the pg-free walker follows workspace edges instead of stopping at them

### DIFF
--- a/apps/web/src/client-bundle.integration.test.ts
+++ b/apps/web/src/client-bundle.integration.test.ts
@@ -15,6 +15,21 @@
  * survive minification: the projection table name and the DB-URL / secret env
  * names. Any hit means server code leaked into the client.
  *
+ * WHICH GUARD IS AUTHORITATIVE. Two tests defend this invariant, and they are not
+ * peers:
+ *
+ *   - THIS one scans the BUILT client assets. It reads what actually shipped —
+ *     after bundling, tree-shaking and minification, through whatever path the
+ *     bytes took. It is the AUTHORITATIVE boundary.
+ *   - `apps/web/src/projection/contract.test.ts` walks the module graph from
+ *     `contract.ts` in source. That is a FAST LOCAL PRE-CHECK, not the real
+ *     boundary: it runs without a build (which is why it exists), it sees static
+ *     imports only, and it stops at true third-party packages. It fails EARLIER
+ *     and more cheaply than this test; it does not fail more authoritatively.
+ *
+ * So: a green pre-check is not this invariant proven. If the two ever disagree,
+ * this one wins.
+ *
  * SUBSTRATE-GATED, like the Postgres integration tests: it needs a build to
  * inspect, so it SKIPS with a loud warning when `.vercel/output/static` is
  * absent (a plain `pnpm test` on an unbuilt tree still passes). CI builds the

--- a/apps/web/src/projection/contract.test.ts
+++ b/apps/web/src/projection/contract.test.ts
@@ -5,10 +5,25 @@
  *
  * The first suite below is the seam's own guard — it asserts, from the module
  * graph rather than from a comment, that `contract.ts` stays pg-free.
+ *
+ * WHICH GUARD IS AUTHORITATIVE. Two tests defend the ADR-007 invariant that no pg
+ * driver, connection string or auth secret reaches the browser, and they are not
+ * peers:
+ *
+ *   - `apps/web/src/client-bundle.integration.test.ts` scans the BUILT client
+ *     assets. It reads what actually shipped, so it is the AUTHORITATIVE boundary.
+ *   - the module-graph walk below is a FAST LOCAL PRE-CHECK, not the real boundary.
+ *     It reads source, so it runs on a plain `pnpm test` with no build — which is
+ *     exactly why it exists, and exactly why it is not what the invariant rests on.
+ *     It reasons about static imports only; a dynamic `import()`, a re-export
+ *     through an installed package, or anything a bundler injects is outside it.
+ *
+ * So: a failure here is a real defect, but a PASS here is not the invariant being
+ * proven. If the two ever disagree, the built-asset scan wins.
  */
-import { readFileSync } from "node:fs";
+import { existsSync, readFileSync, readdirSync } from "node:fs";
 import { fileURLToPath } from "node:url";
-import { dirname, resolve } from "node:path";
+import { dirname, join, resolve } from "node:path";
 import type { CompositionReport } from "@numisma/engine";
 import { describe, expect, it } from "vitest";
 import { fundIdOf } from "./contract.ts";
@@ -61,35 +76,141 @@ function runtimeImportsOf(source: string): string[] {
 }
 
 /**
- * Walks the RELATIVE import graph from `entry`, returning every bare (package)
- * specifier reachable through runtime imports. Relative edges are followed to any
- * depth; bare specifiers are LEAVES — the walker stops at the package boundary and
- * does not resolve into `node_modules` or into workspace packages. So a package the
- * app pulls in (say `@numisma/engine/calendar`, which `contract.ts` reaches via
- * `as-of.ts`) is recorded by name only, and whatever IT imports is out of view.
- *
- * That is the walker's stated edge: this guards `pg` through the APP's relative
- * graph — a value import of the driver written anywhere in `apps/web`'s own files
- * downstream of `contract.ts`. A driver pulled in transitively by a workspace
- * package is a different failure and belongs to that package's own guard.
+ * The workspace's own packages, by published name — read from the layout rather
+ * than assumed. `pnpm-workspace.yaml` globs `packages/*` and `apps/*`; each
+ * directory's `package.json` supplies both its name and its `exports` map, which
+ * is what a specifier actually resolves THROUGH (`@numisma/engine/calendar` is
+ * an export-map key, not a path convention — nothing guarantees the two agree).
  */
-function reachablePackages(entry: string): Set<string> {
-  const seen = new Set<string>();
+const REPO_ROOT_DIR = resolve(HERE, "../../../..");
+
+const workspacePackages = new Map<
+  string,
+  { dir: string; exports: Record<string, string> }
+>(
+  ["packages", "apps"].flatMap((group) => {
+    const groupDir = resolve(REPO_ROOT_DIR, group);
+    if (!existsSync(groupDir)) return [];
+    return readdirSync(groupDir, { withFileTypes: true })
+      .filter((entry) => entry.isDirectory())
+      .flatMap((entry) => {
+        const dir = join(groupDir, entry.name);
+        const manifestPath = join(dir, "package.json");
+        if (!existsSync(manifestPath)) return [];
+        const manifest = JSON.parse(readFileSync(manifestPath, "utf-8")) as {
+          name?: string;
+          exports?: Record<string, unknown>;
+        };
+        if (!manifest.name) return [];
+        // Only string export targets; this repo uses no conditional objects, and
+        // guessing at one would be worse than leaving the edge unresolved.
+        const exports: Record<string, string> = {};
+        for (const [key, target] of Object.entries(manifest.exports ?? {})) {
+          if (typeof target === "string") exports[key] = target;
+        }
+        return [[manifest.name, { dir, exports }] as const];
+      });
+  }),
+);
+
+/**
+ * Resolve a bare specifier to a file inside this workspace, or `null` if it is a
+ * true third-party package (or a node: builtin) — which is what keeps the walk
+ * out of `node_modules`.
+ */
+function resolveWorkspaceModule(spec: string): string | null {
+  // Scoped names carry the scope in their first segment: `@numisma/engine/calendar`
+  // is package `@numisma/engine` + subpath `./calendar`.
+  const segments = spec.split("/");
+  const name = spec.startsWith("@")
+    ? segments.slice(0, 2).join("/")
+    : (segments[0] ?? spec);
+  const pkg = workspacePackages.get(name);
+  if (!pkg) return null;
+
+  const subpath = spec.slice(name.length);
+  const target = pkg.exports[subpath === "" ? "." : `.${subpath}`];
+  if (!target) {
+    throw new Error(
+      `${spec} is a workspace package but "${subpath === "" ? "." : `.${subpath}`}" ` +
+        `is not in ${name}'s exports map — the walker cannot follow it.`,
+    );
+  }
+  return resolve(pkg.dir, target);
+}
+
+/**
+ * The on-disk file a followed edge names. Relative specifiers inside the
+ * workspace packages are written NodeNext-style (`./calendar.js` for
+ * `calendar.ts`), while `apps/web` writes `.ts` directly; both are handled here.
+ * An unresolvable edge THROWS rather than being skipped — a walk that quietly
+ * drops edges is the failure mode this whole guard exists to prevent.
+ */
+function moduleFileFor(candidate: string): string {
+  const attempts = [
+    candidate,
+    candidate.replace(/\.js$/, ".ts"),
+    candidate.replace(/\.js$/, ".tsx"),
+    join(candidate, "index.ts"),
+  ];
+  const hit = attempts.find((path) => existsSync(path));
+  if (!hit) {
+    throw new Error(
+      `module-graph walker could not resolve ${candidate} (tried ${attempts.join(", ")})`,
+    );
+  }
+  return hit;
+}
+
+/**
+ * Walks the import graph from `entry`, returning both the FILES opened and every
+ * bare (package) specifier reached through runtime imports.
+ *
+ * Two kinds of edge, two behaviors:
+ *
+ *   - RELATIVE edges are followed to any depth, as they always were.
+ *   - BARE specifiers are all RECORDED by name, and the ones naming a package of
+ *     THIS WORKSPACE are additionally FOLLOWED — resolved through that package's
+ *     `exports` map and walked like any other file. So `@numisma/engine/calendar`,
+ *     which `contract.ts` reaches via `as-of.ts`, no longer ends the walk: a driver
+ *     a workspace package pulls in transitively is now in view (#295).
+ *
+ * True third-party specifiers (`pg`, `react`, `node:fs`) remain LEAVES. The walker
+ * never opens `node_modules` — resolving installed packages would mean implementing
+ * node resolution, and the built-asset scan (the AUTHORITATIVE guard; see this
+ * file's header) already covers what those packages contribute to a real bundle.
+ *
+ * An edge that resolves to no file THROWS rather than being skipped: a walk that
+ * silently drops edges is precisely the blind spot this guard exists to close.
+ */
+function reachableGraph(entry: string): {
+  files: Set<string>;
+  packages: Set<string>;
+} {
+  const files = new Set<string>();
   const packages = new Set<string>();
   const queue = [entry];
   while (queue.length > 0) {
     const file = queue.pop() as string;
-    if (seen.has(file)) continue;
-    seen.add(file);
+    if (files.has(file)) continue;
+    files.add(file);
     for (const spec of runtimeImportsOf(readFileSync(file, "utf-8"))) {
       if (spec.startsWith(".")) {
-        queue.push(resolve(dirname(file), spec));
-      } else {
-        packages.add(spec);
+        queue.push(moduleFileFor(resolve(dirname(file), spec)));
+        continue;
       }
+      // Every package edge is NAMED, workspace or not — that set is what the
+      // pg-free assertion reads. Workspace ones are additionally FOLLOWED.
+      packages.add(spec);
+      const workspaceFile = resolveWorkspaceModule(spec);
+      if (workspaceFile) queue.push(moduleFileFor(workspaceFile));
     }
   }
-  return packages;
+  return { files, packages };
+}
+
+function reachablePackages(entry: string): Set<string> {
+  return reachableGraph(entry).packages;
 }
 
 /**
@@ -98,12 +219,13 @@ function reachablePackages(entry: string): Set<string> {
  * reachable from it, any runtime value taken from the contract — a schema version,
  * a shared key list — drags the driver toward the client bundle.
  *
- * `client-bundle.integration.test.ts` already asserts the CONSEQUENCE, but only
- * against a built tree (it skips without one) and only for the surfaces that happen
- * to be imported today. This asserts the CAUSE, on every `pnpm test`, from the app's
- * own relative module graph — which is what makes the pg-free half safe to put
- * shared runtime constants in. Scope, per `reachablePackages` above: relative edges
- * to any depth, package specifiers as leaves.
+ * `client-bundle.integration.test.ts` asserts the CONSEQUENCE and is the
+ * authoritative boundary (see this file's header), but only against a built tree —
+ * it skips without one. This asserts the CAUSE, on every `pnpm test`, from the
+ * module graph — which is what makes the pg-free half safe to put shared runtime
+ * constants in. Scope, per `reachableGraph` above: relative edges to any depth,
+ * workspace packages followed through their export maps, true third-party
+ * specifiers recorded as leaves.
  */
 describe("contract.ts stays pg-free", () => {
   const CONTRACT = resolve(HERE, "contract.ts");
@@ -126,6 +248,56 @@ describe("contract.ts stays pg-free", () => {
     // And the assertion above has teeth only if the reader really does import pg —
     // otherwise a future move could empty both files and pass vacuously.
     expect(reachablePackages(READER)).toContain("pg");
+  });
+});
+
+/**
+ * THE WALKER'S OWN BOUNDARY. The guard above is only worth its assertion if the
+ * walk actually goes where it claims, so these pin BOTH halves of the rule:
+ * workspace edges are followed, true third-party edges are leaves. A walker that
+ * resolved nothing fails the first; a walker that resolved everything (into
+ * `node_modules`) fails the second.
+ *
+ * Deliberately asserting what the walk CONTAINS, not merely what it lacks: a
+ * silently-empty walk that finds no `pg` because it found nothing at all is the
+ * exact defect this pair exists to prevent.
+ */
+describe("the module-graph walker's boundary", () => {
+  const CONTRACT = resolve(HERE, "contract.ts");
+  const READER = resolve(HERE, "snapshot-reader.ts");
+  const REPO_ROOT = resolve(HERE, "../../../..");
+
+  it("follows a @numisma/* edge into the workspace package's own source", () => {
+    // contract.ts -> ./as-of.ts -> `export { addDays, daysBetween } from
+    // "@numisma/engine/calendar"` (a RUNTIME re-export, not `export type`). The
+    // walk must cross that specifier and land on the file the export map names.
+    const { files } = reachableGraph(CONTRACT);
+    const calendar = resolve(REPO_ROOT, "packages/engine/src/calendar.ts");
+    expect([...files].sort().join("\n")).toContain(calendar);
+  });
+
+  it("records a true third-party specifier as a leaf and does not walk node_modules", () => {
+    const { files, packages } = reachableGraph(READER);
+    // The specifier is still NAMED — that is what the pg-free assertion reads.
+    expect(packages).toContain("pg");
+    // But nothing behind it is opened: no file in the walk comes from an
+    // installed package. (`pg` itself pulls pg-pool/pg-protocol/pg-types; a
+    // resolve-everything walker would drag all of them in here.)
+    expect([...files].filter((f) => f.includes("node_modules"))).toEqual([]);
+  });
+
+  it("resolves the workspace export map, and refuses everything outside the workspace", () => {
+    // The subpath comes from packages/engine/package.json `exports`, not from a
+    // guessed src/<name>.ts convention.
+    expect(resolveWorkspaceModule("@numisma/engine/calendar")).toBe(
+      resolve(REPO_ROOT, "packages/engine/src/calendar.ts"),
+    );
+    expect(resolveWorkspaceModule("@numisma/engine")).toBe(
+      resolve(REPO_ROOT, "packages/engine/src/index.ts"),
+    );
+    for (const thirdParty of ["pg", "react", "better-auth", "node:fs"]) {
+      expect(resolveWorkspaceModule(thirdParty), thirdParty).toBeNull();
+    }
   });
 });
 

--- a/apps/web/src/projection/contract.test.ts
+++ b/apps/web/src/projection/contract.test.ts
@@ -21,7 +21,15 @@
  * So: a failure here is a real defect, but a PASS here is not the invariant being
  * proven. If the two ever disagree, the built-asset scan wins.
  */
-import { existsSync, readFileSync, readdirSync } from "node:fs";
+import {
+  existsSync,
+  mkdtempSync,
+  readFileSync,
+  readdirSync,
+  rmSync,
+  writeFileSync,
+} from "node:fs";
+import { tmpdir } from "node:os";
 import { fileURLToPath } from "node:url";
 import { dirname, join, resolve } from "node:path";
 import type { CompositionReport } from "@numisma/engine";
@@ -75,20 +83,64 @@ function runtimeImportsOf(source: string): string[] {
   return specifiers;
 }
 
+const REPO_ROOT_DIR = resolve(HERE, "../../../..");
+const CONTRACT = resolve(HERE, "contract.ts");
+const READER = resolve(HERE, "snapshot-reader.ts");
+
+/**
+ * The directories `pnpm-workspace.yaml` globs, READ FROM THE YAML rather than
+ * hardcoded — a hardcoded `["packages", "apps"]` and the yaml can drift with no
+ * signal, and a workspace group the walker does not know about is a group whose
+ * packages it would treat as third-party (see `resolveWorkspaceModule`).
+ *
+ * Only the `<dir>/*` glob shape is understood, which is the only shape this repo
+ * uses. Anything else THROWS: an unrecognised glob means the walker's idea of
+ * the workspace is no longer the yaml's, and that must be loud.
+ */
+function workspaceGroupsIn(yaml: string): string[] {
+  const groups: string[] = [];
+  let insidePackages = false;
+  for (const raw of yaml.split("\n")) {
+    const line = raw.replace(/#.*$/, "").trimEnd();
+    if (line.trim() === "") continue;
+    if (/^\S/.test(line)) {
+      insidePackages = line.trim() === "packages:";
+      continue;
+    }
+    if (!insidePackages) continue;
+    const glob = /^\s*-\s*["']?(?<glob>[^"'\s]+)["']?\s*$/
+      .exec(line)
+      ?.groups?.glob;
+    const dir = glob ? /^(?<dir>[^*]+)\/\*$/.exec(glob)?.groups?.dir : undefined;
+    if (!dir) {
+      throw new Error(
+        `pnpm-workspace.yaml declares a workspace glob this walker does not ` +
+          `understand (${line.trim()}) — only "<dir>/*" is handled, and a group ` +
+          `the walker cannot see would have its packages treated as third-party.`,
+      );
+    }
+    groups.push(dir);
+  }
+  return groups;
+}
+
+const WORKSPACE_GROUPS = workspaceGroupsIn(
+  readFileSync(resolve(REPO_ROOT_DIR, "pnpm-workspace.yaml"), "utf-8"),
+);
+
 /**
  * The workspace's own packages, by published name — read from the layout rather
- * than assumed. `pnpm-workspace.yaml` globs `packages/*` and `apps/*`; each
- * directory's `package.json` supplies both its name and its `exports` map, which
- * is what a specifier actually resolves THROUGH (`@numisma/engine/calendar` is
- * an export-map key, not a path convention — nothing guarantees the two agree).
+ * than assumed. Each directory's `package.json` supplies both its name and its
+ * `exports` map, which is what a specifier actually resolves THROUGH
+ * (`@numisma/engine/calendar` is an export-map key, not a path convention —
+ * nothing guarantees the two agree). Export targets are kept RAW; reducing them
+ * to a file is `exportedTargetFor`'s job.
  */
-const REPO_ROOT_DIR = resolve(HERE, "../../../..");
-
 const workspacePackages = new Map<
   string,
-  { dir: string; exports: Record<string, string> }
+  { dir: string; exports: Record<string, unknown> }
 >(
-  ["packages", "apps"].flatMap((group) => {
+  WORKSPACE_GROUPS.flatMap((group) => {
     const groupDir = resolve(REPO_ROOT_DIR, group);
     if (!existsSync(groupDir)) return [];
     return readdirSync(groupDir, { withFileTypes: true })
@@ -102,21 +154,87 @@ const workspacePackages = new Map<
           exports?: Record<string, unknown>;
         };
         if (!manifest.name) return [];
-        // Only string export targets; this repo uses no conditional objects, and
-        // guessing at one would be worse than leaving the edge unresolved.
-        const exports: Record<string, string> = {};
-        for (const [key, target] of Object.entries(manifest.exports ?? {})) {
-          if (typeof target === "string") exports[key] = target;
-        }
-        return [[manifest.name, { dir, exports }] as const];
+        return [
+          [manifest.name, { dir, exports: manifest.exports ?? {} }] as const,
+        ];
       });
   }),
 );
 
 /**
+ * The scopes this workspace publishes under, derived from the packages actually
+ * found. A specifier in one of these scopes is a workspace edge by construction,
+ * so failing to resolve it is a defect rather than a third-party leaf.
+ */
+const WORKSPACE_SCOPES = new Set(
+  [...workspacePackages.keys()]
+    .filter((name) => name.startsWith("@"))
+    .map((name) => name.split("/")[0]),
+);
+
+/**
+ * Reduce one package's `exports` map + a subpath to the relative target a runtime
+ * import takes. Three shapes, three outcomes:
+ *
+ *   - a STRING target is the target.
+ *   - a CONDITIONAL object is resolved through `import` / `default` / `node`, in
+ *     that order — the conditions a bundler or node takes for the ES imports this
+ *     walker follows. A `types`-only object reduces to nothing and throws.
+ *   - a WILDCARD key (`"./*": "./src/*.ts"`) matches around the star and
+ *     substitutes the matched segment into the target.
+ *
+ * The two failure messages are deliberately distinct: an ABSENT key and a target
+ * shape the walker cannot REDUCE are different defects, and reporting the second
+ * as the first sends the reader hunting for a key that is right there.
+ */
+function exportedTargetFor(
+  pkgName: string,
+  exports: Record<string, unknown>,
+  subpath: string,
+): string {
+  const key = subpath === "" ? "." : `.${subpath}`;
+
+  const reduce = (matchedKey: string, target: unknown): string => {
+    if (typeof target === "string") return target;
+    if (target && typeof target === "object" && !Array.isArray(target)) {
+      for (const condition of ["import", "default", "node"]) {
+        const branch = (target as Record<string, unknown>)[condition];
+        if (typeof branch === "string") return branch;
+      }
+    }
+    throw new Error(
+      `${pkgName}'s exports entry "${matchedKey}" IS in the map, but its target ` +
+        `shape is one this walker cannot reduce to a single file ` +
+        `(${JSON.stringify(target)}) — no import/default/node string condition.`,
+    );
+  };
+
+  if (Object.hasOwn(exports, key)) return reduce(key, exports[key]);
+
+  for (const [pattern, target] of Object.entries(exports)) {
+    if (!pattern.includes("*")) continue;
+    const [prefix = "", suffix = ""] = pattern.split("*");
+    if (!key.startsWith(prefix) || !key.endsWith(suffix)) continue;
+    if (key.length < prefix.length + suffix.length) continue;
+    const star = key.slice(prefix.length, key.length - suffix.length);
+    return reduce(pattern, target).replace("*", star);
+  }
+
+  throw new Error(
+    `"${key}" is not in ${pkgName}'s exports map (no exact and no wildcard key ` +
+      `matches) — the walker cannot follow it.`,
+  );
+}
+
+/**
  * Resolve a bare specifier to a file inside this workspace, or `null` if it is a
  * true third-party package (or a node: builtin) — which is what keeps the walk
  * out of `node_modules`.
+ *
+ * A name in one of the WORKSPACE'S OWN SCOPES that is not in the map THROWS. It
+ * cannot be a third-party leaf, and returning `null` for it was the one path
+ * where a workspace edge could vanish without a sound — the exact blind spot the
+ * guard exists to close.
  */
 function resolveWorkspaceModule(spec: string): string | null {
   // Scoped names carry the scope in their first segment: `@numisma/engine/calendar`
@@ -126,33 +244,42 @@ function resolveWorkspaceModule(spec: string): string | null {
     ? segments.slice(0, 2).join("/")
     : (segments[0] ?? spec);
   const pkg = workspacePackages.get(name);
-  if (!pkg) return null;
-
-  const subpath = spec.slice(name.length);
-  const target = pkg.exports[subpath === "" ? "." : `.${subpath}`];
-  if (!target) {
-    throw new Error(
-      `${spec} is a workspace package but "${subpath === "" ? "." : `.${subpath}`}" ` +
-        `is not in ${name}'s exports map — the walker cannot follow it.`,
-    );
+  if (!pkg) {
+    if (WORKSPACE_SCOPES.has(segments[0] ?? "")) {
+      throw new Error(
+        `${spec} names the workspace scope "${segments[0]}" but no package ` +
+          `'${name}' was found under ${WORKSPACE_GROUPS.join("/, ")}/ — the ` +
+          `walker would otherwise treat a workspace edge as a third-party leaf.`,
+      );
+    }
+    return null;
   }
-  return resolve(pkg.dir, target);
+  return resolve(pkg.dir, exportedTargetFor(name, pkg.exports, spec.slice(name.length)));
 }
 
 /**
- * The on-disk file a followed edge names. Relative specifiers inside the
- * workspace packages are written NodeNext-style (`./calendar.js` for
- * `calendar.ts`), while `apps/web` writes `.ts` directly; both are handled here.
- * An unresolvable edge THROWS rather than being skipped — a walk that quietly
- * drops edges is the failure mode this whole guard exists to prevent.
+ * The on-disk file a followed edge names. Three import styles reach here and all
+ * three must resolve, because a false throw reds the pg-free guard on a defect
+ * that does not exist — and a guard people learn to distrust defends nothing:
+ *
+ *   - NodeNext (`./calendar.js` for `calendar.ts`), used inside the workspace
+ *     packages. The `.ts`/`.tsx` rewrite is tried BEFORE the literal `.js`, so a
+ *     stray compiled emit beside its source never wins over the source.
+ *   - EXTENSIONLESS (`./as-of`), legal under `apps/web`'s
+ *     `"moduleResolution": "Bundler"` — the sibling `.ts`/`.tsx` is tried.
+ *   - QUERY/HASH-suffixed (`../styles.css?url`, live at `routes/__root.tsx`),
+ *     which names the file to its left.
+ *
+ * An edge that still resolves to no file THROWS rather than being skipped — a
+ * walk that quietly drops edges is the failure mode this whole guard exists to
+ * prevent.
  */
 function moduleFileFor(candidate: string): string {
-  const attempts = [
-    candidate,
-    candidate.replace(/\.js$/, ".ts"),
-    candidate.replace(/\.js$/, ".tsx"),
-    join(candidate, "index.ts"),
-  ];
+  const path = candidate.replace(/[?#].*$/, "");
+  const attempts = path.endsWith(".js")
+    ? [path.replace(/\.js$/, ".ts"), path.replace(/\.js$/, ".tsx"), path]
+    : [path, `${path}.ts`, `${path}.tsx`];
+  attempts.push(join(path, "index.ts"), join(path, "index.tsx"));
   const hit = attempts.find((path) => existsSync(path));
   if (!hit) {
     throw new Error(
@@ -228,9 +355,6 @@ function reachablePackages(entry: string): Set<string> {
  * specifiers recorded as leaves.
  */
 describe("contract.ts stays pg-free", () => {
-  const CONTRACT = resolve(HERE, "contract.ts");
-  const READER = resolve(HERE, "snapshot-reader.ts");
-
   it("reaches no runtime pg import through the app's relative import graph", () => {
     const packages = reachablePackages(CONTRACT);
     const pgish = [...packages].filter((p) => p === "pg" || p.startsWith("pg/"));
@@ -263,17 +387,15 @@ describe("contract.ts stays pg-free", () => {
  * exact defect this pair exists to prevent.
  */
 describe("the module-graph walker's boundary", () => {
-  const CONTRACT = resolve(HERE, "contract.ts");
-  const READER = resolve(HERE, "snapshot-reader.ts");
-  const REPO_ROOT = resolve(HERE, "../../../..");
-
   it("follows a @numisma/* edge into the workspace package's own source", () => {
     // contract.ts -> ./as-of.ts -> `export { addDays, daysBetween } from
     // "@numisma/engine/calendar"` (a RUNTIME re-export, not `export type`). The
     // walk must cross that specifier and land on the file the export map names.
     const { files } = reachableGraph(CONTRACT);
-    const calendar = resolve(REPO_ROOT, "packages/engine/src/calendar.ts");
-    expect([...files].sort().join("\n")).toContain(calendar);
+    const calendar = resolve(REPO_ROOT_DIR, "packages/engine/src/calendar.ts");
+    // Set membership, not a substring of a joined blob: `calendar.tsx` or a
+    // `calendar.ts.bak` would satisfy the latter without the edge being followed.
+    expect(files).toContain(calendar);
   });
 
   it("records a true third-party specifier as a leaf and does not walk node_modules", () => {
@@ -290,14 +412,147 @@ describe("the module-graph walker's boundary", () => {
     // The subpath comes from packages/engine/package.json `exports`, not from a
     // guessed src/<name>.ts convention.
     expect(resolveWorkspaceModule("@numisma/engine/calendar")).toBe(
-      resolve(REPO_ROOT, "packages/engine/src/calendar.ts"),
+      resolve(REPO_ROOT_DIR, "packages/engine/src/calendar.ts"),
     );
     expect(resolveWorkspaceModule("@numisma/engine")).toBe(
-      resolve(REPO_ROOT, "packages/engine/src/index.ts"),
+      resolve(REPO_ROOT_DIR, "packages/engine/src/index.ts"),
     );
     for (const thirdParty of ["pg", "react", "better-auth", "node:fs"]) {
       expect(resolveWorkspaceModule(thirdParty), thirdParty).toBeNull();
     }
+  });
+});
+
+/**
+ * THE WALKER'S FAILURE MODES. Every one of these is a case where the walk must
+ * either resolve correctly or FAIL LOUDLY — never quietly record a leaf and move
+ * on. Fixtures here are authored inline; nothing is read from real data.
+ */
+describe("the module-graph walker's failure modes", () => {
+  it("throws rather than leafing a workspace-scope specifier it cannot resolve", () => {
+    // The blind spot: an `@numisma/*` name absent from the map used to return
+    // null and be recorded as a third-party leaf, so a pg-importing package in
+    // a workspace group the walker did not know about would pass the guard.
+    expect(() =>
+      resolveWorkspaceModule("@numisma/authored-absent-package"),
+    ).toThrow(/workspace scope/);
+    expect(() =>
+      resolveWorkspaceModule("@numisma/authored-absent-package/sub"),
+    ).toThrow(/workspace scope/);
+  });
+
+  it("fails the whole walk on an unresolvable workspace edge instead of leafing it", () => {
+    // The unit throw above is only worth anything if the WALK propagates it.
+    // Authored entry file, obviously synthetic: it names a workspace-scope
+    // package that does not exist, which is the shape a `services/*` group the
+    // walker cannot see would produce.
+    const scratch = mkdtempSync(join(tmpdir(), "numisma-walker-"));
+    try {
+      const entry = join(scratch, "authored-entry.ts");
+      writeFileSync(
+        entry,
+        'export { ledger } from "@numisma/authored-absent-package";\n',
+      );
+      expect(() => reachableGraph(entry)).toThrow(/workspace scope/);
+      // And a true third-party name in the same position stays a silent leaf.
+      writeFileSync(entry, 'import { Pool } from "pg";\nexport { Pool };\n');
+      expect(reachableGraph(entry).packages).toContain("pg");
+    } finally {
+      rmSync(scratch, { recursive: true, force: true });
+    }
+  });
+
+  it("derives its workspace groups from pnpm-workspace.yaml rather than a hardcoded list", () => {
+    // Independent read: if the walker ever goes back to hardcoding
+    // ["packages", "apps"], adding a group to the yaml reds this test instead
+    // of silently shrinking the walk.
+    const yaml = readFileSync(
+      resolve(REPO_ROOT_DIR, "pnpm-workspace.yaml"),
+      "utf-8",
+    );
+    const block = yaml.slice(yaml.indexOf("\npackages:") + 1);
+    const declared = block
+      .split("\n")
+      .slice(1)
+      .filter((line) => /^\s+-\s/.test(line))
+      .map((line) => line.replace(/^\s+-\s*/, "").trim());
+    expect(declared.length).toBeGreaterThan(0);
+    expect([...WORKSPACE_GROUPS].sort()).toEqual(
+      declared.map((glob) => glob.replace(/\/\*$/, "")).sort(),
+    );
+  });
+
+  it("resolves an extensionless relative import, which moduleResolution Bundler allows", () => {
+    // apps/web/tsconfig.json sets "moduleResolution": "Bundler"; `./contract`
+    // is legal there and must not red the pg-free guard as a phantom defect.
+    expect(moduleFileFor(resolve(HERE, "contract"))).toBe(
+      resolve(HERE, "contract.ts"),
+    );
+  });
+
+  it("prefers the .ts source over a stray compiled .js sitting beside it", () => {
+    const scratch = mkdtempSync(join(tmpdir(), "numisma-walker-"));
+    try {
+      // Authored, obviously synthetic: two files, same basename.
+      writeFileSync(join(scratch, "authored.ts"), "export const authored = 1;\n");
+      writeFileSync(join(scratch, "authored.js"), "export const authored = 1;\n");
+      expect(moduleFileFor(join(scratch, "authored.js"))).toBe(
+        join(scratch, "authored.ts"),
+      );
+    } finally {
+      rmSync(scratch, { recursive: true, force: true });
+    }
+  });
+
+  it("resolves a bundler query suffix to the file it names", () => {
+    // Live today at apps/web/src/routes/__root.tsx: `../styles.css?url`.
+    const styles = resolve(HERE, "../styles.css");
+    expect(moduleFileFor(`${styles}?url`)).toBe(styles);
+  });
+
+  it("resolves a conditional export object to the file a runtime import takes", () => {
+    expect(
+      exportedTargetFor("@numisma/authored", { ".": "./src/index.ts" }, ""),
+    ).toBe("./src/index.ts");
+    expect(
+      exportedTargetFor(
+        "@numisma/authored",
+        { ".": { types: "./src/index.ts", default: "./src/index.ts" } },
+        "",
+      ),
+    ).toBe("./src/index.ts");
+    expect(
+      exportedTargetFor(
+        "@numisma/authored",
+        { ".": { types: "./src/index.ts", import: "./src/esm.ts" } },
+        "",
+      ),
+    ).toBe("./src/esm.ts");
+  });
+
+  it("resolves a wildcard export key by substituting the matched segment", () => {
+    expect(
+      exportedTargetFor(
+        "@numisma/authored",
+        { "./*": "./src/*.ts" },
+        "/calendar",
+      ),
+    ).toBe("./src/calendar.ts");
+  });
+
+  it("names the real cause when an export target has a shape it cannot reduce", () => {
+    // An ABSENT key and an UNREDUCIBLE target are different defects; the walker
+    // used to report both as "not in the exports map".
+    expect(() =>
+      exportedTargetFor("@numisma/authored", { ".": "./src/index.ts" }, "/nope"),
+    ).toThrow(/not in @numisma\/authored's exports map/);
+    expect(() =>
+      exportedTargetFor(
+        "@numisma/authored",
+        { ".": { types: "./src/index.d.ts" } },
+        "",
+      ),
+    ).toThrow(/target shape/);
   });
 });
 


### PR DESCRIPTION
The module-graph guard that proves `contract.ts` stays pg-free followed relative import edges to any depth but treated **every** bare specifier as a leaf. So `contract.ts` importing `@numisma/engine` ended the walk there, and a pg driver reached **through a workspace package** was invisible to it.

## Why this matters, and what it is not

**ADR-016 makes authentication the disclosure ceiling.** The invariant these guards defend — that the browser bundle carries no pg driver, no connection string, no auth secret — is now what stands between private fund data and the network. That is the reason to close the hole.

**It is not the reason the issue gave, and that correction is half of what this PR delivers.** #295 argues the module-graph walker is "the only guard standing" because the built-asset guard is `describe.skipIf(!hasBuild)`. **That is true locally and false in CI.** Re-verified on this branch: `.github/workflows/ci.yml` runs a `Build web app (ADR-007 — produces the client bundle to inspect)` step invoking `pnpm --filter @numisma/web build` immediately before the test step, and `CLIENT_DIR` resolves to `apps/web/.vercel/output/static`, exactly what `vite build` produces. The authoritative guard runs on every push to every branch and on every PR.

So the issue's suggestion to make the built-asset guard "non-skippable in CI" is **not implemented, because there is nothing to implement** — its skip condition and forbidden-token list are untouched, and `.github/workflows/ci.yml` gains no diff. The real gap was narrower than filed: a local `pnpm test` gave false confidence, and neither guard said which one was authoritative.

## What changed

**1. Workspace specifiers are now followed; true third-party ones are still leaves.**

`reachablePackages` became `reachableGraph`, returning both the files opened and the package specifiers reached — the pg-free assertion reads that specifier set exactly as before, so the existing guarantee is unchanged. What is new is that `@numisma/*` edges are additionally *walked*.

Resolution follows the repo's real layout rather than a naming convention: the workspace groups are **parsed out of `pnpm-workspace.yaml`** rather than hardcoded, each `package.json` in them supplies a `name` and `exports`, and a specifier resolves **through that `exports` map** — `@numisma/engine/calendar` via its `"./calendar"` key, not by guessing at a source path. Conditional targets (`{"types": …, "default": …}`) reduce through `import` → `default` → `node`; wildcard keys match around the star. Anything outside the workspace — `pg`, `react`, `better-auth`, `node:fs` — stays a leaf. **`node_modules` is never opened**, which was the whole point of preferring this fix over the alternative.

**Nothing in the workspace scope can silently become a leaf, and unresolvable edges throw.** A walk that quietly drops an edge is precisely the defect being fixed, so it must not be able to reappear as a silent no-op. Concretely: a specifier naming a scope the workspace publishes but no package that exists throws; a glob shape in the yaml the walker cannot handle throws, because a shape it cannot handle is itself a blind spot; and an `exports` entry it cannot reduce throws with a message distinguishing *absent key* from *target shape I cannot reduce*. The scope set is derived from the names actually found rather than hardcoded to `@numisma/`, so it stays true if the workspace ever publishes a second scope.

**2. Both files now say which guard is authoritative.** Previously neither did, and that ambiguity was the other half of the issue. Each header now states the relationship, so a reader landing in either file learns it without having to find the other:

- `client-bundle.integration.test.ts` scans the **built** assets — it reads what actually shipped, after bundling, tree-shaking and minification, through whatever path the bytes took. It is the **authoritative** boundary.
- `contract.test.ts` walks the module graph in **source**. It is a **fast local pre-check**: it runs with no build, which is exactly why it exists and exactly why it is not what the invariant rests on. It sees static imports only — a dynamic `import()`, a re-export through an installed package, or anything a bundler injects is outside it.

Stated in both: a failure in the pre-check is a real defect, but **a pass is not the invariant proven**, and if the two ever disagree the built-asset scan wins.

## Tests

Three new tests under `the module-graph walker's boundary`. Both halves are pinned, deliberately: a walker that resolves **nothing** fails the first, and a walker that resolves **everything** fails the second (`files` would contain `node_modules` paths, since `pg` drags in pg-pool, pg-protocol and pg-types).

Assertions are **containment, not absence** — the walk must be shown to land on `packages/engine/src/calendar.ts` and to still name `pg`. That matters here more than usual: a walk that silently found nothing would pass an absence-only assertion, and silently finding nothing is the exact failure this PR exists to remove.

The red was staged honestly — the walker was first restructured to expose `files` while keeping the old leaf-stopping behavior verbatim, and the two tests failed for the right reason (the walk stopped at `as-of.ts` and never reached `calendar.ts`). The third test, covering leaf behavior and the absence of `node_modules` paths, passed already, which is correct: that half was never broken and must stay unbroken.

## Verification

The widened walk found **no** forbidden token. The new edge from `contract.ts` is `as-of.ts → @numisma/engine/calendar → packages/engine/src/calendar.ts`, which imports nothing. A broader probe across engine, event-store and preferences reached 53 files across three workspace packages leaving only `node:` builtins as leaves — that probe was temporary and is not in the diff.

`pnpm typecheck` green. `pnpm test`: 133 files passed, 4 skipped; 1964 tests passed, 0 failed. The 4 skipped files are the pre-existing `NUMISMA_TEST_DATABASE_URL`-gated integration suites and the build-gated client-bundle suite.

No production source changed — the diff is two test files.

## Review

A fresh-context `pr-review` raised five findings and **all five were real and are fixed in this PR**:

1. **A silent-skip hole that defeated the widening** — and it contradicted this PR's own "throw, never skip" rule, which is why it mattered most. An unknown `@numisma/*` name returned `null` and was dropped as a leaf, reachable because the workspace groups were hardcoded to `packages`/`apps` while the comment claimed they followed the yaml. The reviewer's scenario: add `services/*` to `pnpm-workspace.yaml`, put a pg-importing `@numisma/ledger` there, and the guard goes green on **exactly the case this PR exists to catch**. Closed at both ends — the groups now come from the yaml, and a workspace-scope specifier that resolves to nothing throws. A drift test re-reads the yaml and asserts the derived globs match it; its teeth were verified by mutation.
2. **A false-red risk in extension resolution.** `moduleFileFor` only rewrote a `.js` suffix and never appended `.ts`, so an extensionless relative import — legal under the `Bundler` resolution this app sets — threw and reddened the guard on a non-defect. A false red on a security guard is expensive: it trains people to distrust it. Resolution is now shape-aware, tries `.ts`/`.tsx` **before** a literal `.js` so a stray emit never beats its source, and strips `?`/`#` query suffixes (live today at `routes/__root.tsx`).
3. **Misnamed failure causes** — conditional export objects and wildcard keys both reported "not in exports map". Failed loud rather than silently, so a diagnosis-quality fix; both are now handled and the two failure messages are distinct.
4. **A substring assertion posing as set membership** — `[...files].sort().join("\n")` with `toContain`. Now `expect(files).toContain(calendar)`.
5. **Duplicated `REPO_ROOT` / `CONTRACT` / `READER` declarations**, hoisted.

The reviewer separately verified that the refactor **does not weaken the original guard** — the pg-free assertion and the reader teeth-check are byte-identical and the specifier set is strictly larger — and confirmed the walk is cycle-safe, bounded, derives its root from `import.meta.url` with no cwd or env dependence, and carries no empty-string env fallback.

Green tests are not the gate. This PR has had its fresh-context review and awaits an explicit go; **it is not to be merged by the authoring session.**

## Merge order

**Independent.** This branch is cut from `main` and is file-disjoint from lane D's other PR (#342, the Discard Channel), so it can merge in any order relative to it and to lane A's stack. It targets `main` directly.

## What this retires

Closes #295.
