### PR TITLE
A committed test harness for run-daily-fetch.sh: arms on change, 12 runs, three assertions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -85,6 +85,16 @@ jobs:
         run: pnpm --filter @numisma/web build
 
       - name: Test (unit + DB-backed ADR-007 invariants, push idempotency, client-bundle guard)
+        # ⚠️ THE PRICE-FEED WRAPPER HARNESS DOES NOT RUN HERE, AND A GREEN CHECK ON THIS
+        # STEP DOES NOT MEAN IT PASSED — IT MEANS IT WAS NOT ATTEMPTED.
+        # `apps/price-feed/src/wrapper-harness/` drives ops/price-feed/run-daily-fetch.sh
+        # as a real process. It targets macOS /bin/bash 3.2.57, BSD ps/pgrep and a
+        # watchdog hand-rolled *because* macOS ships no timeout(1), so it cannot run on
+        # this ubuntu-latest runner. Its platform gate skips it here and SAYS SO in the
+        # test output (one always-running test prints the decision either way). The
+        # harness runs on a macOS machine, automatically when its own subject code
+        # changes, or on demand via `pnpm test:wrapper`. See docs/price-feed-ops.md.
+        #
         # --testTimeout raises the default 5s ceiling for the git-heavy tui tests,
         # which flake on slower CI runners under full-suite parallel load. This is
         # a CI-runner mitigation, not a change to any assertion.

--- a/apps/price-feed/src/config.ts
+++ b/apps/price-feed/src/config.ts
@@ -6,16 +6,27 @@
  * knob-turner exists (there is one operator today), so these are named defaults,
  * not a sidecar.
  */
-import { resolveDataDir, type MarkClock } from "@numisma/engine";
+import {
+  resolveDataDir,
+  MARK_TIME,
+  TRADING_DAY_TIME_ZONE,
+  type MarkClock,
+} from "@numisma/engine";
 
 export interface PriceFeedConfig extends MarkClock {
   /**
-   * IANA trading-day timezone the mark `asOf` is anchored to. Default CDMX so a
-   * CDMX-evening fetch is dated the local trading day, not the provider's UTC
-   * tomorrow.
+   * IANA trading-day timezone the mark `asOf` is anchored to. Defaults to the
+   * engine's `TRADING_DAY_TIME_ZONE` (CDMX) so a CDMX-evening fetch is dated the
+   * local trading day, not the provider's UTC tomorrow. DERIVED, NOT RESTATED: the
+   * durable log's gap report and the daily wrapper have to agree with this value,
+   * and a second literal here would let them drift apart while both compile.
    */
   timeZone: string;
-  /** Daily mark time (`HH:MM` local). A fetch before it upserts the store only. */
+  /**
+   * Daily mark time (`HH:MM` local). A fetch before it upserts the store only.
+   * Defaults to the engine's `MARK_TIME`, built from the same `MARK_HOUR` the
+   * wrapper's mark-window comparison is pinned against.
+   */
   markTime: string;
   /**
    * Per-request network budget in milliseconds, covering CONNECT + HEADERS + BODY
@@ -61,8 +72,8 @@ export interface PriceFeedConfig extends MarkClock {
 }
 
 export const DEFAULT_CONFIG: PriceFeedConfig = {
-  timeZone: "America/Mexico_City",
-  markTime: "18:00",
+  timeZone: TRADING_DAY_TIME_ZONE,
+  markTime: MARK_TIME,
   requestTimeoutMs: 30_000,
   fixMaxStaleDays: 4,
   // The SINGLE engine resolver: `NUMISMA_DATA_DIR` override with an absolute,

--- a/apps/price-feed/src/schedule-window.test.ts
+++ b/apps/price-feed/src/schedule-window.test.ts
@@ -1,8 +1,10 @@
 import { describe, expect, it } from "vitest";
-import { execFileSync } from "node:child_process";
-import { readFileSync } from "node:fs";
+import { execFileSync, spawnSync } from "node:child_process";
+import { existsSync, mkdtempSync, readFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
 import { fileURLToPath } from "node:url";
-import { instrumentsForSource } from "@numisma/engine";
+import { MARK_HOUR, TRADING_DAY_TIME_ZONE, instrumentsForSource } from "@numisma/engine";
 import { DEFAULT_CONFIG } from "./config.js";
 
 /**
@@ -104,6 +106,28 @@ function firesPerDay(intervals: CalendarInterval[]): number {
   }, 0);
 }
 
+/**
+ * Run the real wrapper under the real `/bin/bash`, for the config-refusal paths ONLY.
+ *
+ * SAFE BECAUSE IT NEVER GETS PAST VALIDATION. Both callers hand it a value the
+ * wrapper is required to reject, and that rejection happens before `mkdir -p
+ * "$LOG_DIR"`, before the EXIT-trap heartbeat is installed and long before anything
+ * touches pnpm, the durable log or a provider — the assertion on the absent log dir
+ * is what holds that true. Never call this with a VALID config: the wrapper would go
+ * on to run the actual daily pipeline against the real data dir. Driving the wrapper
+ * on its succeeding paths is the wrapper harness's job, not this file's.
+ *
+ * `/bin/bash` explicitly, never the shebang's `env bash`: launchd runs 3.2.57, and a
+ * Homebrew bash 5 would silently accept shapes 3.2 rejects.
+ */
+function runWrapper(env: Record<string, string>): { status: number | null; output: string } {
+  const result = spawnSync("/bin/bash", [WRAPPER_PATH], {
+    encoding: "utf8",
+    env: { ...process.env, ...env },
+  });
+  return { status: result.status, output: `${result.stdout ?? ""}${result.stderr ?? ""}` };
+}
+
 describe("the launchd fetch window", () => {
   it.skipIf(!onMac)("is a plist launchd can actually load", () => {
     // A malformed plist is silently ignored by launchd — no error, just no job.
@@ -164,26 +188,41 @@ describe("the launchd fetch window", () => {
     );
   });
 
-  it("keeps the wrapper's own mark hour equal to the contract's, with no leading zero", () => {
+  it("keeps the wrapper's own mark hour DEFAULT equal to the contract's, with no leading zero", () => {
     // The wrapper duplicates the mark hour in bash to decide whether a run could
     // mark at all (the heartbeat's `markWindow`). It cannot import `DEFAULT_CONFIG`,
     // so this is the join: change the contract and a test fails rather than the
     // breadcrumb quietly mis-classifying every run.
     //
-    // THE REGEX REFUSES A LEADING ZERO ON PURPOSE. `[[ x -ge $MARK_HOUR ]]`
+    // THE HOUR IS NOW OVERRIDABLE, WHICH MOVES THIS GUARD BUT DOES NOT RETIRE IT.
+    // What is pinned is the DEFAULT — the `:-` half of the expansion, the value every
+    // scheduled fire actually uses. Matching the whole expansion rather than a bare
+    // literal is deliberate: a wrapper that dropped the `NUMISMA_MARK_HOUR` override
+    // and went back to `MARK_HOUR=18` would fail here, because a caller that can no
+    // longer put a run on either side of the window is a silent loss of exactly the
+    // capability this line exists to provide.
+    //
+    // THE REGEX STILL REFUSES A LEADING ZERO ON PURPOSE. `[[ x -ge $MARK_HOUR ]]`
     // arithmetic-evaluates its right operand, and `08`/`09` are invalid octal. That
     // does not abort — it is an `if` condition, so `set -e` never fires — it silently
     // classifies EVERY run as out-of-window. `Number("08") === 8` would let a guard
     // written the obvious way sail straight past it, so the SHAPE is asserted, not
-    // just the value. (The wrapper also wraps both operands in `10#`; this is the
-    // second lock on the same door, because either alone is enough to be forgotten.)
+    // just the value. (The wrapper also wraps both operands in `10#`, and the sibling
+    // test below drives its actual comparison line to prove it: two locks on one
+    // door, because either alone is enough to be forgotten.)
     const markHour = Number(DEFAULT_CONFIG.markTime.split(":")[0]);
-    const declared = /^MARK_HOUR=([1-9]?[0-9])$/m.exec(readFileSync(WRAPPER_PATH, "utf8"));
+    // The contract's own hour derives from the engine — assert that too, so
+    // re-literalising `DEFAULT_CONFIG` cannot quietly reopen the second copy this
+    // increment closed.
+    expect(markHour).toBe(MARK_HOUR);
+    const declared = /^MARK_HOUR="\$\{NUMISMA_MARK_HOUR:-([1-9]?[0-9])\}"$/m.exec(
+      readFileSync(WRAPPER_PATH, "utf8"),
+    );
     expect(declared?.[1]).toBeDefined();
     expect(Number(declared?.[1])).toBe(markHour);
   });
 
-  it("keeps the wrapper's own mark timezone equal to the contract's", () => {
+  it("keeps the wrapper's own mark timezone DEFAULT equal to the contract's", () => {
     // The hour is meaningless without the zone. The real gate resolves the mark
     // instant through Intl in CDMX explicitly, so a wrapper reading the bare local
     // hour would agree only by coincidence of the OS setting — and the install docs
@@ -191,8 +230,110 @@ describe("the launchd fetch window", () => {
     // supported. Under that config every scheduled fire would classify itself
     // out-of-window, nothing would ever stamp, and the staleness trigger would be
     // permanently and silently dead while the runs themselves marked correctly.
-    const declared = /^MARK_TZ="([^"]+)"$/m.exec(readFileSync(WRAPPER_PATH, "utf8"));
+    //
+    // Same move as the hour above: the OVERRIDE is what lets a caller drive the
+    // window, and the DEFAULT is what every scheduled fire uses, so the default is
+    // what has to equal the contract.
+    expect(DEFAULT_CONFIG.timeZone).toBe(TRADING_DAY_TIME_ZONE);
+    const declared = /^MARK_TZ="\$\{NUMISMA_MARK_TZ:-([^"}]+)\}"$/m.exec(
+      readFileSync(WRAPPER_PATH, "utf8"),
+    );
     expect(declared?.[1]).toBe(DEFAULT_CONFIG.timeZone);
+  });
+
+  it("classifies an 08/09 mark hour by base 10, using the wrapper's own comparison", () => {
+    // THE OCTAL LOCK, EXERCISED RATHER THAN DESCRIBED. The hour became configurable,
+    // so `08`/`09` stopped being hypothetical — and that band is the one where bash
+    // fails in the worst possible way: `[[ 09 -ge 08 ]]` is invalid octal, prints an
+    // error, does NOT abort (an `if` condition is exempt from `set -e`) and takes the
+    // else branch. Every run then records itself as out-of-window, nothing ever
+    // stamps, and the staleness channel dies silently while the marks land fine.
+    //
+    // THE CODE UNDER TEST IS LIFTED FROM THE WRAPPER, not re-typed here — that is the
+    // whole point. Strip the `10#` from either operand in the wrapper and this goes
+    // red (measured: the unguarded form answers `false` for 09 ≥ 08 and exits 0).
+    const wrapper = readFileSync(WRAPPER_PATH, "utf8");
+    const comparison = /^(if \[\[ .*MARK_NOW_HOUR.*MARK_HOUR.*\]\]; then)$/m.exec(wrapper)?.[1];
+    expect(comparison).toBeDefined();
+
+    // `/bin/bash` EXPLICITLY: that is what launchd runs (3.2.57 on macOS), and a
+    // Homebrew bash 5 would let a bash-5-only shape pass here and die in production.
+    const classify = (nowHour: string, markHour: string): string =>
+      execFileSync(
+        "/bin/bash",
+        [
+          "-c",
+          [
+            "set -euo pipefail",
+            `MARK_NOW_HOUR=${nowHour}`,
+            `MARK_HOUR=${markHour}`,
+            comparison!,
+            "  MARK_WINDOW=true",
+            "else",
+            "  MARK_WINDOW=false",
+            "fi",
+            'printf %s "$MARK_WINDOW"',
+          ].join("\n"),
+        ],
+        { encoding: "utf8", stdio: ["ignore", "pipe", "ignore"] },
+      );
+
+    expect(classify("09", "08")).toBe("true");
+    expect(classify("07", "08")).toBe("false");
+    expect(classify("08", "08")).toBe("true");
+    // And the shape the schedule actually runs, so the guard cannot pass by only
+    // caring about the octal band.
+    expect(classify("18", "18")).toBe("true");
+    expect(classify("09", "18")).toBe("false");
+  });
+
+  it("refuses an unresolvable mark timezone on BOTH sides, instead of quietly becoming UTC", () => {
+    // THE ASYMMETRY THIS CLOSES. TypeScript already fails loudly on a bad zone;
+    // bash does not — `TZ=Not/AZone date +%H` prints the UTC hour with no error and a
+    // zero exit (verified on this box). UTC is disjoint from the CDMX evening window,
+    // so a typo'd override would flip the window wrong on every single run while the
+    // runs kept marking correctly. Now that the zone is settable, that typo is a
+    // thing a caller can actually make.
+    const BAD_ZONE = "Not/AZone";
+    expect(() => new Intl.DateTimeFormat("en-US", { timeZone: BAD_ZONE })).toThrow(RangeError);
+
+    const sandbox = mkdtempSync(join(tmpdir(), "numisma-mark-zone-"));
+    const logDir = join(sandbox, "logs");
+    const result = runWrapper({
+      NUMISMA_MARK_TZ: BAD_ZONE,
+      NUMISMA_PRICEFEED_LOG_DIR: logDir,
+      NUMISMA_DATA_DIR: join(sandbox, "data"),
+      NUMISMA_REPO_DIR: sandbox,
+    });
+
+    expect(result.status).not.toBe(0);
+    // It NAMES THE VALUE. A bare "bad timezone" would leave an operator staring at a
+    // plist and an env file trying to work out which one was read.
+    expect(result.output).toContain(BAD_ZONE);
+    expect(result.output).toContain("FATAL");
+    // BEFORE the mark window, and before anything else happens at all: the run never
+    // reaches `mkdir -p "$LOG_DIR"`, so there is no per-run log, no heartbeat and no
+    // half-done work to explain. A fallback to UTC would have reached all of it.
+    expect(existsSync(logDir)).toBe(false);
+  });
+
+  it("refuses a mark hour that is not an hour, which would classify every run out-of-window", () => {
+    // Same failure mode as the bad zone, through the other override: a non-numeric
+    // hour makes the comparison's arithmetic fail, and that failure does not abort —
+    // it just answers `false`, forever, on every run.
+    const sandbox = mkdtempSync(join(tmpdir(), "numisma-mark-hour-"));
+    const logDir = join(sandbox, "logs");
+    const result = runWrapper({
+      NUMISMA_MARK_HOUR: "noon",
+      NUMISMA_PRICEFEED_LOG_DIR: logDir,
+      NUMISMA_DATA_DIR: join(sandbox, "data"),
+      NUMISMA_REPO_DIR: sandbox,
+    });
+
+    expect(result.status).not.toBe(0);
+    expect(result.output).toContain("noon");
+    expect(result.output).toContain("FATAL");
+    expect(existsSync(logDir)).toBe(false);
   });
 
   it("lists exactly the wrapper steps that follow the one appending marks", () => {

--- a/apps/price-feed/src/schedule-window.test.ts
+++ b/apps/price-feed/src/schedule-window.test.ts
@@ -4,6 +4,7 @@ import { existsSync, readFileSync, readdirSync } from "node:fs";
 import { join } from "node:path";
 import { fileURLToPath } from "node:url";
 import { MARK_HOUR, TRADING_DAY_TIME_ZONE, instrumentsForSource } from "@numisma/engine";
+import { parseHeartbeat } from "@numisma/event-store";
 import { DEFAULT_CONFIG } from "./config.js";
 import { caseEnv, makeCaseDir, type CaseDirs, type CaseOptions } from "./wrapper-harness/case-dir.testkit.js";
 import { assertIsolated } from "./wrapper-harness/isolation.testkit.js";
@@ -174,8 +175,59 @@ function runWrapper(overrides: Record<string, string>): {
   return { status: result.status, output: `${result.stdout ?? ""}${result.stderr ?? ""}`, dirs };
 }
 
-/** It refused before it ran anything: no fake `pnpm` was ever invoked. */
-function expectReachedNoStep(dirs: CaseDirs): void {
+/** The per-run log the wrapper's `tee` wrote, concatenated. Empty if it never got that far. */
+function runLogText(logDir: string): string {
+  if (!existsSync(logDir)) {
+    return "";
+  }
+  return readdirSync(logDir)
+    .filter((name) => name.startsWith("price-feed-") && name.endsWith(".log"))
+    .map((name) => readFileSync(join(logDir, name), "utf8"))
+    .join("");
+}
+
+/**
+ * Assert the shape a config refusal must have — and it is deliberately NOT silence.
+ *
+ * The two guards are the newest way for every scheduled fire to die, so where they die
+ * decides whether the operator ever finds out. They now run after the EXIT-trap heartbeat
+ * and the per-run log are installed, which means a typo'd zone leaves a FATAL line in the
+ * log and a breadcrumb saying `exit 1 at step 'startup'` instead of nothing at all. The
+ * earlier ordering exited before either existed: `job-heartbeat.json` went on describing
+ * the last good run, and the TUI read "healthy" for as long as it took the staleness
+ * channel to age out — the same silent rot the guard was written to prevent.
+ *
+ * And it still refuses: `lastStep` is `startup`, no `pnpm` sentinel exists, and
+ * `markWindow` declines rather than claims a side it could not compute.
+ */
+function expectRefusedLoudly(dirs: CaseDirs, output: string, value: string): void {
+  // It NAMES THE VALUE. A bare "bad timezone" would leave an operator staring at a plist
+  // and an env file trying to work out which one was read.
+  expect(output).toContain(value);
+  expect(output).toContain("FATAL");
+
+  const logText = runLogText(dirs.logDir);
+  expect(logText, "the refusal left no per-run log — it died on the quietest channel").toContain(
+    "FATAL",
+  );
+  expect(logText).toContain(value);
+
+  const heartbeat = parseHeartbeat(
+    existsSync(join(dirs.dataDir, "job-heartbeat.json"))
+      ? readFileSync(join(dirs.dataDir, "job-heartbeat.json"), "utf8")
+      : undefined,
+  );
+  expect(heartbeat, "the refusal left no breadcrumb, so the TUI keeps reading the last good run")
+    .toBeDefined();
+  expect(heartbeat?.exitCode).toBe(1);
+  expect(heartbeat?.lastStep).toBe("startup");
+  // It DECLINES the window rather than claiming one, and stamps nothing: `markWindow`
+  // records whether the run could have marked, and this one marked nothing.
+  expect(heartbeat?.markWindow).toBe(false);
+  expect(heartbeat?.lastMarkWindowFinishedAt).toBeUndefined();
+
+  // AND IT REFUSED BEFORE IT RAN ANYTHING. A guard that fired after the fetch would have
+  // let a run with an unknowable window append to the log first.
   for (const command of WRAPPER_PNPM_COMMANDS) {
     expect(
       existsSync(join(dirs.caseDir, "sentinels", sentinelNameFor(command))),
@@ -355,16 +407,8 @@ describe("the launchd fetch window", () => {
 
     const result = runWrapper({ NUMISMA_MARK_TZ: BAD_ZONE });
 
-    expect(result.status).not.toBe(0);
-    // It NAMES THE VALUE. A bare "bad timezone" would leave an operator staring at a
-    // plist and an env file trying to work out which one was read.
-    expect(result.output).toContain(BAD_ZONE);
-    expect(result.output).toContain("FATAL");
-    // BEFORE the mark window, and before anything else happens at all: the run never
-    // gets past its own startup, so it writes no per-run log and leaves no half-done
-    // work to explain. A fallback to UTC would have reached all of it.
-    expect(readdirSync(result.dirs.logDir)).toEqual([]);
-    expectReachedNoStep(result.dirs);
+    expect(result.status).toBe(1);
+    expectRefusedLoudly(result.dirs, result.output, BAD_ZONE);
   });
 
   it("refuses a mark hour that is not an hour, which would classify every run out-of-window", () => {
@@ -373,11 +417,8 @@ describe("the launchd fetch window", () => {
     // it just answers `false`, forever, on every run.
     const result = runWrapper({ NUMISMA_MARK_HOUR: "noon" });
 
-    expect(result.status).not.toBe(0);
-    expect(result.output).toContain("noon");
-    expect(result.output).toContain("FATAL");
-    expect(readdirSync(result.dirs.logDir)).toEqual([]);
-    expectReachedNoStep(result.dirs);
+    expect(result.status).toBe(1);
+    expectRefusedLoudly(result.dirs, result.output, "noon");
   });
 
   it("lists exactly the wrapper steps that follow the one appending marks", () => {

--- a/apps/price-feed/src/schedule-window.test.ts
+++ b/apps/price-feed/src/schedule-window.test.ts
@@ -1,11 +1,14 @@
 import { describe, expect, it } from "vitest";
 import { execFileSync, spawnSync } from "node:child_process";
-import { existsSync, mkdtempSync, readFileSync } from "node:fs";
-import { tmpdir } from "node:os";
+import { existsSync, readFileSync, readdirSync } from "node:fs";
 import { join } from "node:path";
 import { fileURLToPath } from "node:url";
 import { MARK_HOUR, TRADING_DAY_TIME_ZONE, instrumentsForSource } from "@numisma/engine";
 import { DEFAULT_CONFIG } from "./config.js";
+import { caseEnv, makeCaseDir, type CaseDirs, type CaseOptions } from "./wrapper-harness/case-dir.testkit.js";
+import { assertIsolated } from "./wrapper-harness/isolation.testkit.js";
+import { CONTRACT_MARK_CONFIG } from "./wrapper-harness/mark-window.testkit.js";
+import { WRAPPER_PNPM_COMMANDS, sentinelNameFor } from "./wrapper-harness/fake-bin.testkit.js";
 
 /**
  * The launchd schedule template is CONFIG, not code, so most of what could be
@@ -106,26 +109,79 @@ function firesPerDay(intervals: CalendarInterval[]): number {
   }, 0);
 }
 
+/** A short ceiling and grace: these runs refuse before the watchdog is ever armed. */
+const REFUSAL_CASE_OPTIONS: CaseOptions = {
+  maxRunSeconds: 5,
+  watchdogGraceSeconds: 1,
+  mark: CONTRACT_MARK_CONFIG,
+};
+
+/**
+ * A hard cap on the blocking call. `spawnSync` cannot be preempted by a vitest timer, so
+ * without this a run that ever blocked — a credential prompt, a stalled socket — would
+ * WEDGE THE WORKER rather than fail. Expiry is a named failure below, never a pass.
+ */
+const REFUSAL_RUN_TIMEOUT_MS = 60_000;
+
 /**
  * Run the real wrapper under the real `/bin/bash`, for the config-refusal paths ONLY.
  *
- * SAFE BECAUSE IT NEVER GETS PAST VALIDATION. Both callers hand it a value the
- * wrapper is required to reject, and that rejection happens before `mkdir -p
- * "$LOG_DIR"`, before the EXIT-trap heartbeat is installed and long before anything
- * touches pnpm, the durable log or a provider — the assertion on the absent log dir
- * is what holds that true. Never call this with a VALID config: the wrapper would go
- * on to run the actual daily pipeline against the real data dir. Driving the wrapper
- * on its succeeding paths is the wrapper harness's job, not this file's.
+ * SAFE BECAUSE THE REAL DEFAULTS ARE STRUCTURALLY UNREACHABLE, NOT BECAUSE THE CALLERS
+ * ARE CAREFUL. There is no `...process.env` here: the environment is built fresh by
+ * {@link caseEnv}, every one of the nine `NUMISMA_*` overrides points inside a per-run
+ * temp dir, and {@link assertIsolated} refuses the launch otherwise — the same contract
+ * the wrapper harness's launcher enforces, imported rather than re-stated. That matters
+ * for a reason a docstring cannot cover: with `NUMISMA_PRICEFEED_ENV` inherited the
+ * wrapper would `source` the operator's real chmod-600 token file under `set -a`, and
+ * with `NUMISMA_PATH_PREPEND` inherited it would resolve the REAL `pnpm` and `node`. A
+ * guard that is only offered can be walked past by any later edit that moves it; a
+ * refusal taken before the spawn cannot.
+ *
+ * The fake bin the case dir installs is the second layer: if a refusal ever stopped
+ * refusing, the run would reach a fake `pnpm` that writes a sentinel — which the callers
+ * assert is absent — rather than a real one.
  *
  * `/bin/bash` explicitly, never the shebang's `env bash`: launchd runs 3.2.57, and a
  * Homebrew bash 5 would silently accept shapes 3.2 rejects.
  */
-function runWrapper(env: Record<string, string>): { status: number | null; output: string } {
+function runWrapper(overrides: Record<string, string>): {
+  status: number | null;
+  output: string;
+  dirs: CaseDirs;
+} {
+  const dirs = makeCaseDir(REFUSAL_CASE_OPTIONS);
+  const env = { ...caseEnv(dirs, REFUSAL_CASE_OPTIONS), ...overrides };
+  assertIsolated(env, dirs.caseDir);
+
   const result = spawnSync("/bin/bash", [WRAPPER_PATH], {
     encoding: "utf8",
-    env: { ...process.env, ...env },
+    env,
+    cwd: dirs.caseDir,
+    timeout: REFUSAL_RUN_TIMEOUT_MS,
   });
-  return { status: result.status, output: `${result.stdout ?? ""}${result.stderr ?? ""}` };
+  if (result.error !== undefined) {
+    throw result.error;
+  }
+  // A timeout kill arrives as a SIGNAL with a null status, which is indistinguishable
+  // from a real refusal if only `status` is read. Name it: a wrapper that hung on a
+  // path whose whole claim is that it exits immediately is a failure of this test.
+  if (result.signal !== null) {
+    throw new Error(
+      `the wrapper was killed by ${result.signal} rather than exiting — it did not refuse ` +
+        `within ${REFUSAL_RUN_TIMEOUT_MS}ms. That is a failure of this case, never a pass.`,
+    );
+  }
+  return { status: result.status, output: `${result.stdout ?? ""}${result.stderr ?? ""}`, dirs };
+}
+
+/** It refused before it ran anything: no fake `pnpm` was ever invoked. */
+function expectReachedNoStep(dirs: CaseDirs): void {
+  for (const command of WRAPPER_PNPM_COMMANDS) {
+    expect(
+      existsSync(join(dirs.caseDir, "sentinels", sentinelNameFor(command))),
+      `the wrapper reached \`${command}\` despite refusing its own configuration`,
+    ).toBe(false);
+  }
 }
 
 describe("the launchd fetch window", () => {
@@ -297,14 +353,7 @@ describe("the launchd fetch window", () => {
     const BAD_ZONE = "Not/AZone";
     expect(() => new Intl.DateTimeFormat("en-US", { timeZone: BAD_ZONE })).toThrow(RangeError);
 
-    const sandbox = mkdtempSync(join(tmpdir(), "numisma-mark-zone-"));
-    const logDir = join(sandbox, "logs");
-    const result = runWrapper({
-      NUMISMA_MARK_TZ: BAD_ZONE,
-      NUMISMA_PRICEFEED_LOG_DIR: logDir,
-      NUMISMA_DATA_DIR: join(sandbox, "data"),
-      NUMISMA_REPO_DIR: sandbox,
-    });
+    const result = runWrapper({ NUMISMA_MARK_TZ: BAD_ZONE });
 
     expect(result.status).not.toBe(0);
     // It NAMES THE VALUE. A bare "bad timezone" would leave an operator staring at a
@@ -312,28 +361,23 @@ describe("the launchd fetch window", () => {
     expect(result.output).toContain(BAD_ZONE);
     expect(result.output).toContain("FATAL");
     // BEFORE the mark window, and before anything else happens at all: the run never
-    // reaches `mkdir -p "$LOG_DIR"`, so there is no per-run log, no heartbeat and no
-    // half-done work to explain. A fallback to UTC would have reached all of it.
-    expect(existsSync(logDir)).toBe(false);
+    // gets past its own startup, so it writes no per-run log and leaves no half-done
+    // work to explain. A fallback to UTC would have reached all of it.
+    expect(readdirSync(result.dirs.logDir)).toEqual([]);
+    expectReachedNoStep(result.dirs);
   });
 
   it("refuses a mark hour that is not an hour, which would classify every run out-of-window", () => {
     // Same failure mode as the bad zone, through the other override: a non-numeric
     // hour makes the comparison's arithmetic fail, and that failure does not abort —
     // it just answers `false`, forever, on every run.
-    const sandbox = mkdtempSync(join(tmpdir(), "numisma-mark-hour-"));
-    const logDir = join(sandbox, "logs");
-    const result = runWrapper({
-      NUMISMA_MARK_HOUR: "noon",
-      NUMISMA_PRICEFEED_LOG_DIR: logDir,
-      NUMISMA_DATA_DIR: join(sandbox, "data"),
-      NUMISMA_REPO_DIR: sandbox,
-    });
+    const result = runWrapper({ NUMISMA_MARK_HOUR: "noon" });
 
     expect(result.status).not.toBe(0);
     expect(result.output).toContain("noon");
     expect(result.output).toContain("FATAL");
-    expect(existsSync(logDir)).toBe(false);
+    expect(readdirSync(result.dirs.logDir)).toEqual([]);
+    expectReachedNoStep(result.dirs);
   });
 
   it("lists exactly the wrapper steps that follow the one appending marks", () => {

--- a/apps/price-feed/src/wrapper-harness/arming-trigger.testkit.ts
+++ b/apps/price-feed/src/wrapper-harness/arming-trigger.testkit.ts
@@ -1,0 +1,287 @@
+/**
+ * S7 · THE ARMING TRIGGER — the runner boundary of the wrapper harness (PRD #314 §7).
+ *
+ * It owns one decision — *should the wrapper suite run at all?* — and, when the answer
+ * is no, it owns saying so out loud.
+ *
+ * IT IS A MODULE AND NOT AN `if`, because the decision has to be a PURE function of
+ * `(changedPaths, base, pathSet, platform, override)`. A trigger embedded in the runner
+ * cannot be proven to fire, and an unfireable trigger is the exact failure the harness
+ * exists to eliminate, relocated one level up: a typo'd glob (`ops/price-feeed/**`)
+ * matches nothing, the suite skips forever, every PR is green, and the skip line reads
+ * perfectly normal. Nothing else in the harness can detect that — which is why
+ * {@link decideArming} is unit-tested against authored inputs, why {@link TRIGGER_PATH_SET}
+ * is fed the REAL wrapper path in a separate assertion, and why every glob in the set is
+ * checked for liveness. All three of those live in the ALWAYS-RUNNING part of the suite,
+ * so they survive the very skip they guard against.
+ *
+ * TWO DIRECTIONS, DELIBERATELY OPPOSITE:
+ *
+ *   - **The trigger fails toward RUNNING.** An unresolvable base — detached HEAD, a
+ *     shallow clone, no `origin/main`, git unavailable — arms the suite and says why.
+ *     Failing closed here would buy silence, which is the one thing §7 exists to prevent.
+ *   - **The isolation contract (S2) fails toward REFUSING.** See `isolation.testkit.ts`.
+ *
+ * The asymmetry is the point: failing open there means writing to the real durable log,
+ * failing open here costs one slow test run.
+ *
+ * GATE ORDER IS LOAD-BEARING: PLATFORM FIRST, TRIGGER SECOND. CI is a single
+ * `ubuntu-latest` job whose `actions/checkout` sets no `fetch-depth`, so CI clones
+ * shallow and has no `origin/main` to merge-base against. Evaluate the trigger first and
+ * every CI run fails open into a suite that cannot work on Linux at all — turning the
+ * fail-open rule into a guaranteed red. The platform gate evaluating first makes that
+ * unreachable, and a test asserts the ordering directly rather than trusting the reading.
+ */
+
+import { execFileSync } from "node:child_process";
+
+/** The one platform this suite can run on. See the darwin caveat in the suite header. */
+export const HARNESS_PLATFORM = "darwin";
+
+/**
+ * WHAT THE HARNESS CAN FALSIFY — not everything topically related (§7.3).
+ *
+ * - `ops/price-feed/**` — the subject. The wrapper, the launchd plist template (the
+ *   oracle for the watchdog ceiling and the source of the `/bin/bash` invocation the
+ *   launcher mirrors) and the reinstall runbook.
+ * - the harness's own directory — a change to the harness must run the harness. The
+ *   easiest entry to omit, and omitting it means you can break the suite and sail past
+ *   on a green PR.
+ * - `packages/event-store/src/heartbeat.ts` — the ORACLE assertion 2 parses against. The
+ *   heartbeat has a bash writer and a TypeScript reader with nothing else joining them at
+ *   runtime, so if the reader's accepted schema versions or ISO-instant validation move,
+ *   the wrapper's `printf` can start producing a file the reader condemns and this suite
+ *   is the only thing positioned to notice.
+ *
+ * DELIBERATELY OUT OF SET: the four commands the wrapper shells out to
+ * (`apps/price-feed/src/cli.ts`, `apps/tui/src/spine.ts`,
+ * `apps/web/src/push/{gap-report,backfill}.ts`), because the harness fakes all four by
+ * construction and so cannot change its verdict when they change; and
+ * `apps/price-feed/src/schedule-window.test.ts`, which asserts the wrapper's TEXT, has no
+ * bearing on its RUNTIME, and already runs unconditionally on every `pnpm test`.
+ */
+export const TRIGGER_PATH_SET: readonly string[] = [
+  "ops/price-feed/**",
+  "apps/price-feed/src/wrapper-harness/**",
+  "packages/event-store/src/heartbeat.ts",
+];
+
+/** `NUMISMA_WRAPPER_TEST`. `auto` lets the trigger decide; the other two overrule it. */
+export type WrapperTestOverride = "auto" | "always" | "never";
+
+/**
+ * The comparison point for "has the subject changed?", or the reason there isn't one.
+ * Unresolved is not an error — it is an input, and it arms the suite.
+ */
+export type BaseResolution =
+  | { readonly kind: "resolved"; readonly sha: string }
+  | { readonly kind: "unresolved"; readonly why: string };
+
+export interface ArmingInput {
+  readonly changedPaths: readonly string[];
+  readonly base: BaseResolution;
+  readonly pathSet: readonly string[];
+  readonly platform: string;
+  readonly override: WrapperTestOverride;
+}
+
+export interface ArmingDecision {
+  readonly run: boolean;
+  /** Which gate decided. Lets a test assert the ORDER, not merely the outcome. */
+  readonly gate: "platform" | "override" | "base" | "changes";
+  /** The one line printed on every `pnpm test`, armed or not. Never empty. */
+  readonly reason: string;
+  /** The in-set paths that armed it, for the report line. */
+  readonly matched: readonly string[];
+}
+
+/**
+ * Does one changed path fall in the set? Two forms only, both exact about what they mean:
+ * a trailing `/**` matches everything beneath that directory, anything else is an exact
+ * file path. Nothing fuzzy — a fuzzy matcher would make the typo'd-glob failure this
+ * module is built around HARDER to detect, not easier.
+ */
+export function matchesPathSet(path: string, pathSet: readonly string[]): boolean {
+  return pathSet.some((glob) => {
+    if (glob.endsWith("/**")) {
+      return path.startsWith(`${glob.slice(0, -2)}`);
+    }
+    return path === glob;
+  });
+}
+
+/**
+ * The pure decision. **An empty path set is a hard error, not a skip** — an empty set is
+ * definitionally a trigger that can never fire, which is precisely the silent failure
+ * this module is built to make impossible. Refusing loudly is the only honest answer.
+ */
+export function decideArming(input: ArmingInput): ArmingDecision {
+  if (input.pathSet.length === 0) {
+    throw new Error(
+      "wrapper harness: the trigger path set is EMPTY — a trigger that can never fire is " +
+        "indistinguishable from a healthy skip, so this is a hard error rather than a skip.",
+    );
+  }
+
+  // PLATFORM FIRST. Before the override and before the base, unconditionally: this suite
+  // targets macOS bash 3.2, BSD ps/pgrep and a watchdog hand-rolled because macOS ships
+  // no timeout(1). Nothing downstream can make it work elsewhere, so nothing downstream
+  // gets a vote. `pnpm test:wrapper` and `NUMISMA_WRAPPER_TEST=always` bypass the
+  // trigger; neither bypasses this.
+  if (input.platform !== HARNESS_PLATFORM) {
+    return {
+      run: false,
+      gate: "platform",
+      reason: `harness skipped: platform is ${input.platform}, this suite is darwin-only`,
+      matched: [],
+    };
+  }
+
+  if (input.override === "never") {
+    return {
+      run: false,
+      gate: "override",
+      // A mute button on this channel must announce itself.
+      reason: "harness skipped: NUMISMA_WRAPPER_TEST=never (explicitly disabled)",
+      matched: [],
+    };
+  }
+
+  if (input.override === "always") {
+    return {
+      run: true,
+      gate: "override",
+      reason: "harness armed: NUMISMA_WRAPPER_TEST=always (trigger bypassed, platform gate not)",
+      matched: [],
+    };
+  }
+
+  if (input.base.kind === "unresolved") {
+    // FAIL TOWARD RUNNING, and say why. A slow test run is the whole cost; silence is not.
+    return {
+      run: true,
+      gate: "base",
+      reason: `harness armed: base could not be resolved (${input.base.why}) — failing toward running`,
+      matched: [],
+    };
+  }
+
+  const matched = input.changedPaths.filter((path) => matchesPathSet(path, input.pathSet));
+  if (matched.length === 0) {
+    return {
+      run: false,
+      gate: "changes",
+      // The base SHA and the path set are both in the message on purpose: a skip that
+      // does not say what it compared against cannot be distinguished from a broken glob.
+      reason: `harness skipped: no changes under ${input.pathSet.join(", ")} since ${input.base.sha}`,
+      matched: [],
+    };
+  }
+  return {
+    run: true,
+    gate: "changes",
+    reason:
+      `harness armed: ${matched.length} changed path(s) under ${input.pathSet.join(", ")} ` +
+      `since ${input.base.sha} (e.g. ${matched[0]})`,
+    matched,
+  };
+}
+
+/** Reads `NUMISMA_WRAPPER_TEST`, refusing a value it does not recognise rather than guessing. */
+export function readOverride(raw: string | undefined): WrapperTestOverride {
+  if (raw === undefined || raw === "" || raw === "auto") {
+    return "auto";
+  }
+  if (raw === "always" || raw === "never") {
+    return raw;
+  }
+  throw new Error(
+    `wrapper harness: NUMISMA_WRAPPER_TEST=${raw} is not one of auto | always | never. ` +
+      "Refused rather than defaulted: silently reading an unknown value as `auto` would " +
+      "make a typo'd `nver` look like a working mute button.",
+  );
+}
+
+function git(repoRoot: string, args: readonly string[]): string {
+  return execFileSync("git", ["-C", repoRoot, ...args], {
+    encoding: "utf8",
+    stdio: ["ignore", "pipe", "pipe"],
+  }).trim();
+}
+
+/**
+ * Parse `git status --porcelain` into paths. Renames report `R  old -> new`; the NEW path
+ * is the one that exists to be tested.
+ */
+export function parsePorcelain(porcelain: string): string[] {
+  return porcelain
+    .split("\n")
+    .filter((line) => line.length > 3)
+    .map((line) => {
+      const body = line.slice(3);
+      const arrow = body.indexOf(" -> ");
+      const path = arrow === -1 ? body : body.slice(arrow + 4);
+      return path.replace(/^"|"$/g, "");
+    });
+}
+
+/**
+ * The impure half: ask git what changed and against what.
+ *
+ * BASE = `git merge-base HEAD origin/main`, so a branch that edited the wrapper three
+ * commits back still arms — the range is `base...HEAD`, never `HEAD~1`. On the default
+ * branch itself that merge-base degenerates to HEAD, and there the base is `HEAD~1`.
+ *
+ * CHANGED SET = that diff UNIONED with `git status --porcelain`, because a wrapper edit
+ * that has not been committed yet is exactly when you most want the suite.
+ *
+ * `--untracked-files=all`, NOT THE DEFAULT. Plain porcelain collapses an untracked
+ * directory to `?? ops/`, which matches nothing in a path set made of file paths — so a
+ * brand-new wrapper, or a whole new harness directory, would not arm the suite it is the
+ * whole reason to arm.
+ *
+ * Every failure path returns an UNRESOLVED base rather than throwing: unresolved arms.
+ */
+export function resolveTriggerFacts(repoRoot: string): {
+  base: BaseResolution;
+  changedPaths: string[];
+} {
+  const dirty: string[] = [];
+  try {
+    dirty.push(...parsePorcelain(git(repoRoot, ["status", "--porcelain", "--untracked-files=all"])));
+  } catch {
+    return { base: { kind: "unresolved", why: "git is unavailable or this is not a repo" }, changedPaths: [] };
+  }
+
+  let base: BaseResolution;
+  try {
+    if (git(repoRoot, ["rev-parse", "--is-shallow-repository"]) === "true") {
+      // A shallow clone can resolve a merge-base that is wrong for this purpose, which is
+      // worse than resolving none. This is the configuration CI actually presents.
+      return { base: { kind: "unresolved", why: "shallow clone" }, changedPaths: dirty };
+    }
+    const head = git(repoRoot, ["rev-parse", "HEAD"]);
+    git(repoRoot, ["rev-parse", "--verify", "refs/remotes/origin/main"]);
+    const mergeBase = git(repoRoot, ["merge-base", "HEAD", "refs/remotes/origin/main"]);
+    base = {
+      kind: "resolved",
+      sha: mergeBase === head ? git(repoRoot, ["rev-parse", "HEAD~1"]) : mergeBase,
+    };
+  } catch {
+    return {
+      base: { kind: "unresolved", why: "no origin/main, no parent commit, or a detached/empty HEAD" },
+      changedPaths: dirty,
+    };
+  }
+
+  let committed: string[] = [];
+  try {
+    committed = git(repoRoot, ["diff", "--name-only", `${base.sha}...HEAD`])
+      .split("\n")
+      .filter((line) => line.length > 0);
+  } catch {
+    return { base: { kind: "unresolved", why: "the base...HEAD range could not be diffed" }, changedPaths: dirty };
+  }
+
+  return { base, changedPaths: [...new Set([...committed, ...dirty])] };
+}

--- a/apps/price-feed/src/wrapper-harness/case-dir.testkit.ts
+++ b/apps/price-feed/src/wrapper-harness/case-dir.testkit.ts
@@ -27,6 +27,7 @@ import { mkdirSync, mkdtempSync, readFileSync, writeFileSync, chmodSync } from "
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { installFakeBin } from "./fake-bin.testkit.js";
+import { markEnv, type MarkConfig } from "./mark-window.testkit.js";
 
 /** The bare, non-login PATH launchd actually hands the job. */
 export const LAUNCHD_BARE_PATH = "/usr/bin:/bin:/usr/sbin:/sbin";
@@ -46,6 +47,14 @@ export interface CaseOptions {
   readonly maxRunSeconds: number;
   /** How long the watchdog waits after SIGTERM before escalating, in seconds. */
   readonly watchdogGraceSeconds: number;
+  /**
+   * WHICH SIDE OF THE MARK WINDOW THIS CASE'S RUN FALLS ON (#315, #319). Carried on the
+   * options rather than defaulted anywhere, because a default is how `markWindow` goes
+   * back to being a function of what time the suite happened to start — see
+   * `mark-window.testkit.ts`. Every case states its side, and the SAME value feeds the
+   * environment below and the oracle that judges the result.
+   */
+  readonly mark: MarkConfig;
 }
 
 /**
@@ -113,12 +122,19 @@ export function makeCaseDir(options: CaseOptions): CaseDirs {
 }
 
 /**
- * The seven overrides, and nothing that could reach outside the case dir.
+ * The nine overrides, and nothing that could reach outside the case dir.
  *
  * `NUMISMA_PATH_PREPEND` is the case's fake bin AND NOTHING ELSE. Adding a real directory
  * to this list — even a plausible-looking one — is how this suite becomes a live run
  * against real, private data. The isolation contract refuses it; this is where it would
  * be tempting.
+ *
+ * THE TWO MARK OVERRIDES ARE ALWAYS SET, INCLUDING FOR THE CASES THAT DO NOT CARE. They
+ * carry no real-data risk — neither is path-valued and neither selects data — but leaving
+ * them unset lets the wrapper fall back to the contract zone, and a case that meant to be
+ * in-window is then in-window only between 18:00 and 23:59 CDMX. That is the vacuity #319
+ * exists to kill, so the isolation contract refuses them unset like the other seven and
+ * every case states its side.
  */
 export function caseEnv(dirs: CaseDirs, options: CaseOptions): NodeJS.ProcessEnv {
   return {
@@ -139,6 +155,7 @@ export function caseEnv(dirs: CaseDirs, options: CaseOptions): NodeJS.ProcessEnv
     NUMISMA_DATA_DIR: dirs.dataDir,
     NUMISMA_PRICEFEED_MAX_RUN_SECONDS: String(options.maxRunSeconds),
     NUMISMA_PRICEFEED_WATCHDOG_GRACE_SECONDS: String(options.watchdogGraceSeconds),
+    ...markEnv(options.mark),
   };
 }
 

--- a/apps/price-feed/src/wrapper-harness/case-dir.testkit.ts
+++ b/apps/price-feed/src/wrapper-harness/case-dir.testkit.ts
@@ -1,0 +1,195 @@
+/**
+ * THE CASE DIRECTORY — where a single wrapper run is allowed to have effects, and the
+ * only place it is allowed to have them.
+ *
+ * Every one of the seven `NUMISMA_*` overrides points inside here, and the launcher's
+ * isolation contract (S2) refuses to start otherwise. A fresh directory per RUN, not per
+ * case: the 12 repetitions of a case must not be able to pass by leaning on each other's
+ * leftovers, and a heartbeat carried forward from run 3 into run 4 would make run 4's
+ * assertion about a carried field meaningless.
+ *
+ * ── THE INHERITED `PATH` IS THE LAUNCHD PATH, ON PURPOSE ──────────────────────────────
+ * `/usr/bin:/bin:/usr/sbin:/sbin` — exactly the bare, non-login `PATH` launchd hands the
+ * job, and the reason the wrapper prepends anything at all. It is also a second,
+ * independent safety layer under the sentinel: the real pnpm lives in neither the
+ * inherited `PATH` nor the prepend, so even a harness bug that lost the fake could not
+ * reach it. The fake arrives ONLY through `NUMISMA_PATH_PREPEND`.
+ *
+ * ── `HOME` IS INSIDE THE CASE DIR TOO ─────────────────────────────────────────────────
+ * Not because the wrapper reads it — all seven of its `$HOME`-derived defaults are
+ * overridden — but because `git` does. A real `~/.gitconfig` could bring hooks, signing,
+ * or a `core.excludesFile` into a run whose whole purpose is to be uninfluenced by this
+ * machine.
+ */
+
+import { execFileSync } from "node:child_process";
+import { mkdirSync, mkdtempSync, readFileSync, writeFileSync, chmodSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { installFakeBin } from "./fake-bin.testkit.js";
+
+/** The bare, non-login PATH launchd actually hands the job. */
+export const LAUNCHD_BARE_PATH = "/usr/bin:/bin:/usr/sbin:/sbin";
+
+export interface CaseDirs {
+  readonly caseDir: string;
+  readonly binDir: string;
+  readonly repoDir: string;
+  readonly dataDir: string;
+  readonly logDir: string;
+  readonly envFile: string;
+  readonly sentinelDir: string;
+}
+
+export interface CaseOptions {
+  /** The wrapper's wall-clock ceiling for this case, in seconds. */
+  readonly maxRunSeconds: number;
+  /** How long the watchdog waits after SIGTERM before escalating, in seconds. */
+  readonly watchdogGraceSeconds: number;
+}
+
+/**
+ * Build one run's directory. The data dir is a real (empty, isolated) git repo, because
+ * the wrapper's step 3 and step 4 both branch on `git -C "$DATA_DIR" rev-parse --git-dir`
+ * and a non-repo would take the "not inside a git repo — skipping commit" branch on every
+ * run, leaving the healthy case's most consequential steps unexercised. It holds nothing
+ * but its own `.git`, so the commit is the idempotent no-op the wrapper documents.
+ */
+export function makeCaseDir(options: CaseOptions): CaseDirs {
+  const caseDir = mkdtempSync(join(tmpdir(), "numisma-wrapper-case-"));
+  const binDir = installFakeBin(caseDir);
+  const repoDir = join(caseDir, "repo");
+  const dataDir = join(caseDir, "data");
+  const logDir = join(caseDir, "logs");
+  const homeDir = join(caseDir, "home");
+  const envDir = join(caseDir, "env");
+  for (const dir of [repoDir, dataDir, logDir, homeDir, envDir]) {
+    mkdirSync(dir, { recursive: true });
+  }
+
+  // AUTHORED, and deliberately holding nothing that resembles a credential. The wrapper
+  // sources this file if it exists, and that `source` is a code path worth exercising —
+  // the real file is chmod-600 and outside the repo, and nothing about it is reproduced
+  // here beyond the fact that it is a shell file that can be sourced.
+  const envFile = join(envDir, "price-feed.env");
+  writeFileSync(
+    envFile,
+    "# Authored fixture for the wrapper harness. No real credential is, or may be, here.\n" +
+      "NUMISMA_HARNESS_ENV_FILE_WAS_SOURCED=yes\n",
+    "utf8",
+  );
+  chmodSync(envFile, 0o600);
+
+  // AND IT HAS A COMMIT IN IT. Not decoration: the wrapper's step 3 runs
+  // `git add -u -- .`, and in a repo with no tracked file at all git refuses that
+  // pathspec and exits 128 — so a virgin `git init` would fail the healthy case at
+  // `commit` for a reason that has nothing to do with the wrapper and cannot happen to
+  // the real durable log, which has years of history. The tracked file is an EMPTY
+  // `events.jsonl`: it is the name the wrapper's own explicit-add loop and its strict
+  // post-check both reach for, and being empty it reproduces no real trade data in
+  // content or in shape.
+  const gitEnv = {
+    PATH: LAUNCHD_BARE_PATH,
+    HOME: homeDir,
+    GIT_CONFIG_GLOBAL: "/dev/null",
+    GIT_CONFIG_SYSTEM: "/dev/null",
+    GIT_AUTHOR_NAME: "numisma wrapper harness",
+    GIT_AUTHOR_EMAIL: "harness@invalid",
+    GIT_COMMITTER_NAME: "numisma wrapper harness",
+    GIT_COMMITTER_EMAIL: "harness@invalid",
+  };
+  const git = (...args: string[]): void => {
+    execFileSync("git", ["-C", dataDir, ...args], { stdio: ["ignore", "ignore", "pipe"], env: gitEnv });
+  };
+  execFileSync("git", ["init", "--quiet", "--initial-branch", "main", dataDir], {
+    stdio: ["ignore", "ignore", "pipe"],
+    env: gitEnv,
+  });
+  writeFileSync(join(dataDir, "events.jsonl"), "", "utf8");
+  git("add", "--", "events.jsonl");
+  git("commit", "--quiet", "-m", "authored fixture: an empty durable log");
+
+  return { caseDir, binDir, repoDir, dataDir, logDir, envFile, sentinelDir: join(caseDir, "sentinels") };
+}
+
+/**
+ * The seven overrides, and nothing that could reach outside the case dir.
+ *
+ * `NUMISMA_PATH_PREPEND` is the case's fake bin AND NOTHING ELSE. Adding a real directory
+ * to this list — even a plausible-looking one — is how this suite becomes a live run
+ * against real, private data. The isolation contract refuses it; this is where it would
+ * be tempting.
+ */
+export function caseEnv(dirs: CaseDirs, options: CaseOptions): NodeJS.ProcessEnv {
+  return {
+    PATH: LAUNCHD_BARE_PATH,
+    HOME: join(dirs.caseDir, "home"),
+    // Keep this machine's git identity and hooks out of a run that must depend on nothing
+    // but its own directory.
+    GIT_CONFIG_GLOBAL: "/dev/null",
+    GIT_CONFIG_SYSTEM: "/dev/null",
+    GIT_AUTHOR_NAME: "numisma wrapper harness",
+    GIT_AUTHOR_EMAIL: "harness@invalid",
+    GIT_COMMITTER_NAME: "numisma wrapper harness",
+    GIT_COMMITTER_EMAIL: "harness@invalid",
+    NUMISMA_REPO_DIR: dirs.repoDir,
+    NUMISMA_PRICEFEED_ENV: dirs.envFile,
+    NUMISMA_PRICEFEED_LOG_DIR: dirs.logDir,
+    NUMISMA_PATH_PREPEND: dirs.binDir,
+    NUMISMA_DATA_DIR: dirs.dataDir,
+    NUMISMA_PRICEFEED_MAX_RUN_SECONDS: String(options.maxRunSeconds),
+    NUMISMA_PRICEFEED_WATCHDOG_GRACE_SECONDS: String(options.watchdogGraceSeconds),
+  };
+}
+
+/**
+ * S6 · A MUTATION CONTROL — a guard nobody has seen fail is a guard nobody should trust.
+ *
+ * Copies the wrapper into the case dir and applies one named textual change there. **The
+ * committed wrapper is never touched**, and the mutated copy never leaves the temp dir.
+ *
+ * IT FAILS LOUDLY IF THE ANCHOR IS GONE. A mutation whose anchor text has rotted away
+ * would silently apply nothing, the case would pass, and the report would read "the guard
+ * was seen red" about a run that mutated nothing at all. Throwing is the same fail-closed
+ * doctrine `parseIntervals()` in `schedule-window.test.ts` already applies when it throws
+ * rather than returning an empty array.
+ */
+export function mutateWrapper(
+  wrapperPath: string,
+  caseDir: string,
+  mutation: { readonly name: string; readonly anchor: string; readonly replacement: string },
+): string {
+  const source = readFileSync(wrapperPath, "utf8");
+  const occurrences = source.split(mutation.anchor).length - 1;
+  if (occurrences !== 1) {
+    throw new Error(
+      `wrapper harness: the mutation "${mutation.name}" found its anchor ${occurrences} times in ` +
+        `${wrapperPath}, expected exactly 1. The anchor has rotted, so this guard has stopped ` +
+        "guarding — that must break the build, not pass quietly.\n" +
+        `anchor: ${mutation.anchor}`,
+    );
+  }
+  const mutatedPath = join(caseDir, "mutated-run-daily-fetch.sh");
+  writeFileSync(mutatedPath, source.replace(mutation.anchor, mutation.replacement), "utf8");
+  chmodSync(mutatedPath, 0o755);
+  return mutatedPath;
+}
+
+/**
+ * THE CHILD-REAP MUTATION — it inverts assertion 3, which is what slice 1 is really
+ * claiming.
+ *
+ * The wrapper cancels its watchdog by SIGKILLing the subshell AND the `sleep` the subshell
+ * forked, because killing the subshell alone leaves the timer orphaned into the run's
+ * process group — where it holds launchd's per-label job slot and keeps the log `tee`
+ * alive on the inherited pipe. That was observed for real: a HEALTHY run reported
+ * "complete" and then sat there with a stray `sleep`, a live `tee` and a held job slot.
+ *
+ * Drop the child kill and a healthy run leaves a stray `sleep` behind — so a suite that
+ * has lost assertion 3 goes green here, and this control is what notices.
+ */
+export const CHILD_REAP_MUTATION = {
+  name: "drop the watchdog child kill from write_heartbeat",
+  anchor: '[[ -n "$WATCHDOG_KIDS" ]] && kill -KILL $WATCHDOG_KIDS 2>/dev/null',
+  replacement: ': "mutation: the watchdog child kill was removed"',
+} as const;

--- a/apps/price-feed/src/wrapper-harness/case-dir.testkit.ts
+++ b/apps/price-feed/src/wrapper-harness/case-dir.testkit.ts
@@ -2,7 +2,7 @@
  * THE CASE DIRECTORY — where a single wrapper run is allowed to have effects, and the
  * only place it is allowed to have them.
  *
- * Every one of the seven `NUMISMA_*` overrides points inside here, and the launcher's
+ * Every one of the nine `NUMISMA_*` overrides points inside here, and the launcher's
  * isolation contract (S2) refuses to start otherwise. A fresh directory per RUN, not per
  * case: the 12 repetitions of a case must not be able to pass by leaning on each other's
  * leftovers, and a heartbeat carried forward from run 3 into run 4 would make run 4's
@@ -16,8 +16,10 @@
  * reach it. The fake arrives ONLY through `NUMISMA_PATH_PREPEND`.
  *
  * ── `HOME` IS INSIDE THE CASE DIR TOO ─────────────────────────────────────────────────
- * Not because the wrapper reads it — all seven of its `$HOME`-derived defaults are
- * overridden — but because `git` does. A real `~/.gitconfig` could bring hooks, signing,
+ * Not because the wrapper reads it — all four of its `$HOME`-derived defaults are
+ * overridden (`ENV_FILE`, `LOG_DIR`, `PATH_PREPEND`, `DATA_DIR`; `REPO_DIR` defaults to
+ * the `__REPO_DIR__` placeholder and the remaining four name no path at all) — but
+ * because `git` does. A real `~/.gitconfig` could bring hooks, signing,
  * or a `core.excludesFile` into a run whose whole purpose is to be uninfluenced by this
  * machine.
  */

--- a/apps/price-feed/src/wrapper-harness/case-dir.testkit.ts
+++ b/apps/price-feed/src/wrapper-harness/case-dir.testkit.ts
@@ -193,3 +193,29 @@ export const CHILD_REAP_MUTATION = {
   anchor: '[[ -n "$WATCHDOG_KIDS" ]] && kill -KILL $WATCHDOG_KIDS 2>/dev/null',
   replacement: ': "mutation: the watchdog child kill was removed"',
 } as const;
+
+/**
+ * THE `tee`-DEAFNESS MUTATION — it inverts assertion 2, which is what slice 2 is really
+ * claiming.
+ *
+ * The logging `tee` runs inside a process substitution that ignores TERM and PIPE. Without
+ * that trap the `tee` is an ordinary member of the run's process group, so the watchdog's
+ * group-TERM kills it FIRST and the shell is left writing into a dead pipe while it tries
+ * to run its EXIT trap. Measured during development at THREE RUNS IN FIVE: the shell died
+ * of SIGPIPE partway through `exit`, before the trap body was even entered, and the
+ * heartbeat — the one breadcrumb the entire watchdog exists to leave — was lost.
+ *
+ * THAT IT IS RACY IS THE REASON THIS CONTROL EXISTS AT ALL. A single lucky green run had
+ * already pronounced this fixed once. The control therefore repeats until it observes a
+ * loss, and a suite that has quietly stopped asserting the heartbeat on the timeout path
+ * cannot pass it.
+ *
+ * Note what is NOT mutated: the TERM handler's own `trap '' PIPE` stays. It is the second
+ * half of a two-part fix and was measurably not enough on its own, which is precisely what
+ * this mutation reproduces.
+ */
+export const TEE_DEAFNESS_MUTATION = {
+  name: "drop `trap '' TERM PIPE` from the logging process substitution",
+  anchor: "exec > >(trap '' TERM PIPE; tee -a \"$LOG_FILE\") 2>&1",
+  replacement: 'exec > >(tee -a "$LOG_FILE") 2>&1',
+} as const;

--- a/apps/price-feed/src/wrapper-harness/fake-bin.testkit.ts
+++ b/apps/price-feed/src/wrapper-harness/fake-bin.testkit.ts
@@ -7,9 +7,11 @@
  *
  * ONE FAKE `pnpm` THAT DISPATCHES ON ITS FIRST ARGUMENT, not four unrelated scripts. The
  * wrapper calls `pnpm` four times with distinct first arguments — `prices:fetch`,
- * `spine`, `gap-report -- --write`, `backfill` — and a later slice needs a run that
- * succeeds through `spine` and then hangs at `backfill` specifically. A single-behavior
- * fake cannot express that; a per-command behavior table can.
+ * `spine`, `gap-report -- --write`, `backfill` — and case 6 needs a run that succeeds
+ * through `spine` and then hangs at `backfill` specifically, which is what makes it a
+ * CRY-WOLF case: the day's marks are in the log and the run wedged afterwards. A
+ * single-behavior fake cannot express that; a per-command behavior table can, and case 6
+ * asserts the dispatch record ({@link dispatchRecordNameFor}) rather than trusting it.
  *
  * INSTALLED THROUGH `NUMISMA_PATH_PREPEND`, NEVER ON THE INHERITED `PATH`. This is the
  * single most dangerous mistake available in this increment. The wrapper re-exports
@@ -96,6 +98,20 @@ export function sentinelNameFor(command: string): string {
   return `pnpm-${command.replace(/[^A-Za-z0-9._-]/g, "-")}`;
 }
 
+/**
+ * The file recording WHICH BEHAVIOR the fake's per-first-argument dispatch selected for
+ * one sub-command. It is what lets case 6 prove its hang originated in that dispatch —
+ * `succeeds` for the three steps before it, `hangs` for `backfill` — rather than in a
+ * single-behavior fake that could not have expressed "hangs at backfill specifically" at
+ * all.
+ */
+export function dispatchRecordNameFor(command: string): string {
+  return `behavior-${command.replace(/[^A-Za-z0-9._-]/g, "-")}`;
+}
+
+/** The file every invocation appends one line to, in the order the wrapper made them. */
+export const INVOCATION_LOG_NAME = "pnpm-invocations.log";
+
 function behaviorKeyFor(command: string): string {
   return command.replace(/[^A-Za-z0-9._-]/g, "-");
 }
@@ -129,6 +145,14 @@ BEHAVIOR="succeeds"
 if [[ -f "\${CASE_DIR}/behavior/\${KEY}" ]]; then
   BEHAVIOR="$(cat "\${CASE_DIR}/behavior/\${KEY}")"
 fi
+
+# WHICH BRANCH THIS INVOCATION TOOK, RECORDED IN A FILE rather than only announced on
+# stdout. A case that must prove a LATER step hung — case 6 hangs at \`backfill\` after
+# succeeding through \`spine\` — needs evidence that the divergence came from THIS
+# dispatch on the first argument, and stdout cannot carry it: a hanging fake is killed
+# by the watchdog's group TERM with whatever bash had buffered still unwritten. A
+# redirect that closes with the \`printf\` is on disk before the hang begins.
+printf '%s\\n' "\${BEHAVIOR}" > "\${CASE_DIR}/sentinels/behavior-\${KEY}"
 
 # BLOCK UNTIL RELEASED, IN ONE-SECOND HOPS. No case that wants a timeout ever writes the
 # release file, so for those this is a hang with no end but the watchdog's. Short hops keep

--- a/apps/price-feed/src/wrapper-harness/fake-bin.testkit.ts
+++ b/apps/price-feed/src/wrapper-harness/fake-bin.testkit.ts
@@ -1,0 +1,171 @@
+/**
+ * S3 · THE FAKE-TOOL BIN — the fixture module of the wrapper harness (PRD #314 §4).
+ *
+ * EVERY BYTE HERE IS AUTHORED for this purpose. Nothing is captured from a real run, in
+ * content or in shape — the repo's transaction data is private and lives in a gitignored
+ * sibling repo, and the line is authorship, not resemblance.
+ *
+ * ONE FAKE `pnpm` THAT DISPATCHES ON ITS FIRST ARGUMENT, not four unrelated scripts. The
+ * wrapper calls `pnpm` four times with distinct first arguments — `prices:fetch`,
+ * `spine`, `gap-report -- --write`, `backfill` — and a later slice needs a run that
+ * succeeds through `spine` and then hangs at `backfill` specifically. A single-behavior
+ * fake cannot express that; a per-command behavior table can.
+ *
+ * INSTALLED THROUGH `NUMISMA_PATH_PREPEND`, NEVER ON THE INHERITED `PATH`. This is the
+ * single most dangerous mistake available in this increment. The wrapper re-exports
+ * `PATH="$PATH_PREPEND:$PATH"` in its own body, and the documented default prepend holds
+ * the directories where the REAL pnpm and node live — so a fake installed early on the
+ * inherited `PATH` is overridden BY THE SCRIPT ITSELF, and the run executes a real
+ * `prices:fetch`, a real `spine` append, a real `git commit` against the durable event
+ * log and a real `backfill` against the hosted database. **That failure does not go red.
+ * It passes green while running the real pipeline against real, private data.**
+ *
+ * THE SENTINEL IS THE GUARD AGAINST EXACTLY THAT, and it is not optional (§6). Every fake
+ * writes a sentinel into the case dir when it is invoked and every case asserts the
+ * sentinels exist, so a `NUMISMA_PATH_PREPEND` mistake becomes a RED TEST rather than a
+ * real run that happens to pass.
+ *
+ * THE BEHAVIOR TABLE FAILS CLOSED. A behavior name this fake does not implement exits 99
+ * with a message rather than falling through to `succeeds` — otherwise a later slice
+ * could ask for `hangs`, silently get a success, and ship a timeout case that never times
+ * out. Slice 1 implements `succeeds`; slices 2-4 add entries here.
+ */
+
+import { chmodSync, mkdirSync, writeFileSync } from "node:fs";
+import { join } from "node:path";
+
+/** Behaviors the fake implements. Slice 1 ships one; the dispatch is what is being built. */
+export type FakeBehavior = "succeeds";
+
+/** The four first-arguments the wrapper invokes `pnpm` with, in the order it invokes them. */
+export const WRAPPER_PNPM_COMMANDS = ["prices:fetch", "spine", "gap-report", "backfill"] as const;
+
+/**
+ * The sentinel filename a given `pnpm` sub-command writes. Mirrors the `tr` in the fake
+ * itself: anything outside `[A-Za-z0-9._-]` becomes `-`, so `prices:fetch` lands as
+ * `pnpm-prices-fetch`.
+ */
+export function sentinelNameFor(command: string): string {
+  return `pnpm-${command.replace(/[^A-Za-z0-9._-]/g, "-")}`;
+}
+
+function behaviorKeyFor(command: string): string {
+  return command.replace(/[^A-Za-z0-9._-]/g, "-");
+}
+
+/**
+ * The authored fake `pnpm`. The case dir is BAKED IN rather than read from the
+ * environment: the sentinel is the harness's proof that this script — and not the real
+ * pnpm — was what ran, so it must not depend on an environment variable the subject under
+ * test is free to rewrite. The wrapper rewrites `PATH` and sources a token file; a
+ * sentinel that could be redirected by either would be proving the wrong thing.
+ */
+function fakePnpmSource(caseDir: string): string {
+  return `#!/bin/bash
+# AUTHORED fake \`pnpm\` for the wrapper test harness. Not captured from any real run.
+# It exists so a case can drive ops/price-feed/run-daily-fetch.sh end to end without a
+# real fetch, a real spine append, a real commit against the durable log, or a real
+# backfill against the hosted database.
+set -u
+
+CASE_DIR="${caseDir}"
+COMMAND="\${1:-}"
+KEY="$(printf '%s' "\${COMMAND}" | tr -c 'A-Za-z0-9._-' '-')"
+
+# THE SENTINEL, written FIRST and unconditionally: it is the harness's only proof that
+# the fake — and not the real pnpm — is what the wrapper's own re-exported PATH selected.
+mkdir -p "\${CASE_DIR}/sentinels" 2>/dev/null || true
+: > "\${CASE_DIR}/sentinels/pnpm-\${KEY}"
+printf 'pnpm %s\\n' "$*" >> "\${CASE_DIR}/sentinels/pnpm-invocations.log"
+
+BEHAVIOR="succeeds"
+if [[ -f "\${CASE_DIR}/behavior/\${KEY}" ]]; then
+  BEHAVIOR="$(cat "\${CASE_DIR}/behavior/\${KEY}")"
+fi
+
+case "\${BEHAVIOR}" in
+  succeeds)
+    printf 'fake pnpm: %s succeeded (authored fixture)\\n' "\${COMMAND}"
+    exit 0
+    ;;
+  *)
+    # FAIL CLOSED. An unimplemented behavior must not degrade into a success, or a
+    # timeout case would ship green while never timing out.
+    printf 'fake pnpm: UNIMPLEMENTED behavior %s requested for %s\\n' "\${BEHAVIOR}" "\${COMMAND}" >&2
+    exit 99
+    ;;
+esac
+`;
+}
+
+/**
+ * The authored fake `node`. The wrapper never EXECUTES node — it only asserts
+ * `command -v node` resolves, because with asdf-managed node a resolvable pnpm whose node
+ * is invisible dies as a bare exit 127 mid-run. So this exists to be FOUND. If it is ever
+ * actually run, something has changed in the wrapper and the harness should say so loudly
+ * rather than pretend to be a node.
+ */
+function fakeNodeSource(caseDir: string): string {
+  return `#!/bin/bash
+# AUTHORED fake \`node\` for the wrapper test harness. It exists to be FOUND by the
+# wrapper's \`command -v node\` check, not to be run.
+set -u
+CASE_DIR="${caseDir}"
+mkdir -p "\${CASE_DIR}/sentinels" 2>/dev/null || true
+: > "\${CASE_DIR}/sentinels/node-executed"
+printf 'fake node: EXECUTED, which the harness does not expect — the fakes stand in for pnpm, not for node\\n' >&2
+exit 97
+`;
+}
+
+/**
+ * A DECOY `pnpm`, used by the one assertion that proves the fake actually won.
+ *
+ * It stands in for what the wrapper's real default `NUMISMA_PATH_PREPEND` holds: a
+ * directory that shadows the inherited `PATH`. The assertion installs the case's fake on
+ * the INHERITED `PATH` and this decoy on the PREPEND, then resolves `pnpm` exactly as the
+ * wrapper's own `export PATH="$PATH_PREPEND:$PATH"` would — and gets the decoy. In the
+ * real world the decoy is the real pnpm and the run is a live one.
+ *
+ * It refuses to do anything if executed. Nothing should ever execute it.
+ */
+function decoyPnpmSource(): string {
+  return `#!/bin/bash
+# AUTHORED decoy standing in for the REAL pnpm that the wrapper's default
+# NUMISMA_PATH_PREPEND would resolve. It must never be executed by anything.
+printf 'decoy pnpm: executed — the harness resolved the WRONG pnpm\\n' >&2
+exit 98
+`;
+}
+
+function writeExecutable(path: string, source: string): void {
+  writeFileSync(path, source, "utf8");
+  chmodSync(path, 0o755);
+}
+
+/**
+ * Materialise the fake bin for a case. Returns the directory that becomes
+ * `NUMISMA_PATH_PREPEND` — and it is the ONLY way the fakes reach the wrapper.
+ */
+export function installFakeBin(caseDir: string): string {
+  const binDir = join(caseDir, "bin");
+  mkdirSync(binDir, { recursive: true });
+  mkdirSync(join(caseDir, "sentinels"), { recursive: true });
+  mkdirSync(join(caseDir, "behavior"), { recursive: true });
+  writeExecutable(join(binDir, "pnpm"), fakePnpmSource(caseDir));
+  writeExecutable(join(binDir, "node"), fakeNodeSource(caseDir));
+  return binDir;
+}
+
+/** Materialise the decoy bin. Never on a launch path — only the fake-won assertion uses it. */
+export function installDecoyBin(caseDir: string): string {
+  const decoyDir = join(caseDir, "decoy");
+  mkdirSync(decoyDir, { recursive: true });
+  writeExecutable(join(decoyDir, "pnpm"), decoyPnpmSource());
+  return decoyDir;
+}
+
+/** Set the behavior for one `pnpm` sub-command. Absent an entry, the fake succeeds. */
+export function setFakeBehavior(caseDir: string, command: string, behavior: FakeBehavior): void {
+  writeFileSync(join(caseDir, "behavior", behaviorKeyFor(command)), behavior, "utf8");
+}

--- a/apps/price-feed/src/wrapper-harness/fake-bin.testkit.ts
+++ b/apps/price-feed/src/wrapper-harness/fake-bin.testkit.ts
@@ -28,14 +28,61 @@
  * THE BEHAVIOR TABLE FAILS CLOSED. A behavior name this fake does not implement exits 99
  * with a message rather than falling through to `succeeds` — otherwise a later slice
  * could ask for `hangs`, silently get a success, and ship a timeout case that never times
- * out. Slice 1 implements `succeeds`; slices 2-4 add entries here.
+ * out. Slice 1 implemented `succeeds`; slice 2 adds the timeout family.
+ *
+ * ── A HANG IS "FOREVER" UNLESS THE HARNESS RELEASES IT (slice 2) ──────────────────────
+ * The hanging behaviors block until a release file appears in the case dir. No case that
+ * wants a timeout ever writes one, so for cases 2 and 3 this IS `hangs forever` — the
+ * watchdog is what ends those runs, exactly as the contract says.
+ *
+ * The release exists for the one case that needs a hang the watchdog will NOT end: case 7
+ * runs with the watchdog disabled, and its whole claim is that such a run does **not**
+ * time out. Proving that needs a run which is genuinely wedged past its own ceiling and
+ * grace and then finishes normally — a hang with no exit is unobservable (it would only
+ * ever hit the harness cap, which is a failure, not a proof) and a run killed from outside
+ * would be the external-stop path, which belongs to another slice entirely.
+ *
+ * ── THE HANGS WAIT IN SHORT HOPS, NEVER ONE LONG `sleep` ──────────────────────────────
+ * A bash script waiting on a foreground `sleep 99999` is only as reactive as that `sleep`,
+ * and "reactive to TERM" is precisely what case 2 is measuring. One-second hops make the
+ * distinction between the reactive child (case 2) and the TERM-deaf one (case 3) a
+ * property of the `trap`, which is what it is supposed to be, rather than of `sleep`.
  */
 
 import { chmodSync, mkdirSync, writeFileSync } from "node:fs";
 import { join } from "node:path";
 
-/** Behaviors the fake implements. Slice 1 ships one; the dispatch is what is being built. */
-export type FakeBehavior = "succeeds";
+/**
+ * Behaviors the fake implements.
+ *
+ * - `succeeds` — prints and exits 0 (slice 1).
+ * - `hangs` — blocks until released; reactive to TERM, since neither it nor its `sleep`
+ *   traps anything. Case 2's child, and case 7's.
+ * - `exits-127` — exits 127 immediately, the shape a missing `pnpm`/`node` takes. Case 5.
+ * - `ignores-term` — `trap '' TERM` plus a sleep loop: survives the watchdog's group TERM
+ *   and dies only to the SIGKILL escalation.
+ * - `hangs-with-term-deaf-grandchild` — forks a TERM-deaf child, then hangs reactively
+ *   itself. Case 3, and the exact historical shape: the grandchild outlived the group
+ *   TERM while holding the inherited write end of the log pipe, so `tee` never saw EOF
+ *   and both sat in the run's process group holding launchd's per-label job slot.
+ */
+export type FakeBehavior =
+  | "succeeds"
+  | "hangs"
+  | "exits-127"
+  | "ignores-term"
+  | "hangs-with-term-deaf-grandchild";
+
+/**
+ * The authored TERM-deaf child's filename. It is matched against `ps` output, so case 3
+ * can prove the deaf process was still in the run's process group AFTER the group TERM
+ * and gone only after the SIGKILL escalation — the difference between "reaped" and
+ * "merely orphaned", which is the whole of that case.
+ */
+export const TERM_DEAF_CHILD_NAME = "numisma-harness-term-deaf-child";
+
+/** The sentinel the TERM-deaf child writes on start, so case 3 cannot silently become case 2. */
+export const TERM_DEAF_CHILD_SENTINEL = "term-deaf-grandchild-started";
 
 /** The four first-arguments the wrapper invokes `pnpm` with, in the order it invokes them. */
 export const WRAPPER_PNPM_COMMANDS = ["prices:fetch", "spine", "gap-report", "backfill"] as const;
@@ -83,9 +130,47 @@ if [[ -f "\${CASE_DIR}/behavior/\${KEY}" ]]; then
   BEHAVIOR="$(cat "\${CASE_DIR}/behavior/\${KEY}")"
 fi
 
+# BLOCK UNTIL RELEASED, IN ONE-SECOND HOPS. No case that wants a timeout ever writes the
+# release file, so for those this is a hang with no end but the watchdog's. Short hops keep
+# reactivity to TERM a property of the trap rather than of the sleep's remaining duration.
+hang_until_released() {
+  RELEASE_FILE="\${CASE_DIR}/release/\${KEY}"
+  while [[ ! -e "\${RELEASE_FILE}" ]]; do
+    sleep 1
+  done
+  printf 'fake pnpm: %s released by the harness (authored fixture)\\n' "\${COMMAND}"
+}
+
 case "\${BEHAVIOR}" in
   succeeds)
     printf 'fake pnpm: %s succeeded (authored fixture)\\n' "\${COMMAND}"
+    exit 0
+    ;;
+  hangs)
+    printf 'fake pnpm: %s hanging (authored fixture)\\n' "\${COMMAND}"
+    hang_until_released
+    exit 0
+    ;;
+  exits-127)
+    # The shape a missing pnpm or an invisible node takes in production, and the reason
+    # the heartbeat writer is pure bash: on this path nothing node-shaped can run.
+    printf 'fake pnpm: %s exiting 127 immediately (authored fixture)\\n' "\${COMMAND}" >&2
+    exit 127
+    ;;
+  ignores-term)
+    # Deaf to the watchdog's group TERM, and its \`sleep\` is reforked every hop, so the
+    # SIGKILL escalation is the only thing that ends it.
+    trap '' TERM
+    printf 'fake pnpm: %s hanging and DEAF to TERM (authored fixture)\\n' "\${COMMAND}"
+    hang_until_released
+    exit 0
+    ;;
+  hangs-with-term-deaf-grandchild)
+    # Forked BEFORE the hang, and it inherits this process's stdout — which is the wrapper's
+    # \`tee\` pipe. That inheritance is the historical defect verbatim.
+    "\${CASE_DIR}/bin/${TERM_DEAF_CHILD_NAME}" &
+    printf 'fake pnpm: %s hanging after forking a TERM-deaf grandchild (authored fixture)\\n' "\${COMMAND}"
+    hang_until_released
     exit 0
     ;;
   *)
@@ -115,6 +200,32 @@ mkdir -p "\${CASE_DIR}/sentinels" 2>/dev/null || true
 : > "\${CASE_DIR}/sentinels/node-executed"
 printf 'fake node: EXECUTED, which the harness does not expect — the fakes stand in for pnpm, not for node\\n' >&2
 exit 97
+`;
+}
+
+/**
+ * THE AUTHORED TERM-DEAF CHILD — case 3's whole subject.
+ *
+ * `trap '' TERM` plus a sleep loop, reforking its `sleep` every hop so nothing about it is
+ * killable by TERM. It is forked by the fake `pnpm`, so it is an ordinary member of the
+ * run's process group AND it inherits the write end of the wrapper's log pipe. That pair
+ * of facts is the historical defect exactly: the group TERM left it alive, `tee` never saw
+ * EOF and stayed alive with it, and both went on holding launchd's per-label job slot after
+ * the run itself was long gone. Only the watchdog's SIGKILL escalation reaps it.
+ */
+function termDeafChildSource(caseDir: string): string {
+  return `#!/bin/bash
+# AUTHORED TERM-deaf child for the wrapper test harness. Not captured from any real run.
+# It exists to survive a SIGTERM sent to the whole process group, so the harness can prove
+# the watchdog's SIGKILL escalation actually reaps it rather than merely orphaning it.
+set -u
+trap '' TERM
+CASE_DIR="${caseDir}"
+mkdir -p "\${CASE_DIR}/sentinels" 2>/dev/null || true
+: > "\${CASE_DIR}/sentinels/${TERM_DEAF_CHILD_SENTINEL}"
+while true; do
+  sleep 1
+done
 `;
 }
 
@@ -152,8 +263,10 @@ export function installFakeBin(caseDir: string): string {
   mkdirSync(binDir, { recursive: true });
   mkdirSync(join(caseDir, "sentinels"), { recursive: true });
   mkdirSync(join(caseDir, "behavior"), { recursive: true });
+  mkdirSync(join(caseDir, "release"), { recursive: true });
   writeExecutable(join(binDir, "pnpm"), fakePnpmSource(caseDir));
   writeExecutable(join(binDir, "node"), fakeNodeSource(caseDir));
+  writeExecutable(join(binDir, TERM_DEAF_CHILD_NAME), termDeafChildSource(caseDir));
   return binDir;
 }
 
@@ -168,4 +281,17 @@ export function installDecoyBin(caseDir: string): string {
 /** Set the behavior for one `pnpm` sub-command. Absent an entry, the fake succeeds. */
 export function setFakeBehavior(caseDir: string, command: string, behavior: FakeBehavior): void {
   writeFileSync(join(caseDir, "behavior", behaviorKeyFor(command)), behavior, "utf8");
+}
+
+/**
+ * Release a hanging fake so the run can finish on its own terms.
+ *
+ * ONLY CASE 7 CALLS THIS, and the restraint is the point: a timeout case that released its
+ * own hang would be asserting a timeout it had already prevented. Case 7 needs it because
+ * it is the one case whose claim is that the run does NOT get killed at the ceiling, and a
+ * run that is never released can only ever end at the harness cap — which is a failure of
+ * the case, never a proof of anything.
+ */
+export function releaseFakeHang(caseDir: string, command: string): void {
+  writeFileSync(join(caseDir, "release", behaviorKeyFor(command)), "released by the harness\n", "utf8");
 }

--- a/apps/price-feed/src/wrapper-harness/isolation.testkit.ts
+++ b/apps/price-feed/src/wrapper-harness/isolation.testkit.ts
@@ -1,0 +1,154 @@
+/**
+ * S2 · THE ISOLATION CONTRACT — the safety module of the wrapper harness (PRD #314 §4).
+ *
+ * IT OWNS THE SEVEN `NUMISMA_*` VARIABLES THE WRAPPER READS, and its whole interface is a
+ * REFUSAL. That is why it is a module of its own rather than three lines inside the
+ * launcher: a missing override is not a flaky test, it is a real `prices:fetch`, a real
+ * `spine` append, a real `git commit` against the durable event log and a real `backfill`
+ * against the hosted database — **and the run passes green while doing it.**
+ *
+ * Exactly seven, verified against the wrapper's own configuration block
+ * (`ops/price-feed/run-daily-fetch.sh`, lines 38-65): every one of them must be set, and
+ * every path-valued one must resolve INSIDE the case's temp directory. Refusal, never a
+ * default — a default is how the real durable log gets written by a test.
+ *
+ * `NUMISMA_PATH_PREPEND` GETS THE STRICTEST TREATMENT OF THE SEVEN, and it is the reason
+ * this module exists at all. The wrapper re-exports `PATH="$PATH_PREPEND:$PATH"` in its
+ * OWN body, so the prepend — not the inherited `PATH` — is what decides which `pnpm` the
+ * run executes. Its documented default contains the directories where the REAL pnpm and
+ * node live. So every colon-separated entry is checked individually: one stray
+ * `/opt/homebrew/bin` in that list silently converts the whole suite into a live run
+ * against real, private data, and nothing downstream would go red.
+ *
+ * FAIL-CLOSED, deliberately the opposite direction from the arming trigger, which fails
+ * toward running. Failing open here means touching real private data; failing open there
+ * costs a slow test run.
+ */
+
+import { existsSync, realpathSync } from "node:fs";
+import { dirname, isAbsolute, resolve } from "node:path";
+
+/**
+ * The complete set the wrapper reads — no more, no fewer. Verified line by line against
+ * the wrapper's configuration block; a wrapper edit that adds an eighth is a change to
+ * this contract, and the trigger arms the suite on exactly that edit.
+ */
+export const WRAPPER_ENV_VARS = [
+  "NUMISMA_REPO_DIR",
+  "NUMISMA_PRICEFEED_ENV",
+  "NUMISMA_PRICEFEED_LOG_DIR",
+  "NUMISMA_PATH_PREPEND",
+  "NUMISMA_DATA_DIR",
+  "NUMISMA_PRICEFEED_MAX_RUN_SECONDS",
+  "NUMISMA_PRICEFEED_WATCHDOG_GRACE_SECONDS",
+] as const;
+
+/**
+ * The five that name a filesystem location, each of which defaults — when unset — to
+ * something REAL: the live checkout, the private token file, `~/Library/Logs/numisma`,
+ * the directories holding the real pnpm/node, and the durable accumulus data root.
+ */
+export const PATH_VALUED_ENV_VARS = [
+  "NUMISMA_REPO_DIR",
+  "NUMISMA_PRICEFEED_ENV",
+  "NUMISMA_PRICEFEED_LOG_DIR",
+  "NUMISMA_PATH_PREPEND",
+  "NUMISMA_DATA_DIR",
+] as const;
+
+/** The two that must be integers, since the wrapper arithmetic-compares them. */
+export const NUMERIC_ENV_VARS = [
+  "NUMISMA_PRICEFEED_MAX_RUN_SECONDS",
+  "NUMISMA_PRICEFEED_WATCHDOG_GRACE_SECONDS",
+] as const;
+
+export class IsolationRefusal extends Error {
+  constructor(message: string) {
+    super(
+      `wrapper harness REFUSED to launch: ${message}. This is not a fallback — an ` +
+        "unisolated run executes the real pipeline against real, private data and passes green.",
+    );
+    this.name = "IsolationRefusal";
+  }
+}
+
+/**
+ * Resolve a path to its real location for containment checking. macOS matters here: the
+ * system temp dir is `/var/folders/…`, and `/var` is a symlink to `/private/var`, so a
+ * naive string comparison between a realpath'd case dir and an unresolved candidate would
+ * report "outside" for a path that is plainly inside. Resolve the deepest existing
+ * ancestor, since a path may legitimately not exist yet (a log file, a token file).
+ */
+function realOrNearest(path: string): string {
+  let candidate = resolve(path);
+  const seen = new Set<string>();
+  while (!existsSync(candidate)) {
+    const parent = dirname(candidate);
+    if (parent === candidate || seen.has(parent)) {
+      return candidate;
+    }
+    seen.add(parent);
+    candidate = parent;
+  }
+  const real = realpathSync(candidate);
+  return resolve(path) === candidate ? real : resolve(real, resolve(path).slice(candidate.length + 1));
+}
+
+function isInside(path: string, root: string): boolean {
+  const realRoot = realpathSync(root);
+  const realPath = realOrNearest(path);
+  return realPath === realRoot || realPath.startsWith(`${realRoot}/`);
+}
+
+/**
+ * THE REFUSAL. Throws {@link IsolationRefusal} unless all seven are set and every
+ * path-valued one — every colon-separated entry of `NUMISMA_PATH_PREPEND` included —
+ * resolves inside `caseDir`.
+ *
+ * Called by the launcher on every single launch, never by a case: a case that could
+ * choose to skip it is a case that will eventually skip it.
+ */
+export function assertIsolated(env: NodeJS.ProcessEnv, caseDir: string): void {
+  if (!isAbsolute(caseDir)) {
+    throw new IsolationRefusal(`the case dir ${caseDir} is not an absolute path`);
+  }
+  if (!existsSync(caseDir)) {
+    throw new IsolationRefusal(`the case dir ${caseDir} does not exist`);
+  }
+
+  for (const name of WRAPPER_ENV_VARS) {
+    const value = env[name];
+    if (value === undefined || value === "") {
+      throw new IsolationRefusal(
+        `${name} is unset, so the wrapper would fall back to its REAL default`,
+      );
+    }
+  }
+
+  for (const name of NUMERIC_ENV_VARS) {
+    const value = env[name] ?? "";
+    if (!/^-?\d+$/.test(value)) {
+      throw new IsolationRefusal(`${name}=${value} is not an integer`);
+    }
+  }
+
+  for (const name of PATH_VALUED_ENV_VARS) {
+    const raw = env[name] ?? "";
+    // Only PATH_PREPEND is a list, but splitting all five costs nothing and means a
+    // colon smuggled into any of them is checked rather than assumed away.
+    const entries = raw.split(":").filter((entry) => entry.length > 0);
+    if (entries.length === 0) {
+      throw new IsolationRefusal(`${name} is empty`);
+    }
+    for (const entry of entries) {
+      if (!isAbsolute(entry)) {
+        throw new IsolationRefusal(`${name} entry ${entry} is not an absolute path`);
+      }
+      if (!isInside(entry, caseDir)) {
+        throw new IsolationRefusal(
+          `${name} entry ${entry} resolves OUTSIDE the case dir ${caseDir}`,
+        );
+      }
+    }
+  }
+}

--- a/apps/price-feed/src/wrapper-harness/isolation.testkit.ts
+++ b/apps/price-feed/src/wrapper-harness/isolation.testkit.ts
@@ -27,7 +27,7 @@
  * leave the wrapper's own guard untested. Presence is the contract; content is the
  * wrapper's, and the harness proves it there.
  *
- * `NUMISMA_PATH_PREPEND` GETS THE STRICTEST TREATMENT OF THE SEVEN, and it is the reason
+ * `NUMISMA_PATH_PREPEND` GETS THE STRICTEST TREATMENT OF THE NINE, and it is the reason
  * this module exists at all. The wrapper re-exports `PATH="$PATH_PREPEND:$PATH"` in its
  * OWN body, so the prepend — not the inherited `PATH` — is what decides which `pnpm` the
  * run executes. Its documented default contains the directories where the REAL pnpm and
@@ -41,7 +41,7 @@
  */
 
 import { existsSync, realpathSync } from "node:fs";
-import { dirname, isAbsolute, resolve } from "node:path";
+import { dirname, isAbsolute, join, relative, resolve } from "node:path";
 
 /**
  * The complete set the wrapper reads — no more, no fewer. Verified line by line against
@@ -108,7 +108,15 @@ function realOrNearest(path: string): string {
     candidate = parent;
   }
   const real = realpathSync(candidate);
-  return resolve(path) === candidate ? real : resolve(real, resolve(path).slice(candidate.length + 1));
+  // `relative`, NOT `slice(candidate.length + 1)`. The arithmetic assumed the deepest
+  // existing ancestor never carries a trailing separator, which is true of every
+  // `dirname` result EXCEPT root: with `candidate === "/"` it dropped one character too
+  // many and turned `/nope/data` into `/ope/data`. Reachable only when the whole path
+  // sits under a nonexistent top-level directory, and it failed CLOSED (the mangled path
+  // is still outside the case dir, so the refusal still fired) — but this is the one
+  // function in the safety module that decides inside from outside, and it should be
+  // right rather than accidentally right.
+  return join(real, relative(candidate, resolve(path)));
 }
 
 function isInside(path: string, root: string): boolean {
@@ -118,7 +126,7 @@ function isInside(path: string, root: string): boolean {
 }
 
 /**
- * THE REFUSAL. Throws {@link IsolationRefusal} unless all seven are set and every
+ * THE REFUSAL. Throws {@link IsolationRefusal} unless all nine are set and every
  * path-valued one — every colon-separated entry of `NUMISMA_PATH_PREPEND` included —
  * resolves inside `caseDir`.
  *

--- a/apps/price-feed/src/wrapper-harness/isolation.testkit.ts
+++ b/apps/price-feed/src/wrapper-harness/isolation.testkit.ts
@@ -1,16 +1,31 @@
 /**
  * S2 · THE ISOLATION CONTRACT — the safety module of the wrapper harness (PRD #314 §4).
  *
- * IT OWNS THE SEVEN `NUMISMA_*` VARIABLES THE WRAPPER READS, and its whole interface is a
+ * IT OWNS THE NINE `NUMISMA_*` VARIABLES THE WRAPPER READS, and its whole interface is a
  * REFUSAL. That is why it is a module of its own rather than three lines inside the
  * launcher: a missing override is not a flaky test, it is a real `prices:fetch`, a real
  * `spine` append, a real `git commit` against the durable event log and a real `backfill`
  * against the hosted database — **and the run passes green while doing it.**
  *
- * Exactly seven, verified against the wrapper's own configuration block
- * (`ops/price-feed/run-daily-fetch.sh`, lines 38-65): every one of them must be set, and
- * every path-valued one must resolve INSIDE the case's temp directory. Refusal, never a
+ * Exactly nine, verified against the wrapper's own configuration block
+ * (`ops/price-feed/run-daily-fetch.sh`): every one of them must be set, and every
+ * path-valued one must resolve INSIDE the case's temp directory. Refusal, never a
  * default — a default is how the real durable log gets written by a test.
+ *
+ * THE TWO MARK VARIABLES ARE HERE FOR A DIFFERENT REASON THAN THE OTHER SEVEN, and the
+ * difference is worth stating because it decides how far the refusal goes. Neither is
+ * path-valued and neither selects data, so an unset one cannot touch the real ledger. What
+ * it CAN do is let the wrapper fall back to the contract zone — and then a case that meant
+ * to be in-window is in-window only between 18:00 and 23:59 CDMX, so its heartbeat
+ * assertions quietly stop meaning anything for most of the day. That is the same
+ * green-while-testing-nothing failure the other seven prevent, arriving through the clock,
+ * so it is refused the same way: unset is a refusal, never a default.
+ *
+ * THEIR VALUES ARE DELIBERATELY NOT VALIDATED HERE. The wrapper refuses an unresolvable
+ * zone and a non-hour mark hour itself (#315), and a case ASSERTS that refusal by launching
+ * with a bad one — a contract that pre-screened them would make that case unreachable and
+ * leave the wrapper's own guard untested. Presence is the contract; content is the
+ * wrapper's, and the harness proves it there.
  *
  * `NUMISMA_PATH_PREPEND` GETS THE STRICTEST TREATMENT OF THE SEVEN, and it is the reason
  * this module exists at all. The wrapper re-exports `PATH="$PATH_PREPEND:$PATH"` in its
@@ -30,7 +45,7 @@ import { dirname, isAbsolute, resolve } from "node:path";
 
 /**
  * The complete set the wrapper reads — no more, no fewer. Verified line by line against
- * the wrapper's configuration block; a wrapper edit that adds an eighth is a change to
+ * the wrapper's configuration block; a wrapper edit that adds a tenth is a change to
  * this contract, and the trigger arms the suite on exactly that edit.
  */
 export const WRAPPER_ENV_VARS = [
@@ -41,6 +56,8 @@ export const WRAPPER_ENV_VARS = [
   "NUMISMA_DATA_DIR",
   "NUMISMA_PRICEFEED_MAX_RUN_SECONDS",
   "NUMISMA_PRICEFEED_WATCHDOG_GRACE_SECONDS",
+  "NUMISMA_MARK_TZ",
+  "NUMISMA_MARK_HOUR",
 ] as const;
 
 /**

--- a/apps/price-feed/src/wrapper-harness/launcher.testkit.ts
+++ b/apps/price-feed/src/wrapper-harness/launcher.testkit.ts
@@ -1,0 +1,228 @@
+/**
+ * S1 · THE LAUNCHER — the process boundary of the wrapper harness (PRD #314 §4).
+ *
+ * It owns starting `ops/price-feed/run-daily-fetch.sh` CORRECTLY and returning a run
+ * record. Nothing downstream touches a process API, which is what keeps every case
+ * honest about the two things that are easy to get subtly wrong.
+ *
+ * ── IT INVOKES `/bin/bash <wrapper>` EXPLICITLY ───────────────────────────────────────
+ * Not the shebang's `env bash`. That is what the launchd plist does, and what runs in
+ * production is `/bin/bash` 3.2.57 — a GPLv2 bash from 2007 with no `${var^^}`, no
+ * associative arrays, and a different `trap` inheritance story than bash 5. Running the
+ * suite against a Homebrew bash 5 would test a shell the job never uses. The observed
+ * version is RECORDED in every run record so a newer `/bin/bash` landing on this machine
+ * later cannot silently change what is under test.
+ *
+ * ── IT STARTS THE CHILD IN ITS OWN SESSION ────────────────────────────────────────────
+ * `detached: true` is `setsid`, and **it is the single most important line in the
+ * harness.** Without it the wrapper is not its own process-group leader, its own
+ * leader check prints `watchdog DISABLED (not a process-group leader: …)`, the watchdog
+ * no-ops, and every timeout case in every later slice passes while testing nothing. The
+ * suite asserts `watchdog armed:` on the healthy case precisely so that dropping this
+ * line goes RED rather than quiet.
+ *
+ * ── THE NON-LEADER LAUNCH IS A REAL CONFIGURATION, NOT AN OMISSION ────────────────────
+ * Case 7 — the suite's anti-vacuity control — needs the wrapper to run WITHOUT being its
+ * group leader. It gets there through an intermediate `/bin/bash` that is itself detached
+ * and does NOT `exec`: the intermediate leads the group, the wrapper is an ordinary
+ * member of it. Simply dropping `detached` would put the wrapper in VITEST's process
+ * group, where "zero processes remaining in the run's pgid" is unassertable — the third
+ * and historically highest-value assertion would have to be waived for exactly the case
+ * that exists to prove the suite is not vacuous. This way the pgid is still a group the
+ * harness owns alone, and the assertion triple applies uniformly.
+ *
+ * ── THE PGID IS KNOWN WITHOUT ASKING ──────────────────────────────────────────────────
+ * In both shapes the spawned child IS the group leader, so the run's pgid is its pid. No
+ * `ps` race at startup, and the residue scan has a stable key even for a run that exited
+ * before the first poll.
+ */
+
+import { spawn } from "node:child_process";
+import { execFileSync } from "node:child_process";
+import { existsSync, readFileSync, readdirSync } from "node:fs";
+import { join } from "node:path";
+import { parseHeartbeat, type JobHeartbeat } from "@numisma/event-store";
+import { assertIsolated } from "./isolation.testkit.js";
+
+/** The shell the plist invokes, and therefore the only shell this suite tests against. */
+export const LAUNCH_SHELL = "/bin/bash";
+
+export interface RunRecord {
+  /** Exactly what `/bin/bash --version` reported, first line. Recorded, never inferred. */
+  readonly bashVersion: string;
+  /** The run's process group. The spawned child leads it, so this is its pid. */
+  readonly pgid: number;
+  readonly exitCode: number | null;
+  readonly signal: NodeJS.Signals | null;
+  /** Parsed by the SAME reader the TUI uses — the oracle, not a second parser. */
+  readonly heartbeat: JobHeartbeat | undefined;
+  readonly heartbeatRaw: string | undefined;
+  /** The per-run log file's contents, which is what the wrapper's `tee` actually wrote. */
+  readonly logText: string;
+  /** What the harness captured off the child's stdio, kept separate from the log file. */
+  readonly stdout: string;
+  /** Whether the watchdog left its calling card — the TERM handler's own discriminator. */
+  readonly watchdogFired: boolean;
+  /** `pid command` for anything still in the run's pgid when the settle window closed. */
+  readonly pgidResidue: readonly string[];
+  /** How long the pgid took to empty. Recorded so 0.1s → 4.9s is visible, not merely passing. */
+  readonly settleMs: number;
+  readonly durationMs: number;
+}
+
+export interface LaunchOptions {
+  readonly caseDir: string;
+  readonly wrapperPath: string;
+  readonly env: NodeJS.ProcessEnv;
+  /**
+   * `true` (production shape) makes the wrapper its own session and group leader.
+   * `false` runs it as a non-leading member of a group the harness still owns — case 7.
+   */
+  readonly groupLeader: boolean;
+  /** How long the pgid may take to empty before the residue is reported as-is. */
+  readonly settleDeadlineMs: number;
+  /** A hard cap so a wedged run cannot wedge the suite. Exceeding it is a failure, not a pass. */
+  readonly maxWaitMs: number;
+}
+
+/** Read once per process: `/bin/bash --version`'s first line, verbatim. */
+export function observedBashVersion(): string {
+  return execFileSync(LAUNCH_SHELL, ["--version"], { encoding: "utf8" }).split("\n")[0] ?? "";
+}
+
+/** `pid command` for every process currently in `pgid`, the harness's own excluded by construction. */
+export function processesInPgid(pgid: number): string[] {
+  let table: string;
+  try {
+    table = execFileSync("ps", ["-A", "-o", "pid=,pgid=,command="], { encoding: "utf8" });
+  } catch {
+    return [];
+  }
+  const found: string[] = [];
+  for (const line of table.split("\n")) {
+    const match = /^\s*(\d+)\s+(\d+)\s+(.*)$/.exec(line);
+    if (match && Number(match[2]) === pgid) {
+      found.push(`${match[1]} ${match[3]}`);
+    }
+  }
+  return found;
+}
+
+function sleep(ms: number): Promise<void> {
+  return new Promise((done) => setTimeout(done, ms));
+}
+
+/** The per-run log the wrapper's `tee` wrote, plus the watchdog's calling card beside it. */
+function readRunLog(logDir: string): { logText: string; watchdogFired: boolean } {
+  if (!existsSync(logDir)) {
+    return { logText: "", watchdogFired: false };
+  }
+  const entries = readdirSync(logDir);
+  const logText = entries
+    .filter((name) => name.startsWith("price-feed-") && name.endsWith(".log"))
+    .map((name) => readFileSync(join(logDir, name), "utf8"))
+    .join("");
+  return { logText, watchdogFired: entries.some((name) => name.endsWith(".watchdog-fired")) };
+}
+
+/**
+ * Launch the wrapper and observe it. **The isolation contract is asserted here, on every
+ * launch** — not by the caller, because a caller that could choose to skip it eventually
+ * will, and the cost of skipping it once is a real commit against the durable event log.
+ */
+export async function launchWrapper(options: LaunchOptions): Promise<RunRecord> {
+  assertIsolated(options.env, options.caseDir);
+
+  const logDir = options.env.NUMISMA_PRICEFEED_LOG_DIR ?? "";
+  const dataDir = options.env.NUMISMA_DATA_DIR ?? "";
+
+  // THE NON-LEADER SHAPE MUST NOT `exec`. bash short-circuits `bash -c '"$0"'` into an
+  // exec of the single command, which would hand the group leadership straight back to
+  // the wrapper and quietly turn case 7 into a second copy of case 1. Capturing the
+  // status in a variable and exiting on it keeps a real fork in between, and forwards the
+  // wrapper's exit code unchanged.
+  const args = options.groupLeader
+    ? [options.wrapperPath]
+    : ["-c", 'rc=0; "$0" "$@" || rc=$?; exit "$rc"', LAUNCH_SHELL, options.wrapperPath];
+
+  const startedAt = Date.now();
+  const child = spawn(LAUNCH_SHELL, args, {
+    cwd: options.caseDir,
+    env: options.env,
+    detached: true,
+    stdio: ["ignore", "pipe", "pipe"],
+  });
+  const pgid = child.pid ?? -1;
+  if (pgid <= 0) {
+    throw new Error("wrapper harness: the launch produced no pid");
+  }
+
+  let captured = "";
+  child.stdout.setEncoding("utf8");
+  child.stderr.setEncoding("utf8");
+  child.stdout.on("data", (chunk: string) => (captured += chunk));
+  child.stderr.on("data", (chunk: string) => (captured += chunk));
+
+  const exited = await new Promise<{ code: number | null; signal: NodeJS.Signals | null }>(
+    (resolve, reject) => {
+      const cap = setTimeout(() => {
+        // Reap the whole group before failing: leaving it behind would poison every later
+        // case's residue assertion with this run's wreckage.
+        try {
+          process.kill(-pgid, "SIGKILL");
+        } catch {
+          /* already gone */
+        }
+        reject(
+          new Error(
+            `wrapper harness: the run exceeded the harness cap of ${options.maxWaitMs}ms. ` +
+              "That is a failure of the case, never a pass — the wrapper's own watchdog was " +
+              "supposed to bound this.",
+          ),
+        );
+      }, options.maxWaitMs);
+      child.on("error", (error) => {
+        clearTimeout(cap);
+        reject(error);
+      });
+      child.on("exit", (code, signal) => {
+        clearTimeout(cap);
+        resolve({ code, signal });
+      });
+    },
+  );
+  const durationMs = Date.now() - startedAt;
+
+  // THE SETTLE WINDOW, bounded in BOTH directions. Asserting emptiness the instant the
+  // shell exits gives a false red on the timeout path, where the watchdog is deliberately
+  // left alive to serve its grace and group-SIGKILL. Waiting with unbounded patience gives
+  // a false green: the historical stray `sleep` DID eventually exit — after holding
+  // launchd's per-label job slot through the next fire. So poll to a deadline and record
+  // what it cost.
+  const settleStartedAt = Date.now();
+  let residue = processesInPgid(pgid);
+  while (residue.length > 0 && Date.now() - settleStartedAt < options.settleDeadlineMs) {
+    await sleep(25);
+    residue = processesInPgid(pgid);
+  }
+  const settleMs = Date.now() - settleStartedAt;
+
+  const { logText, watchdogFired } = readRunLog(logDir);
+  const heartbeatPath = join(dataDir, "job-heartbeat.json");
+  const heartbeatRaw = existsSync(heartbeatPath) ? readFileSync(heartbeatPath, "utf8") : undefined;
+
+  return {
+    bashVersion: observedBashVersion(),
+    pgid,
+    exitCode: exited.code,
+    signal: exited.signal,
+    heartbeat: parseHeartbeat(heartbeatRaw),
+    heartbeatRaw,
+    logText,
+    stdout: captured,
+    watchdogFired,
+    pgidResidue: residue,
+    settleMs,
+    durationMs,
+  };
+}

--- a/apps/price-feed/src/wrapper-harness/launcher.testkit.ts
+++ b/apps/price-feed/src/wrapper-harness/launcher.testkit.ts
@@ -65,6 +65,16 @@ export interface RunRecord {
   readonly watchdogFired: boolean;
   /** `pid command` for anything still in the run's pgid when the settle window closed. */
   readonly pgidResidue: readonly string[];
+  /**
+   * `pid command` for the pgid sampled at the INSTANT the shell exited, before any settle
+   * wait. It is what makes the settle assertion bounded in BOTH directions: on the timeout
+   * path the watchdog is deliberately left alive to serve its grace and its group SIGKILL,
+   * so this must be NON-empty there — a case that found it empty would be asserting
+   * emptiness before grace had been served, which is a false red waiting to happen. It is
+   * also how case 3 tells "the deaf child was reaped" from "the deaf child was never
+   * there": it has to be visible here and gone from {@link pgidResidue}.
+   */
+  readonly residueAtExit: readonly string[];
   /** How long the pgid took to empty. Recorded so 0.1s → 4.9s is visible, not merely passing. */
   readonly settleMs: number;
   readonly durationMs: number;
@@ -83,6 +93,14 @@ export interface LaunchOptions {
   readonly settleDeadlineMs: number;
   /** A hard cap so a wedged run cannot wedge the suite. Exceeding it is a failure, not a pass. */
   readonly maxWaitMs: number;
+  /**
+   * Run concurrently with the launched wrapper, from just after the spawn. Case 7's hook,
+   * and it exists for one reason: proving a run does NOT time out requires observing it
+   * still alive past its own ceiling and grace and then letting it finish. If it throws,
+   * the group is SIGKILLed so a wedged run cannot outlive the failed observation, and the
+   * error is re-raised once the child is reaped.
+   */
+  readonly duringRun?: (pgid: number) => Promise<void>;
 }
 
 /** Read once per process: `/bin/bash --version`'s first line, verbatim. */
@@ -94,7 +112,11 @@ export function observedBashVersion(): string {
 export function processesInPgid(pgid: number): string[] {
   let table: string;
   try {
-    table = execFileSync("ps", ["-A", "-o", "pid=,pgid=,command="], { encoding: "utf8" });
+    // `-ww` because macOS `ps` truncates the command column to the terminal width — and to
+    // 80 columns when stdout is a pipe, which is exactly what this is. The residue of a run
+    // rooted in a temp dir is long-pathed by construction, so without this the one column
+    // that names WHAT survived is cut off precisely when it matters.
+    table = execFileSync("ps", ["-A", "-ww", "-o", "pid=,pgid=,command="], { encoding: "utf8" });
   } catch {
     return [];
   }
@@ -157,6 +179,22 @@ export async function launchWrapper(options: LaunchOptions): Promise<RunRecord> 
     throw new Error("wrapper harness: the launch produced no pid");
   }
 
+  // Started BEFORE the exit is awaited, so it genuinely overlaps the run. Its failure is
+  // held rather than thrown here: throwing out of an unawaited promise would escape the
+  // test that owns it, and leaving the group alive would poison every later case's residue.
+  let duringError: unknown;
+  const during: Promise<void> =
+    options.duringRun === undefined
+      ? Promise.resolve()
+      : options.duringRun(pgid).catch((error: unknown) => {
+          duringError = error;
+          try {
+            process.kill(-pgid, "SIGKILL");
+          } catch {
+            /* already gone */
+          }
+        });
+
   let captured = "";
   child.stdout.setEncoding("utf8");
   child.stderr.setEncoding("utf8");
@@ -192,6 +230,10 @@ export async function launchWrapper(options: LaunchOptions): Promise<RunRecord> 
     },
   );
   const durationMs = Date.now() - startedAt;
+  await during;
+  if (duringError !== undefined) {
+    throw duringError;
+  }
 
   // THE SETTLE WINDOW, bounded in BOTH directions. Asserting emptiness the instant the
   // shell exits gives a false red on the timeout path, where the watchdog is deliberately
@@ -201,6 +243,7 @@ export async function launchWrapper(options: LaunchOptions): Promise<RunRecord> 
   // what it cost.
   const settleStartedAt = Date.now();
   let residue = processesInPgid(pgid);
+  const residueAtExit = residue;
   while (residue.length > 0 && Date.now() - settleStartedAt < options.settleDeadlineMs) {
     await sleep(25);
     residue = processesInPgid(pgid);
@@ -222,6 +265,7 @@ export async function launchWrapper(options: LaunchOptions): Promise<RunRecord> 
     stdout: captured,
     watchdogFired,
     pgidResidue: residue,
+    residueAtExit,
     settleMs,
     durationMs,
   };

--- a/apps/price-feed/src/wrapper-harness/mark-window.testkit.ts
+++ b/apps/price-feed/src/wrapper-harness/mark-window.testkit.ts
@@ -77,8 +77,13 @@ function hourNowIn(timeZone: string): number {
  * `date`, no clock manipulation and no edit to the script.
  *
  * The range is the one every installed tzdata carries — `Etc/GMT-14` through `Etc/GMT+12`
- * — so exactly one of them is at hour 00 at any instant and the search cannot come up
- * empty. It throwing would mean the zone database itself had moved, which must be loud.
+ * — so AT LEAST ONE of them is at hour 00 at any instant and the search cannot come up
+ * empty. Not exactly one: that is 27 offsets spread over a 24-hour cycle, so three pairs
+ * share a local hour (`Etc/GMT-14`/`Etc/GMT+10`, `-13`/`+11`, `-12`/`+12`) and for part of
+ * the day TWO zones sit at hour 00 together. Returning the first match is correct either
+ * way — the two are equally valid answers to the same question — but "exactly one" was
+ * never true and should not be relied on by a later edit. It throwing would mean the zone
+ * database itself had moved, which must be loud.
  */
 export function markConfigFor(window: "in" | "out"): MarkConfig {
   for (let offset = -14; offset <= 12; offset += 1) {

--- a/apps/price-feed/src/wrapper-harness/mark-window.testkit.ts
+++ b/apps/price-feed/src/wrapper-harness/mark-window.testkit.ts
@@ -1,0 +1,217 @@
+/**
+ * S8 · THE MARK WINDOW — the clock module of the wrapper harness (PRD #314 §8, D2).
+ *
+ * It owns two things a case cannot be trusted to own for itself: WHICH SIDE OF THE MARK
+ * WINDOW A RUN FALLS ON, and the authored heartbeat a run finds already on disk.
+ *
+ * ── WHY THIS IS A MODULE AND NOT A CONSTANT ───────────────────────────────────────────
+ * `markWindow` — and with it `lastMarkWindowFinishedAt`, which case 6 exists to assert —
+ * is computed by the wrapper from a configured zone against a configured hour. Before
+ * #315 that pair was a literal, so the only way to be in-window was for the suite to
+ * happen to run between 18:00 and 23:59 CDMX. **Run it in the morning and case 6 passes
+ * while asserting nothing** — the same green-while-testing-nothing failure the
+ * group-leader trap produces, arriving through the clock instead of the process group and
+ * equally invisible. The zone is an INPUT now, and this module is where that input is
+ * chosen and where the oracle that judges it is written, so the two cannot drift apart.
+ *
+ * ── THE `Etc/GMT±n` TRICK, AND WHY THE OBVIOUS THING IS WRONG ─────────────────────────
+ * The obvious thing is to pick a zone where it is currently evening. That works for most
+ * of the day and BREAKS ONCE A DAY, when a suite run straddles the boundary it chose —
+ * and the way it breaks is that a case starts asserting the wrong side, which is the
+ * vacuity this whole slice exists to eliminate.
+ *
+ * The wrapper compares the current hour IN THE CONFIGURED ZONE against the configured
+ * hour, so "in" is free: hour 0 is at or below every hour there is. "out" needs a
+ * configured hour ABOVE the current one, and the only hour guaranteed to be above it is
+ * one measured against a zone we picked. So {@link markConfigFor} finds the fixed-offset
+ * zone where it is currently the 00 hour and asks for hour 0 (in) or hour 23 (out). That
+ * leaves ~23 hours of margin in both directions, so no run of this suite — however long —
+ * can straddle the boundary. Fixed-offset zones also have no DST discontinuity to
+ * reason about.
+ *
+ * `Etc/GMT+5` means UTC-5: POSIX inverts the sign. Irrelevant here, because `Intl` below
+ * and the wrapper's `TZ=… date` read the same tzdata and therefore agree by construction
+ * whatever the label means. `packages/event-store/src/heartbeat.test.ts` uses the same
+ * technique against the same wrapper; this is that technique, not a second one.
+ *
+ * ── EVERY SEEDED HEARTBEAT HERE IS AUTHORED ───────────────────────────────────────────
+ * Byte for byte, written for this purpose. Nothing is captured from a real run, in
+ * content or in shape — the line is authorship, not resemblance, and the instants below
+ * are deliberately far from any date this repo has ever run on so a leaked real value
+ * could never hide among them.
+ */
+
+import { writeFileSync } from "node:fs";
+import { join } from "node:path";
+import { MARK_HOUR, TRADING_DAY_TIME_ZONE } from "@numisma/engine";
+
+/** The zone and hour a run's mark window is computed from. */
+export interface MarkConfig {
+  readonly timeZone: string;
+  readonly hour: number;
+}
+
+/**
+ * THE CONTRACT'S OWN PAIR, imported rather than restated. The wrapper's `${VAR:-default}`
+ * halves are pinned against these constants by `apps/price-feed/src/schedule-window.test.ts`,
+ * so a case configured with this is configured with exactly what an unconfigured run
+ * would have used — which is what keeps every case written before the zone became an
+ * input behaving precisely as it did.
+ */
+export const CONTRACT_MARK_CONFIG: MarkConfig = {
+  timeZone: TRADING_DAY_TIME_ZONE,
+  hour: MARK_HOUR,
+};
+
+/** The hour of day, right now, in `timeZone` — the same question the wrapper's `date` asks. */
+function hourNowIn(timeZone: string): number {
+  return Number(
+    new Intl.DateTimeFormat("en-GB", { timeZone, hour: "2-digit", hourCycle: "h23" }).format(
+      new Date(),
+    ),
+  );
+}
+
+/**
+ * A configuration that puts a run on the chosen side of the mark window, with NO fake
+ * `date`, no clock manipulation and no edit to the script.
+ *
+ * The range is the one every installed tzdata carries — `Etc/GMT-14` through `Etc/GMT+12`
+ * — so exactly one of them is at hour 00 at any instant and the search cannot come up
+ * empty. It throwing would mean the zone database itself had moved, which must be loud.
+ */
+export function markConfigFor(window: "in" | "out"): MarkConfig {
+  for (let offset = -14; offset <= 12; offset += 1) {
+    const timeZone = `Etc/GMT${offset >= 0 ? "+" : "-"}${Math.abs(offset)}`;
+    if (hourNowIn(timeZone) === 0) {
+      return { timeZone, hour: window === "in" ? 0 : 23 };
+    }
+  }
+  throw new Error(
+    "wrapper harness: no fixed-offset zone is currently at hour 00, which is impossible — " +
+      "the tz database this suite drives the mark window through has moved underneath it.",
+  );
+}
+
+/** The two overrides the wrapper reads, as the environment carries them. */
+export function markEnv(config: MarkConfig): { NUMISMA_MARK_TZ: string; NUMISMA_MARK_HOUR: string } {
+  return { NUMISMA_MARK_TZ: config.timeZone, NUMISMA_MARK_HOUR: String(config.hour) };
+}
+
+/**
+ * Whether this run was in the mark window, computed the way THE RUN'S OWN CONFIGURATION
+ * computes it rather than from the machine's local clock, which would agree only by
+ * coincidence of an OS setting.
+ *
+ * IT TAKES THE CASE'S CONFIG, NOT THE CONTRACT'S, and that is the whole correction #319
+ * makes to the oracle. While the zone was a literal the two were the same thing; now that
+ * a case chooses its side, an oracle still reading `America/Mexico_City` would judge the
+ * in-window case against the wrong side — failing permanently, or worse, passing for the
+ * wrong reason for six hours a day.
+ *
+ * Read off the heartbeat's own `startedAt`, so a run that straddles the configured hour is
+ * still judged against the instant the wrapper judged itself at.
+ */
+export function expectedMarkWindow(startedAt: string, config: MarkConfig): boolean {
+  const hour = Number(
+    new Intl.DateTimeFormat("en-GB", {
+      timeZone: config.timeZone,
+      hour: "2-digit",
+      hourCycle: "h23",
+    }).format(new Date(startedAt)),
+  );
+  return hour >= config.hour;
+}
+
+/**
+ * AN AUTHORED PRIOR STAMP. Deliberately an instant this repo has never run at, so
+ * "carried forward unchanged" and "re-stamped with this run's finish" can never be
+ * confused for one another by coincidence.
+ */
+export const AUTHORED_PRIOR_STAMP = "2001-02-03T04:05:06Z";
+
+/** Authored instants for the seeded files below. Same reasoning; never a captured value. */
+const AUTHORED_SEED_STARTED_AT = "2001-02-03T04:00:00Z";
+const AUTHORED_V1_FINISHED_AT = "2001-02-03T04:44:44Z";
+
+function seed(dataDir: string, contents: string): void {
+  writeFileSync(join(dataDir, "job-heartbeat.json"), contents, "utf8");
+}
+
+/**
+ * A v2 breadcrumb from an earlier evening that DID land the day's marks.
+ *
+ * What a run finding it must do splits cleanly on the window: in-window and landed, it
+ * overwrites this stamp with its own finish; anything else re-emits it unchanged. Both
+ * halves are asserted, and seeding the SAME file for both is what makes them a pair —
+ * without a prior stamp, "carried forward" and "invented nothing" are the same assertion.
+ */
+export function seedMarkedEveningHeartbeat(dataDir: string): void {
+  seed(
+    dataDir,
+    `{
+  "schemaVersion": 2,
+  "startedAt": "${AUTHORED_SEED_STARTED_AT}",
+  "finishedAt": "${AUTHORED_PRIOR_STAMP}",
+  "exitCode": 0,
+  "lastStep": "complete",
+  "markWindow": true,
+  "lastMarkWindowFinishedAt": "${AUTHORED_PRIOR_STAMP}"
+}
+`,
+  );
+}
+
+/**
+ * A SCHEMA-VERSION-1 breadcrumb — the shape written before the mark window existed.
+ *
+ * Every v1 run was read as evidence of a marked day, so its `finishedAt` IS the last
+ * in-window finish and the wrapper migrates it forward. This is the only path on which
+ * the wrapper derives a stamp from a field that is not one, and case 8 is the only place
+ * it is exercised end to end.
+ */
+export function seedV1Heartbeat(dataDir: string): void {
+  seed(
+    dataDir,
+    `{
+  "schemaVersion": 1,
+  "startedAt": "${AUTHORED_SEED_STARTED_AT}",
+  "finishedAt": "${AUTHORED_V1_FINISHED_AT}",
+  "exitCode": 0,
+  "lastStep": "complete"
+}
+`,
+  );
+}
+
+/** {@link seedV1Heartbeat}'s `finishedAt` — what a run reading it must carry, and nothing else. */
+export const AUTHORED_V1_CARRY = AUTHORED_V1_FINISHED_AT;
+
+/**
+ * A v2 breadcrumb from an IN-WINDOW run that died before `spine` — in the window, marked
+ * nothing, and correctly carrying no stamp at all.
+ *
+ * THIS IS THE DANGEROUS ONE, and it is the exact shape of the defect that opened this
+ * line of work. The wrapper's v1 fallback used to be gated NEGATIVELY — it fired whenever
+ * the file did not say `"markWindow": false` — so this perfectly ordinary v2 file was read
+ * as v1 and its `finishedAt` was promoted into a marked-day stamp. That MANUFACTURES
+ * EVIDENCE THAT THE DAY WAS COVERED out of a run that covered nothing, silencing the
+ * staleness warning on precisely the morning it was needed: a false *no* on the coverage
+ * question, the most dangerous defect class in this system. The watchdog makes this shape
+ * routine — a timed-out run is in-window and unmarked by construction — so nothing about
+ * it is hypothetical.
+ */
+export function seedInWindowDiedBeforeSpineHeartbeat(dataDir: string): void {
+  seed(
+    dataDir,
+    `{
+  "schemaVersion": 2,
+  "startedAt": "${AUTHORED_SEED_STARTED_AT}",
+  "finishedAt": "${AUTHORED_PRIOR_STAMP}",
+  "exitCode": 127,
+  "lastStep": "prices-fetch",
+  "markWindow": true
+}
+`,
+  );
+}

--- a/apps/price-feed/src/wrapper-harness/repetition.testkit.ts
+++ b/apps/price-feed/src/wrapper-harness/repetition.testkit.ts
@@ -1,0 +1,43 @@
+/**
+ * S5 · REPETITION — the confidence module of the wrapper harness (PRD #314 §4, D3).
+ *
+ * **12 consecutive runs per case, on every armed run, for every case.** Not a default of
+ * 6 with a knob to 12 — twelve is what every case pays, always.
+ *
+ * A single green run means nothing about this subject, and that is not a stylistic
+ * preference: it is literally how the `tee` race survived its first review. The wrapper's
+ * teardown is a set of races — the watchdog cancel versus the `sleep` fork, the group
+ * TERM versus the `tee`, the EXIT trap versus SIGPIPE — and every one of them was
+ * observed to fail on 3 runs in 5, or 1 in 12, rather than on demand.
+ *
+ * Repetition is a property of the RUNNER, not of a case, so cases are written once and
+ * repeated here.
+ *
+ * `NUMISMA_WRAPPER_TEST_RUNS` may RAISE the count for a deliberate soak. It may not lower
+ * it, and a value below the floor is REFUSED rather than clamped: clamping would let
+ * `NUMISMA_WRAPPER_TEST_RUNS=1` look like it worked while the suite quietly did the right
+ * thing, which teaches exactly the wrong lesson about what this knob is for.
+ */
+
+/** The committed floor. Ruled by U (#314 D3). Not a default — a floor. */
+export const REPETITION_FLOOR = 12;
+
+export function resolveRunCount(raw: string | undefined): number {
+  if (raw === undefined || raw === "") {
+    return REPETITION_FLOOR;
+  }
+  if (!/^\d+$/.test(raw)) {
+    throw new Error(
+      `wrapper harness: NUMISMA_WRAPPER_TEST_RUNS=${raw} is not a whole number.`,
+    );
+  }
+  const requested = Number(raw);
+  if (requested < REPETITION_FLOOR) {
+    throw new Error(
+      `wrapper harness: NUMISMA_WRAPPER_TEST_RUNS=${requested} is below the committed floor of ` +
+        `${REPETITION_FLOOR}. This knob RAISES the count for a soak; it cannot lower it. A single ` +
+        "green run means nothing here — that is how the `tee` race survived its first review.",
+    );
+  }
+  return requested;
+}

--- a/apps/price-feed/src/wrapper-harness/run-daily-fetch.test.ts
+++ b/apps/price-feed/src/wrapper-harness/run-daily-fetch.test.ts
@@ -49,7 +49,7 @@
  * nothing to say about them, and a trigger that armed on them would be claiming otherwise.
  */
 
-import { execFileSync } from "node:child_process";
+import { execFileSync, spawn } from "node:child_process";
 import { existsSync, mkdirSync, mkdtempSync, readFileSync, readdirSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { dirname, join } from "node:path";
@@ -68,6 +68,7 @@ import {
 import {
   CHILD_REAP_MUTATION,
   LAUNCHD_BARE_PATH,
+  TEE_DEAFNESS_MUTATION,
   caseEnv,
   makeCaseDir,
   mutateWrapper,
@@ -957,6 +958,46 @@ describe.runIf(decision.run)("wrapper harness — the real wrapper, armed", () =
   }
 
   it(
+    "the fake's `ignores-term` behavior really is deaf — the dispatch entry is not a comment",
+    async () => {
+      // The one behavior in the table that no case drives end-to-end, exercised directly so
+      // it cannot rot into a fake that quietly dies on TERM. A later case that reached for
+      // it would then be a timeout case that no longer needs an escalation, which is the
+      // shape of a test that has stopped testing anything.
+      const dirs = makeCaseDir(TIMEOUT_CASE_OPTIONS);
+      setFakeBehavior(dirs.caseDir, "prices:fetch", "ignores-term");
+      const child = spawn(join(dirs.binDir, "pnpm"), ["prices:fetch"], {
+        cwd: dirs.caseDir,
+        env: caseEnv(dirs, TIMEOUT_CASE_OPTIONS),
+        detached: true,
+        stdio: "ignore",
+      });
+      const pid = child.pid ?? -1;
+      expect(pid).toBeGreaterThan(0);
+      try {
+        await sleep(750);
+        expect(
+          existsSync(join(dirs.caseDir, "sentinels", sentinelNameFor("prices:fetch"))),
+          "the fake never started",
+        ).toBe(true);
+        process.kill(-pid, "SIGTERM");
+        await sleep(1_000);
+        expect(
+          processesInPgid(pid).length,
+          "the `ignores-term` fake died of the very TERM it exists to ignore",
+        ).toBeGreaterThan(0);
+      } finally {
+        try {
+          process.kill(-pid, "SIGKILL");
+        } catch {
+          /* already gone */
+        }
+      }
+    },
+    60_000,
+  );
+
+  it(
     `case 2 — watchdog timeout with a REACTIVE child, ${RUNS_PER_CASE} consecutive times`,
     async () => {
       const settles: number[] = [];
@@ -1171,6 +1212,94 @@ describe.runIf(decision.run)("wrapper harness — the real wrapper, armed", () =
         expect(healthy.pgidResidue).toEqual([]);
       },
       120_000,
+    );
+  });
+
+  // ── S6 · THE `tee`-DEAFNESS MUTATION CONTROL ──────────────────────────────────────
+  describe("the `tee`-deafness mutation — assertion 2 is seen RED before it is trusted", () => {
+    it("fails LOUDLY when its anchor text is gone, rather than mutating nothing", () => {
+      const dirs = makeCaseDir(TIMEOUT_CASE_OPTIONS);
+      expect(() =>
+        mutateWrapper(WRAPPER_PATH, dirs.caseDir, {
+          name: "an anchor that has rotted away",
+          anchor: "exec > >(trap '' TERM PIPE; tee -a \"$LOG_FILE_THAT_NEVER_EXISTED\") 2>&1",
+          replacement: ":",
+        }),
+      ).toThrow(/anchor has rotted/);
+      // And the REAL anchor is still there — the half that catches the rot rather than
+      // merely reporting that a made-up string is missing.
+      expect(() => mutateWrapper(WRAPPER_PATH, dirs.caseDir, TEE_DEAFNESS_MUTATION)).not.toThrow();
+    });
+
+    it(
+      "makes case 2 go RED by losing the heartbeat on the timeout path",
+      async () => {
+        // WHY THIS REPEATS. The defect is RACY: whether the shell dies of SIGPIPE depends on
+        // whether the group-TERM has already taken `tee` by the time the shell writes its
+        // next byte to the log pipe. It was measured at roughly three runs in five, and a
+        // single lucky green had already pronounced it fixed once — so a control that ran
+        // the mutation ONCE and saw the heartbeat survive would report "the guard was seen
+        // red" about a run that proved nothing. It attempts up to the repetition floor and
+        // stops at the first observed loss.
+        const outcomes: string[] = [];
+        let losses = 0;
+        for (let attempt = 1; attempt <= RUNS_PER_CASE && losses === 0; attempt += 1) {
+          const dirs = makeCaseDir(TIMEOUT_CASE_OPTIONS);
+          setFakeBehavior(dirs.caseDir, "prices:fetch", "hangs");
+          // The committed wrapper is never touched: the mutation lives and dies in the case
+          // dir, exactly as the child-reap control's does.
+          const mutated = mutateWrapper(WRAPPER_PATH, dirs.caseDir, TEE_DEAFNESS_MUTATION);
+          expect(mutated.startsWith(dirs.caseDir)).toBe(true);
+
+          const record = await launchWrapper({
+            caseDir: dirs.caseDir,
+            wrapperPath: mutated,
+            env: caseEnv(dirs, TIMEOUT_CASE_OPTIONS),
+            groupLeader: true,
+            settleDeadlineMs: timeoutSettleDeadlineMs(TIMEOUT_CASE_OPTIONS),
+            maxWaitMs: 120_000,
+          });
+
+          // The watchdog still fired — this run really is the timeout path, so a lost
+          // heartbeat is the mutation's doing and not a run that never timed out.
+          expect(record.watchdogFired, `attempt ${attempt}: the watchdog never fired`).toBe(true);
+          if (record.heartbeat === undefined) {
+            losses += 1;
+          }
+          outcomes.push(
+            `${record.heartbeat === undefined ? "LOST" : "kept"}` +
+              `(exit=${record.exitCode ?? `signal ${record.signal ?? "?"}`})`,
+          );
+        }
+        console.log(`[wrapper harness] tee-deafness mutation outcomes: ${outcomes.join(", ")}`);
+
+        expect(
+          losses,
+          `the tee-deafness mutation never lost the heartbeat in ${outcomes.length} runs, so ` +
+            "assertion 2 has not been seen red and this control is guarding nothing: " +
+            outcomes.join(", "),
+        ).toBeGreaterThan(0);
+
+        // AND THE UNMUTATED WRAPPER KEEPS IT, on the same case and the same path — so what
+        // went red is the missing `trap '' TERM PIPE` and not the timeout path itself.
+        const clean = makeCaseDir(TIMEOUT_CASE_OPTIONS);
+        setFakeBehavior(clean.caseDir, "prices:fetch", "hangs");
+        const healthy = await launchWrapper({
+          caseDir: clean.caseDir,
+          wrapperPath: WRAPPER_PATH,
+          env: caseEnv(clean, TIMEOUT_CASE_OPTIONS),
+          groupLeader: true,
+          settleDeadlineMs: timeoutSettleDeadlineMs(TIMEOUT_CASE_OPTIONS),
+          maxWaitMs: 120_000,
+        });
+        expect(healthy.watchdogFired).toBe(true);
+        expect(healthy.exitCode, "the unmutated timeout path exited by signal").toBe(124);
+        expect(
+          healthy.heartbeat?.lastStep,
+          "the unmutated wrapper lost the heartbeat too — the `tee` trap is not what is keeping it",
+        ).toBe("timeout:prices-fetch");
+      },
+      600_000,
     );
   });
 });

--- a/apps/price-feed/src/wrapper-harness/run-daily-fetch.test.ts
+++ b/apps/price-feed/src/wrapper-harness/run-daily-fetch.test.ts
@@ -78,7 +78,7 @@ import { tmpdir } from "node:os";
 import { dirname, join } from "node:path";
 import { fileURLToPath } from "node:url";
 import type { JobHeartbeat } from "@numisma/event-store";
-import { describe, expect, it } from "vitest";
+import { describe, expect, it, onTestFinished } from "vitest";
 import {
   HARNESS_PLATFORM,
   TRIGGER_PATH_SET,
@@ -797,6 +797,22 @@ function assertTriple(
 }
 
 describe.runIf(decision.run)("wrapper harness — the real wrapper, armed", () => {
+  // ── THE ARMED SUITE LAUNCHES SOMETHING, ASSERTED RATHER THAN REASONED ─────────────
+  //
+  // `RUNS_PER_CASE` is the loop bound of every case below, and it is `0` whenever the
+  // trigger says not to run. Were it ever 0 INSIDE this block, all eight cases and both
+  // mutation controls would go green having launched nothing — the exact failure this
+  // suite exists to be incapable of. It is unreachable today (`resolveRunCount` refuses
+  // anything below the floor and never returns 0), but every other claim in this file is
+  // held to a bar higher than "unreachable by an argument about another module", and this
+  // is the claim the rest of them rest on.
+  it("has a repetition count, so a case cannot pass by looping zero times", () => {
+    expect(
+      RUNS_PER_CASE,
+      "the armed suite would launch nothing and every case below would pass vacuously",
+    ).toBeGreaterThanOrEqual(REPETITION_FLOOR);
+  });
+
   // ── THE FAKE MUST HAVE WON, AND IT IS PROVEN, NOT ASSUMED ─────────────────────────
   it("resolves `pnpm` the way the WRAPPER's own re-exported PATH does — to the case dir's fake", () => {
     const dirs = makeCaseDir(CASE_OPTIONS);
@@ -930,6 +946,21 @@ describe.runIf(decision.run)("wrapper harness — the real wrapper, armed", () =
     `case 1 — healthy run, ${RUNS_PER_CASE} consecutive times`,
     async () => {
       const settles: number[] = [];
+      // ── THE DIAGNOSTICS SURVIVE A THROW, WHICH IS THE ONLY TIME THEY MATTER ────────
+      //
+      // Every case in this file records a per-run series and prints it at the end. Printed
+      // after the loop, that print is skipped by exactly the event it exists to explain: a
+      // red on run 9 reports `expected 143 to be …` and takes the whole history with it,
+      // so a one-off is indistinguishable from a drift and the next intermittent failure
+      // is a mystery rather than evidence. `onTestFinished` runs whether the test passed
+      // or threw — a `try`/`finally` around each loop with none of the re-indentation —
+      // and the series is captured by reference, so whatever the loop managed to record
+      // before it died is what gets printed.
+      onTestFinished(() => {
+        // Recorded, not merely passed: a regression from 0.1s to 1.9s is inside the
+        // window and would otherwise be invisible.
+        console.log(`[wrapper harness] case 1 settle ms: ${settles.join(", ")}`);
+      });
       for (let run = 1; run <= RUNS_PER_CASE; run += 1) {
         const dirs = makeCaseDir(CASE_OPTIONS);
         const record = await launchWrapper({
@@ -964,9 +995,6 @@ describe.runIf(decision.run)("wrapper harness — the real wrapper, armed", () =
         });
         settles.push(record.settleMs);
       }
-      // Recorded, not merely passed: a regression from 0.1s to 1.9s is inside the window
-      // and would otherwise be invisible.
-      console.log(`[wrapper harness] case 1 settle ms: ${settles.join(", ")}`);
     },
     240_000,
   );
@@ -993,6 +1021,11 @@ describe.runIf(decision.run)("wrapper harness — the real wrapper, armed", () =
         (TIMEOUT_CASE_OPTIONS.maxRunSeconds + TIMEOUT_CASE_OPTIONS.watchdogGraceSeconds) * 1_000;
       const observeAtMs = ceilingAndGraceMs + CASE_7_OBSERVE_MARGIN_MS;
       const survivals: number[] = [];
+      onTestFinished(() => {
+        console.log(
+          `[wrapper harness] case 7 survived (ms, ceiling+grace=${ceilingAndGraceMs}): ${survivals.join(", ")}`,
+        );
+      });
 
       for (let run = 1; run <= RUNS_PER_CASE; run += 1) {
         const dirs = makeCaseDir(TIMEOUT_CASE_OPTIONS);
@@ -1045,9 +1078,6 @@ describe.runIf(decision.run)("wrapper harness — the real wrapper, armed", () =
         });
         survivals.push(record.durationMs);
       }
-      console.log(
-        `[wrapper harness] case 7 survived (ms, ceiling+grace=${ceilingAndGraceMs}): ${survivals.join(", ")}`,
-      );
     },
     600_000,
   );
@@ -1137,6 +1167,12 @@ describe.runIf(decision.run)("wrapper harness — the real wrapper, armed", () =
     `case 2 — watchdog timeout with a REACTIVE child, ${RUNS_PER_CASE} consecutive times`,
     async () => {
       const settles: number[] = [];
+      onTestFinished(() => {
+        console.log(
+          `[wrapper harness] case 2 settle ms (bound ${timeoutSettleDeadlineMs(TIMEOUT_CASE_OPTIONS)}): ` +
+            settles.join(", "),
+        );
+      });
       for (let run = 1; run <= RUNS_PER_CASE; run += 1) {
         const dirs = makeCaseDir(TIMEOUT_CASE_OPTIONS);
         // The fake hangs at the fetch step, reactively: neither it nor its `sleep` traps
@@ -1177,10 +1213,6 @@ describe.runIf(decision.run)("wrapper harness — the real wrapper, armed", () =
         watchdogTermObserved = observeTermPath(record, label);
         settles.push(record.settleMs);
       }
-      console.log(
-        `[wrapper harness] case 2 settle ms (bound ${timeoutSettleDeadlineMs(TIMEOUT_CASE_OPTIONS)}): ` +
-          settles.join(", "),
-      );
     },
     600_000,
   );
@@ -1189,6 +1221,12 @@ describe.runIf(decision.run)("wrapper harness — the real wrapper, armed", () =
     `case 3 — watchdog timeout with a TERM-DEAF grandchild, ${RUNS_PER_CASE} consecutive times`,
     async () => {
       const settles: number[] = [];
+      onTestFinished(() => {
+        console.log(
+          `[wrapper harness] case 3 settle ms (bound ${timeoutSettleDeadlineMs(TIMEOUT_CASE_OPTIONS)}): ` +
+            settles.join(", "),
+        );
+      });
       for (let run = 1; run <= RUNS_PER_CASE; run += 1) {
         const dirs = makeCaseDir(TIMEOUT_CASE_OPTIONS);
         // The historical shape verbatim: the grandchild ignores TERM and holds the
@@ -1236,10 +1274,6 @@ describe.runIf(decision.run)("wrapper harness — the real wrapper, armed", () =
         });
         settles.push(record.settleMs);
       }
-      console.log(
-        `[wrapper harness] case 3 settle ms (bound ${timeoutSettleDeadlineMs(TIMEOUT_CASE_OPTIONS)}): ` +
-          settles.join(", "),
-      );
     },
     600_000,
   );
@@ -1248,6 +1282,9 @@ describe.runIf(decision.run)("wrapper harness — the real wrapper, armed", () =
     `case 5 — an early non-zero exit, ${RUNS_PER_CASE} consecutive times`,
     async () => {
       const settles: number[] = [];
+      onTestFinished(() => {
+        console.log(`[wrapper harness] case 5 settle ms: ${settles.join(", ")}`);
+      });
       for (let run = 1; run <= RUNS_PER_CASE; run += 1) {
         // The FULL ceiling, deliberately: this run must end on its own terms long before
         // any watchdog could touch it, and a short ceiling would blur those two endings.
@@ -1263,6 +1300,12 @@ describe.runIf(decision.run)("wrapper harness — the real wrapper, armed", () =
           wrapperPath: WRAPPER_PATH,
           env: caseEnv(dirs, CASE_OPTIONS),
           groupLeader: true,
+          // THE SHORT WINDOW, AS ON EVERY NON-TIMEOUT PATH. This run ends on its own terms,
+          // so its EXIT trap cancels the watchdog — subshell and forked `sleep` both —
+          // before the shell leaves. Giving this case the grace-derived bound would let a
+          // watchdog left sleeping out its full ceiling over an already-dead run pass
+          // unnoticed, which is precisely the held-job-slot failure the cancellation exists
+          // to prevent.
           settleDeadlineMs: SETTLE_DEADLINE_MS,
           maxWaitMs: 60_000,
         });
@@ -1276,11 +1319,6 @@ describe.runIf(decision.run)("wrapper harness — the real wrapper, armed", () =
         expect(record.watchdogFired, `${label}: a run that was never timed out left a calling card`).toBe(
           false,
         );
-        // AND THE SETTLE WINDOW STAYS THE SHORT ONE. This is not a timeout path, so the
-        // watchdog was cancelled — subshell and forked `sleep` both — before the shell left.
-        // Giving this case the grace-derived bound would let a watchdog left sleeping out
-        // its full ceiling over an already-dead run pass unnoticed, which is precisely the
-        // held-job-slot failure the wrapper's own cancellation exists to prevent.
 
         assertTriple(record, dirs.caseDir, {
           exitCode: 127,
@@ -1291,7 +1329,6 @@ describe.runIf(decision.run)("wrapper harness — the real wrapper, armed", () =
         });
         settles.push(record.settleMs);
       }
-      console.log(`[wrapper harness] case 5 settle ms: ${settles.join(", ")}`);
     },
     600_000,
   );
@@ -1322,8 +1359,14 @@ describe.runIf(decision.run)("wrapper harness — the real wrapper, armed", () =
    *
    * Cases 2, 3 and 4 hang at the FIRST step, so their run has nothing to accomplish before
    * the ceiling and 3 seconds is generous. Case 6 has to get all the way to the LAST step
-   * first — four fake `pnpm` invocations, a `git add`/`git commit` against the case's own
-   * repo, and a `git status` post-check — and only then wedge. A healthy run does that in
+   * first — four fake `pnpm` invocations plus the wrapper's whole git step against the
+   * case's own repo (`rev-parse`, the explicit `add`, `diff --cached` and the `status`
+   * post-check) — and only then wedge. What it does NOT traverse is a `git commit`: the
+   * fixture commits an EMPTY `events.jsonl` and the fake `spine` writes nothing, so
+   * `git diff --cached --quiet` succeeds and the wrapper takes its documented
+   * "no tracked data changes to commit" no-op arm. An earlier version of this comment
+   * claimed the commit as part of the traversal it is buying margin for; the margin is
+   * real, the commit is not. A healthy run does all of it in
    * about 0.7s (case 1 measures it every suite run), but a 3-second ceiling gave only ~4x
    * margin and lost the race on a loaded machine: the run timed out at an earlier step and
    * the case quietly became case 2 with a different label. Widened, not removed — the
@@ -1388,6 +1431,9 @@ describe.runIf(decision.run)("wrapper harness — the real wrapper, armed", () =
     `case 6 — cry-wolf: a timeout at \`backfill\` IN the mark window, ${RUNS_PER_CASE} consecutive times`,
     async () => {
       const settles: number[] = [];
+      onTestFinished(() => {
+        console.log(`[wrapper harness] case 6 in-window settle ms: ${settles.join(", ")}`);
+      });
       for (let run = 1; run <= RUNS_PER_CASE; run += 1) {
         const options = markCaseOptions("in", CASE_6_OPTIONS);
         const dirs = makeCaseDir(options);
@@ -1463,7 +1509,6 @@ describe.runIf(decision.run)("wrapper harness — the real wrapper, armed", () =
 
         settles.push(record.settleMs);
       }
-      console.log(`[wrapper harness] case 6 in-window settle ms: ${settles.join(", ")}`);
     },
     900_000,
   );
@@ -1480,6 +1525,9 @@ describe.runIf(decision.run)("wrapper harness — the real wrapper, armed", () =
     `case 6 — the same cry-wolf run OUT of the window carries the prior stamp, ${RUNS_PER_CASE} consecutive times`,
     async () => {
       const settles: number[] = [];
+      onTestFinished(() => {
+        console.log(`[wrapper harness] case 6 out-of-window settle ms: ${settles.join(", ")}`);
+      });
       for (let run = 1; run <= RUNS_PER_CASE; run += 1) {
         const options = markCaseOptions("out", CASE_6_OPTIONS);
         const dirs = makeCaseDir(options);
@@ -1523,7 +1571,6 @@ describe.runIf(decision.run)("wrapper harness — the real wrapper, armed", () =
 
         settles.push(record.settleMs);
       }
-      console.log(`[wrapper harness] case 6 out-of-window settle ms: ${settles.join(", ")}`);
     },
     900_000,
   );
@@ -1749,6 +1796,16 @@ describe.runIf(decision.run)("wrapper harness — the real wrapper, armed", () =
       const reaches: number[] = [];
       const durations: number[] = [];
       const ceilingMs = TIMEOUT_CASE_OPTIONS.maxRunSeconds * 1_000;
+      // THREE SERIES, AND THIS IS THE CASE THAT NEEDS THEM MOST. It carries the suite's
+      // tightest wall-clock margins, so a red here is exactly the failure where knowing
+      // whether run 9 was slow — or whether every run had been drifting — is the whole
+      // diagnosis. Printed after the loop, none of it survives the throw.
+      onTestFinished(() => {
+        console.log(
+          `[wrapper harness] case 4 reached the step in (ms): ${reaches.join(", ")} · ran for (ms, ` +
+            `ceiling ${ceilingMs}): ${durations.join(", ")} · settle ms: ${settles.join(", ")}`,
+        );
+      });
 
       for (let run = 1; run <= RUNS_PER_CASE; run += 1) {
         const dirs = makeCaseDir(TIMEOUT_CASE_OPTIONS);
@@ -1822,10 +1879,6 @@ describe.runIf(decision.run)("wrapper harness — the real wrapper, armed", () =
         settles.push(record.settleMs);
         durations.push(record.durationMs);
       }
-      console.log(
-        `[wrapper harness] case 4 reached the step in (ms): ${reaches.join(", ")} · ran for (ms, ` +
-          `ceiling ${ceilingMs}): ${durations.join(", ")} · settle ms: ${settles.join(", ")}`,
-      );
     },
     600_000,
   );
@@ -1855,6 +1908,16 @@ describe.runIf(decision.run)("wrapper harness — the real wrapper, armed", () =
     if (timeout === undefined || external === undefined) {
       return;
     }
+    // Same reasoning as every case loop: the summary of what the two halves actually
+    // recorded is worth most when one of the comparisons below has just gone red.
+    onTestFinished(() => {
+      console.log(
+        `[wrapper harness] the pair — ${timeout.label}: exit ${timeout.heartbeat.exitCode} at ` +
+          `\`${timeout.heartbeat.lastStep}\`, card ${timeout.watchdogCard} · ${external.label}: ` +
+          `exit ${external.heartbeat.exitCode} at \`${external.heartbeat.lastStep}\`, card ` +
+          `${external.watchdogCard}`,
+      );
+    });
 
     // ── THE THREE THINGS THAT MUST DIFFER ───────────────────────────────────────────
     // (1) The exit code. `not.toBe` as well as the two literals, because the literals alone
@@ -1950,12 +2013,6 @@ describe.runIf(decision.run)("wrapper harness — the real wrapper, armed", () =
       ).toBe(expectedMarkWindow(observed.heartbeat.startedAt, CONTRACT_MARK_CONFIG));
     }
 
-    console.log(
-      `[wrapper harness] the pair — ${timeout.label}: exit ${timeout.heartbeat.exitCode} at ` +
-        `\`${timeout.heartbeat.lastStep}\`, card ${timeout.watchdogCard} · ${external.label}: ` +
-        `exit ${external.heartbeat.exitCode} at \`${external.heartbeat.lastStep}\`, card ` +
-        `${external.watchdogCard}`,
-    );
   });
 
   // ── S6 · THE CHILD-REAP MUTATION CONTROL ──────────────────────────────────────────
@@ -2047,6 +2104,12 @@ describe.runIf(decision.run)("wrapper harness — the real wrapper, armed", () =
         // stops at the first observed loss.
         const outcomes: string[] = [];
         let losses = 0;
+        // The attempt-by-attempt series is the whole diagnosis if this control ever fails:
+        // "kept on all 12" and "threw on attempt 3" are different problems, and only the
+        // series tells them apart. It must survive a throw inside the loop.
+        onTestFinished(() => {
+          console.log(`[wrapper harness] tee-deafness mutation outcomes: ${outcomes.join(", ")}`);
+        });
         for (let attempt = 1; attempt <= RUNS_PER_CASE && losses === 0; attempt += 1) {
           const dirs = makeCaseDir(TIMEOUT_CASE_OPTIONS);
           setFakeBehavior(dirs.caseDir, "prices:fetch", "hangs");
@@ -2075,7 +2138,6 @@ describe.runIf(decision.run)("wrapper harness — the real wrapper, armed", () =
               `(exit=${record.exitCode ?? `signal ${record.signal ?? "?"}`})`,
           );
         }
-        console.log(`[wrapper harness] tee-deafness mutation outcomes: ${outcomes.join(", ")}`);
 
         expect(
           losses,

--- a/apps/price-feed/src/wrapper-harness/run-daily-fetch.test.ts
+++ b/apps/price-feed/src/wrapper-harness/run-daily-fetch.test.ts
@@ -1652,10 +1652,20 @@ describe.runIf(decision.run)("wrapper harness — the real wrapper, armed", () =
   // than through the clock, which is why the guard is asserted here and not taken on
   // trust.
   //
-  // BOTH RUNS DIE BEFORE THE EXIT TRAP IS INSTALLED, so there is no heartbeat and no log
-  // file to read — the refusal is on the child's own stdout, and the assertion triple
-  // does not apply. That is the correct shape: a run that cannot say which side of the
-  // window it is on must not write a breadcrumb claiming one.
+  // AND IT REFUSES OUT LOUD, WHICH IS A SEPARATE CLAIM FROM REFUSING. These guards are the
+  // newest way for EVERY scheduled fire to die, so where they die decides whether anyone
+  // finds out. They used to run before the EXIT trap and before the log existed: a typo'd
+  // zone in the plist killed all six fires of an evening leaving no per-run log and no
+  // breadcrumb, `job-heartbeat.json` went on describing the last good run, and the TUI read
+  // "healthy" until the staleness channel aged out days later — the same silent rot the
+  // guard exists to prevent, re-entered through the guard. They now run after the trap and
+  // the log, so the refusal lands as a FATAL log line and a breadcrumb reading `exit 1 at
+  // step 'startup'`, and these cases assert exactly that.
+  //
+  // IT STILL REFUSES: no `pnpm` sentinel exists, `lastStep` never left `startup`, and
+  // `markWindow` is `false` — which DECLINES a side rather than claiming one. A run that
+  // died in its own startup guards marked nothing, so `false` is what "was this run capable
+  // of marking?" honestly answers, and the stamp is neither written nor erased.
   describe("the configured mark window refuses a value it cannot resolve", () => {
     for (const [name, value, expected] of [
       ["NUMISMA_MARK_TZ", "Not/AZone", "is not a resolvable IANA zone"],
@@ -1685,8 +1695,28 @@ describe.runIf(decision.run)("wrapper harness — the real wrapper, armed", () =
             `${name}=${value}: the wrapper reached \`${command}\` despite refusing its own configuration`,
           ).toBe(false);
         }
-        expect(record.heartbeat, `${name}=${value}: a run that refused its own configuration ` +
-          "still wrote a breadcrumb claiming a side of the window").toBeUndefined();
+        // AND IT SAID SO ON BOTH CHANNELS THAT REACH A HUMAN. The per-run log is the one an
+        // operator reads; the heartbeat is the one the TUI reads. A refusal that produced
+        // neither is indistinguishable from a machine that was switched off.
+        expect(
+          record.logText,
+          `${name}=${value}: the refusal left no per-run log — every fire of the evening would ` +
+            "die on the one channel that reaches nobody",
+        ).toContain("FATAL");
+        expect(
+          record.heartbeat,
+          `${name}=${value}: the refusal left no breadcrumb, so job-heartbeat.json goes on ` +
+            "describing the last good run and the TUI reads healthy",
+        ).toBeDefined();
+        expect(record.heartbeat?.exitCode, `${name}=${value}: heartbeat exit code`).toBe(1);
+        expect(record.heartbeat?.lastStep, `${name}=${value}: heartbeat step`).toBe("startup");
+        // DECLINED, NOT CLAIMED — and nothing stamped: a run that died at `startup` marked
+        // nothing, which is exactly what `markWindow: false` says.
+        expect(record.heartbeat?.markWindow, `${name}=${value}: heartbeat markWindow`).toBe(false);
+        expect(
+          record.heartbeat?.lastMarkWindowFinishedAt,
+          `${name}=${value}: a run that refused its own configuration invented a marked-day stamp`,
+        ).toBeUndefined();
         expect(record.pgidResidue, `${name}=${value}: processes left in pgid ${record.pgid}`).toEqual([]);
       });
     }

--- a/apps/price-feed/src/wrapper-harness/run-daily-fetch.test.ts
+++ b/apps/price-feed/src/wrapper-harness/run-daily-fetch.test.ts
@@ -1,0 +1,808 @@
+/**
+ * THE COMMITTED TEST HARNESS FOR `ops/price-feed/run-daily-fetch.sh` (PRD #314, slice #316).
+ *
+ * ⚠️ **THIS SUITE CAN NEVER RUN IN CI AS CI EXISTS TODAY. A GREEN CI RUN DOES NOT MEAN
+ * THIS HARNESS PASSED — IT MEANS IT WAS NOT ATTEMPTED.** CI is a single `ubuntu-latest`
+ * job. This suite targets macOS `/bin/bash` 3.2.57, BSD `ps`/`pgrep`, and a watchdog that
+ * is hand-rolled *because* macOS ships no `timeout(1)`. The same sentence is written in
+ * `docs/price-feed-ops.md` and beside the test step in `.github/workflows/ci.yml`, which
+ * is where someone reading a green check actually looks.
+ *
+ * ── WHY THIS EXISTS ───────────────────────────────────────────────────────────────────
+ * The wrapper's teardown has produced four real defects, and every one of them was found
+ * by hand, after the fact, on a throwaway script that was then discarded: a stray `sleep`
+ * orphaned into the run's process group holding launchd's per-label job slot; a `tee`
+ * killed by the group TERM taking the heartbeat with it; a TERM-deaf grandchild surviving
+ * a timeout; a decorated `LAST_STEP` silently breaking the marks-landed predicate. Three
+ * of the four were caught by ONE observation — *is anything still in the run's process
+ * group?* — and none of them was visible to a linter or to a single green run.
+ *
+ * ── WHAT IS ARMED, AND WHEN ───────────────────────────────────────────────────────────
+ * The expensive block runs when its own subject changed (§7's ruling), never silently:
+ * one always-running test reports the decision, the base SHA it compared against and the
+ * path set, so every `pnpm test` carries a line about this harness whether or not it ran.
+ * `pnpm test:wrapper` runs it on demand. `NUMISMA_WRAPPER_TEST=never` mutes it and says so.
+ *
+ * ── WHAT SLICE 1 CLAIMS, AND WHAT IT DOES NOT ─────────────────────────────────────────
+ * Claims: the launcher, the isolation refusal, the fake-tool bin and its sentinel, the
+ * assertion triple, 12-run repetition, the arming trigger and its three guard layers,
+ * case 1 (healthy), case 7 (not a group leader) and the child-reap mutation control.
+ * Does not: any timeout, external-stop or mark-window case — slices 2-4 — nor the `hangs`,
+ * `exits 127` and TERM-deaf fakes those need. Case 7 here therefore proves the leader
+ * DETECTION with a fast, succeeding run; slice 2 will additionally prove that a genuine
+ * hang under a disabled watchdog does not time out, once the `hangs` behavior exists.
+ *
+ * ── A BLIND SPOT THIS DESIGN CREATES, NAMED RATHER THAN IMPLIED ───────────────────────
+ * The fake `pnpm` is what makes every case fast and safe, and it is therefore exactly what
+ * blinds this suite to the REAL pnpm. Rename a script in the root `package.json` and the
+ * wrapper's `pnpm backfill` breaks in production while every case here stays green. That
+ * is why §7.3 keeps the four command implementations OUT of the trigger set: the suite has
+ * nothing to say about them, and a trigger that armed on them would be claiming otherwise.
+ */
+
+import { execFileSync } from "node:child_process";
+import { existsSync, mkdirSync, mkdtempSync, readFileSync, readdirSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { dirname, join } from "node:path";
+import { fileURLToPath } from "node:url";
+import { describe, expect, it } from "vitest";
+import {
+  HARNESS_PLATFORM,
+  TRIGGER_PATH_SET,
+  decideArming,
+  matchesPathSet,
+  parsePorcelain,
+  readOverride,
+  resolveTriggerFacts,
+  type BaseResolution,
+} from "./arming-trigger.testkit.js";
+import {
+  CHILD_REAP_MUTATION,
+  LAUNCHD_BARE_PATH,
+  caseEnv,
+  makeCaseDir,
+  mutateWrapper,
+  type CaseOptions,
+} from "./case-dir.testkit.js";
+import { WRAPPER_PNPM_COMMANDS, installDecoyBin, sentinelNameFor } from "./fake-bin.testkit.js";
+import { IsolationRefusal, WRAPPER_ENV_VARS, assertIsolated } from "./isolation.testkit.js";
+import { launchWrapper, observedBashVersion, type RunRecord } from "./launcher.testkit.js";
+import { REPETITION_FLOOR, resolveRunCount } from "./repetition.testkit.js";
+
+const REPO_ROOT = fileURLToPath(new URL("../../../../", import.meta.url));
+const WRAPPER_RELATIVE_PATH = "ops/price-feed/run-daily-fetch.sh";
+const WRAPPER_PATH = join(REPO_ROOT, WRAPPER_RELATIVE_PATH);
+
+// ── THE ARMING DECISION, TAKEN ONCE ───────────────────────────────────────────────────
+const override = readOverride(process.env.NUMISMA_WRAPPER_TEST);
+const facts = resolveTriggerFacts(REPO_ROOT);
+const decision = decideArming({
+  changedPaths: facts.changedPaths,
+  base: facts.base,
+  pathSet: TRIGGER_PATH_SET,
+  platform: process.platform,
+  override,
+});
+
+/**
+ * These five build a real repository and run several `git` processes against a brand-new
+ * temp directory, which on this machine costs a second or two — comfortably over vitest's
+ * 5s default once the machine is under parallel test load. Raised explicitly rather than
+ * globally: it is a fixture cost, not a change to any assertion.
+ */
+const GIT_FIXTURE_TIMEOUT_MS = 60_000;
+
+/** An isolated git environment, so a temp repo cannot inherit this machine's config. */
+function gitEnv(home: string): NodeJS.ProcessEnv {
+  return {
+    PATH: LAUNCHD_BARE_PATH,
+    HOME: home,
+    GIT_CONFIG_GLOBAL: "/dev/null",
+    GIT_CONFIG_SYSTEM: "/dev/null",
+    GIT_AUTHOR_NAME: "numisma wrapper harness",
+    GIT_AUTHOR_EMAIL: "harness@invalid",
+    GIT_COMMITTER_NAME: "numisma wrapper harness",
+    GIT_COMMITTER_EMAIL: "harness@invalid",
+    GIT_AUTHOR_DATE: "2026-01-01T00:00:00Z",
+    GIT_COMMITTER_DATE: "2026-01-01T00:00:00Z",
+  };
+}
+
+/**
+ * A throwaway repository for the trigger's REAL git behavior. The decision function can be
+ * unit-tested over authored inputs, but "a wrapper edit three commits back on a branch
+ * still arms" is a claim about `git merge-base` and the `base...HEAD` range — it is only
+ * provable against real git, and it is exactly the claim that separates a correct base
+ * from a lazy `HEAD~1`.
+ */
+function makeTempRepo(): { dir: string; env: NodeJS.ProcessEnv; git: (...args: string[]) => string } {
+  const dir = mkdtempSync(join(tmpdir(), "numisma-trigger-repo-"));
+  const env = gitEnv(join(dir, "home"));
+  mkdirSync(join(dir, "home"), { recursive: true });
+  const git = (...args: string[]): string =>
+    execFileSync("git", ["-C", dir, ...args], { encoding: "utf8", env, stdio: ["ignore", "pipe", "pipe"] }).trim();
+  git("init", "--quiet", "--initial-branch", "main");
+  return { dir, env, git };
+}
+
+function writeIn(dir: string, relativePath: string, contents: string): void {
+  const full = join(dir, relativePath);
+  mkdirSync(dirname(full), { recursive: true });
+  writeFileSync(full, contents, "utf8");
+}
+
+// ══════════════════════════════════════════════════════════════════════════════════════
+// ALWAYS RUNS. Everything below this line survives the very skip it is guarding against —
+// that is the whole point of §7.5. A conditional suite's new silent failure is "always
+// skipped", and it is indistinguishable from healthy: a typo'd glob matches nothing, the
+// suite skips forever, every PR is green, and the skip line reads perfectly normal.
+// ══════════════════════════════════════════════════════════════════════════════════════
+describe("wrapper harness — the arming trigger (always runs)", () => {
+  it("reports its decision out loud, with the base it compared against and the path set", () => {
+    const base: BaseResolution = facts.base;
+    // The point of this test IS the line it prints — §7.4's "it never skips silently".
+    console.log(
+      `[wrapper harness] ${decision.reason}\n` +
+        `[wrapper harness] base: ${base.kind === "resolved" ? base.sha : `unresolved (${base.why})`}\n` +
+        `[wrapper harness] path set: ${TRIGGER_PATH_SET.join(", ")}\n` +
+        `[wrapper harness] platform: ${process.platform} · override: ${override} · ` +
+        `runs per case: ${resolveRunCount(process.env.NUMISMA_WRAPPER_TEST_RUNS)}` +
+        (process.platform === HARNESS_PLATFORM ? ` · shell: ${observedBashVersion()}` : ""),
+    );
+    expect(decision.reason.length).toBeGreaterThan(0);
+    expect(decision.reason.startsWith(decision.run ? "harness armed" : "harness skipped")).toBe(true);
+  });
+
+  // ── GUARD-THE-GUARD, LAYER (a): the decision function over authored inputs ──────────
+  describe("layer (a) — the decision function, over authored inputs", () => {
+    const armedInput = {
+      base: { kind: "resolved", sha: "0000000000000000000000000000000000000000" } as BaseResolution,
+      pathSet: TRIGGER_PATH_SET,
+      platform: HARNESS_PLATFORM,
+      override: "auto" as const,
+    };
+
+    it("arms on a wrapper edit", () => {
+      const result = decideArming({ ...armedInput, changedPaths: [WRAPPER_RELATIVE_PATH] });
+      expect(result.run).toBe(true);
+      expect(result.gate).toBe("changes");
+      expect(result.matched).toEqual([WRAPPER_RELATIVE_PATH]);
+    });
+
+    it("arms on a plist edit — the oracle for the ceiling and the /bin/bash invocation", () => {
+      const result = decideArming({
+        ...armedInput,
+        changedPaths: ["ops/price-feed/com.numisma.pricefeed.daily.plist"],
+      });
+      expect(result.run).toBe(true);
+    });
+
+    it("arms on an edit to the harness itself — omit this and you can break the suite and sail past green", () => {
+      const result = decideArming({
+        ...armedInput,
+        changedPaths: ["apps/price-feed/src/wrapper-harness/launcher.testkit.ts"],
+      });
+      expect(result.run).toBe(true);
+    });
+
+    it("arms on an edit to the heartbeat oracle", () => {
+      const result = decideArming({
+        ...armedInput,
+        changedPaths: ["packages/event-store/src/heartbeat.ts"],
+      });
+      expect(result.run).toBe(true);
+    });
+
+    it("does NOT arm on an unrelated edit, and says what it compared against", () => {
+      const result = decideArming({ ...armedInput, changedPaths: ["apps/web/src/lib/dashboard.ts"] });
+      expect(result.run).toBe(false);
+      expect(result.gate).toBe("changes");
+      expect(result.reason).toContain("no changes under");
+      expect(result.reason).toContain("0000000000000000000000000000000000000000");
+      expect(result.reason).toContain("ops/price-feed/**");
+    });
+
+    it("does NOT arm on the four faked command implementations — the suite cannot falsify them", () => {
+      const result = decideArming({
+        ...armedInput,
+        changedPaths: [
+          "apps/price-feed/src/cli.ts",
+          "apps/tui/src/spine.ts",
+          "apps/web/src/push/gap-report.ts",
+          "apps/web/src/push/backfill.ts",
+          "apps/price-feed/src/schedule-window.test.ts",
+        ],
+      });
+      expect(result.run).toBe(false);
+    });
+
+    it("arms when the base cannot be resolved, and says why — it fails TOWARD running", () => {
+      const result = decideArming({
+        ...armedInput,
+        changedPaths: [],
+        base: { kind: "unresolved", why: "shallow clone" },
+      });
+      expect(result.run).toBe(true);
+      expect(result.gate).toBe("base");
+      expect(result.reason).toContain("shallow clone");
+      expect(result.reason).toContain("failing toward running");
+    });
+
+    it("treats an EMPTY path set as a hard error, never as a skip", () => {
+      // An empty set is definitionally a trigger that can never fire. A skip here would be
+      // the silent failure this whole layer exists to make impossible.
+      expect(() => decideArming({ ...armedInput, changedPaths: [], pathSet: [] })).toThrow(
+        /path set is EMPTY/,
+      );
+    });
+
+    it("prints three DISTINCT skip reasons — they mean opposite things about whether to worry", () => {
+      const noChanges = decideArming({ ...armedInput, changedPaths: [] }).reason;
+      const wrongPlatform = decideArming({ ...armedInput, changedPaths: [], platform: "linux" }).reason;
+      const muted = decideArming({ ...armedInput, changedPaths: [], override: "never" }).reason;
+      expect(new Set([noChanges, wrongPlatform, muted]).size).toBe(3);
+      expect(noChanges).toContain("no changes under");
+      expect(wrongPlatform).toContain("darwin-only");
+      expect(muted).toContain("NUMISMA_WRAPPER_TEST=never");
+    });
+
+    it("bypasses the trigger for `always` — but never the platform gate", () => {
+      const forced = decideArming({ ...armedInput, changedPaths: [], override: "always" });
+      expect(forced.run).toBe(true);
+      expect(forced.gate).toBe("override");
+
+      const forcedOnLinux = decideArming({
+        ...armedInput,
+        changedPaths: [],
+        override: "always",
+        platform: "linux",
+      });
+      expect(forcedOnLinux.run).toBe(false);
+      expect(forcedOnLinux.gate).toBe("platform");
+    });
+
+    it("evaluates the PLATFORM gate before the trigger, including in CI's exact configuration", () => {
+      // CI checks out shallow, so it has no `origin/main` to merge-base against. Evaluate
+      // the trigger first and every CI run fails open into a suite that cannot work on
+      // Linux — converting the fail-open rule into a guaranteed red. Reversing the two
+      // gates fails THIS assertion: with an unresolvable base the trigger would say `run`.
+      const ciShaped = decideArming({
+        ...armedInput,
+        changedPaths: [WRAPPER_RELATIVE_PATH],
+        base: { kind: "unresolved", why: "shallow clone" },
+        platform: "linux",
+      });
+      expect(ciShaped.run).toBe(false);
+      expect(ciShaped.gate).toBe("platform");
+    });
+
+    it("refuses an unrecognised NUMISMA_WRAPPER_TEST rather than defaulting to `auto`", () => {
+      expect(readOverride(undefined)).toBe("auto");
+      expect(readOverride("always")).toBe("always");
+      expect(readOverride("never")).toBe("never");
+      expect(() => readOverride("nver")).toThrow(/not one of auto/);
+    });
+  });
+
+  // ── GUARD-THE-GUARD, LAYER (b): the real config against the real subject ────────────
+  it("layer (b) — the COMMITTED path set arms on the REAL wrapper path", () => {
+    // Layer (a) uses its own fixtures and would pass happily beside a typo'd real glob
+    // (`ops/price-feeed/**`). This is the layer that actually catches the typo, which is
+    // how a conditional suite dies in practice.
+    expect(existsSync(WRAPPER_PATH)).toBe(true);
+    const result = decideArming({
+      changedPaths: [WRAPPER_RELATIVE_PATH],
+      base: { kind: "resolved", sha: "deadbeef" },
+      pathSet: TRIGGER_PATH_SET,
+      platform: HARNESS_PLATFORM,
+      override: "auto",
+    });
+    expect(result.run).toBe(true);
+    expect(matchesPathSet(WRAPPER_RELATIVE_PATH, TRIGGER_PATH_SET)).toBe(true);
+  });
+
+  // ── GUARD-THE-GUARD, LAYER (c): liveness ───────────────────────────────────────────
+  it("layer (c) — every glob in the path set matches at least one existing file", () => {
+    // A set with a dead entry is a set that has already started rotting.
+    for (const glob of TRIGGER_PATH_SET) {
+      const relative = glob.endsWith("/**") ? glob.slice(0, -3) : glob;
+      const absolute = join(REPO_ROOT, relative);
+      expect(existsSync(absolute), `${glob} matches nothing that exists`).toBe(true);
+      if (glob.endsWith("/**")) {
+        expect(readdirSync(absolute).length, `${glob} is an empty directory`).toBeGreaterThan(0);
+      }
+    }
+  });
+
+  // ── THE TRIGGER'S REAL GIT BEHAVIOR ────────────────────────────────────────────────
+  describe("the base is a merge-base, not HEAD~1 — proven against real git", () => {
+    it("arms on a wrapper edit made THREE COMMITS BACK on a branch", () => {
+      const { dir, git } = makeTempRepo();
+      writeIn(dir, "README.md", "authored fixture\n");
+      git("add", "-A");
+      git("commit", "--quiet", "-m", "base");
+      git("update-ref", "refs/remotes/origin/main", "HEAD");
+      git("checkout", "--quiet", "-b", "feature");
+
+      writeIn(dir, WRAPPER_RELATIVE_PATH, "# authored fixture standing in for the wrapper\n");
+      git("add", "-A");
+      git("commit", "--quiet", "-m", "edit the wrapper");
+      writeIn(dir, "README.md", "authored fixture, second\n");
+      git("add", "-A");
+      git("commit", "--quiet", "-m", "unrelated 1");
+      writeIn(dir, "README.md", "authored fixture, third\n");
+      git("add", "-A");
+      git("commit", "--quiet", "-m", "unrelated 2");
+
+      const resolved = resolveTriggerFacts(dir);
+      expect(resolved.base.kind).toBe("resolved");
+      expect(resolved.changedPaths).toContain(WRAPPER_RELATIVE_PATH);
+      // `HEAD~1` would see only "unrelated 2" and skip — this is the assertion that pins
+      // the range as `base...HEAD`.
+      expect(
+        decideArming({
+          changedPaths: resolved.changedPaths,
+          base: resolved.base,
+          pathSet: TRIGGER_PATH_SET,
+          platform: HARNESS_PLATFORM,
+          override: "auto",
+        }).run,
+      ).toBe(true);
+    }, GIT_FIXTURE_TIMEOUT_MS);
+
+    it("skips on an unrelated edit, printing the resolved base SHA and the path set", () => {
+      const { dir, git } = makeTempRepo();
+      writeIn(dir, "README.md", "authored fixture\n");
+      git("add", "-A");
+      git("commit", "--quiet", "-m", "base");
+      git("update-ref", "refs/remotes/origin/main", "HEAD");
+      git("checkout", "--quiet", "-b", "feature");
+      writeIn(dir, "apps/web/src/lib/dashboard.ts", "// authored fixture\n");
+      git("add", "-A");
+      git("commit", "--quiet", "-m", "unrelated");
+
+      const resolved = resolveTriggerFacts(dir);
+      const result = decideArming({
+        changedPaths: resolved.changedPaths,
+        base: resolved.base,
+        pathSet: TRIGGER_PATH_SET,
+        platform: HARNESS_PLATFORM,
+        override: "auto",
+      });
+      expect(result.run).toBe(false);
+      expect(resolved.base.kind).toBe("resolved");
+      if (resolved.base.kind === "resolved") {
+        expect(result.reason).toContain(resolved.base.sha);
+      }
+      expect(result.reason).toContain("ops/price-feed/**");
+    }, GIT_FIXTURE_TIMEOUT_MS);
+
+    it("sees an UNCOMMITTED wrapper edit — the moment you most want the suite", () => {
+      const { dir, git } = makeTempRepo();
+      writeIn(dir, "README.md", "authored fixture\n");
+      git("add", "-A");
+      git("commit", "--quiet", "-m", "base");
+      git("update-ref", "refs/remotes/origin/main", "HEAD");
+      writeIn(dir, WRAPPER_RELATIVE_PATH, "# authored fixture, uncommitted\n");
+
+      expect(resolveTriggerFacts(dir).changedPaths).toContain(WRAPPER_RELATIVE_PATH);
+    }, GIT_FIXTURE_TIMEOUT_MS);
+
+    it("falls back to HEAD~1 on the default branch, where the merge-base degenerates to HEAD", () => {
+      const { dir, git } = makeTempRepo();
+      writeIn(dir, "README.md", "authored fixture\n");
+      git("add", "-A");
+      git("commit", "--quiet", "-m", "base");
+      const first = git("rev-parse", "HEAD");
+      writeIn(dir, WRAPPER_RELATIVE_PATH, "# authored fixture\n");
+      git("add", "-A");
+      git("commit", "--quiet", "-m", "edit the wrapper on main");
+      git("update-ref", "refs/remotes/origin/main", "HEAD");
+
+      const resolved = resolveTriggerFacts(dir);
+      expect(resolved.base).toEqual({ kind: "resolved", sha: first });
+      expect(resolved.changedPaths).toContain(WRAPPER_RELATIVE_PATH);
+    }, GIT_FIXTURE_TIMEOUT_MS);
+
+    it("returns an UNRESOLVED base — which arms the suite — when there is no origin/main", () => {
+      const { dir, git } = makeTempRepo();
+      writeIn(dir, "README.md", "authored fixture\n");
+      git("add", "-A");
+      git("commit", "--quiet", "-m", "base");
+
+      const resolved = resolveTriggerFacts(dir);
+      expect(resolved.base.kind).toBe("unresolved");
+      expect(
+        decideArming({
+          changedPaths: resolved.changedPaths,
+          base: resolved.base,
+          pathSet: TRIGGER_PATH_SET,
+          platform: HARNESS_PLATFORM,
+          override: "auto",
+        }).run,
+      ).toBe(true);
+    }, GIT_FIXTURE_TIMEOUT_MS);
+
+    it("reads a rename's NEW path out of `git status --porcelain`", () => {
+      expect(parsePorcelain(" M ops/price-feed/run-daily-fetch.sh")).toEqual([WRAPPER_RELATIVE_PATH]);
+      expect(parsePorcelain("R  old/path.sh -> ops/price-feed/run-daily-fetch.sh")).toEqual([
+        WRAPPER_RELATIVE_PATH,
+      ]);
+      expect(parsePorcelain("")).toEqual([]);
+    });
+  });
+
+  // ── S5 · THE REPETITION FLOOR ──────────────────────────────────────────────────────
+  describe("the repetition floor is a floor, not a default", () => {
+    it("is 12 when unset", () => {
+      expect(resolveRunCount(undefined)).toBe(REPETITION_FLOOR);
+      expect(REPETITION_FLOOR).toBe(12);
+    });
+
+    it("can be RAISED for a deliberate soak", () => {
+      expect(resolveRunCount("50")).toBe(50);
+    });
+
+    it("REFUSES a value below the floor rather than clamping it", () => {
+      expect(() => resolveRunCount("1")).toThrow(/below the committed floor/);
+      expect(() => resolveRunCount("11")).toThrow(/below the committed floor/);
+      expect(() => resolveRunCount("many")).toThrow(/not a whole number/);
+    });
+  });
+});
+
+// ══════════════════════════════════════════════════════════════════════════════════════
+// ARMED. Everything below launches the real wrapper.
+// ══════════════════════════════════════════════════════════════════════════════════════
+
+const RUNS_PER_CASE = decision.run ? resolveRunCount(process.env.NUMISMA_WRAPPER_TEST_RUNS) : 0;
+
+/**
+ * The settle window for a case with no timeout in it. Short ON PURPOSE, and the shortness
+ * is load-bearing: the child-reap mutation leaves a stray `sleep` with most of a
+ * 5-second watchdog poll still to run, so a generous window here would let the mutated run
+ * pass and the control would prove nothing.
+ */
+const SETTLE_DEADLINE_MS = 2_000;
+
+/** A case's own ceiling. Comfortably above a fake-tool run, far below the harness cap. */
+const CASE_OPTIONS: CaseOptions = { maxRunSeconds: 30, watchdogGraceSeconds: 2 };
+
+/**
+ * Whether this run was in the mark window, computed the way the CONTRACT computes it —
+ * `America/Mexico_City`, hour ≥ 18 — rather than from the machine's local clock, which
+ * would agree only by coincidence of an OS setting. Read off the heartbeat's own
+ * `startedAt` so a run that straddles 18:00 CDMX is still judged against the instant the
+ * wrapper judged itself at.
+ */
+function expectedMarkWindow(startedAt: string): boolean {
+  const hour = new Intl.DateTimeFormat("en-US", {
+    timeZone: "America/Mexico_City",
+    hour: "2-digit",
+    hourCycle: "h23",
+  }).format(new Date(startedAt));
+  return Number(hour) >= 18;
+}
+
+/**
+ * S4 · THE ASSERTION TRIPLE, applied uniformly and never selectively. (1) the exit code,
+ * (2) the heartbeat's contents parsed by the reader that reads it in production, (3) zero
+ * processes remaining in the run's process group — historically the highest-value
+ * assertion, and the one that caught three of the four defects.
+ *
+ * The fake-tool sentinel is asserted alongside them on every case (§6): without it a
+ * `NUMISMA_PATH_PREPEND` mistake is not a red test, it is a real run against real data
+ * that happens to pass.
+ */
+function assertTriple(
+  record: RunRecord,
+  caseDir: string,
+  expected: { exitCode: number; lastStep: string; label: string },
+): void {
+  const where = `${expected.label}: `;
+
+  // (0) The fake won. Asserted first, because if it did not, everything below is a
+  //     description of a live run against real, private data.
+  for (const command of WRAPPER_PNPM_COMMANDS) {
+    expect(
+      existsSync(join(caseDir, "sentinels", sentinelNameFor(command))),
+      `${where}the fake pnpm never recorded \`${command}\` — the REAL pnpm may have run`,
+    ).toBe(true);
+  }
+  expect(
+    existsSync(join(caseDir, "sentinels", "node-executed")),
+    `${where}the fake node was EXECUTED, which the wrapper is not supposed to do`,
+  ).toBe(false);
+
+  // (1) Exit code.
+  expect(record.exitCode, `${where}exit code (signal=${record.signal})`).toBe(expected.exitCode);
+
+  // (2) Heartbeat, through the production reader.
+  expect(record.heartbeat, `${where}the heartbeat was unreadable or absent: ${record.heartbeatRaw}`).toBeDefined();
+  const heartbeat = record.heartbeat;
+  if (heartbeat === undefined) {
+    return;
+  }
+  expect(heartbeat.exitCode, `${where}heartbeat exitCode`).toBe(expected.exitCode);
+  expect(heartbeat.lastStep, `${where}heartbeat lastStep`).toBe(expected.lastStep);
+  const inWindow = expectedMarkWindow(heartbeat.startedAt);
+  expect(heartbeat.markWindow, `${where}heartbeat markWindow`).toBe(inWindow);
+  if (inWindow) {
+    // `complete` is in MARKS_LANDED_STEPS, so an in-window run that reached it stamps
+    // ITSELF as the last in-window finish.
+    expect(heartbeat.lastMarkWindowFinishedAt, `${where}lastMarkWindowFinishedAt`).toBe(
+      heartbeat.finishedAt,
+    );
+  } else {
+    // A fresh case dir carries nothing forward, and the writer must INVENT nothing.
+    expect(heartbeat.lastMarkWindowFinishedAt, `${where}lastMarkWindowFinishedAt`).toBeUndefined();
+  }
+
+  // (3) Zero processes remaining in the run's process group.
+  expect(
+    record.pgidResidue,
+    `${where}${record.pgidResidue.length} process(es) still in pgid ${record.pgid} after ` +
+      `${record.settleMs}ms: ${record.pgidResidue.join(" | ")}`,
+  ).toEqual([]);
+}
+
+describe.runIf(decision.run)("wrapper harness — the real wrapper, armed", () => {
+  // ── THE FAKE MUST HAVE WON, AND IT IS PROVEN, NOT ASSUMED ─────────────────────────
+  it("resolves `pnpm` the way the WRAPPER's own re-exported PATH does — to the case dir's fake", () => {
+    const dirs = makeCaseDir(CASE_OPTIONS);
+    const env = caseEnv(dirs, CASE_OPTIONS);
+
+    // The replication below is only faithful while the wrapper still builds its PATH this
+    // way. Pinned, fail-closed: if that line moves, this assertion must break loudly
+    // rather than keep resolving a PATH the subject no longer uses.
+    const wrapperSource = readFileSync(WRAPPER_PATH, "utf8");
+    expect(wrapperSource).toContain('export PATH="$PATH_PREPEND:$PATH"');
+    expect(wrapperSource).toContain('PATH_PREPEND="${NUMISMA_PATH_PREPEND:-');
+
+    const resolvePnpmAsWrapperWould = (candidate: NodeJS.ProcessEnv): string =>
+      execFileSync(
+        "/bin/bash",
+        ["-c", 'export PATH="${NUMISMA_PATH_PREPEND}:$PATH"; command -v pnpm'],
+        { env: candidate, encoding: "utf8" },
+      ).trim();
+
+    expect(resolvePnpmAsWrapperWould(env)).toBe(join(dirs.binDir, "pnpm"));
+
+    // AND THE NEGATIVE HALF, which is the whole reason this assertion exists. Install the
+    // fake on the INHERITED PATH instead — the intuitive, wrong thing — and the wrapper's
+    // own prepend overrides it. In this repo the decoy stands in for what that prepend
+    // really holds by default: the directories where the REAL pnpm lives. The consequence
+    // in production is a real `prices:fetch`, a real `spine` append, a real commit against
+    // the durable event log and a real `backfill` — all passing green.
+    const decoyDir = installDecoyBin(dirs.caseDir);
+    const misinstalled: NodeJS.ProcessEnv = {
+      ...env,
+      PATH: `${dirs.binDir}:${LAUNCHD_BARE_PATH}`,
+      NUMISMA_PATH_PREPEND: decoyDir,
+    };
+    const wrongly = resolvePnpmAsWrapperWould(misinstalled);
+    expect(wrongly).toBe(join(decoyDir, "pnpm"));
+    expect(wrongly).not.toBe(join(dirs.binDir, "pnpm"));
+  });
+
+  it("launches `/bin/bash` explicitly, and records the version it observed", () => {
+    const version = observedBashVersion();
+    expect(version).toMatch(/^GNU bash, version /);
+    // 3.2.57 is what launchd runs, and it is what every assertion in this suite was
+    // written against. If /bin/bash has genuinely moved to 4 or 5, the suite's assumptions
+    // must be RE-VERIFIED against the new shell — not loosened here.
+    expect(version, `/bin/bash is no longer 3.2 — re-verify this suite, do not relax it`).toContain(
+      "version 3.2",
+    );
+  });
+
+  // ── S2 · THE ISOLATION REFUSAL ────────────────────────────────────────────────────
+  describe("the isolation contract refuses, it never falls back", () => {
+    it("accepts a properly isolated case", () => {
+      const dirs = makeCaseDir(CASE_OPTIONS);
+      expect(() => assertIsolated(caseEnv(dirs, CASE_OPTIONS), dirs.caseDir)).not.toThrow();
+    });
+
+    it("refuses when ANY of the seven overrides is unset", () => {
+      const dirs = makeCaseDir(CASE_OPTIONS);
+      expect(WRAPPER_ENV_VARS).toHaveLength(7);
+      for (const name of WRAPPER_ENV_VARS) {
+        const env = { ...caseEnv(dirs, CASE_OPTIONS) };
+        delete env[name];
+        expect(() => assertIsolated(env, dirs.caseDir), `${name} unset must refuse`).toThrow(
+          IsolationRefusal,
+        );
+      }
+    });
+
+    it("refuses a path-valued override that resolves OUTSIDE the case dir", () => {
+      const dirs = makeCaseDir(CASE_OPTIONS);
+      const outside: Array<[string, string]> = [
+        ["NUMISMA_DATA_DIR", join(process.env.HOME ?? "/tmp", "Dev/accumulus/data")],
+        ["NUMISMA_REPO_DIR", REPO_ROOT],
+        ["NUMISMA_PRICEFEED_LOG_DIR", join(process.env.HOME ?? "/tmp", "Library/Logs/numisma")],
+        ["NUMISMA_PRICEFEED_ENV", join(process.env.HOME ?? "/tmp", ".config/numisma/price-feed.env")],
+        ["NUMISMA_PATH_PREPEND", "/opt/homebrew/bin"],
+      ];
+      for (const [name, value] of outside) {
+        const env = { ...caseEnv(dirs, CASE_OPTIONS), [name]: value };
+        expect(() => assertIsolated(env, dirs.caseDir), `${name}=${value} must refuse`).toThrow(
+          IsolationRefusal,
+        );
+      }
+    });
+
+    it("refuses a PATH_PREPEND whose LAST entry escapes — every entry is checked, not the first", () => {
+      // The wrapper's own default is a colon list, so this is the shape a careless edit
+      // takes: the fake bin, and then "just one more" real directory.
+      const dirs = makeCaseDir(CASE_OPTIONS);
+      const env = {
+        ...caseEnv(dirs, CASE_OPTIONS),
+        NUMISMA_PATH_PREPEND: `${dirs.binDir}:/opt/homebrew/bin`,
+      };
+      expect(() => assertIsolated(env, dirs.caseDir)).toThrow(/resolves OUTSIDE/);
+    });
+
+    it("refuses a non-integer ceiling or grace", () => {
+      const dirs = makeCaseDir(CASE_OPTIONS);
+      expect(() =>
+        assertIsolated(
+          { ...caseEnv(dirs, CASE_OPTIONS), NUMISMA_PRICEFEED_MAX_RUN_SECONDS: "30s" },
+          dirs.caseDir,
+        ),
+      ).toThrow(IsolationRefusal);
+    });
+
+    it("is enforced by the LAUNCHER, not left to the caller", async () => {
+      const dirs = makeCaseDir(CASE_OPTIONS);
+      const env = { ...caseEnv(dirs, CASE_OPTIONS) };
+      delete env.NUMISMA_DATA_DIR;
+      await expect(
+        launchWrapper({
+          caseDir: dirs.caseDir,
+          wrapperPath: WRAPPER_PATH,
+          env,
+          groupLeader: true,
+          settleDeadlineMs: SETTLE_DEADLINE_MS,
+          maxWaitMs: 60_000,
+        }),
+      ).rejects.toThrow(IsolationRefusal);
+    });
+  });
+
+  // ── CASE 1 · THE HEALTHY RUN ──────────────────────────────────────────────────────
+  it(
+    `case 1 — healthy run, ${RUNS_PER_CASE} consecutive times`,
+    async () => {
+      const settles: number[] = [];
+      for (let run = 1; run <= RUNS_PER_CASE; run += 1) {
+        const dirs = makeCaseDir(CASE_OPTIONS);
+        const record = await launchWrapper({
+          caseDir: dirs.caseDir,
+          wrapperPath: WRAPPER_PATH,
+          env: caseEnv(dirs, CASE_OPTIONS),
+          groupLeader: true,
+          settleDeadlineMs: SETTLE_DEADLINE_MS,
+          maxWaitMs: 60_000,
+        });
+        const label = `case 1 run ${run}/${RUNS_PER_CASE}`;
+
+        // THE ANTI-VACUITY ASSERTION FOR THE WHOLE SUITE'S MOST IMPORTANT LINE. `detached`
+        // is what makes the wrapper its own process-group leader; drop it and the wrapper
+        // itself prints `watchdog DISABLED` and the watchdog no-ops, and every later
+        // slice's timeout case passes while testing nothing. This is the assertion that
+        // goes red when that happens.
+        expect(record.logText, `${label}: the watchdog did not arm — was the child detached?`).toContain(
+          "watchdog armed:",
+        );
+        expect(record.logText).not.toContain("watchdog DISABLED");
+        // A healthy run is not a timeout: the watchdog left no calling card and the step
+        // name carries no `timeout:` decoration.
+        expect(record.watchdogFired, `${label}: the watchdog's calling card was left behind`).toBe(false);
+
+        assertTriple(record, dirs.caseDir, { exitCode: 0, lastStep: "complete", label });
+        settles.push(record.settleMs);
+      }
+      // Recorded, not merely passed: a regression from 0.1s to 1.9s is inside the window
+      // and would otherwise be invisible.
+      console.log(`[wrapper harness] case 1 settle ms: ${settles.join(", ")}`);
+    },
+    240_000,
+  );
+
+  // ── CASE 7 · THE ANTI-VACUITY CONTROL ─────────────────────────────────────────────
+  it(
+    `case 7 — watchdog disabled because the wrapper is NOT a process-group leader, ${RUNS_PER_CASE} times`,
+    async () => {
+      // The inverse of the suite's most important line. If this case ever starts arming
+      // the watchdog, leader detection has changed; if the timeout cases in slice 2 stop
+      // timing out while this still passes, the suite has gone green-and-empty. Neither
+      // state is visible from any other case.
+      for (let run = 1; run <= RUNS_PER_CASE; run += 1) {
+        const dirs = makeCaseDir(CASE_OPTIONS);
+        const record = await launchWrapper({
+          caseDir: dirs.caseDir,
+          wrapperPath: WRAPPER_PATH,
+          env: caseEnv(dirs, CASE_OPTIONS),
+          groupLeader: false,
+          settleDeadlineMs: SETTLE_DEADLINE_MS,
+          maxWaitMs: 60_000,
+        });
+        const label = `case 7 run ${run}/${RUNS_PER_CASE}`;
+
+        expect(record.logText, `${label}: the wrapper did not notice it was not the leader`).toContain(
+          "watchdog DISABLED (not a process-group leader:",
+        );
+        expect(record.logText, `${label}: the watchdog armed anyway`).not.toContain("watchdog armed:");
+        // AND IT DOES NOT TIME OUT: no calling card, no 124, no `timeout:` decoration.
+        expect(record.watchdogFired, `${label}: a disabled watchdog left a calling card`).toBe(false);
+        expect(record.exitCode, `${label}: a disabled watchdog produced a timeout exit`).not.toBe(124);
+        expect(record.heartbeat?.lastStep ?? "", `${label}: decorated step`).not.toContain("timeout:");
+
+        assertTriple(record, dirs.caseDir, { exitCode: 0, lastStep: "complete", label });
+      }
+    },
+    240_000,
+  );
+
+  // ── S6 · THE CHILD-REAP MUTATION CONTROL ──────────────────────────────────────────
+  describe("the child-reap mutation — assertion 3 is seen RED before it is trusted", () => {
+    it("fails LOUDLY when its anchor text is gone, rather than mutating nothing", () => {
+      const dirs = makeCaseDir(CASE_OPTIONS);
+      expect(() =>
+        mutateWrapper(WRAPPER_PATH, dirs.caseDir, {
+          name: "an anchor that has rotted away",
+          anchor: "kill -KILL $WATCHDOG_GRANDCHILDREN_THAT_NEVER_EXISTED",
+          replacement: ":",
+        }),
+      ).toThrow(/anchor has rotted/);
+    });
+
+    it(
+      "makes the healthy case go RED on a stray process left in the run's pgid",
+      async () => {
+        const dirs = makeCaseDir(CASE_OPTIONS);
+        // The committed wrapper is never touched: the mutation is applied to a copy that
+        // lives and dies inside the case dir.
+        const mutated = mutateWrapper(WRAPPER_PATH, dirs.caseDir, CHILD_REAP_MUTATION);
+        expect(mutated.startsWith(dirs.caseDir)).toBe(true);
+
+        const record = await launchWrapper({
+          caseDir: dirs.caseDir,
+          wrapperPath: mutated,
+          env: caseEnv(dirs, CASE_OPTIONS),
+          groupLeader: true,
+          settleDeadlineMs: SETTLE_DEADLINE_MS,
+          maxWaitMs: 60_000,
+        });
+
+        // The run itself still reports success — that is precisely the danger. Without the
+        // reaped child the wrapper's own EXIT trap SIGKILLs the watchdog subshell and
+        // orphans its `sleep` into the run's process group, where it holds launchd's
+        // per-label job slot and keeps the log `tee` alive. Assertion 3 is the only thing
+        // that sees it.
+        expect(record.exitCode).toBe(0);
+        expect(record.heartbeat?.lastStep).toBe("complete");
+        expect(
+          record.pgidResidue.length,
+          "the child-reap mutation left NOTHING in the pgid — assertion 3 is no longer guarding anything",
+        ).toBeGreaterThan(0);
+        expect(record.pgidResidue.join(" | ")).toMatch(/sleep/);
+
+        // And the same assertion, applied to the same case, passes on the UNMUTATED
+        // wrapper — so what went red is the mutation and not the settle window.
+        const clean = makeCaseDir(CASE_OPTIONS);
+        const healthy = await launchWrapper({
+          caseDir: clean.caseDir,
+          wrapperPath: WRAPPER_PATH,
+          env: caseEnv(clean, CASE_OPTIONS),
+          groupLeader: true,
+          settleDeadlineMs: SETTLE_DEADLINE_MS,
+          maxWaitMs: 60_000,
+        });
+        expect(healthy.pgidResidue).toEqual([]);
+      },
+      120_000,
+    );
+  });
+});

--- a/apps/price-feed/src/wrapper-harness/run-daily-fetch.test.ts
+++ b/apps/price-feed/src/wrapper-harness/run-daily-fetch.test.ts
@@ -1,5 +1,6 @@
 /**
- * THE COMMITTED TEST HARNESS FOR `ops/price-feed/run-daily-fetch.sh` (PRD #314, slice #316).
+ * THE COMMITTED TEST HARNESS FOR `ops/price-feed/run-daily-fetch.sh` (PRD #314, slices
+ * #316 and #317).
  *
  * ⚠️ **THIS SUITE CAN NEVER RUN IN CI AS CI EXISTS TODAY. A GREEN CI RUN DOES NOT MEAN
  * THIS HARNESS PASSED — IT MEANS IT WAS NOT ATTEMPTED.** CI is a single `ubuntu-latest`
@@ -23,14 +24,22 @@
  * path set, so every `pnpm test` carries a line about this harness whether or not it ran.
  * `pnpm test:wrapper` runs it on demand. `NUMISMA_WRAPPER_TEST=never` mutes it and says so.
  *
- * ── WHAT SLICE 1 CLAIMS, AND WHAT IT DOES NOT ─────────────────────────────────────────
- * Claims: the launcher, the isolation refusal, the fake-tool bin and its sentinel, the
+ * ── WHAT SLICES 1-2 CLAIM, AND WHAT THEY DO NOT ───────────────────────────────────────
+ * Slice 1: the launcher, the isolation refusal, the fake-tool bin and its sentinel, the
  * assertion triple, 12-run repetition, the arming trigger and its three guard layers,
  * case 1 (healthy), case 7 (not a group leader) and the child-reap mutation control.
- * Does not: any timeout, external-stop or mark-window case — slices 2-4 — nor the `hangs`,
- * `exits 127` and TERM-deaf fakes those need. Case 7 here therefore proves the leader
- * DETECTION with a fast, succeeding run; slice 2 will additionally prove that a genuine
- * hang under a disabled watchdog does not time out, once the `hangs` behavior exists.
+ *
+ * Slice 2 — the TIMEOUT FAMILY: the `hangs`, `exits 127`, `ignores TERM` and TERM-deaf
+ * grandchild fakes; cases 2, 3 and 5; the grace-bounded settle assertion; and the
+ * `tee`-deafness mutation control. **It also completes case 7**, which slice 1 could only
+ * half-prove: with nothing but the `succeeds` fake, "the run does not time out" was
+ * unfalsifiable, because nothing could have timed out anyway. Case 7 now HANGS under a
+ * disabled watchdog, is observed still alive well past its own ceiling and grace with no
+ * calling card, and is then released to finish normally.
+ *
+ * Neither slice claims: the external-stop path and case 4 (slice 3) — nothing here asserts
+ * anything about exit 143 or about the calling card's absence as a discriminator — nor the
+ * mark window and cases 6 and 8 (slice 4).
  *
  * ── A BLIND SPOT THIS DESIGN CREATES, NAMED RATHER THAN IMPLIED ───────────────────────
  * The fake `pnpm` is what makes every case fast and safe, and it is therefore exactly what
@@ -64,9 +73,22 @@ import {
   mutateWrapper,
   type CaseOptions,
 } from "./case-dir.testkit.js";
-import { WRAPPER_PNPM_COMMANDS, installDecoyBin, sentinelNameFor } from "./fake-bin.testkit.js";
+import {
+  TERM_DEAF_CHILD_NAME,
+  TERM_DEAF_CHILD_SENTINEL,
+  WRAPPER_PNPM_COMMANDS,
+  installDecoyBin,
+  releaseFakeHang,
+  sentinelNameFor,
+  setFakeBehavior,
+} from "./fake-bin.testkit.js";
 import { IsolationRefusal, WRAPPER_ENV_VARS, assertIsolated } from "./isolation.testkit.js";
-import { launchWrapper, observedBashVersion, type RunRecord } from "./launcher.testkit.js";
+import {
+  launchWrapper,
+  observedBashVersion,
+  processesInPgid,
+  type RunRecord,
+} from "./launcher.testkit.js";
 import { REPETITION_FLOOR, resolveRunCount } from "./repetition.testkit.js";
 
 const REPO_ROOT = fileURLToPath(new URL("../../../../", import.meta.url));
@@ -469,6 +491,85 @@ const SETTLE_DEADLINE_MS = 2_000;
 const CASE_OPTIONS: CaseOptions = { maxRunSeconds: 30, watchdogGraceSeconds: 2 };
 
 /**
+ * A ceiling a case can actually WAIT OUT. Every timeout case pays it in full, twelve times,
+ * so it is as short as the wrapper's own arithmetic allows and no shorter: the watchdog
+ * clamps its poll to the ceiling when the ceiling is the smaller of the two, and a ceiling
+ * under a second would measure `sleep`'s rounding rather than the watchdog's decision.
+ */
+const TIMEOUT_CASE_OPTIONS: CaseOptions = { maxRunSeconds: 3, watchdogGraceSeconds: 2 };
+
+/** How long past its own ceiling AND grace case 7's hang is observed still alive. */
+const CASE_7_OBSERVE_MARGIN_MS = 1_000;
+
+/**
+ * THE WRAPPER'S OWN POLL LENGTH, READ OFF THE SUBJECT rather than guessed. The settle bound
+ * below is grace + one poll + a margin, so a poll that moved in the wrapper while a literal
+ * `5` sat here would silently loosen or tighten every timeout case's only bound. Fail-closed
+ * for the same reason `mutateWrapper` throws on a rotted anchor: a bound derived from text
+ * that has moved is not a bound.
+ */
+function wrapperPollSeconds(): number {
+  const match = /^\s*WATCHDOG_POLL_SECONDS=(\d+)\s*$/m.exec(readFileSync(WRAPPER_PATH, "utf8"));
+  if (match === null) {
+    throw new Error(
+      "wrapper harness: WATCHDOG_POLL_SECONDS could not be read out of the wrapper. Every " +
+        "timeout case's settle bound derives from it, and a guessed bound is not a bound.",
+    );
+  }
+  return Number(match[1]);
+}
+
+/**
+ * THE GRACE-BOUNDED SETTLE WINDOW, and it is wrong in BOTH directions if unbounded.
+ *
+ * On the timeout path the watchdog is DELIBERATELY left alive — `write_heartbeat` skips its
+ * own cancellation when `TIMED_OUT=true` — so that it can serve its grace and then group-
+ * SIGKILL whatever ignored the TERM. The run's pgid is therefore legitimately occupied for
+ * the whole grace AFTER the shell has exited. Asserting emptiness immediately is a false
+ * red; asserting it with unbounded patience is a false green, because the historical stray
+ * `sleep` DID eventually exit — after holding launchd's per-label job slot through the next
+ * fire.
+ *
+ * Grace + one watchdog poll + a margin: the grace is what the escalation waits, the poll is
+ * the most a `sleep` the watchdog forked can outlive it by (§ the wrapper's own bound on a
+ * lost child), and the margin is process teardown on a loaded machine. The observed settle
+ * time is printed on every case, so a regression from a fifth of the bound to nearly all of
+ * it is VISIBLE rather than merely passing.
+ */
+function timeoutSettleDeadlineMs(options: CaseOptions): number {
+  // The wrapper CLAMPS its poll to the ceiling when the ceiling is smaller, so that a small
+  // ceiling is still honoured rather than rounded up. Mirrored here rather than approximated
+  // by the unclamped 5: a bound that ignored the clamp would be seconds looser than the
+  // watchdog it is bounding, which is most of the way back to unbounded patience.
+  const pollSeconds = Math.min(wrapperPollSeconds(), options.maxRunSeconds);
+  return (options.watchdogGraceSeconds + pollSeconds) * 1_000 + 1_500;
+}
+
+/**
+ * WHICH STEPS MEAN THE DAY'S MARKS ACTUALLY LANDED — the wrapper's own `MARKS_LANDED_STEPS`,
+ * authored here as the oracle the heartbeat assertion needs. `pnpm spine` appends the marks,
+ * so every step after it implies they landed; a run that died at `prices-fetch` is in-window
+ * and marked NOTHING, and a harness that expected a stamp there would be demanding the
+ * wrapper record a failure as evidence the day was covered.
+ */
+const MARKS_LANDED_STEPS: readonly string[] = [
+  "commit",
+  "post-check",
+  "gap-report",
+  "backfill",
+  "complete",
+];
+
+function sleep(ms: number): Promise<void> {
+  return new Promise((done) => setTimeout(done, ms));
+}
+
+/** Whether the watchdog has left its calling card in a case's log dir, read DURING a run. */
+function watchdogCardPresent(logDir: string): boolean {
+  return existsSync(logDir) && readdirSync(logDir).some((name) => name.endsWith(".watchdog-fired"));
+}
+
+/**
  * Whether this run was in the mark window, computed the way the CONTRACT computes it —
  * `America/Mexico_City`, hour ≥ 18 — rather than from the machine's local clock, which
  * would agree only by coincidence of an OS setting. Read off the heartbeat's own
@@ -497,17 +598,31 @@ function expectedMarkWindow(startedAt: string): boolean {
 function assertTriple(
   record: RunRecord,
   caseDir: string,
-  expected: { exitCode: number; lastStep: string; label: string },
+  expected: {
+    exitCode: number;
+    lastStep: string;
+    /**
+     * The `pnpm` sub-commands this case must have reached, as a PREFIX of
+     * {@link WRAPPER_PNPM_COMMANDS}. The ones after it are asserted ABSENT, which is how a
+     * case that dies at `prices-fetch` proves the wrapper's central contract — a non-zero
+     * fetch HALTS the run before `spine`, so a doomed mark is never appended.
+     */
+    pnpmReached: readonly string[];
+    label: string;
+  },
 ): void {
   const where = `${expected.label}: `;
 
   // (0) The fake won. Asserted first, because if it did not, everything below is a
   //     description of a live run against real, private data.
   for (const command of WRAPPER_PNPM_COMMANDS) {
+    const reached = expected.pnpmReached.includes(command);
     expect(
       existsSync(join(caseDir, "sentinels", sentinelNameFor(command))),
-      `${where}the fake pnpm never recorded \`${command}\` — the REAL pnpm may have run`,
-    ).toBe(true);
+      reached
+        ? `${where}the fake pnpm never recorded \`${command}\` — the REAL pnpm may have run`
+        : `${where}the fake pnpm recorded \`${command}\`, which this case must never reach`,
+    ).toBe(reached);
   }
   expect(
     existsSync(join(caseDir, "sentinels", "node-executed")),
@@ -527,14 +642,19 @@ function assertTriple(
   expect(heartbeat.lastStep, `${where}heartbeat lastStep`).toBe(expected.lastStep);
   const inWindow = expectedMarkWindow(heartbeat.startedAt);
   expect(heartbeat.markWindow, `${where}heartbeat markWindow`).toBe(inWindow);
-  if (inWindow) {
+  // IN-WINDOW ALONE IS NOT ENOUGH, and the decorated step name is not a step name: the
+  // wrapper compares the BARE `LAST_STEP` against its landed-steps list and only decorates
+  // at print time, so the oracle has to undecorate before it asks the same question.
+  const marksLanded = MARKS_LANDED_STEPS.includes(expected.lastStep.replace(/^timeout:/, ""));
+  if (inWindow && marksLanded) {
     // `complete` is in MARKS_LANDED_STEPS, so an in-window run that reached it stamps
     // ITSELF as the last in-window finish.
     expect(heartbeat.lastMarkWindowFinishedAt, `${where}lastMarkWindowFinishedAt`).toBe(
       heartbeat.finishedAt,
     );
   } else {
-    // A fresh case dir carries nothing forward, and the writer must INVENT nothing.
+    // A fresh case dir carries nothing forward, and the writer must INVENT nothing — least
+    // of all on a run that died before `spine` and therefore marked nothing at all.
     expect(heartbeat.lastMarkWindowFinishedAt, `${where}lastMarkWindowFinishedAt`).toBeUndefined();
   }
 
@@ -700,7 +820,12 @@ describe.runIf(decision.run)("wrapper harness — the real wrapper, armed", () =
         // name carries no `timeout:` decoration.
         expect(record.watchdogFired, `${label}: the watchdog's calling card was left behind`).toBe(false);
 
-        assertTriple(record, dirs.caseDir, { exitCode: 0, lastStep: "complete", label });
+        assertTriple(record, dirs.caseDir, {
+          exitCode: 0,
+          lastStep: "complete",
+          pnpmReached: WRAPPER_PNPM_COMMANDS,
+          label,
+        });
         settles.push(record.settleMs);
       }
       // Recorded, not merely passed: a regression from 0.1s to 1.9s is inside the window
@@ -712,37 +837,280 @@ describe.runIf(decision.run)("wrapper harness — the real wrapper, armed", () =
 
   // ── CASE 7 · THE ANTI-VACUITY CONTROL ─────────────────────────────────────────────
   it(
-    `case 7 — watchdog disabled because the wrapper is NOT a process-group leader, ${RUNS_PER_CASE} times`,
+    `case 7 — a HANG under a watchdog disabled for not leading its group, ${RUNS_PER_CASE} times`,
     async () => {
       // The inverse of the suite's most important line. If this case ever starts arming
-      // the watchdog, leader detection has changed; if the timeout cases in slice 2 stop
-      // timing out while this still passes, the suite has gone green-and-empty. Neither
-      // state is visible from any other case.
+      // the watchdog, leader detection has changed; if the timeout cases stop timing out
+      // while this still passes, the suite has gone green-and-empty. Neither state is
+      // visible from any other case.
+      //
+      // IT HANGS, and until slice 2 it could not. With only the `succeeds` fake, "a
+      // disabled watchdog does not time out" was unfalsifiable — nothing in the run could
+      // have timed out under an ARMED watchdog either, so the claim cost nothing to make.
+      // Now the same fake that drives case 2 to exit 124 at its ceiling drives this run,
+      // which is observed still alive well past that ceiling AND its grace with no calling
+      // card, and is then released to finish normally. A hang with no release would only
+      // ever reach the harness cap, which is a failure of the case rather than a proof of
+      // anything; a run killed from outside would be the external-stop path, which is a
+      // different slice's subject entirely.
+      const ceilingAndGraceMs =
+        (TIMEOUT_CASE_OPTIONS.maxRunSeconds + TIMEOUT_CASE_OPTIONS.watchdogGraceSeconds) * 1_000;
+      const observeAtMs = ceilingAndGraceMs + CASE_7_OBSERVE_MARGIN_MS;
+      const survivals: number[] = [];
+
       for (let run = 1; run <= RUNS_PER_CASE; run += 1) {
-        const dirs = makeCaseDir(CASE_OPTIONS);
+        const dirs = makeCaseDir(TIMEOUT_CASE_OPTIONS);
+        setFakeBehavior(dirs.caseDir, "prices:fetch", "hangs");
+        const label = `case 7 run ${run}/${RUNS_PER_CASE}`;
+
         const record = await launchWrapper({
           caseDir: dirs.caseDir,
           wrapperPath: WRAPPER_PATH,
-          env: caseEnv(dirs, CASE_OPTIONS),
+          env: caseEnv(dirs, TIMEOUT_CASE_OPTIONS),
           groupLeader: false,
           settleDeadlineMs: SETTLE_DEADLINE_MS,
-          maxWaitMs: 60_000,
+          maxWaitMs: 120_000,
+          duringRun: async (pgid) => {
+            await sleep(observeAtMs);
+            // STILL ALIVE, past a ceiling and a grace that would have ended case 2 twice.
+            const alive = processesInPgid(pgid);
+            expect(
+              alive.join(" | "),
+              `${label}: the wrapper was gone ${observeAtMs}ms in — a disabled watchdog killed it`,
+            ).toContain("run-daily-fetch.sh");
+            expect(
+              watchdogCardPresent(dirs.logDir),
+              `${label}: a DISABLED watchdog left a calling card`,
+            ).toBe(false);
+            releaseFakeHang(dirs.caseDir, "prices:fetch");
+          },
         });
-        const label = `case 7 run ${run}/${RUNS_PER_CASE}`;
 
         expect(record.logText, `${label}: the wrapper did not notice it was not the leader`).toContain(
           "watchdog DISABLED (not a process-group leader:",
         );
         expect(record.logText, `${label}: the watchdog armed anyway`).not.toContain("watchdog armed:");
-        // AND IT DOES NOT TIME OUT: no calling card, no 124, no `timeout:` decoration.
+        // AND IT DOES NOT TIME OUT: it outlived its own ceiling and grace, left no calling
+        // card, exited 0, and its step name carries no `timeout:` decoration.
+        expect(
+          record.durationMs,
+          `${label}: the run ended before it could outlive its own ceiling and grace`,
+        ).toBeGreaterThan(ceilingAndGraceMs);
         expect(record.watchdogFired, `${label}: a disabled watchdog left a calling card`).toBe(false);
         expect(record.exitCode, `${label}: a disabled watchdog produced a timeout exit`).not.toBe(124);
         expect(record.heartbeat?.lastStep ?? "", `${label}: decorated step`).not.toContain("timeout:");
 
-        assertTriple(record, dirs.caseDir, { exitCode: 0, lastStep: "complete", label });
+        assertTriple(record, dirs.caseDir, {
+          exitCode: 0,
+          lastStep: "complete",
+          pnpmReached: WRAPPER_PNPM_COMMANDS,
+          label,
+        });
+        survivals.push(record.durationMs);
       }
+      console.log(
+        `[wrapper harness] case 7 survived (ms, ceiling+grace=${ceilingAndGraceMs}): ${survivals.join(", ")}`,
+      );
     },
-    240_000,
+    600_000,
+  );
+
+  // ── THE TIMEOUT FAMILY · CASES 2, 3 AND 5 ─────────────────────────────────────────
+  //
+  // These are the racy ones. The historical `tee` defect reproduced on roughly three runs
+  // in five, and a single lucky green had already pronounced it fixed once — which is the
+  // entire argument for the 12-run floor being a floor and not a default.
+  //
+  // Each pays a real ceiling and a real grace, twelve times, and each asserts the fake-pnpm
+  // sentinel: a case that "hangs" because the REAL pnpm was slow, or that "exits 127"
+  // because a real binary was missing, is indistinguishable from a passing case without it.
+
+  /**
+   * The settle assertion, bounded in BOTH directions and recorded either way.
+   *
+   * LOWER: the watchdog is still serving its grace when the shell exits, so the pgid CANNOT
+   * be empty yet. A harness that found it empty there would be asserting emptiness before
+   * grace had been served — a false red waiting to happen, and the reason the launcher
+   * samples the group at the instant of exit as well as after the wait.
+   *
+   * UPPER: the launcher stops polling at the deadline this case passed it, so a pgid still
+   * occupied past grace + one poll + margin arrives at assertion 3 as residue and goes red.
+   * The bound is derived from the wrapper's own numbers, never guessed.
+   */
+  function assertGraceBoundedSettle(record: RunRecord, label: string, options: CaseOptions): void {
+    const graceMs = options.watchdogGraceSeconds * 1_000;
+    expect(
+      record.residueAtExit.length,
+      `${label}: the pgid was ALREADY empty when the shell exited — the watchdog is supposed ` +
+        "to outlive it and serve the grace, so either it was cancelled on the timeout path " +
+        "or this run never timed out at all",
+    ).toBeGreaterThan(0);
+    expect(
+      record.settleMs,
+      `${label}: the pgid emptied in ${record.settleMs}ms, far inside the ${graceMs}ms grace — ` +
+        "the escalation cannot have waited what it claims to wait",
+    ).toBeGreaterThanOrEqual(graceMs / 2);
+    expect(
+      record.settleMs,
+      `${label}: the pgid took ${record.settleMs}ms to empty, past the derived bound`,
+    ).toBeLessThan(timeoutSettleDeadlineMs(options));
+  }
+
+  it(
+    `case 2 — watchdog timeout with a REACTIVE child, ${RUNS_PER_CASE} consecutive times`,
+    async () => {
+      const settles: number[] = [];
+      for (let run = 1; run <= RUNS_PER_CASE; run += 1) {
+        const dirs = makeCaseDir(TIMEOUT_CASE_OPTIONS);
+        // The fake hangs at the fetch step, reactively: neither it nor its `sleep` traps
+        // anything, so the watchdog's group TERM is what ends it — and the wrapper's own
+        // TERM handler is what turns that into an orderly exit 124 with a breadcrumb.
+        setFakeBehavior(dirs.caseDir, "prices:fetch", "hangs");
+        const label = `case 2 run ${run}/${RUNS_PER_CASE}`;
+
+        const record = await launchWrapper({
+          caseDir: dirs.caseDir,
+          wrapperPath: WRAPPER_PATH,
+          env: caseEnv(dirs, TIMEOUT_CASE_OPTIONS),
+          groupLeader: true,
+          settleDeadlineMs: timeoutSettleDeadlineMs(TIMEOUT_CASE_OPTIONS),
+          maxWaitMs: 120_000,
+        });
+
+        expect(record.logText, `${label}: the watchdog did not arm — was the child detached?`).toContain(
+          "watchdog armed:",
+        );
+        expect(record.logText, `${label}: the watchdog never fired`).toContain(
+          `WATCHDOG: run exceeded ${TIMEOUT_CASE_OPTIONS.maxRunSeconds}s`,
+        );
+        // THE CALLING CARD. It is the TERM handler's only discriminator between the
+        // watchdog's signal and an operator's, and it is what makes the 124 honest.
+        expect(record.watchdogFired, `${label}: the watchdog left no calling card`).toBe(true);
+        assertGraceBoundedSettle(record, label, TIMEOUT_CASE_OPTIONS);
+
+        assertTriple(record, dirs.caseDir, {
+          exitCode: 124,
+          lastStep: "timeout:prices-fetch",
+          pnpmReached: ["prices:fetch"],
+          label,
+        });
+        settles.push(record.settleMs);
+      }
+      console.log(
+        `[wrapper harness] case 2 settle ms (bound ${timeoutSettleDeadlineMs(TIMEOUT_CASE_OPTIONS)}): ` +
+          settles.join(", "),
+      );
+    },
+    600_000,
+  );
+
+  it(
+    `case 3 — watchdog timeout with a TERM-DEAF grandchild, ${RUNS_PER_CASE} consecutive times`,
+    async () => {
+      const settles: number[] = [];
+      for (let run = 1; run <= RUNS_PER_CASE; run += 1) {
+        const dirs = makeCaseDir(TIMEOUT_CASE_OPTIONS);
+        // The historical shape verbatim: the grandchild ignores TERM and holds the
+        // inherited write end of the log pipe, so it survived the group TERM and kept `tee`
+        // alive with it — both sitting in the run's process group holding launchd's
+        // per-label job slot long after the run itself was gone.
+        setFakeBehavior(dirs.caseDir, "prices:fetch", "hangs-with-term-deaf-grandchild");
+        const label = `case 3 run ${run}/${RUNS_PER_CASE}`;
+
+        const record = await launchWrapper({
+          caseDir: dirs.caseDir,
+          wrapperPath: WRAPPER_PATH,
+          env: caseEnv(dirs, TIMEOUT_CASE_OPTIONS),
+          groupLeader: true,
+          settleDeadlineMs: timeoutSettleDeadlineMs(TIMEOUT_CASE_OPTIONS),
+          maxWaitMs: 120_000,
+        });
+
+        expect(record.logText, `${label}: the watchdog did not arm`).toContain("watchdog armed:");
+        expect(record.watchdogFired, `${label}: the watchdog left no calling card`).toBe(true);
+        expect(
+          existsSync(join(dirs.caseDir, "sentinels", TERM_DEAF_CHILD_SENTINEL)),
+          `${label}: the TERM-deaf grandchild never started — this case has silently become case 2`,
+        ).toBe(true);
+        // GONE, NOT MERELY ORPHANED. It has to be visible in the group at the instant the
+        // shell exited — it ignored the TERM — and absent once the SIGKILL escalation has
+        // run. Assertion 3 below is the half that says "absent"; this is the half that says
+        // there was something there to reap.
+        expect(
+          record.residueAtExit.join(" | "),
+          `${label}: the deaf grandchild was not in the pgid when the shell exited`,
+        ).toContain(TERM_DEAF_CHILD_NAME);
+        assertGraceBoundedSettle(record, label, TIMEOUT_CASE_OPTIONS);
+        expect(
+          record.pgidResidue.join(" | "),
+          `${label}: the deaf grandchild survived the SIGKILL escalation`,
+        ).not.toContain(TERM_DEAF_CHILD_NAME);
+
+        assertTriple(record, dirs.caseDir, {
+          exitCode: 124,
+          lastStep: "timeout:prices-fetch",
+          pnpmReached: ["prices:fetch"],
+          label,
+        });
+        settles.push(record.settleMs);
+      }
+      console.log(
+        `[wrapper harness] case 3 settle ms (bound ${timeoutSettleDeadlineMs(TIMEOUT_CASE_OPTIONS)}): ` +
+          settles.join(", "),
+      );
+    },
+    600_000,
+  );
+
+  it(
+    `case 5 — an early non-zero exit, ${RUNS_PER_CASE} consecutive times`,
+    async () => {
+      const settles: number[] = [];
+      for (let run = 1; run <= RUNS_PER_CASE; run += 1) {
+        // The FULL ceiling, deliberately: this run must end on its own terms long before
+        // any watchdog could touch it, and a short ceiling would blur those two endings.
+        const dirs = makeCaseDir(CASE_OPTIONS);
+        // Exit 127 is the shape a missing `pnpm` or an invisible `node` takes in
+        // production, and it is the case that justifies the heartbeat writer being pure
+        // bash: on this path nothing node-shaped can run.
+        setFakeBehavior(dirs.caseDir, "prices:fetch", "exits-127");
+        const label = `case 5 run ${run}/${RUNS_PER_CASE}`;
+
+        const record = await launchWrapper({
+          caseDir: dirs.caseDir,
+          wrapperPath: WRAPPER_PATH,
+          env: caseEnv(dirs, CASE_OPTIONS),
+          groupLeader: true,
+          settleDeadlineMs: SETTLE_DEADLINE_MS,
+          maxWaitMs: 60_000,
+        });
+
+        expect(record.logText, `${label}: the watchdog did not arm`).toContain("watchdog armed:");
+        expect(record.logText, `${label}: the wrapper did not report the failed fetch`).toContain(
+          "prices:fetch exited 127 — NOT running spine.",
+        );
+        // NOT A TIMEOUT, and the step name says so: no calling card, no `timeout:` prefix.
+        // The step is undecorated because the run ended on its own terms.
+        expect(record.watchdogFired, `${label}: a run that was never timed out left a calling card`).toBe(
+          false,
+        );
+        // AND THE SETTLE WINDOW STAYS THE SHORT ONE. This is not a timeout path, so the
+        // watchdog was cancelled — subshell and forked `sleep` both — before the shell left.
+        // Giving this case the grace-derived bound would let a watchdog left sleeping out
+        // its full ceiling over an already-dead run pass unnoticed, which is precisely the
+        // held-job-slot failure the wrapper's own cancellation exists to prevent.
+
+        assertTriple(record, dirs.caseDir, {
+          exitCode: 127,
+          lastStep: "prices-fetch",
+          pnpmReached: ["prices:fetch"],
+          label,
+        });
+        settles.push(record.settleMs);
+      }
+      console.log(`[wrapper harness] case 5 settle ms: ${settles.join(", ")}`);
+    },
+    600_000,
   );
 
   // ── S6 · THE CHILD-REAP MUTATION CONTROL ──────────────────────────────────────────

--- a/apps/price-feed/src/wrapper-harness/run-daily-fetch.test.ts
+++ b/apps/price-feed/src/wrapper-harness/run-daily-fetch.test.ts
@@ -99,15 +99,28 @@ import {
   type CaseOptions,
 } from "./case-dir.testkit.js";
 import {
+  INVOCATION_LOG_NAME,
   TERM_DEAF_CHILD_NAME,
   TERM_DEAF_CHILD_SENTINEL,
   WRAPPER_PNPM_COMMANDS,
+  dispatchRecordNameFor,
   installDecoyBin,
   releaseFakeHang,
   sentinelNameFor,
   setFakeBehavior,
 } from "./fake-bin.testkit.js";
 import { IsolationRefusal, WRAPPER_ENV_VARS, assertIsolated } from "./isolation.testkit.js";
+import {
+  AUTHORED_PRIOR_STAMP,
+  AUTHORED_V1_CARRY,
+  CONTRACT_MARK_CONFIG,
+  expectedMarkWindow,
+  markConfigFor,
+  seedInWindowDiedBeforeSpineHeartbeat,
+  seedMarkedEveningHeartbeat,
+  seedV1Heartbeat,
+  type MarkConfig,
+} from "./mark-window.testkit.js";
 import {
   launchWrapper,
   observedBashVersion,
@@ -512,8 +525,19 @@ const RUNS_PER_CASE = decision.run ? resolveRunCount(process.env.NUMISMA_WRAPPER
  */
 const SETTLE_DEADLINE_MS = 2_000;
 
-/** A case's own ceiling. Comfortably above a fake-tool run, far below the harness cap. */
-const CASE_OPTIONS: CaseOptions = { maxRunSeconds: 30, watchdogGraceSeconds: 2 };
+/**
+ * A case's own ceiling. Comfortably above a fake-tool run, far below the harness cap.
+ *
+ * `mark` IS THE CONTRACT'S OWN PAIR, stated rather than defaulted. For every case written
+ * before the zone became an input the case's zone simply IS the contract's zone, so
+ * naming it here changes nothing about what those cases assert — and it means no case
+ * anywhere can inherit its side of the mark window from the time of day.
+ */
+const CASE_OPTIONS: CaseOptions = {
+  maxRunSeconds: 30,
+  watchdogGraceSeconds: 2,
+  mark: CONTRACT_MARK_CONFIG,
+};
 
 /**
  * A ceiling a case can actually WAIT OUT. Every timeout case pays it in full, twelve times,
@@ -521,7 +545,11 @@ const CASE_OPTIONS: CaseOptions = { maxRunSeconds: 30, watchdogGraceSeconds: 2 }
  * clamps its poll to the ceiling when the ceiling is the smaller of the two, and a ceiling
  * under a second would measure `sleep`'s rounding rather than the watchdog's decision.
  */
-const TIMEOUT_CASE_OPTIONS: CaseOptions = { maxRunSeconds: 3, watchdogGraceSeconds: 2 };
+const TIMEOUT_CASE_OPTIONS: CaseOptions = {
+  maxRunSeconds: 3,
+  watchdogGraceSeconds: 2,
+  mark: CONTRACT_MARK_CONFIG,
+};
 
 /** How long past its own ceiling AND grace case 7's hang is observed still alive. */
 const CASE_7_OBSERVE_MARGIN_MS = 1_000;
@@ -656,22 +684,6 @@ function observeTermPath(record: RunRecord, label: string): TermPathObservation 
 }
 
 /**
- * Whether this run was in the mark window, computed the way the CONTRACT computes it —
- * `America/Mexico_City`, hour ≥ 18 — rather than from the machine's local clock, which
- * would agree only by coincidence of an OS setting. Read off the heartbeat's own
- * `startedAt` so a run that straddles 18:00 CDMX is still judged against the instant the
- * wrapper judged itself at.
- */
-function expectedMarkWindow(startedAt: string): boolean {
-  const hour = new Intl.DateTimeFormat("en-US", {
-    timeZone: "America/Mexico_City",
-    hour: "2-digit",
-    hourCycle: "h23",
-  }).format(new Date(startedAt));
-  return Number(hour) >= 18;
-}
-
-/**
  * S4 · THE ASSERTION TRIPLE, applied uniformly and never selectively. (1) the exit code,
  * (2) the heartbeat's contents parsed by the reader that reads it in production, (3) zero
  * processes remaining in the run's process group — historically the highest-value
@@ -694,6 +706,21 @@ function assertTriple(
      * fetch HALTS the run before `spine`, so a doomed mark is never appended.
      */
     pnpmReached: readonly string[];
+    /**
+     * THE CASE'S OWN MARK CONFIGURATION, and the oracle below judges `markWindow` against
+     * IT rather than against the contract's. While the zone was a literal the two were the
+     * same thing; now that a case chooses its side, an oracle still reading the contract
+     * zone would judge an in-window case against the wrong side — permanently red, or
+     * worse, green for the wrong reason for the six hours a day the two happen to agree.
+     */
+    mark: MarkConfig;
+    /**
+     * The `lastMarkWindowFinishedAt` the run found ALREADY ON DISK, or `undefined` for a
+     * fresh case dir. It is what a run that did not mark must re-emit unchanged, and what
+     * a run that DID mark must overwrite — the two halves of the carry-forward contract,
+     * indistinguishable from each other unless a prior stamp exists to tell them apart.
+     */
+    carriedStamp?: string;
     label: string;
   },
 ): void {
@@ -726,8 +753,12 @@ function assertTriple(
   }
   expect(heartbeat.exitCode, `${where}heartbeat exitCode`).toBe(expected.exitCode);
   expect(heartbeat.lastStep, `${where}heartbeat lastStep`).toBe(expected.lastStep);
-  const inWindow = expectedMarkWindow(heartbeat.startedAt);
-  expect(heartbeat.markWindow, `${where}heartbeat markWindow`).toBe(inWindow);
+  const inWindow = expectedMarkWindow(heartbeat.startedAt, expected.mark);
+  expect(
+    heartbeat.markWindow,
+    `${where}heartbeat markWindow, against the case's configured zone ` +
+      `${expected.mark.timeZone} and hour ${expected.mark.hour}`,
+  ).toBe(inWindow);
   // IN-WINDOW ALONE IS NOT ENOUGH, and the decorated step name is not a step name: the
   // wrapper compares the BARE `LAST_STEP` against its landed-steps list and only decorates
   // at print time, so the oracle has to undecorate before it asks the same question.
@@ -738,10 +769,23 @@ function assertTriple(
     expect(heartbeat.lastMarkWindowFinishedAt, `${where}lastMarkWindowFinishedAt`).toBe(
       heartbeat.finishedAt,
     );
-  } else {
+  } else if (expected.carriedStamp === undefined) {
     // A fresh case dir carries nothing forward, and the writer must INVENT nothing — least
     // of all on a run that died before `spine` and therefore marked nothing at all.
     expect(heartbeat.lastMarkWindowFinishedAt, `${where}lastMarkWindowFinishedAt`).toBeUndefined();
+  } else {
+    // A PRIOR STAMP WAS ON DISK AND THIS RUN DID NOT EARN A NEW ONE, so it must re-emit
+    // that one byte for byte. `toBe`, not merely "defined": a run that replaced it with
+    // its OWN finish would still be defined, and that substitution is precisely the defect
+    // — a run that marked nothing claiming the day as covered.
+    expect(heartbeat.lastMarkWindowFinishedAt, `${where}lastMarkWindowFinishedAt`).toBe(
+      expected.carriedStamp,
+    );
+    expect(
+      heartbeat.lastMarkWindowFinishedAt,
+      `${where}lastMarkWindowFinishedAt was RE-STAMPED with this run's own finish by a run ` +
+        "that marked nothing — the carried value must survive untouched",
+    ).not.toBe(heartbeat.finishedAt);
   }
 
   // (3) Zero processes remaining in the run's process group.
@@ -809,9 +853,14 @@ describe.runIf(decision.run)("wrapper harness — the real wrapper, armed", () =
       expect(() => assertIsolated(caseEnv(dirs, CASE_OPTIONS), dirs.caseDir)).not.toThrow();
     });
 
-    it("refuses when ANY of the seven overrides is unset", () => {
+    it("refuses when ANY of the nine overrides is unset", () => {
       const dirs = makeCaseDir(CASE_OPTIONS);
-      expect(WRAPPER_ENV_VARS).toHaveLength(7);
+      // NINE SINCE #315, not seven: `NUMISMA_MARK_TZ` and `NUMISMA_MARK_HOUR` joined the
+      // set, and they are refused unset for the same reason as the other seven even though
+      // neither is path-valued — an unset one lets the wrapper fall back to the contract
+      // zone, and a case that meant to be in-window is then in-window only between 18:00
+      // and 23:59 CDMX. Green while asserting nothing, arriving through the clock.
+      expect(WRAPPER_ENV_VARS).toHaveLength(9);
       for (const name of WRAPPER_ENV_VARS) {
         const env = { ...caseEnv(dirs, CASE_OPTIONS) };
         delete env[name];
@@ -910,6 +959,7 @@ describe.runIf(decision.run)("wrapper harness — the real wrapper, armed", () =
           exitCode: 0,
           lastStep: "complete",
           pnpmReached: WRAPPER_PNPM_COMMANDS,
+          mark: CASE_OPTIONS.mark,
           label,
         });
         settles.push(record.settleMs);
@@ -990,6 +1040,7 @@ describe.runIf(decision.run)("wrapper harness — the real wrapper, armed", () =
           exitCode: 0,
           lastStep: "complete",
           pnpmReached: WRAPPER_PNPM_COMMANDS,
+          mark: TIMEOUT_CASE_OPTIONS.mark,
           label,
         });
         survivals.push(record.durationMs);
@@ -1118,6 +1169,7 @@ describe.runIf(decision.run)("wrapper harness — the real wrapper, armed", () =
           exitCode: 124,
           lastStep: "timeout:prices-fetch",
           pnpmReached: ["prices:fetch"],
+          mark: TIMEOUT_CASE_OPTIONS.mark,
           label,
         });
         // KEPT FOR THE PAIR COMPARISON below, which is how the watchdog-TERM and
@@ -1179,6 +1231,7 @@ describe.runIf(decision.run)("wrapper harness — the real wrapper, armed", () =
           exitCode: 124,
           lastStep: "timeout:prices-fetch",
           pnpmReached: ["prices:fetch"],
+          mark: TIMEOUT_CASE_OPTIONS.mark,
           label,
         });
         settles.push(record.settleMs);
@@ -1233,6 +1286,7 @@ describe.runIf(decision.run)("wrapper harness — the real wrapper, armed", () =
           exitCode: 127,
           lastStep: "prices-fetch",
           pnpmReached: ["prices:fetch"],
+          mark: CASE_OPTIONS.mark,
           label,
         });
         settles.push(record.settleMs);
@@ -1335,6 +1389,7 @@ describe.runIf(decision.run)("wrapper harness — the real wrapper, armed", () =
           // hung, spending the credibility the breadcrumb exists to hold.
           lastStep: "prices-fetch",
           pnpmReached: ["prices:fetch"],
+          mark: TIMEOUT_CASE_OPTIONS.mark,
           label,
         });
         externalTermObserved = observeTermPath(record, label);
@@ -1466,7 +1521,7 @@ describe.runIf(decision.run)("wrapper harness — the real wrapper, armed", () =
       expect(
         observed.heartbeat.markWindow,
         `${observed.label}: markWindow disagrees with the contract's own zone`,
-      ).toBe(expectedMarkWindow(observed.heartbeat.startedAt));
+      ).toBe(expectedMarkWindow(observed.heartbeat.startedAt, CONTRACT_MARK_CONFIG));
     }
 
     console.log(

--- a/apps/price-feed/src/wrapper-harness/run-daily-fetch.test.ts
+++ b/apps/price-feed/src/wrapper-harness/run-daily-fetch.test.ts
@@ -1296,6 +1296,402 @@ describe.runIf(decision.run)("wrapper harness — the real wrapper, armed", () =
     600_000,
   );
 
+  // ── S8 · THE MARK WINDOW — CASES 6 AND 8 ──────────────────────────────────────────
+  //
+  // BOTH CASES CHOOSE THEIR SIDE OF THE WINDOW BY SETTING A VALUE, never by hoping the
+  // suite runs in the evening. Every case below computes its configuration FRESH, inside
+  // the loop, from `markConfigFor` — see `mark-window.testkit.ts` for why the zone it
+  // picks leaves ~23 hours of margin on both sides and therefore cannot be straddled by a
+  // run of this suite.
+  //
+  // EACH CASE ALSO ASSERTS THE SIDE IT ASKED FOR, in so many words, and that assertion is
+  // not redundant with the triple. The triple judges `markWindow` against an ORACLE, and
+  // an oracle agrees with the run just as happily when both say `false` — so an in-window
+  // case whose configuration silently stopped working would still pass the triple while
+  // asserting nothing about the stamp it exists to prove. The bare `toBe(true)` /
+  // `toBe(false)` below is what makes that impossible.
+
+  /** A case's configuration for one run, on the side of the window it asks for. */
+  function markCaseOptions(window: "in" | "out", base: CaseOptions): CaseOptions {
+    return { ...base, mark: markConfigFor(window) };
+  }
+
+  /**
+   * CASE 6'S CEILING IS DELIBERATELY LOOSER THAN EVERY OTHER TIMEOUT CASE'S, and the extra
+   * seconds are the whole difference between a cry-wolf case and a second copy of case 2.
+   *
+   * Cases 2, 3 and 4 hang at the FIRST step, so their run has nothing to accomplish before
+   * the ceiling and 3 seconds is generous. Case 6 has to get all the way to the LAST step
+   * first — four fake `pnpm` invocations, a `git add`/`git commit` against the case's own
+   * repo, and a `git status` post-check — and only then wedge. A healthy run does that in
+   * about 0.7s (case 1 measures it every suite run), but a 3-second ceiling gave only ~4x
+   * margin and lost the race on a loaded machine: the run timed out at an earlier step and
+   * the case quietly became case 2 with a different label. Widened, not removed — the
+   * timeout still has to happen, it just has to happen at the step this case names.
+   */
+  const CASE_6_OPTIONS: CaseOptions = { ...TIMEOUT_CASE_OPTIONS, maxRunSeconds: 5 };
+
+  /**
+   * The dispatch assertion's failure message, carrying the step the run ACTUALLY died at.
+   * Without it, "expected undefined to be 'hangs'" says nothing about whether the run
+   * wedged early or never wedged at all — the two failures needing opposite fixes.
+   */
+  function dispatchContext(record: RunRecord): string {
+    return (
+      `run ended at \`${record.heartbeat?.lastStep ?? "<no heartbeat>"}\` after ` +
+      `${record.durationMs}ms`
+    );
+  }
+
+  /**
+   * The `pnpm` first-arguments the fake recorded, in the order the wrapper made them.
+   *
+   * Read off the fake's own append-only log rather than off the sentinels, because the
+   * sentinels are a SET and case 6's whole claim is about ORDER: the three steps before
+   * `backfill` succeeded and the run wedged at `backfill` itself.
+   */
+  function invocationOrder(caseDir: string): string[] {
+    const logPath = join(caseDir, "sentinels", INVOCATION_LOG_NAME);
+    if (!existsSync(logPath)) {
+      return [];
+    }
+    return readFileSync(logPath, "utf8")
+      .split("\n")
+      .filter((line) => line.startsWith("pnpm "))
+      .map((line) => line.slice("pnpm ".length).split(" ")[0] ?? "");
+  }
+
+  /** The behavior the fake's per-first-argument dispatch selected for one sub-command. */
+  function dispatchedBehavior(caseDir: string, command: string): string | undefined {
+    const path = join(caseDir, "sentinels", dispatchRecordNameFor(command));
+    return existsSync(path) ? readFileSync(path, "utf8").trim() : undefined;
+  }
+
+  /**
+   * CASE 6 · THE CRY-WOLF RUN — a timeout AFTER the day's marks are already in the log.
+   *
+   * Cases 2 and 3 hang at `prices-fetch`, so nothing landed and nothing may be stamped.
+   * This one succeeds through `spine`, `commit`, `post-check` and `gap-report` and wedges
+   * at `backfill` — the derived, networked step — so the marks ARE in the log and an
+   * in-window run must say so even though it exited 124. Under-stamping here is what
+   * would make the next morning claim "nothing recorded" for a day the log plainly holds.
+   *
+   * IT IS ALSO THE WORST PLACE IN THE SUITE FOR THE `PATH` MISTAKE. "Succeeds through the
+   * spine step, then hangs at the backfill" is precisely what a REAL pipeline does against
+   * a slow hosted database — so a case 6 that accidentally resolved the real `pnpm` would
+   * look like a passing cry-wolf case while having appended to the real event log and
+   * committed it. The sentinel assertions inside the triple are the guard, and the
+   * dispatch record below is what proves the hang came from the fake's own per-argument
+   * table rather than from anything real being slow.
+   */
+  it(
+    `case 6 — cry-wolf: a timeout at \`backfill\` IN the mark window, ${RUNS_PER_CASE} consecutive times`,
+    async () => {
+      const settles: number[] = [];
+      for (let run = 1; run <= RUNS_PER_CASE; run += 1) {
+        const options = markCaseOptions("in", CASE_6_OPTIONS);
+        const dirs = makeCaseDir(options);
+        // THE ONE BEHAVIOR ENTRY THAT MAKES THIS CASE ITSELF. Everything before `backfill`
+        // falls through to the fake's default `succeeds`, so the run reaches the last step
+        // with the day's marks appended and committed, and only then wedges.
+        setFakeBehavior(dirs.caseDir, "backfill", "hangs");
+        const label = `case 6 run ${run}/${RUNS_PER_CASE} (in-window, ${options.mark.timeZone} hour ${options.mark.hour})`;
+
+        const record = await launchWrapper({
+          caseDir: dirs.caseDir,
+          wrapperPath: WRAPPER_PATH,
+          env: caseEnv(dirs, options),
+          groupLeader: true,
+          settleDeadlineMs: timeoutSettleDeadlineMs(options),
+          maxWaitMs: 120_000,
+        });
+
+        expect(record.logText, `${label}: the watchdog did not arm — was the child detached?`).toContain(
+          "watchdog armed:",
+        );
+        expect(record.logText, `${label}: the watchdog never fired`).toContain(
+          `WATCHDOG: run exceeded ${options.maxRunSeconds}s`,
+        );
+        expect(record.watchdogFired, `${label}: the watchdog left no calling card`).toBe(true);
+        assertGraceBoundedSettle(record, label, options);
+
+        // THE HANG CAME FROM THE DISPATCH, and it is proven rather than assumed. Three
+        // `succeeds` and one `hangs`, selected by the fake on its FIRST ARGUMENT — which
+        // is the capability a single-behavior fake does not have and the reason this case
+        // is expressible at all.
+        for (const command of ["prices:fetch", "spine", "gap-report"]) {
+          expect(
+            dispatchedBehavior(dirs.caseDir, command),
+            `${label}: the fake did not take its \`succeeds\` branch for \`${command}\``,
+          ).toBe("succeeds");
+        }
+        expect(
+          dispatchedBehavior(dirs.caseDir, "backfill"),
+          `${label}: the fake did not take its \`hangs\` branch for \`backfill\` — this run wedged ` +
+            "somewhere the harness did not put a hang, which is what a REAL slow backfill would " +
+            `look like (${dispatchContext(record)})`,
+        ).toBe("hangs");
+        // AND IN THAT ORDER. The sentinels are a set; the wedge is a position.
+        expect(invocationOrder(dirs.caseDir), `${label}: the wrapper's step order`).toEqual([
+          ...WRAPPER_PNPM_COMMANDS,
+        ]);
+
+        assertTriple(record, dirs.caseDir, {
+          exitCode: 124,
+          lastStep: "timeout:backfill",
+          pnpmReached: WRAPPER_PNPM_COMMANDS,
+          mark: options.mark,
+          label,
+        });
+
+        // THE SIDE THIS CASE ASKED FOR, stated bare. Without it the triple's oracle would
+        // be satisfied by an out-of-window run agreeing with an out-of-window oracle, and
+        // the stamp assertion below would never be reached.
+        expect(
+          record.heartbeat?.markWindow,
+          `${label}: the configured zone did not put this run IN the window — every ` +
+            "assertion about the stamp below is vacuous until it does",
+        ).toBe(true);
+        // THE PAYLOAD OF THE WHOLE CASE. `backfill` is past `spine`, so the marks landed;
+        // in-window and landed means this run IS the day's last in-window finish, and the
+        // heartbeat has to say so even though the run itself timed out.
+        expect(
+          record.heartbeat?.lastMarkWindowFinishedAt,
+          `${label}: a run that appended and committed the day's marks and THEN wedged left ` +
+            "the day unstamped — the next morning would read it as nothing recorded",
+        ).toBe(record.heartbeat?.finishedAt);
+
+        settles.push(record.settleMs);
+      }
+      console.log(`[wrapper harness] case 6 in-window settle ms: ${settles.join(", ")}`);
+    },
+    900_000,
+  );
+
+  /**
+   * CASE 6, THE OTHER SIDE — the same run, out of the window, must CARRY rather than stamp.
+   *
+   * A prior stamp is seeded, and seeding it is what makes this case say anything: with a
+   * fresh case dir "carried the previous value forward" and "invented nothing" are the same
+   * observation, and only one of them is the contract. The heartbeat has ONE slot, so this
+   * is the run that would erase the evening's evidence if it stamped itself.
+   */
+  it(
+    `case 6 — the same cry-wolf run OUT of the window carries the prior stamp, ${RUNS_PER_CASE} consecutive times`,
+    async () => {
+      const settles: number[] = [];
+      for (let run = 1; run <= RUNS_PER_CASE; run += 1) {
+        const options = markCaseOptions("out", CASE_6_OPTIONS);
+        const dirs = makeCaseDir(options);
+        seedMarkedEveningHeartbeat(dirs.dataDir);
+        setFakeBehavior(dirs.caseDir, "backfill", "hangs");
+        const label = `case 6 run ${run}/${RUNS_PER_CASE} (out-of-window, ${options.mark.timeZone} hour ${options.mark.hour})`;
+
+        const record = await launchWrapper({
+          caseDir: dirs.caseDir,
+          wrapperPath: WRAPPER_PATH,
+          env: caseEnv(dirs, options),
+          groupLeader: true,
+          settleDeadlineMs: timeoutSettleDeadlineMs(options),
+          maxWaitMs: 120_000,
+        });
+
+        expect(record.watchdogFired, `${label}: the watchdog left no calling card`).toBe(true);
+        assertGraceBoundedSettle(record, label, options);
+        expect(
+          dispatchedBehavior(dirs.caseDir, "backfill"),
+          `${label}: the fake did not take its \`hangs\` branch for \`backfill\` ` +
+            `(${dispatchContext(record)})`,
+        ).toBe("hangs");
+        expect(invocationOrder(dirs.caseDir), `${label}: the wrapper's step order`).toEqual([
+          ...WRAPPER_PNPM_COMMANDS,
+        ]);
+
+        assertTriple(record, dirs.caseDir, {
+          exitCode: 124,
+          lastStep: "timeout:backfill",
+          pnpmReached: WRAPPER_PNPM_COMMANDS,
+          mark: options.mark,
+          carriedStamp: AUTHORED_PRIOR_STAMP,
+          label,
+        });
+
+        expect(
+          record.heartbeat?.markWindow,
+          `${label}: the configured zone did not put this run OUT of the window`,
+        ).toBe(false);
+
+        settles.push(record.settleMs);
+      }
+      console.log(`[wrapper harness] case 6 out-of-window settle ms: ${settles.join(", ")}`);
+    },
+    900_000,
+  );
+
+  /**
+   * CASE 8 · THE HEARTBEAT CARRY-FORWARD, and the join it is the only case to exercise.
+   *
+   * The heartbeat has a BASH WRITER and a TYPESCRIPT READER with nothing else joining them
+   * at runtime. That is why the event-store's heartbeat module is in the arming path set,
+   * and it is why this case is not droppable: without it the suite arms on a file whose
+   * behavior no case verifies.
+   *
+   * Both directions run OUT of the window deliberately. An in-window run that reaches
+   * `complete` stamps ITSELF, which would overwrite whatever it carried and make both
+   * halves below unobservable — the carry is only visible on a run that did not earn a
+   * stamp of its own.
+   *
+   * Deterministic and therefore cheap: the fake succeeds everywhere, so there is no
+   * ceiling to wait out and the twelve runs cost a second each.
+   */
+  it(
+    `case 8 — a schemaVersion-1 file's \`finishedAt\` is CARRIED, ${RUNS_PER_CASE} consecutive times`,
+    async () => {
+      for (let run = 1; run <= RUNS_PER_CASE; run += 1) {
+        const options = markCaseOptions("out", CASE_OPTIONS);
+        const dirs = makeCaseDir(options);
+        // v1 predates the mark-window field entirely, and every v1 run was read as
+        // in-window — so its `finishedAt` IS the last in-window finish, and the wrapper
+        // migrates it forward. This is the ONLY path on which the wrapper derives a stamp
+        // from a field that is not one.
+        seedV1Heartbeat(dirs.dataDir);
+        const label = `case 8 run ${run}/${RUNS_PER_CASE} (v1 carry, ${options.mark.timeZone} hour ${options.mark.hour})`;
+
+        const record = await launchWrapper({
+          caseDir: dirs.caseDir,
+          wrapperPath: WRAPPER_PATH,
+          env: caseEnv(dirs, options),
+          groupLeader: true,
+          settleDeadlineMs: SETTLE_DEADLINE_MS,
+          maxWaitMs: 60_000,
+        });
+
+        expect(record.logText, `${label}: the watchdog did not arm`).toContain("watchdog armed:");
+        expect(record.watchdogFired, `${label}: a healthy run left a calling card`).toBe(false);
+
+        assertTriple(record, dirs.caseDir, {
+          exitCode: 0,
+          lastStep: "complete",
+          pnpmReached: WRAPPER_PNPM_COMMANDS,
+          mark: options.mark,
+          carriedStamp: AUTHORED_V1_CARRY,
+          label,
+        });
+
+        expect(
+          record.heartbeat?.markWindow,
+          `${label}: the configured zone did not put this run OUT of the window — an ` +
+            "in-window run stamps itself and the carry becomes unobservable",
+        ).toBe(false);
+        // AND THE FILE IT WROTE IS v2. The migration is one-way: reading a v1 file must
+        // not re-emit one, or the next run would migrate the same value again forever.
+        expect(record.heartbeat?.schemaVersion, `${label}: heartbeat schemaVersion`).toBe(2);
+      }
+    },
+    600_000,
+  );
+
+  it(
+    `case 8 — an in-window v2 file that died before \`spine\` yields NO stamp, ${RUNS_PER_CASE} consecutive times`,
+    async () => {
+      for (let run = 1; run <= RUNS_PER_CASE; run += 1) {
+        const options = markCaseOptions("out", CASE_OPTIONS);
+        const dirs = makeCaseDir(options);
+        // THE DEFECT THAT OPENED THIS LINE OF WORK, seeded verbatim. The v1 fallback used
+        // to be gated NEGATIVELY — it fired whenever the file did not say
+        // `"markWindow": false` — which is true of this perfectly ordinary v2 file: an
+        // in-window run that died before `spine` correctly omits the stamp (it marked
+        // nothing) while carrying `"markWindow": true`. The old gate read that omission as
+        // v1 and promoted the FAILURE's own `finishedAt` into a marked-day stamp,
+        // manufacturing evidence that the day was covered and silencing the staleness
+        // warning on exactly the morning it was needed.
+        seedInWindowDiedBeforeSpineHeartbeat(dirs.dataDir);
+        const label = `case 8 run ${run}/${RUNS_PER_CASE} (no invention, ${options.mark.timeZone} hour ${options.mark.hour})`;
+
+        const record = await launchWrapper({
+          caseDir: dirs.caseDir,
+          wrapperPath: WRAPPER_PATH,
+          env: caseEnv(dirs, options),
+          groupLeader: true,
+          settleDeadlineMs: SETTLE_DEADLINE_MS,
+          maxWaitMs: 60_000,
+        });
+
+        assertTriple(record, dirs.caseDir, {
+          exitCode: 0,
+          lastStep: "complete",
+          pnpmReached: WRAPPER_PNPM_COMMANDS,
+          mark: options.mark,
+          label,
+        });
+
+        expect(
+          record.heartbeat?.markWindow,
+          `${label}: the configured zone did not put this run OUT of the window`,
+        ).toBe(false);
+        // NAMED, not merely "undefined". The seeded file's `finishedAt` is the exact value
+        // the negatively-gated fallback would have promoted, so this is the assertion that
+        // would have gone red on the defect.
+        expect(
+          record.heartbeat?.lastMarkWindowFinishedAt,
+          `${label}: the wrapper promoted a failed run's \`finishedAt\` into a marked-day ` +
+            "stamp — a day that was never covered now reads as covered",
+        ).not.toBe(AUTHORED_PRIOR_STAMP);
+      }
+    },
+    600_000,
+  );
+
+  // ── THE ZONE INPUT REFUSES, IT DOES NOT DEGRADE ───────────────────────────────────
+  //
+  // The input cases 6 and 8 are driven by is only as good as its failure mode. Bash does
+  // not fail on a bad `TZ` the way `Intl` does — `TZ=Not/AZone date +%H` prints the UTC
+  // hour, silently and with a zero exit — and UTC is DISJOINT from the CDMX evening
+  // window, so one typo would classify every run out-of-window while the runs themselves
+  // kept marking correctly. That is case 6 made vacuous again, through the input rather
+  // than through the clock, which is why the guard is asserted here and not taken on
+  // trust.
+  //
+  // BOTH RUNS DIE BEFORE THE EXIT TRAP IS INSTALLED, so there is no heartbeat and no log
+  // file to read — the refusal is on the child's own stdout, and the assertion triple
+  // does not apply. That is the correct shape: a run that cannot say which side of the
+  // window it is on must not write a breadcrumb claiming one.
+  describe("the configured mark window refuses a value it cannot resolve", () => {
+    for (const [name, value, expected] of [
+      ["NUMISMA_MARK_TZ", "Not/AZone", "is not a resolvable IANA zone"],
+      ["NUMISMA_MARK_HOUR", "evening", "is not an hour of the day"],
+    ] as const) {
+      it(`exits 1 naming the value when \`${name}\` is \`${value}\``, async () => {
+        const dirs = makeCaseDir(CASE_OPTIONS);
+        const record = await launchWrapper({
+          caseDir: dirs.caseDir,
+          wrapperPath: WRAPPER_PATH,
+          env: { ...caseEnv(dirs, CASE_OPTIONS), [name]: value },
+          groupLeader: true,
+          settleDeadlineMs: SETTLE_DEADLINE_MS,
+          maxWaitMs: 60_000,
+        });
+
+        expect(record.exitCode, `${name}=${value}: exit code`).toBe(1);
+        expect(record.stdout, `${name}=${value}: the refusal names the value it refused`).toContain(
+          `'${value}'`,
+        );
+        expect(record.stdout).toContain(expected);
+        // IT REFUSED BEFORE IT RAN ANYTHING. A guard that fired after the fetch would have
+        // let a run with an unknowable window append to the log first.
+        for (const command of WRAPPER_PNPM_COMMANDS) {
+          expect(
+            existsSync(join(dirs.caseDir, "sentinels", sentinelNameFor(command))),
+            `${name}=${value}: the wrapper reached \`${command}\` despite refusing its own configuration`,
+          ).toBe(false);
+        }
+        expect(record.heartbeat, `${name}=${value}: a run that refused its own configuration ` +
+          "still wrote a breadcrumb claiming a side of the window").toBeUndefined();
+        expect(record.pgidResidue, `${name}=${value}: processes left in pgid ${record.pgid}`).toEqual([]);
+      });
+    }
+  });
+
   // ── CASE 4 · THE EXTERNAL STOP ────────────────────────────────────────────────────
   //
   // THE SAME FAKE, THE SAME CEILING AND THE SAME STEP AS CASE 2. Everything about this run

--- a/apps/price-feed/src/wrapper-harness/run-daily-fetch.test.ts
+++ b/apps/price-feed/src/wrapper-harness/run-daily-fetch.test.ts
@@ -1,6 +1,6 @@
 /**
  * THE COMMITTED TEST HARNESS FOR `ops/price-feed/run-daily-fetch.sh` (PRD #314, slices
- * #316 and #317).
+ * #316, #317 and #318).
  *
  * ⚠️ **THIS SUITE CAN NEVER RUN IN CI AS CI EXISTS TODAY. A GREEN CI RUN DOES NOT MEAN
  * THIS HARNESS PASSED — IT MEANS IT WAS NOT ATTEMPTED.** CI is a single `ubuntu-latest`
@@ -24,7 +24,7 @@
  * path set, so every `pnpm test` carries a line about this harness whether or not it ran.
  * `pnpm test:wrapper` runs it on demand. `NUMISMA_WRAPPER_TEST=never` mutes it and says so.
  *
- * ── WHAT SLICES 1-2 CLAIM, AND WHAT THEY DO NOT ───────────────────────────────────────
+ * ── WHAT SLICES 1-3 CLAIM, AND WHAT THEY DO NOT ───────────────────────────────────────
  * Slice 1: the launcher, the isolation refusal, the fake-tool bin and its sentinel, the
  * assertion triple, 12-run repetition, the arming trigger and its three guard layers,
  * case 1 (healthy), case 7 (not a group leader) and the child-reap mutation control.
@@ -37,9 +37,32 @@
  * disabled watchdog, is observed still alive well past its own ceiling and grace with no
  * calling card, and is then released to finish normally.
  *
- * Neither slice claims: the external-stop path and case 4 (slice 3) — nothing here asserts
- * anything about exit 143 or about the calling card's absence as a discriminator — nor the
- * mark window and cases 6 and 8 (slice 4).
+ * Slice 3 — case 4 and THE DISCRIMINATION THE TERM HANDLER MAKES: the same `hangs` fake as
+ * case 2, signalled by the harness with a bare group SIGTERM BEFORE the ceiling can fire,
+ * and the pair-comparison test that holds cases 2 and 4 against each other. **Cases 2 and 4
+ * run inside ONE suite run, and that is a requirement rather than an accident of layout**
+ * (#312): watchdog-TERM and external-TERM are the two halves of a single branch, and split
+ * across two suites or two gates they drift apart silently — a handler that stopped
+ * discriminating would leave each half green on its own. Do not separate them.
+ *
+ * ── WHAT SLICE 3 DOES NOT PROVE, SAID PLAINLY ─────────────────────────────────────────
+ * **This harness delivers the SIGNAL, not the SENDER.** A bare SIGTERM to the run's pgid is
+ * signal-identical to what `launchctl stop`, `launchctl unload`, a logout and a shutdown all
+ * deliver, and signal-identical is exactly what the TERM handler branches on — its whole
+ * discriminator is whether the watchdog's calling card is on disk. So case 4 proves the
+ * HANDLER'S DISCRIMINATION soundly, and it proves nothing whatever about launchd. Therefore:
+ *
+ * - `launchctl stop` and `launchctl unload` mid-run each remain worth ONE MANUAL
+ *   confirmation against the real installed LaunchAgent, recorded in #312. This suite makes
+ *   them cheap to trust; it does not replace them. Nothing here drives `launchctl`.
+ * - **Logout or shutdown mid-run is inherently manual and automatable by nobody.** The
+ *   failure mode is the filesystem going away underneath a single `printf` from an EXIT
+ *   trap; no in-process harness reproduces a real session teardown, and no future harness
+ *   work should be scheduled against it.
+ *
+ * Anyone about to write "the external-stop path is covered" should read this paragraph first.
+ *
+ * No slice yet claims the mark window, or cases 6 and 8 (slice 4).
  *
  * ── A BLIND SPOT THIS DESIGN CREATES, NAMED RATHER THAN IMPLIED ───────────────────────
  * The fake `pnpm` is what makes every case fast and safe, and it is therefore exactly what
@@ -54,6 +77,7 @@ import { existsSync, mkdirSync, mkdtempSync, readFileSync, readdirSync, writeFil
 import { tmpdir } from "node:os";
 import { dirname, join } from "node:path";
 import { fileURLToPath } from "node:url";
+import type { JobHeartbeat } from "@numisma/event-store";
 import { describe, expect, it } from "vitest";
 import {
   HARNESS_PLATFORM,
@@ -571,6 +595,67 @@ function watchdogCardPresent(logDir: string): boolean {
 }
 
 /**
+ * How long case 4 will wait for the run to actually be INSIDE the fetch step before it
+ * signals. Bounded well under the timeout cases' 3s ceiling on purpose: the whole claim of
+ * case 4 is that its signal arrives before the watchdog's, so a wait that could run into the
+ * ceiling would be a wait that could silently turn case 4 into a second copy of case 2.
+ */
+const REACH_STEP_BOUND_MS = 2_000;
+
+/**
+ * Block until the fake has recorded `command`, so a signal aimed at a step lands while the
+ * run is genuinely IN that step rather than somewhere earlier by luck — the step name in the
+ * heartbeat is half of what case 4 asserts, and `LAST_STEP` is set just before the call the
+ * sentinel proves happened.
+ *
+ * FAIL-CLOSED AND BOUNDED. A sentinel that never arrives means the run never reached the
+ * step this signal is aimed at, which is a failure of the case; waiting for it with
+ * unbounded patience would be indistinguishable from a run that hung before it got there.
+ */
+async function waitForFakeToReach(
+  caseDir: string,
+  command: string,
+  label: string,
+): Promise<number> {
+  const sentinel = join(caseDir, "sentinels", sentinelNameFor(command));
+  const startedAt = Date.now();
+  while (!existsSync(sentinel)) {
+    if (Date.now() - startedAt >= REACH_STEP_BOUND_MS) {
+      throw new Error(
+        `${label}: the fake never recorded \`${command}\` within ${REACH_STEP_BOUND_MS}ms — ` +
+          "the run never reached the step this signal is aimed at",
+      );
+    }
+    await sleep(25);
+  }
+  return Date.now() - startedAt;
+}
+
+/**
+ * ONE HALF OF THE PAIR CASES 2 AND 4 FORM — kept so the two can be compared against each
+ * other rather than only against their own expectations. Two independent per-case assertions
+ * cannot see a change that moves BOTH cases in the same direction; the comparison can.
+ */
+interface TermPathObservation {
+  readonly label: string;
+  readonly heartbeat: JobHeartbeat;
+  /** The watchdog's calling card — the TERM handler's entire discriminator. */
+  readonly watchdogCard: boolean;
+}
+
+let watchdogTermObserved: TermPathObservation | undefined;
+let externalTermObserved: TermPathObservation | undefined;
+
+/** Snapshot a finished run for the pair comparison, refusing a run with no heartbeat. */
+function observeTermPath(record: RunRecord, label: string): TermPathObservation {
+  const heartbeat = record.heartbeat;
+  if (heartbeat === undefined) {
+    throw new Error(`${label}: no heartbeat to compare — ${record.heartbeatRaw ?? "(absent)"}`);
+  }
+  return { label, heartbeat, watchdogCard: record.watchdogFired };
+}
+
+/**
  * Whether this run was in the mark window, computed the way the CONTRACT computes it —
  * `America/Mexico_City`, hour ≥ 18 — rather than from the machine's local clock, which
  * would agree only by coincidence of an OS setting. Read off the heartbeat's own
@@ -1035,6 +1120,9 @@ describe.runIf(decision.run)("wrapper harness — the real wrapper, armed", () =
           pnpmReached: ["prices:fetch"],
           label,
         });
+        // KEPT FOR THE PAIR COMPARISON below, which is how the watchdog-TERM and
+        // external-TERM halves of one branch are held against each other.
+        watchdogTermObserved = observeTermPath(record, label);
         settles.push(record.settleMs);
       }
       console.log(
@@ -1153,6 +1241,241 @@ describe.runIf(decision.run)("wrapper harness — the real wrapper, armed", () =
     },
     600_000,
   );
+
+  // ── CASE 4 · THE EXTERNAL STOP ────────────────────────────────────────────────────
+  //
+  // THE SAME FAKE, THE SAME CEILING AND THE SAME STEP AS CASE 2. Everything about this run
+  // is case 2 except WHO SIGNALLED IT, which is the only variable the TERM handler branches
+  // on — so the two cases are a matched pair by construction, and the comparison below can
+  // therefore mean something.
+  //
+  // IT DELIVERS THE SIGNAL, NOT THE SENDER, and that limit is not a hedge. `launchctl stop`,
+  // `launchctl unload`, a logout and a shutdown all deliver this same bare SIGTERM to this
+  // same process group; the handler cannot tell them apart and does not try. What it asks is
+  // whether the watchdog left its calling card first. So this case proves the handler's
+  // discrimination and says nothing about launchd — see the file header before writing that
+  // the external-stop path is covered anywhere.
+  //
+  // WHY THE SIGNAL IS SENT ON A SENTINEL RATHER THAN A TIMER. The run must be INSIDE the
+  // fetch step when it arrives (that is the step name half of the assertion) and the signal
+  // must beat the ceiling (that is the calling-card half). Waiting for the fake's own
+  // sentinel gets both without racing a clock: the sentinel is written by the process the
+  // wrapper is blocked on, so it cannot appear early, and it appears in a fraction of the
+  // 3-second ceiling.
+  it(
+    `case 4 — an EXTERNAL stop before the ceiling, ${RUNS_PER_CASE} consecutive times`,
+    async () => {
+      const settles: number[] = [];
+      const reaches: number[] = [];
+      const durations: number[] = [];
+      const ceilingMs = TIMEOUT_CASE_OPTIONS.maxRunSeconds * 1_000;
+
+      for (let run = 1; run <= RUNS_PER_CASE; run += 1) {
+        const dirs = makeCaseDir(TIMEOUT_CASE_OPTIONS);
+        setFakeBehavior(dirs.caseDir, "prices:fetch", "hangs");
+        const label = `case 4 run ${run}/${RUNS_PER_CASE}`;
+
+        const record = await launchWrapper({
+          caseDir: dirs.caseDir,
+          wrapperPath: WRAPPER_PATH,
+          env: caseEnv(dirs, TIMEOUT_CASE_OPTIONS),
+          groupLeader: true,
+          // The SHORT window, as on every non-timeout path: this run never sets `TIMED_OUT`,
+          // so its EXIT trap cancels the watchdog — subshell and forked `sleep` both — before
+          // the shell leaves. Handing it the grace-derived bound would let a watchdog left
+          // sleeping over an already-dead run pass unnoticed, which is the held-job-slot
+          // failure the cancellation exists to prevent.
+          settleDeadlineMs: SETTLE_DEADLINE_MS,
+          // A REAL CAP, and it matters more here than anywhere else: this is the one case
+          // whose premise is that the wrapper's own watchdog has NOT fired, so the watchdog
+          // cannot be its bound. A TERM that failed to be delivered must arrive as a red
+          // test, never as a wedged worker.
+          maxWaitMs: 60_000,
+          duringRun: async (pgid) => {
+            reaches.push(await waitForFakeToReach(dirs.caseDir, "prices:fetch", label));
+            // BEFORE THE CEILING, ASSERTED RATHER THAN ASSUMED. If the watchdog got there
+            // first this is case 2 wearing case 4's name — a run that would still exit 124
+            // and still pass an exit-code-only test of "something stopped it".
+            expect(
+              watchdogCardPresent(dirs.logDir),
+              `${label}: the watchdog fired BEFORE the harness could signal — this run is a ` +
+                "second copy of case 2, not an external stop",
+            ).toBe(false);
+            // THE EXTERNAL STOP ITSELF: a bare SIGTERM to the run's own process group, with
+            // no calling card, from outside the run. Byte-for-byte what `launchctl stop`
+            // delivers; nothing here goes near `launchctl`.
+            process.kill(-pgid, "SIGTERM");
+          },
+        });
+
+        expect(record.logText, `${label}: the watchdog did not arm — was the child detached?`).toContain(
+          "watchdog armed:",
+        );
+        // THE DISCRIMINATOR, ASSERTED DIRECTLY AND NOT INFERRED FROM THE EXIT CODE. The
+        // calling card is the only thing the TERM handler reads, so its ABSENCE is the fact
+        // that makes the 143 honest. A handler that had stopped discriminating entirely
+        // would still satisfy an exit-code assertion on one side of the pair.
+        expect(
+          record.watchdogFired,
+          `${label}: a calling card was left on a run the watchdog never timed out`,
+        ).toBe(false);
+        expect(record.logText, `${label}: the watchdog fired after all`).not.toContain(
+          "WATCHDOG: run exceeded",
+        );
+        expect(
+          record.durationMs,
+          `${label}: the run outlived its own ${ceilingMs}ms ceiling, so the ending it recorded ` +
+            "may be the watchdog's rather than the harness's",
+        ).toBeLessThan(ceilingMs);
+
+        assertTriple(record, dirs.caseDir, {
+          exitCode: 143,
+          // UNDECORATED, and the bareness is the payload: `timeout:` here would be the
+          // wrapper telling the next morning's TUI that a run someone stopped by hand had
+          // hung, spending the credibility the breadcrumb exists to hold.
+          lastStep: "prices-fetch",
+          pnpmReached: ["prices:fetch"],
+          label,
+        });
+        externalTermObserved = observeTermPath(record, label);
+        settles.push(record.settleMs);
+        durations.push(record.durationMs);
+      }
+      console.log(
+        `[wrapper harness] case 4 reached the step in (ms): ${reaches.join(", ")} · ran for (ms, ` +
+          `ceiling ${ceilingMs}): ${durations.join(", ")} · settle ms: ${settles.join(", ")}`,
+      );
+    },
+    600_000,
+  );
+
+  // ── THE PAIR · CASES 2 AND 4 HELD AGAINST EACH OTHER ──────────────────────────────
+  //
+  // #312's explicit requirement is that these two run inside ONE suite run, and this is
+  // where that requirement is written down rather than merely satisfied by layout. They are
+  // the two branches of a single `if` in the wrapper's TERM handler. Split across two suites
+  // or two gates they drift apart in silence: each half keeps passing on its own while the
+  // handler stops telling them apart. Do not separate them, and do not let one of them be
+  // skipped while the other runs — the guard below turns that into a red test rather than a
+  // quiet one.
+  it("cases 2 and 4 differ in EXACTLY three things — and the same suite run proves it", () => {
+    const timeout = watchdogTermObserved;
+    const external = externalTermObserved;
+    expect(
+      timeout,
+      "case 2 left no observation — the watchdog-TERM half of the pair did not run in THIS " +
+        "suite run, so the comparison would be vacuous",
+    ).toBeDefined();
+    expect(
+      external,
+      "case 4 left no observation — the external-TERM half of the pair did not run in THIS " +
+        "suite run, so the comparison would be vacuous",
+    ).toBeDefined();
+    if (timeout === undefined || external === undefined) {
+      return;
+    }
+
+    // ── THE THREE THINGS THAT MUST DIFFER ───────────────────────────────────────────
+    // (1) The exit code. `not.toBe` as well as the two literals, because the literals alone
+    //     would still pass if a future handler collapsed both paths onto whichever number
+    //     each side happens to expect — the point of a comparison is to see them MOVE APART.
+    expect(timeout.heartbeat.exitCode, "case 2's exit code").toBe(124);
+    expect(external.heartbeat.exitCode, "case 4's exit code").toBe(143);
+    expect(
+      timeout.heartbeat.exitCode,
+      "the two TERM paths recorded the SAME exit code — the handler is no longer discriminating",
+    ).not.toBe(external.heartbeat.exitCode);
+
+    // (2) The step DECORATION, and nothing else about the step. Undecorating case 2's step
+    //     must yield case 4's exactly: same fake, same step, so any difference beyond the
+    //     `timeout:` prefix means the two runs did not die in the same place and the rest of
+    //     this comparison is between two things that were never comparable.
+    expect(
+      timeout.heartbeat.lastStep,
+      "the two TERM paths recorded the SAME step name — one of them lost its decoration, or " +
+        "the other gained one",
+    ).not.toBe(external.heartbeat.lastStep);
+    expect(timeout.heartbeat.lastStep, "case 2's step is decorated").toMatch(/^timeout:/);
+    expect(external.heartbeat.lastStep, "case 4's step is BARE").not.toMatch(/^timeout:/);
+    expect(
+      timeout.heartbeat.lastStep.replace(/^timeout:/, ""),
+      "the pair died at DIFFERENT steps, so they are not a matched pair at all",
+    ).toBe(external.heartbeat.lastStep);
+
+    // (3) The calling card — the fact the handler actually branches on, and the reason the
+    //     other two differences are what they are.
+    expect(timeout.watchdogCard, "case 2's calling card").toBe(true);
+    expect(external.watchdogCard, "case 4's calling card").toBe(false);
+    expect(
+      timeout.watchdogCard,
+      "both TERM paths agreed about the calling card — the discriminator has stopped " +
+        "discriminating, and the exit codes above are then true only by coincidence",
+    ).not.toBe(external.watchdogCard);
+
+    // ── AND NO OTHERS, WHICH IS THE HALF THAT NEEDS CARE ────────────────────────────
+    // "No others" cannot mean "every field is equal": two runs minutes apart legitimately
+    // carry different clocks. So every field is CLASSIFIED, and an unclassified one is a
+    // failure rather than a default — a field added to the heartbeat later must be placed in
+    // one of these three buckets deliberately, not slip past a comparison that is silent
+    // about it.
+    const MUST_DIFFER: readonly string[] = ["exitCode", "lastStep"];
+    /**
+     * Wall-clock, or derived from wall-clock. These CANNOT be compared across the pair
+     * without being either vacuous or permanently red, so each is pinned individually below
+     * instead — `markWindow` in particular is a function of the run's own `startedAt` read in
+     * `America/Mexico_City`, so a suite straddling 18:00 CDMX legitimately produces one of
+     * each, and demanding they match would go red once a day for a correct wrapper.
+     */
+    const MAY_VARY: readonly string[] = ["startedAt", "finishedAt", "markWindow"];
+    /** Everything else: identical across the pair, presence and value alike. */
+    const MUST_MATCH: readonly string[] = ["schemaVersion", "lastMarkWindowFinishedAt"];
+
+    const timeoutKeys = Object.keys(timeout.heartbeat).sort();
+    const externalKeys = Object.keys(external.heartbeat).sort();
+    expect(
+      timeoutKeys,
+      "the two heartbeats do not even carry the same FIELDS — one of them recorded something " +
+        "the other omitted",
+    ).toEqual(externalKeys);
+    const classified = new Set([...MUST_DIFFER, ...MAY_VARY, ...MUST_MATCH]);
+    for (const key of timeoutKeys) {
+      expect(
+        classified.has(key),
+        `\`${key}\` is a heartbeat field this comparison never classified — classify it as ` +
+          "MUST_DIFFER, MAY_VARY or MUST_MATCH rather than leaving the comparison silent about it",
+      ).toBe(true);
+    }
+    for (const key of MUST_MATCH) {
+      const left = (timeout.heartbeat as unknown as Record<string, unknown>)[key];
+      const right = (external.heartbeat as unknown as Record<string, unknown>)[key];
+      expect(left, `\`${key}\` diverged across the pair, and only these three may`).toEqual(right);
+    }
+
+    // The fields that may vary are pinned individually, so "may vary" never becomes
+    // "unchecked". Each run's window is judged against the CONTRACT's zone, the same oracle
+    // the per-case triple uses, rather than against the other run's clock.
+    for (const observed of [timeout, external]) {
+      expect(
+        Number.isNaN(Date.parse(observed.heartbeat.startedAt)),
+        `${observed.label}: unparseable startedAt`,
+      ).toBe(false);
+      expect(
+        Date.parse(observed.heartbeat.finishedAt),
+        `${observed.label}: finished before it started`,
+      ).toBeGreaterThanOrEqual(Date.parse(observed.heartbeat.startedAt));
+      expect(
+        observed.heartbeat.markWindow,
+        `${observed.label}: markWindow disagrees with the contract's own zone`,
+      ).toBe(expectedMarkWindow(observed.heartbeat.startedAt));
+    }
+
+    console.log(
+      `[wrapper harness] the pair — ${timeout.label}: exit ${timeout.heartbeat.exitCode} at ` +
+        `\`${timeout.heartbeat.lastStep}\`, card ${timeout.watchdogCard} · ${external.label}: ` +
+        `exit ${external.heartbeat.exitCode} at \`${external.heartbeat.lastStep}\`, card ` +
+        `${external.watchdogCard}`,
+    );
+  });
 
   // ── S6 · THE CHILD-REAP MUTATION CONTROL ──────────────────────────────────────────
   describe("the child-reap mutation — assertion 3 is seen RED before it is trusted", () => {

--- a/docs/price-feed-ops.md
+++ b/docs/price-feed-ops.md
@@ -569,3 +569,41 @@ bad day never appends a bad mark. The console/log distinguishes the two cases �
 private `<fund>` repo, `~/Dev/<fund>/data` by default. The `inbox/` and
 `prices/` subtrees are the disposable cache: `<fund>`'s allowlist `.gitignore`
 keeps them (and `ingested/`, `*.tmp`, `*.quarantine`) out of the versioned history.
+
+## The committed wrapper test harness (and why a green CI check says nothing about it)
+
+`apps/price-feed/src/wrapper-harness/` drives `ops/price-feed/run-daily-fetch.sh`
+as a real process — launched the way launchd launches it (`/bin/bash <wrapper>`,
+in its own session), against an authored fake `pnpm`, inside a temp directory.
+
+**⚠️ It can never run in CI as CI exists today. A green CI run does not mean this
+harness passed — it means it was not attempted.** CI is a single `ubuntu-latest`
+job; this suite targets macOS `/bin/bash` 3.2.57, BSD `ps`/`pgrep` and a watchdog
+that is hand-rolled *because* macOS ships no `timeout(1)`. The suite's platform
+gate skips it on Linux and prints the reason, so the CI log says so out loud —
+but the check itself is green either way.
+
+Where it runs, and when:
+
+- **Automatically, on a macOS `pnpm test`, when its own subject changed.** The
+  trigger compares `git merge-base HEAD origin/main` (on `main` itself, `HEAD~1`)
+  against `ops/price-feed/**`, the harness's own directory, and
+  `packages/event-store/src/heartbeat.ts` — committed history *and* the dirty
+  tree, because an uncommitted wrapper edit is exactly when you most want it.
+- **On demand:** `pnpm test:wrapper`. Runs it regardless of the trigger; the
+  platform gate still applies.
+- **It never skips silently.** One always-running test prints the decision, the
+  reason, the base SHA it compared against and the path set — on every `pnpm
+  test`, armed or not.
+
+Overrides: `NUMISMA_WRAPPER_TEST` = `auto` (default) · `always` · `never` (which
+still prints its reason — a mute button on this channel announces itself).
+`NUMISMA_WRAPPER_TEST_RUNS` raises the per-case repetition above its committed
+floor of 12; it is refused, not clamped, below it.
+
+**Nothing it runs touches anything real.** All seven `NUMISMA_*` overrides the
+wrapper reads are pointed inside a per-run temp directory and the launcher
+*refuses to start* if any is unset or resolves outside it — because an
+unisolated run is not a flaky test, it is a real `prices:fetch`, a real `spine`
+append, a real commit against the durable event log and a real `backfill`
+against the hosted projection, passing green while it happens.

--- a/docs/price-feed-ops.md
+++ b/docs/price-feed-ops.md
@@ -31,6 +31,17 @@ path, else `__REPO_DIR__`/the plist's `EnvironmentVariables`), `NUMISMA_PRICEFEE
 (the token env file, else `~/.config/numisma/price-feed.env`), and
 `NUMISMA_PRICEFEED_LOG_DIR` (per-run log directory, else `~/Library/Logs/numisma`).
 
+Two more let a caller put a run on either side of the mark window without
+waiting on the machine clock: `NUMISMA_MARK_TZ` and `NUMISMA_MARK_HOUR`, each
+defaulting to the contract the engine authors once — `TRADING_DAY_TIME_ZONE`
+/ `MARK_HOUR` in `packages/engine/src/price-feed/mark.ts` (America/Mexico_City,
+18). Unlike the overrides above, a bad value here is **fatal, not silently
+substituted**: the wrapper rejects an unresolvable `NUMISMA_MARK_TZ` (checked
+against `${TZDIR:-/usr/share/zoneinfo}`) or a non-numeric `NUMISMA_MARK_HOUR`
+before computing the mark window, with a named error, rather than letting
+bash's own silent UTC fallback flip every run's in/out-of-window judgment
+while the runs themselves kept marking fine.
+
 ## Where provider tokens live (scheduled environment)
 
 - **Crypto needs no token.** Binance public REST is keyless, so a crypto-only run
@@ -601,7 +612,7 @@ still prints its reason — a mute button on this channel announces itself).
 `NUMISMA_WRAPPER_TEST_RUNS` raises the per-case repetition above its committed
 floor of 12; it is refused, not clamped, below it.
 
-**Nothing it runs touches anything real.** All seven `NUMISMA_*` overrides the
+**Nothing it runs touches anything real.** All nine `NUMISMA_*` overrides the
 wrapper reads are pointed inside a per-run temp directory and the launcher
 *refuses to start* if any is unset or resolves outside it — because an
 unisolated run is not a flaky test, it is a real `prices:fetch`, a real `spine`

--- a/docs/price-feed-ops.md
+++ b/docs/price-feed-ops.md
@@ -40,7 +40,11 @@ substituted**: the wrapper rejects an unresolvable `NUMISMA_MARK_TZ` (checked
 against `${TZDIR:-/usr/share/zoneinfo}`) or a non-numeric `NUMISMA_MARK_HOUR`
 before computing the mark window, with a named error, rather than letting
 bash's own silent UTC fallback flip every run's in/out-of-window judgment
-while the runs themselves kept marking fine.
+while the runs themselves kept marking fine. **The refusal is loud on both
+channels**: it writes the `FATAL` line to the per-run log and leaves a
+heartbeat reading `exit 1` at step `startup` with `markWindow: false`, so a
+typo that kills every fire of an evening shows up as a failed run rather than
+as `job-heartbeat.json` still describing the last good one.
 
 ## Where provider tokens live (scheduled environment)
 

--- a/ops/price-feed/com.numisma.pricefeed.daily.plist
+++ b/ops/price-feed/com.numisma.pricefeed.daily.plist
@@ -4,9 +4,12 @@
 
   Fires the wrapper (run-daily-fetch.sh) EVERY HOUR from 18:00 through 23:00 in the
   MACHINE's local timezone. The mark-instant contract's default mark time is 18:00
-  America/Mexico_City (ADR-005 / config.ts), so this assumes the Mac's System
-  Settings timezone is CDMX. If the machine runs another timezone, shift all six
-  Hours to the local clock equal to 18:00–23:00 CDMX, or keep the OS on CDMX.
+  America/Mexico_City (ADR-005; authored once as `TRADING_DAY_TIME_ZONE` / `MARK_HOUR`
+  in packages/engine/src/price-feed/mark.ts, which the wrapper's NUMISMA_MARK_TZ /
+  NUMISMA_MARK_HOUR defaults and DEFAULT_CONFIG both derive from), so this assumes
+  the Mac's System Settings timezone is CDMX. If the machine runs another timezone,
+  shift all six Hours to the local clock equal to 18:00–23:00 CDMX, or keep the OS
+  on CDMX.
 
   WHY SIX FIRES AND NOT ONE (#185 S2). A MISSED FIRE IS NOT RECOVERED BY
   IDEMPOTENCY. Those are two different properties and the old note here conflated

--- a/ops/price-feed/run-daily-fetch.sh
+++ b/ops/price-feed/run-daily-fetch.sh
@@ -126,42 +126,19 @@ HEARTBEAT_FILE="$DATA_DIR/job-heartbeat.json"
 MARK_TZ="${NUMISMA_MARK_TZ:-America/Mexico_City}"
 MARK_HOUR="${NUMISMA_MARK_HOUR:-18}"
 
-# REFUSE AN UNRESOLVABLE ZONE, BEFORE ANY OF IT IS USED. Bash does not fail on a bad
-# TZ the way `Intl` does: `TZ=Not/AZone date +%H` prints the UTC hour, with no error
-# and a zero exit. UTC is DISJOINT from the CDMX evening window (12:00-17:59 CDMX vs
-# the 18:00-23:59 fires), so one typo flips the window wrong on EVERY run while the
-# runs themselves keep marking correctly — the silent rot this whole block exists to
-# prevent, entered through the override that was just added. Falling back to UTC (or
-# to local) would be the same bug with a friendlier name, so this exits instead.
-# The shape check comes first so the path built below cannot be anything but a zone
-# name. `TZDIR` is honoured because that is what the C library itself consults.
-if [[ ! "$MARK_TZ" =~ ^[A-Za-z][A-Za-z0-9_+-]*(/[A-Za-z0-9_+-]+)*$ ]] ||
-  [[ ! -f "${TZDIR:-/usr/share/zoneinfo}/$MARK_TZ" ]]; then
-  echo "[$STAMP] FATAL: mark timezone '$MARK_TZ' is not a resolvable IANA zone."
-  echo "[$STAMP] No entry under ${TZDIR:-/usr/share/zoneinfo}. Bash would silently report the UTC"
-  echo "[$STAMP] hour for it, which is disjoint from the mark window, so every run would classify"
-  echo "[$STAMP] itself out-of-window while marking fine. Refusing rather than degrading."
-  echo "[$STAMP] Set NUMISMA_MARK_TZ to a real zone name, or leave it unset for the contract default."
-  exit 1
-fi
-# And refuse a mark hour that is not one. Left unchecked it would not abort either —
-# the comparison below is an `if` condition, so `set -e` never fires — it would just
-# classify every run as out-of-window, exactly like the bad zone.
-if [[ ! "$MARK_HOUR" =~ ^(0?[0-9]|1[0-9]|2[0-3])$ ]]; then
-  echo "[$STAMP] FATAL: mark hour '$MARK_HOUR' is not an hour of the day (0-23)."
-  echo "[$STAMP] Set NUMISMA_MARK_HOUR to a plain hour, or leave it unset for the contract default."
-  exit 1
-fi
-
-# Read once into a named variable so the comparison below is a self-contained
-# expression over two hour-shaped strings — which is what lets a test drive the
-# wrapper's OWN line with `08`/`09` and prove the base-10 forcing still holds.
-MARK_NOW_HOUR="$(TZ="$MARK_TZ" date +%H)"
-if [[ $((10#$MARK_NOW_HOUR)) -ge $((10#$MARK_HOUR)) ]]; then
-  MARK_WINDOW=true
-else
-  MARK_WINDOW=false
-fi
+# PROVISIONAL UNTIL THE RUN IS CLASSIFIED, BECAUSE THE EXIT TRAP BELOW READS IT. The
+# two guards that refuse an unusable zone or hour, and the classification itself, run
+# AFTER the heartbeat trap and the per-run log are installed — see "the mark window,
+# classified" further down for why that ordering is the point rather than an accident.
+# The trap can therefore fire before the window has been computed, and under `set -u`
+# an unset variable inside an EXIT trap would replace the very exit code the heartbeat
+# exists to record.
+#
+# `false` IS THE HONEST VALUE ON THAT PATH, not a convenient one. `markWindow` records
+# whether the run was CAPABLE of marking the day; a run that died in its own startup
+# guards marked nothing, and `MARKS_LANDED_STEPS` withholds a stamp from it for that
+# same reason. It claims no side of a window it could not compute — it declines one.
+MARK_WINDOW=false
 
 # WHICH STEPS MEAN THE DAY'S MARKS ARE ACTUALLY IN THE LOG. `pnpm spine` (step 2) is
 # what appends them, so every step AFTER it implies they landed. Being in the window
@@ -402,6 +379,62 @@ WATCHDOG_FIRED_FILE="$LOG_FILE.watchdog-fired"
 exec > >(trap '' TERM PIPE; tee -a "$LOG_FILE") 2>&1
 
 echo "[$STAMP] price-feed daily run starting (repo=$REPO_DIR)"
+
+# --- the mark window, classified (#185 S2 / #315) ---------------------------
+# DELIBERATELY HERE, AFTER THE EXIT TRAP AND THE LOG — AND STILL BEFORE ANY WORK.
+# These two guards are the newest way for EVERY scheduled fire to die: a typo'd
+# `NUMISMA_MARK_TZ` in the plist, or tzdata moving out from under the DEFAULT path,
+# refuses all six fires of an evening. Run before the trap was installed, they would
+# have refused them on the one channel that reaches nobody — no per-run log, no
+# heartbeat, `job-heartbeat.json` still describing the last good run, and the TUI
+# reading "healthy" for days. That is the same silent rot this block exists to
+# prevent, re-entered through the guard for it, and this file's own argument at the
+# `git commit` step (a launchd job's stdout reaches no one) says so explicitly.
+#
+# Placed after the log and trap, a refusal is now a FATAL line in the per-run log and
+# a breadcrumb reading `exit 1 at step 'startup'`, with `markWindow: false` and the
+# carried stamp re-emitted untouched — it invents no coverage and erases none. Still
+# before the watchdog is armed, before the token file is sourced, before `cd` and
+# before any `pnpm`, so the refusal remains a refusal: nothing with an effect runs
+# on a run that cannot say which side of the window it is on.
+
+# REFUSE AN UNRESOLVABLE ZONE, BEFORE ANY OF IT IS USED. Bash does not fail on a bad
+# TZ the way `Intl` does: `TZ=Not/AZone date +%H` prints the UTC hour, with no error
+# and a zero exit. UTC is DISJOINT from the CDMX evening window (12:00-17:59 CDMX vs
+# the 18:00-23:59 fires), so one typo flips the window wrong on EVERY run while the
+# runs themselves keep marking correctly — the silent rot this whole block exists to
+# prevent, entered through the override that was just added. Falling back to UTC (or
+# to local) would be the same bug with a friendlier name, so this exits instead.
+# The shape check comes first so the path built below cannot be anything but a zone
+# name. `TZDIR` is honoured because that is what the C library itself consults.
+if [[ ! "$MARK_TZ" =~ ^[A-Za-z][A-Za-z0-9_+-]*(/[A-Za-z0-9_+-]+)*$ ]] ||
+  [[ ! -f "${TZDIR:-/usr/share/zoneinfo}/$MARK_TZ" ]]; then
+  echo "[$STAMP] FATAL: mark timezone '$MARK_TZ' is not a resolvable IANA zone."
+  echo "[$STAMP] No entry under ${TZDIR:-/usr/share/zoneinfo}. Bash would silently report the UTC"
+  echo "[$STAMP] hour for it, which is disjoint from the mark window, so every run would classify"
+  echo "[$STAMP] itself out-of-window while marking fine. Refusing rather than degrading."
+  echo "[$STAMP] Set NUMISMA_MARK_TZ to a real zone name, or leave it unset for the contract default."
+  exit 1
+fi
+# And refuse a mark hour that is not one. Left unchecked it would not abort either —
+# the comparison below is an `if` condition, so `set -e` never fires — it would just
+# classify every run as out-of-window, exactly like the bad zone.
+if [[ ! "$MARK_HOUR" =~ ^(0?[0-9]|1[0-9]|2[0-3])$ ]]; then
+  echo "[$STAMP] FATAL: mark hour '$MARK_HOUR' is not an hour of the day (0-23)."
+  echo "[$STAMP] Set NUMISMA_MARK_HOUR to a plain hour, or leave it unset for the contract default."
+  exit 1
+fi
+
+# Read once into a named variable so the comparison below is a self-contained
+# expression over two hour-shaped strings — which is what lets a test drive the
+# wrapper's OWN line with `08`/`09` and prove the base-10 forcing still holds.
+MARK_NOW_HOUR="$(TZ="$MARK_TZ" date +%H)"
+if [[ $((10#$MARK_NOW_HOUR)) -ge $((10#$MARK_HOUR)) ]]; then
+  MARK_WINDOW=true
+else
+  MARK_WINDOW=false
+fi
+# ----------------------------------------------------------------------------
 
 # --- the watchdog (#308 follow-up) ------------------------------------------
 # A WEDGED RUN IS A WORSE FAILURE THAN A RED ONE, and until 2026-08-11 nothing here

--- a/ops/price-feed/run-daily-fetch.sh
+++ b/ops/price-feed/run-daily-fetch.sh
@@ -97,8 +97,8 @@ HEARTBEAT_FILE="$DATA_DIR/job-heartbeat.json"
 # the morning after a lost day. So record the distinction instead of guessing at it.
 #
 # THE ZONE IS PART OF THE CONTRACT, NOT THE MACHINE'S BUSINESS. The real gate is
-# `isAtOrAfterMarkTime(instant, { timeZone: "America/Mexico_City" })`, which resolves
-# through Intl in CDMX explicitly. Reading the bare local hour would agree with it
+# `isAtOrAfterMarkTime(instant, { timeZone: <the contract zone> })`, which resolves
+# through Intl in that zone explicitly. Reading the bare local hour would agree with it
 # only by coincidence of the OS setting — and docs/price-feed-ops.md offers the
 # divergent setup as SUPPORTED ("or shift all six of the plist's Hour entries to the
 # local clock equal to 18:00-23:00 CDMX"). Take that option on a UTC box and every
@@ -111,12 +111,53 @@ HEARTBEAT_FILE="$DATA_DIR/job-heartbeat.json"
 # silently classify EVERY run as out-of-window. Moot at 18, latent the moment the
 # contract moves, which is precisely what the guard below exists to survive.
 #
-# Duplicating the hour AND the zone into bash is deliberate and guarded:
-# apps/price-feed/src/schedule-window.test.ts pins both against DEFAULT_CONFIG, so a
-# change to the contract fails a test rather than rotting here silently.
-MARK_HOUR=18
-MARK_TZ="America/Mexico_City"
-if [[ $((10#$(TZ="$MARK_TZ" date +%H))) -ge $((10#$MARK_HOUR)) ]]; then
+# CONFIGURED, NOT LITERAL — AND STILL GUARDED. The defaults below are the engine's
+# `TRADING_DAY_TIME_ZONE` / `MARK_HOUR` (packages/engine/src/price-feed/mark.ts),
+# which `DEFAULT_CONFIG` also derives from. Duplicating them into bash remains
+# deliberate: this is a shell script and cannot import the contract. The duplication
+# is the COST; the guards in apps/price-feed/src/schedule-window.test.ts are what it
+# buys — they pin these two DEFAULTS (the `:-` halves, matched as shape, so a leading
+# zero cannot creep into the hour) against `DEFAULT_CONFIG`, so a change to the
+# contract fails a test rather than rotting here silently.
+#
+# The overrides exist so a CALLER can put a run on either side of the mark window by
+# setting a value, instead of hoping the machine clock cooperates — which is what the
+# wrapper's own test harness needs and what a manual out-of-window dry run wants.
+MARK_TZ="${NUMISMA_MARK_TZ:-America/Mexico_City}"
+MARK_HOUR="${NUMISMA_MARK_HOUR:-18}"
+
+# REFUSE AN UNRESOLVABLE ZONE, BEFORE ANY OF IT IS USED. Bash does not fail on a bad
+# TZ the way `Intl` does: `TZ=Not/AZone date +%H` prints the UTC hour, with no error
+# and a zero exit. UTC is DISJOINT from the CDMX evening window (12:00-17:59 CDMX vs
+# the 18:00-23:59 fires), so one typo flips the window wrong on EVERY run while the
+# runs themselves keep marking correctly — the silent rot this whole block exists to
+# prevent, entered through the override that was just added. Falling back to UTC (or
+# to local) would be the same bug with a friendlier name, so this exits instead.
+# The shape check comes first so the path built below cannot be anything but a zone
+# name. `TZDIR` is honoured because that is what the C library itself consults.
+if [[ ! "$MARK_TZ" =~ ^[A-Za-z][A-Za-z0-9_+-]*(/[A-Za-z0-9_+-]+)*$ ]] ||
+  [[ ! -f "${TZDIR:-/usr/share/zoneinfo}/$MARK_TZ" ]]; then
+  echo "[$STAMP] FATAL: mark timezone '$MARK_TZ' is not a resolvable IANA zone."
+  echo "[$STAMP] No entry under ${TZDIR:-/usr/share/zoneinfo}. Bash would silently report the UTC"
+  echo "[$STAMP] hour for it, which is disjoint from the mark window, so every run would classify"
+  echo "[$STAMP] itself out-of-window while marking fine. Refusing rather than degrading."
+  echo "[$STAMP] Set NUMISMA_MARK_TZ to a real zone name, or leave it unset for the contract default."
+  exit 1
+fi
+# And refuse a mark hour that is not one. Left unchecked it would not abort either —
+# the comparison below is an `if` condition, so `set -e` never fires — it would just
+# classify every run as out-of-window, exactly like the bad zone.
+if [[ ! "$MARK_HOUR" =~ ^(0?[0-9]|1[0-9]|2[0-3])$ ]]; then
+  echo "[$STAMP] FATAL: mark hour '$MARK_HOUR' is not an hour of the day (0-23)."
+  echo "[$STAMP] Set NUMISMA_MARK_HOUR to a plain hour, or leave it unset for the contract default."
+  exit 1
+fi
+
+# Read once into a named variable so the comparison below is a self-contained
+# expression over two hour-shaped strings — which is what lets a test drive the
+# wrapper's OWN line with `08`/`09` and prove the base-10 forcing still holds.
+MARK_NOW_HOUR="$(TZ="$MARK_TZ" date +%H)"
+if [[ $((10#$MARK_NOW_HOUR)) -ge $((10#$MARK_HOUR)) ]]; then
   MARK_WINDOW=true
 else
   MARK_WINDOW=false
@@ -508,8 +549,14 @@ fi
 # the repo (transaction-data-is-private); the file is machine-local, chmod 600.
 if [[ -f "$ENV_FILE" ]]; then
   echo "[$STAMP] sourcing provider tokens from $ENV_FILE"
+  set -a
+  # ON ITS OWN LINE, because a `shellcheck disable` directive applies to the NEXT
+  # COMMAND — and while these three shared one line it attached to `set -a`, leaving
+  # the `source` it was written for still reported. The file did not pass shellcheck
+  # at all until this moved; the suppression is unchanged, only aimed correctly.
   # shellcheck disable=SC1090
-  set -a; source "$ENV_FILE"; set +a
+  source "$ENV_FILE"
+  set +a
 else
   echo "[$STAMP] no token file at $ENV_FILE (fine: crypto-only Binance is keyless)"
 fi

--- a/package.json
+++ b/package.json
@@ -27,6 +27,7 @@
     "db:provision": "tsx apps/web/src/projection/provision-projection.ts",
     "typecheck": "pnpm --filter @numisma/engine run typecheck && pnpm --filter @numisma/event-store run typecheck && pnpm --filter @numisma/preferences run typecheck && pnpm --filter @numisma/price-feed run typecheck && pnpm --filter @numisma/tui run typecheck && pnpm --filter @numisma/web run typecheck",
     "test": "vitest run",
+    "test:wrapper": "NUMISMA_WRAPPER_TEST=always vitest run apps/price-feed/src/wrapper-harness",
     "verify": "pnpm typecheck && pnpm test && pnpm smoke:startup",
     "coverage": "vitest run --coverage"
   },

--- a/packages/engine/src/index.ts
+++ b/packages/engine/src/index.ts
@@ -326,7 +326,13 @@ export {
   owesMarkOn,
 } from "./price-feed/venue-calendar.js";
 export type { Quote, MarkClock } from "./price-feed/mark.js";
+// The trading-day contract every plane must agree on, authored once. The price-feed
+// config, the gap report's `REPORT_TIME_ZONE` and the daily wrapper's `MARK_TZ` all
+// derive from these rather than restating them.
 export {
+  TRADING_DAY_TIME_ZONE,
+  MARK_HOUR,
+  MARK_TIME,
   tradingDayAsOf,
   isAtOrAfterMarkTime,
   priceMarkId,

--- a/packages/engine/src/price-feed/mark.ts
+++ b/packages/engine/src/price-feed/mark.ts
@@ -31,13 +31,45 @@ export interface Quote {
 }
 
 /**
- * The two configurable knobs of the mark-instant contract. The DEFAULTS
- * (`America/Mexico_City`, `18:00`) live in `@numisma/price-feed`'s config module;
- * the INVARIANT enforced here — a timezone-anchored `asOf` and one mark per period
- * — is not configurable.
+ * THE TRADING-DAY TIMEZONE, AND THE ONE PLACE IT IS AUTHORED. Everything that has
+ * to agree about which calendar day a mark belongs to derives from here:
+ * `apps/price-feed`'s `DEFAULT_CONFIG.timeZone`, the durable log's
+ * `REPORT_TIME_ZONE`, and — through the guarded textual join in
+ * `apps/price-feed/src/schedule-window.test.ts` — the daily wrapper's `MARK_TZ`.
+ *
+ * It lives in the engine beside the instrument registry for the same reason
+ * `VENUE_CADENCE` does (#266): it is code-owned reference data that several
+ * packages must agree on, and the engine is the leaf every one of them already
+ * depends on. Restating it anywhere else is the bug — two copies compile happily
+ * while disagreeing about what "yesterday" means.
+ *
+ * CDMX has been a fixed -06:00 since 2022 (no DST), which is why the wrapper can
+ * compare bare hours at all; the derivations below still go through `Intl` rather
+ * than assuming that offset.
+ */
+export const TRADING_DAY_TIME_ZONE = "America/Mexico_City";
+
+/**
+ * The hour of the trading day at which the daily mark becomes due, in
+ * {@link TRADING_DAY_TIME_ZONE}. Authored as a NUMBER, not as `"18"`: the wrapper's
+ * bash comparison arithmetic-evaluates its operands, and a string carrying a
+ * leading zero (`"08"`) is invalid octal there — a shape that cannot silently
+ * classify every run as out-of-window is worth more than the two characters.
+ */
+export const MARK_HOUR = 18;
+
+/** {@link MARK_HOUR} as the `HH:MM` local mark time a {@link MarkClock} takes. */
+export const MARK_TIME = `${String(MARK_HOUR).padStart(2, "0")}:00`;
+
+/**
+ * The two configurable knobs of the mark-instant contract. The DEFAULTS are
+ * {@link TRADING_DAY_TIME_ZONE} and {@link MARK_TIME} above, which
+ * `@numisma/price-feed`'s config module derives its `DEFAULT_CONFIG` from; the
+ * INVARIANT enforced here — a timezone-anchored `asOf` and one mark per period —
+ * is not configurable.
  */
 export interface MarkClock {
-  /** IANA timezone the trading day is anchored to (e.g. `America/Mexico_City`). */
+  /** IANA timezone the trading day is anchored to; see {@link TRADING_DAY_TIME_ZONE}. */
   timeZone: string;
   /** Daily mark time as `HH:MM` local; a fetch before it emits no mark. */
   markTime: string;

--- a/packages/event-store/src/gap-report.ts
+++ b/packages/event-store/src/gap-report.ts
@@ -113,6 +113,7 @@
  */
 import {
   PRICE_SOURCES,
+  TRADING_DAY_TIME_ZONE,
   addDays,
   instrumentsForSource,
   owesMarkOn,
@@ -147,11 +148,18 @@ export const LAUNCHD_ERA_START = "2026-07-03";
  * The timezone the trading day — and therefore "yesterday" — is anchored to. A
  * BARE STRING, not a `MarkClock`: with the ceiling pinned to yesterday at every
  * hour (below), the mark-TIME check drops out of this derivation entirely, so the
- * only thing left to duplicate is the zone. It matches `apps/price-feed`'s
- * `DEFAULT_CONFIG.timeZone`; this package does not depend on that app and will not
- * grow an edge to read one constant.
+ * only thing left to carry is the zone.
+ *
+ * NO LONGER DUPLICATED — AND THE EDGE THIS STILL DECLINES IS UNCHANGED. It used to
+ * restate `apps/price-feed`'s `DEFAULT_CONFIG.timeZone` as its own literal, on the
+ * grounds that this package will not grow an edge to an APP to read one constant.
+ * That refusal stands: there is still no dependency on `apps/price-feed`, and there
+ * will not be one. What changed is that the constant no longer lives in an app —
+ * `@numisma/engine` authors it, this package's ONLY dependency already, so deriving
+ * it costs no new edge at all and `DEFAULT_CONFIG.timeZone` now derives from the
+ * same place rather than being the place.
  */
-export const REPORT_TIME_ZONE = "America/Mexico_City";
+export const REPORT_TIME_ZONE = TRADING_DAY_TIME_ZONE;
 
 /** Why a day is lost. Both are "day lost"; they differ in what the log holds. */
 export type LostDayReason =

--- a/packages/event-store/src/heartbeat.test.ts
+++ b/packages/event-store/src/heartbeat.test.ts
@@ -459,10 +459,27 @@ describe("the wrapper's own bytes, read by the reader that must consume them", (
           NUMISMA_PRICEFEED_LOG_DIR: join(dataDir, "logs"),
         },
         stdio: "ignore",
+        // A HARD CAP, because this call BLOCKS. `execFileSync` cannot be preempted by a
+        // vitest timer, so a run that ever stalled — a git credential prompt, a stalled
+        // socket — would wedge the worker rather than fail. This path dies at the `cd` in
+        // well under a second; a minute is orders of magnitude of slack.
+        timeout: 60_000,
       });
-    } catch {
+    } catch (error) {
       // EXPECTED: there is no repo to `cd` into, so the run dies early and non-zero.
       // That is the case the breadcrumb exists for, and the trap still fires.
+      //
+      // A TIMEOUT KILL LANDS HERE TOO, and it is not that. It arrives as a SIGNAL rather
+      // than an exit status, so swallowing it would report "the wrapper died early" about
+      // a wrapper that hung — and the assertions below would then fail on a missing file
+      // with no hint of why. Name it instead.
+      const signal = (error as { signal?: NodeJS.Signals | null }).signal ?? null;
+      if (signal !== null) {
+        throw new Error(
+          `the wrapper was killed by ${signal} rather than exiting: it hung instead of dying ` +
+            "at the `cd` into a nonexistent repo. That is a failure of this case, never a pass.",
+        );
+      }
     }
     return readFile(join(dataDir, "job-heartbeat.json"), "utf8");
   }

--- a/packages/event-store/src/heartbeat.test.ts
+++ b/packages/event-store/src/heartbeat.test.ts
@@ -383,9 +383,12 @@ describe("a run outside the mark window is not evidence that the day was marked"
  * breadcrumb exists for.
  *
  * TWO THINGS ARE CONTROLLED SO NOTHING HERE DEPENDS ON THE WALL CLOCK. The window
- * branch is forced by rewriting the script's own `MARK_HOUR` constant in a copy — 0
- * is always in-window, 99 never is — because the wrapper reads the CDMX hour itself
- * and no ambient `TZ` can move it. And the data dir is SEEDED, because a fresh
+ * branch is forced through the wrapper's own `NUMISMA_MARK_TZ` / `NUMISMA_MARK_HOUR`
+ * configuration (#315) — see {@link markWindowEnv}. It used to be forced by
+ * REWRITING the script's `MARK_HOUR=18` line in a copy, which worked but tested a
+ * file that no longer existed anywhere; the wrapper takes the window as
+ * configuration now, so the real bytes can be run unmodified. And the data dir is
+ * SEEDED, because a fresh
  * `mkdtemp` per run means no previous breadcrumb exists and the entire carry-forward
  * path goes unreached. An earlier version of this describe did both the other way
  * and its assertions were vacuous for part of every day.
@@ -396,11 +399,46 @@ describe("the wrapper's own bytes, read by the reader that must consume them", (
   );
 
   /**
+   * The wrapper configuration that puts a run on a chosen side of the mark window,
+   * with NO fake `date` binary, no clock manipulation and no edit to the script.
+   *
+   * BOTH BRANCHES ARE EXACT, NOT MERELY LIKELY, and that costs one small trick. The
+   * wrapper compares the current hour IN THE CONFIGURED ZONE against the configured
+   * hour, so "in" is free — hour 0 is at or below every hour there is. "out" needs a
+   * configured hour ABOVE the current one, and the only hour guaranteed to be above
+   * it is one measured against a zone we picked: this finds the fixed-offset
+   * `Etc/GMT±n` zone where it is currently the 00 hour and asks for 23. That leaves
+   * ~23 hours of margin before the two could meet, so no run of this suite can
+   * straddle the boundary — the failure mode the previous rewrite-the-script version
+   * was also written to avoid.
+   *
+   * `Etc/GMT+5` means UTC-5 (POSIX inverts the sign). Irrelevant here: both `Intl`
+   * below and the wrapper's `date` read the same tzdata, so they agree by
+   * construction whatever the label means.
+   */
+  function markWindowEnv(window: "in" | "out"): Record<string, string> {
+    for (let offset = -14; offset <= 12; offset += 1) {
+      const zone = `Etc/GMT${offset >= 0 ? "+" : "-"}${Math.abs(offset)}`;
+      const hour = Number(
+        new Intl.DateTimeFormat("en-GB", {
+          timeZone: zone,
+          hour: "2-digit",
+          hourCycle: "h23",
+        }).format(new Date()),
+      );
+      if (hour === 0) {
+        return { NUMISMA_MARK_TZ: zone, NUMISMA_MARK_HOUR: window === "in" ? "0" : "23" };
+      }
+    }
+    throw new Error("no fixed-offset zone is currently at hour 00 — impossible, so something moved");
+  }
+
+  /**
    * Run the wrapper and return the breadcrumb it left.
    *
-   * `window` rewrites ONE constant — the mark hour — so the in/out-of-window branch
-   * becomes an input rather than a function of the time of day. Everything else is
-   * the real script, including the `sed` carry-forward read and the printf.
+   * `window` makes the in/out-of-window branch an INPUT rather than a function of
+   * the time of day. Everything run is the real script, byte for byte, including the
+   * `sed` carry-forward read and the printf.
    */
   async function runWrapper(
     options: { window?: "in" | "out"; seed?: string } = {},
@@ -410,20 +448,11 @@ describe("the wrapper's own bytes, read by the reader that must consume them", (
     if (options.seed !== undefined) {
       await writeFile(join(dataDir, "job-heartbeat.json"), options.seed, "utf8");
     }
-    let script = wrapper;
-    if (options.window !== undefined) {
-      const forced = options.window === "in" ? "0" : "99";
-      const source = await readFile(wrapper, "utf8");
-      const rewritten = source.replace(/^MARK_HOUR=18$/m, `MARK_HOUR=${forced}`);
-      // Fail loudly rather than silently testing the unmodified script.
-      expect(rewritten).not.toBe(source);
-      script = join(dataDir, "run-daily-fetch.sh");
-      await writeFile(script, rewritten, "utf8");
-    }
     try {
-      execFileSync("/bin/bash", [script], {
+      execFileSync("/bin/bash", [wrapper], {
         env: {
           ...process.env,
+          ...(options.window === undefined ? {} : markWindowEnv(options.window)),
           NUMISMA_DATA_DIR: dataDir,
           NUMISMA_REPO_DIR: join(dataDir, "no-such-repo"),
           NUMISMA_PRICEFEED_ENV: join(dataDir, "no-such-env"),


### PR DESCRIPTION
`ops/price-feed/run-daily-fetch.sh` is the unattended job that marks the fund's day — several hundred lines of signal handling with **zero committed tests**. Two review rounds found four signal-handling defects; **none was found by reading**, and every harness that found one was thrown away. This commits the shape those throwaway harnesses established.

It also lands the configurable-mark-zone precondition the harness's last slice consumes.

## What this closes

Closes #313 — the harness now exists, committed and armed.
Closes #314 — the spec, all four slices delivered.
Closes #315 — one configured mark zone, derived everywhere.
Closes #316 — slice 1: the spine and its arming.
Closes #317 — slice 2: the timeout family.
Closes #318 — slice 3: the external-stop path.
Closes #319 — slice 4: the mark window.

## What this does NOT close — #312 stays open, deliberately

**#312 must not close on the automated cases alone, and this PR does not close it.**

Slice 3 delivers the **signal, not the sender**. A bare SIGTERM to the run's pgid is signal-identical to what `launchctl stop`, `launchctl unload`, a logout and a shutdown all deliver, and signal-identical is exactly what the TERM handler branches on — so this proves the **handler's discrimination** soundly. It proves nothing about launchd.

Now automated (#312 items 1, 2, 5):
- External TERM records `exit 143` with an undecorated step name, no `timeout:` prefix.
- Watchdog TERM and external TERM are discriminated by the watchdog's calling-card file, asserted directly rather than inferred from the exit code.
- Both paths run **in one suite run**, compared as two heartbeats that must differ in exactly exit code, step decoration and calling-card presence — so they cannot drift apart.

Left for a human at the machine:
- [ ] `launchctl stop` mid-run against the real installed LaunchAgent — one manual confirmation.
- [ ] `launchctl unload` mid-run (the documented reinstall step) — one manual confirmation, and the reinstall still completes.
- [ ] **Logout or shutdown mid-run** → the heartbeat is complete or absent, **never truncated**. **This one is automatable by nobody** — the failure mode is the filesystem going away underneath a single `printf` from an EXIT trap. No in-process harness reproduces a real session teardown, and no future harness work should be scheduled against it.

## The three things that make this worth having

**It launches the real wrapper in its own session.** `detached`, so the script is its own process-group leader. Without that the watchdog silently disables itself and the whole suite passes while testing nothing.

**Every case repeats 12 consecutive runs.** A single green run means nothing here — that is literally how the original `tee` race survived its first review.

**Every case asserts three things, never one:** exit code · heartbeat contents (`exitCode`, `lastStep`, `markWindow`, `lastMarkWindowFinishedAt`) · **zero processes remaining in the run's pgid**. The leak assertion caught three of the four historical defects.

## The guards were seen red before being trusted

Each negative control was confirmed to fail against the defect it covers:

- **Child-reap mutation** — dropping the heartbeat writer's child kill leaves a stray `sleep` in the pgid; case 1 goes red.
- **`tee`-deafness mutation** — dropping `trap '' TERM PIPE` from the logging process substitution loses the heartbeat on the timeout path, with the shell dying by **SIGPIPE**. Observed lost on the first attempt in five of six runs and on the third attempt in the sixth — the raciness is real, which is why the control repeats to the floor.
- **Anchor rot fails loudly** — corrupting a mutation's anchor text stops the build rather than silently ceasing to guard.
- **`detached` removed** → case 1 red: *"the watchdog did not arm — was the child detached?"*
- **Fake installed on the inherited `PATH`** → case 1 red: *"the fake pnpm never recorded `prices:fetch` — the REAL pnpm may have run."*
- **Pair drift** — removing case 4's signal and moving its expectations to `124`/`timeout:prices-fetch` leaves **both cases passing green individually**; only the two-heartbeat comparison goes red. That is the drift per-case assertions provably cannot see.

## The hazard this suite is built around

**The wrapper re-exports `PATH="$PATH_PREPEND:$PATH"` in its own body**, and its default `PATH_PREPEND` contains the directory where the real `pnpm` lives. A fake installed on the *inherited* `PATH` is overridden by the script itself, and the run executes a real fetch, a real `spine` append, a **real `git commit` against the durable event log** and a real backfill against the hosted database — **passing green while it does.**

So the fake reaches the wrapper only through `NUMISMA_PATH_PREPEND`; every case asserts a fake-tool sentinel; and an explicit assertion resolves what the wrapper's *own re-exported* `PATH` selects and pins it to the case dir's fake. Isolation is enforced inside `launchWrapper` as its first statement — a refusal, not a default — because a caller that *could* skip it eventually will.

## #315, and the trap it had to avoid

The hour and zone were duplicated into bash **deliberately and guardedly**: the wrapper cannot import `DEFAULT_CONFIG`, so two textual guards in `schedule-window.test.ts` held bash and TypeScript together. Collapsing the duplication without preserving that join would have been a regression dressed as a cleanup.

The join survives and got stronger — **guard count went from 2 to 5**. The rewritten regexes pin the whole `${NUMISMA_MARK_HOUR:-18}` expansion rather than the value, so reverting to a bare literal now fails too. Mutating either side was observed red and reverted.

Two further locks:
- **The octal trap is now demonstrated, not described.** A test lifts the comparison line out of the wrapper and runs it under `/bin/bash` 3.2.57 with `09`/`08` and friends. Stripping `10#` turns it red. Left unguarded, `[[ 09 -ge 08 ]]` prints `value too great for base`, takes the else branch, and **exits 0** — silently classifying every run as out-of-window, with `set -e` never firing.
- **An unresolvable zone is now fatal on both sides.** Bash previously degraded a bad `TZ` to UTC with no error and no non-zero exit; since UTC is disjoint from the CDMX evening window, a typo flipped the mark window wrong on every run while the runs themselves marked fine. The wrapper now exits non-zero naming the value, *before* computing the window.

## Fixed in passing

**The wrapper never actually passed `shellcheck`.** `# shellcheck disable=SC1090` shared a line with `set -a; source …; set +a`, so it bound to `set -a` and the `source` was still reported. Split onto its own line; behavior identical. The wrapper is now clean under shellcheck 0.11.0.

## Review round — what an independent pass changed

A fresh-context review raised nine findings. Three are fixed in `b11ff6c`, `fa29d70`, `af6e301`; the rest are dispositioned in a comment below.

**A real isolation hole, outside the harness.** `schedule-window.test.ts`'s `runWrapper` launched the real wrapper with `{...process.env, ...env}` and only 3 of the 9 `NUMISMA_*` variables set — so an unset `NUMISMA_PRICEFEED_ENV` would have sourced the **real chmod-600 token file** under `set -a`, and an unset `NUMISMA_PATH_PREPEND` would have resolved the **real `pnpm`/`node`**. The only thing preventing a real run was the guard under test plus a docstring. It now builds its environment through the harness's own `makeCaseDir`/`caseEnv` and takes `assertIsolated` before spawning, so the real defaults are **structurally unreachable rather than merely unused**. Both blocking `spawnSync` calls — here and in `heartbeat.test.ts` — gained explicit timeouts and check `signal`, so a hang is a named failure instead of a wedged worker.

**A behavior change to the wrapper, and it is the notable one.** The two new FATAL zone/hour guards ran *before* the EXIT-trap heartbeat and before the log, so a typo'd `NUMISMA_MARK_TZ` — or tzdata moving under the *default* path — would have made every fire exit 1 with **no log and no heartbeat**, leaving the TUI reading the last good run. That is the same silent rot the guards were written to prevent, re-entered through the guards themselves.

Investigation showed `write_heartbeat` does **not** depend on a valid zone (`TZ=bad date +%H` silently returns the UTC hour, so a bad zone makes the heartbeat *lie* rather than fail). So the guards moved to after the EXIT trap and the `tee`, still ahead of the watchdog arming, the token file, the `cd` and every `pnpm`. `MARK_WINDOW=false` is initialised before the trap — required, since the trap reads it and `set -u` in an EXIT trap would clobber the exit code — and `false` is honest there: a run that died at `startup` did not mark. The carried `lastMarkWindowFinishedAt` is re-emitted untouched, inventing no coverage and erasing none. A bad zone now exits 1 with a `FATAL` log line and `{"exitCode": 1, "lastStep": "startup", "markWindow": false}`.

**The suite can no longer pass having launched nothing.** `RUNS_PER_CASE` is 0 when unarmed; it is now asserted `>= REPETITION_FLOOR` inside the armed block, so the "cannot pass while testing nothing" property rests on an assertion rather than on reasoning.

**Diagnostics now survive a throw.** Every case logged its settle/reach/duration series *after* its loop, so a throw discarded exactly the data needed to explain it. Now emitted via `onTestFinished`, so the next intermittent red arrives as evidence.

## Known limitations — please read before merging

**A green CI run does not mean this harness passed. It means it was not attempted.** The suite targets macOS bash 3.2, BSD `ps`/`pgrep`, and a watchdog hand-rolled *because* macOS ships no `timeout(1)`. CI is a single `ubuntu-latest` job, so the platform gate skips it there. This caveat is written in three places: the suite's own header, the price-feed ops doc, and beside the CI test step.

**One intermittent red, still unexplained — but now instrumented.** On one full run, **case 4 and the child-reap mutation control failed, then passed on every subsequent run.** The review pass tried to reproduce it under deliberate 8-way CPU saturation (load avg 20–23), 24 repetitions per case: **nothing flaked.** Saturation barely moved the margins — case 4's step-reach went 233–291 ms to 258–344 ms against a 2000 ms bound, still 5.8×; case 1's settle 123–169 ms to 132–225 ms against 2000 ms, 8.9×. The timeout cases' settle is grace-dominated and unchanged. What did swing 7.7× is suite-startup filesystem contention from the arming git fixtures, but that storm ends before the armed cases begin.

No mechanism was found that fails exactly those two cases and nothing else, which reads more like a shared external event than a race. **It is not proven, and it is not closed.** The mitigation shipped instead is diagnostic: the per-case series now survive a throw, so the next occurrence produces evidence rather than a mystery. **A follow-up issue is still worth filing** if it recurs.

**Case 6 needed a wider ceiling than its siblings.** Cases 2/3/4 hang at the *first* step; case 6 must traverse four fake invocations plus `git add`/`commit`/`status` and only then wedge. At the shared 3 s ceiling it failed at run 4/12 by timing out at an *earlier* step — quietly becoming case 2 with a different label. Widened to 5 s, and the failure now names the step and duration.

## Verification

- `pnpm typecheck` — clean, all six packages.
- `pnpm test` — 134 passed / 4 skipped (**138 files**), 2006 passed / 21 skipped. The harness **armed and ran inside it** via the changed-file trigger, not skipped.
- `pnpm test:wrapper` — **51/51**. The `tee`-deafness control lost the heartbeat on attempt 2 of its floor, so the repetition is doing real work on this run too.
- `shellcheck` 0.11.0 on the wrapper — clean. `/bin/bash -n` — clean.

Every fixture and heartbeat file in this diff is **authored**. Nothing is seeded from real output, in content or in shape.

## Merge order

Base is **`main`**; this branch is independent of every other lane and shares no line with the TypeScript lanes. It can merge in any position relative to them.

The only ordering constraint is internal and already satisfied: #315 (`b63c295`) lands before slice 4 (`ce94887`) consumes it, on this one branch.

If #311 is subsequently ruled to be closed rather than kept-and-bounded, that work branches off **this** branch and its PR targets `feature/price-feed-test-harness`. Note for whoever reviews it: `closingIssuesReferences` comes back **empty** for any PR whose base is not `main` — that is a GitHub behavior, not a broken body.
