### PR TITLE
fix(tui): a contentless durable log survives migration, and the funding interview refuses a missing terminal

### DIFF
--- a/apps/tui/src/event-store.ts
+++ b/apps/tui/src/event-store.ts
@@ -259,6 +259,19 @@ export async function migrateLegacyLog(
   // `undefined` would quiet this path by destroying the distinction that separates an
   // empty log from an unreadable one. "Nothing to migrate" is a policy this migration
   // owns.
+  //
+  // IT RETURNS ABOVE `loadGenesis`, AND THAT PLACEMENT IS THE POINT, not an oversight —
+  // it is a real behaviour change and it is deliberate. An empty log in a data dir whose
+  // `genesis.json` is missing or corrupt now ends 0 with "No durable log to migrate",
+  // where before #345 it ended 1 naming `genesis.json`. That is the guard's own thesis
+  // applied consistently: an ABSENT log has always returned from here, above the genesis
+  // read, so a CONTENTLESS one — which #345 says is the same answer — has to leave through
+  // the same door or the two shapes are not really one seam. Genesis is loaded to
+  // cross-reference records against; with no records there is nothing to cross-reference,
+  // and demanding the operator repair a file this run was never going to read would be a
+  // refusal about nothing. Pinned in `migrate-legacy-log.test.ts` — the case that plants an
+  // empty log in a dir with no genesis at all — which is what goes red if this guard ever
+  // drifts below the read.
   if (raw === undefined || raw.trim().length === 0) {
     return { migratedCount: 0, unchangedCount: 0, outputPath: paths.log, discarded: [] };
   }

--- a/apps/tui/src/event-store.ts
+++ b/apps/tui/src/event-store.ts
@@ -225,6 +225,10 @@ export interface MigrationReport {
  * deliberate one-time reconstruction, NOT a runtime append path — append-only still
  * holds going forward. Idempotent: re-running a clean log migrates nothing.
  *
+ * A log with nothing in it to migrate — absent, empty, or blank lines only — returns a
+ * zero report and touches no disk at all, so the caller's "no durable log" sentence is
+ * true of the bytes as well as of the counts (#345; the guard carries the reasoning).
+ *
  * IT ALSO REPORTS WHAT THE FOLD DROPPED, and this is the path where that matters most:
  * #293 names the legacy migration as the one the ingest gates cannot cover. The
  * cross-reference below runs the fold (`buildEventReference`), so its discards are in
@@ -236,7 +240,26 @@ export async function migrateLegacyLog(
   cashLegs: Map<string, SuppliedCashLeg>,
 ): Promise<MigrationReport> {
   const raw = await readOptional(paths.log);
-  if (raw === undefined) {
+  // A CONTENTLESS LOG IS THE SAME ANSWER AS A MISSING ONE (#345): nothing to migrate,
+  // nothing written, and the file left byte-for-byte as the operator left it.
+  //
+  // Two shapes reach here as "contentless" and they are ONE seam, not two cases: an
+  // existing empty log, and one holding only blank lines. The loop below trims each line
+  // and skips the empty ones, so neither shape can ever yield a record — but without this
+  // guard both still fell through to `writeLogImage` and were replaced by a single
+  // newline byte, while `migratedCount + unchangedCount === 0` sent the shell down its
+  // "No durable log to migrate" branch. The report was a lie about a write that happened,
+  // on the one tool in the repo that rewrites the whole durable log. Hence the predicate
+  // is the loop's own rule hoisted above the write — no content once blank lines are
+  // discarded — rather than an `=== ""` check that would fix half of it.
+  //
+  // THE GUARD BELONGS HERE, NOT IN `readOptional`. That helper maps ENOENT alone to
+  // `undefined`, and its other callers read it for exactly that: "absent" and "present
+  // but empty" are different facts about the disk. Widening it to fold `""` into
+  // `undefined` would quiet this path by destroying the distinction that separates an
+  // empty log from an unreadable one. "Nothing to migrate" is a policy this migration
+  // owns.
+  if (raw === undefined || raw.trim().length === 0) {
     return { migratedCount: 0, unchangedCount: 0, outputPath: paths.log, discarded: [] };
   }
 

--- a/apps/tui/src/import-orders-cli.test.ts
+++ b/apps/tui/src/import-orders-cli.test.ts
@@ -171,7 +171,13 @@ interface ShellRun {
   stderr: string;
 }
 
-describe("import-orders-cli — the shell's own contract (argv, exit codes, env, readline)", () => {
+// NOT "readline", WHICH THIS TITLE USED TO CLAIM. Every case here is a `spawnSync` with a
+// piped stdin, so `process.stdin.isTTY` is falsy in all of them and the `isTTY` guard in
+// `ask` returns before `createInterface` is ever called. No case in this file constructs a
+// readline interface, and therefore none can observe one being closed. What IS pinned is
+// the no-terminal branch in front of it — the notice, its placement at the first
+// unanswerable question, and the empty answer the domain then refuses on.
+describe("import-orders-cli — the shell's own contract (argv, exit codes, env, no-terminal stdin)", () => {
   const createdDirs: string[] = [];
 
   afterEach(async () => {
@@ -226,10 +232,18 @@ describe("import-orders-cli — the shell's own contract (argv, exit codes, env,
   }
 
   /**
-   * The readline lifecycle assertion, made on EVERY path: the process ended on its own.
-   * `rl.close()` lives in a `finally`, so a path that lost it would leave stdin open and
-   * the process alive until the runner's timeout killed it — which is a signal, not a
-   * status.
+   * THE TERMINATION ASSERTION, MADE ON EVERY PATH: the process ended on its own rather than
+   * being killed by the runner's timeout, which arrives as a signal instead of a status.
+   *
+   * IT IS NOT A READLINE-LIFECYCLE ASSERTION, WHICH IS WHAT THIS DOC USED TO IMPLY. The
+   * `finally { rl?.close() }` in the shell is never exercised from here: no case in this
+   * file has a TTY on stdin, so `rl` is `undefined` on every one of them and deleting the
+   * whole `finally` block leaves all of them green. The close is correct — verified by hand
+   * against a real pty — and it is what keeps a REAL interview from leaving stdin open, but
+   * both halves of its lifecycle, the `createInterface` and the `close`, are observable only
+   * from a terminal, and a spawned test cannot stand in one. What this function actually
+   * holds down is that no path here HANGS — which, on a piped stdin, is a claim about the
+   * no-terminal branch returning promptly rather than about an interface being closed.
    */
   function expectExited(run: ShellRun): void {
     expect(run.signal).toBeNull();
@@ -294,8 +308,19 @@ describe("import-orders-cli — the shell's own contract (argv, exit codes, env,
     // And the unreadable row was reported on the error channel, where per-row problems go.
     expect(run.stderr).toContain(`${csv}:2 skipped`);
     // The operator was never taken into the interview: every readable rung was already on
-    // file, so there was nothing to attribute. The funding prompt's own text is the proof.
-    expect(run.stdout).not.toMatch(/Funding reserve for this batch/);
+    // file, so there was nothing to attribute.
+    //
+    // THE PROOF IS THE MISSING NO-TERMINAL NOTICE, not the missing prompt text. Asserting
+    // that `Funding reserve for this batch` never reaches stdout was the obvious probe and
+    // it went vacuous under #346: that string exists only as the argument handed to `ask`
+    // (`import-orders-funding-declaration.ts:68`), and a spawned run takes the no-terminal
+    // branch, which returns "" WITHOUT writing the question anywhere. The absence proved
+    // nothing — it holds on a run that asked and on a run that did not. The notice does
+    // discriminate: `ask` writes it the first time it is called on a stdin that is no
+    // terminal, so stderr staying clean of it is the observable fact that NO QUESTION WAS
+    // PUT AT ALL. Its twin is the no-terminal block below, where a run that DOES reach the
+    // funding question writes exactly that notice — same probe, opposite sign.
+    expect(run.stderr).not.toMatch(/No terminal on stdin/);
   });
 
   it("exits 0 on imported and leaves no temp sibling beside the sidecar it wrote", async () => {
@@ -354,9 +379,11 @@ describe("import-orders-cli — the shell's own contract (argv, exit codes, env,
     const dir = await dataDir();
     const csv = await exportFile(dir, [FRESH_ROW]);
 
-    // `resolveOrdersPath()` throws inside the try, AFTER the readline was constructed —
-    // so this path exercises both the catch (message to stderr, exit 1) and the `finally`
-    // that must still close the prompt.
+    // `resolveOrdersPath()` throws INSIDE the try, so this path exercises the outer catch:
+    // the message reaches stderr and the run exits 1. It does NOT exercise the `finally`'s
+    // `rl?.close()` in any meaningful sense — stdin here is a pipe, no question was ever
+    // put, and `rl` is `undefined`, so the optional call is a no-op. What the `finally`
+    // costs on this path is exactly the nothing the `?.` was written to cost.
     const run = runImport([csv], { dataDir: "data" });
 
     expectExited(run);
@@ -423,8 +450,17 @@ describe("import-orders-cli — the shell's own contract (argv, exit codes, env,
           "the batch — and there is nowhere to conduct it, so every question goes " +
           "unanswered. Run it from a terminal.",
       );
-      // ONCE, not once per question. Repeating it would bury the flow's refusal in copies.
-      expect(run.stderr.match(/No terminal on stdin/g)).toHaveLength(1);
+      // WHAT IT HONESTLY DOES NOT PIN, in the voice this file uses for that: the notice is
+      // written ONCE PER RUN rather than once per question, and no spawn can see it. This
+      // used to carry a `toHaveLength(1)` count over the notice, which could not fail — a
+      // no-terminal run puts EXACTLY ONE question. `import-orders.ts:586` asks the funding
+      // batch question, gets "", and `:588` refuses the whole import; every later question
+      // (the override pass, the rung walk) sits past that refusal, and no export shape,
+      // argv, or data-dir state reaches one. Delete the `toldThereIsNoTerminal` flag
+      // entirely, write the notice unconditionally, and all nine cases here stay green.
+      // The flag is kept anyway — it is a boolean, and the rung walk on the far side of the
+      // funding wall can put thirty questions, which is the shape that makes the difference
+      // between one notice and thirty legible. Counting a one-element set proved none of it.
       // AND THE FLOW'S OWN SENTENCE, on the flow's own channel, in the flow's own voice —
       // `no-reserve-declared`, asserted end-to-end for the first time. Two refusals, two
       // layers, one story: the shell says why there was no answer, the domain says what it
@@ -433,8 +469,19 @@ describe("import-orders-cli — the shell's own contract (argv, exit codes, env,
         "REFUSED — no funding reserve was declared for this batch",
       );
       expect(run.stderr).toContain(`Nothing was written to ${join(dir, "orders.jsonl")}.`);
-      // THE INTERNAL IS GONE. This is the regression the whole change exists to kill, and a
-      // readline constructed anywhere on this path would bring it straight back.
+      // THE INTERNAL IS GONE FROM THIS PATH — the piped, non-TTY one, which is the path
+      // every unattended caller and every test in this file takes, and where a readline
+      // constructed anywhere would bring `readline was closed` straight back.
+      //
+      // SAID PRECISELY, BECAUSE THE BROADER CLAIM IS FALSE. This is not "no readline
+      // internal ever reaches the operator again". At a REAL terminal, Ctrl-D on the
+      // funding question still surfaces Node's own `Aborted with Ctrl+D` on stderr with
+      // exit 1 — no shell sentence, no `no-reserve-declared`. Reproduced by hand on this
+      // commit (`printf '\004' | script -q /dev/null tsx …`). A BLANK LINE at the same
+      // terminal refuses correctly, in both voices, so this is a gap in the TTY branch
+      // rather than a regression of the fix: what #346 killed is a piped run reporting a
+      // readline internal instead of naming the missing terminal, and that is dead. The
+      // Ctrl-D case is tracked separately; nothing here should be widened to cover it.
       expect(run.stderr).not.toMatch(/readline was closed/);
       // Refused means refused: no sidecar, and no staging sibling of one either.
       expect(await readdir(dir)).not.toContain("orders.jsonl");

--- a/apps/tui/src/import-orders-cli.test.ts
+++ b/apps/tui/src/import-orders-cli.test.ts
@@ -23,7 +23,9 @@
  * door, the same shape `record-fill-cli.test.ts` uses. `input` is always supplied so the
  * readline prompt gets EOF or an authored answer instead of hanging, and every runner call
  * carries a `timeout` so a shell that failed to close its prompt surfaces as a KILLED
- * process rather than as a stuck suite.
+ * process rather than as a stuck suite. A spawn's stdin is a PIPE, never a terminal, which
+ * is not merely an incidental property of this harness — since #346 it is the condition the
+ * last block below tests, and the reason `no-reserve-declared` is assertable at all.
  *
  * EVERY FIXTURE IS AUTHORED — invented ids, an invented instrument, round decade prices,
  * round balances. Nothing is seeded from, or shaped by, a real export, a real ladder or a
@@ -368,9 +370,10 @@ describe("import-orders-cli — the shell's own contract (argv, exit codes, env,
     // so running the same refusal under two different values shows the resolution
     // FOLLOWING the env var rather than merely happening to sit somewhere plausible.
     //
-    // THE OTHER TWO RESOLVERS SIT BEHIND THE PROMPT and cannot be reached from a spawned
-    // run — see the interview-wall case below, and #346, for why — so what is pinned here
-    // is the reachable one plus the negative that matters: no run of this shell falls back
+    // THE OTHER TWO RESOLVERS SIT BEHIND THE PROMPT and STILL cannot be reached from a
+    // spawned run: #346 made a piped run refuse the interview rather than answer it, which
+    // moved the wall without removing it — see the no-terminal block below — so what is
+    // pinned here is the reachable one plus the negative that matters: no run falls back
     // to the real accumulus root. `resolvePlansPath` and `resolveEventStorePaths` share
     // `resolveDataDir` with `resolveOrdersPath`, and that agreement is pinned at the
     // resolver (`packages/preferences/src/plans-reliable.test.ts`, the data-dir drift
@@ -390,43 +393,84 @@ describe("import-orders-cli — the shell's own contract (argv, exit codes, env,
     expect(two.stderr).not.toMatch(/accumulus/);
   });
 
-  it("reaches the funding prompt on good inputs and still exits, closing the readline", async () => {
-    // THE CONTROL CASE, and a finding in its own right. A fresh rung has nothing on file
-    // to compare against, so the flow runs the export read, the header parse, the sidecar
-    // load and the changed-claim partition and then ASKS — and the shell's own readline,
-    // constructed over a PIPE that carries no terminal, has already seen end-of-input by
-    // the time the question is put. The prompt rejects, the outer catch reports it, and
-    // the run exits 1 through the same `finally` every other path uses.
+  describe("a stdin that is no terminal — the interview has nowhere to happen (#346)", () => {
+    // THE CASE THIS BLOCK REPLACED asserted `readline was closed`, a readline internal that
+    // reached the operator verbatim: `createInterface` was constructed at module scope and
+    // eagerly consumed a piped stdin, so the stream had already ended by the time the first
+    // question was put. The shell now builds the interface AT the first question, and when
+    // stdin is no terminal it never builds one at all — it says so in its own voice and
+    // returns an empty answer, which is the one honest answer an unattended run can give.
     //
-    // What that buys the assertions above: this run proves the shell STARTS and gets all
-    // the way through the reads on good inputs, so a refusal elsewhere in this file is the
-    // shell's own decision rather than a process that could not run at all. What it also
-    // records is the wall: the interactive half of this flow — the funding declaration,
-    // the rung picks, the plans read and the fold behind them — is not exercisable from a
-    // non-interactive spawn, and the `no-reserve-declared` refusal is unreachable here.
-    //
-    // FILED AS #346: `createInterface` is constructed at `import-orders-cli.ts:28` and
-    // eagerly consumes stdin, so by the time the first `ask` runs a piped stdin has already
-    // ended and `rl.question` rejects — which is why piping answers to `pnpm orders:import`
-    // cannot work, and why `no-reserve-declared` at `import-orders.ts:588` is unreachable
-    // without a TTY.
-    const dir = await dataDir();
-    const csv = await exportFile(dir, [FRESH_ROW]);
+    // WHAT THAT UNLOCKS is the first test in this repo of `no-reserve-declared`
+    // (`import-orders.ts:588`). That refusal fires only when `declareFunding` returns
+    // undefined, which happens only on an empty batch answer — so before this change it was
+    // reachable exclusively from a TTY, i.e. from nowhere a test can stand. The shell
+    // returning "" rather than throwing is what puts it under a spawn.
 
-    const run = runImport([csv], { dataDir: dir });
+    it("names the missing terminal, lets the FLOW refuse, exits 1, writes nothing", async () => {
+      const dir = await dataDir();
+      // A fresh rung: nothing on file to compare it against, so it is ADMITTED and the
+      // flow reaches the funding interview. The only export shape that gets this far.
+      const csv = await exportFile(dir, [FRESH_ROW]);
 
-    expectExited(run);
-    expect(run.status).toBe(1);
-    // It did NOT fail on any of the reads before the prompt — no refusal was raised.
-    expect(run.stderr).not.toMatch(/REFUSED/);
-    // DELIBERATELY A NODE-INTERNAL STRING, not a contract of ours. `ERR_USE_AFTER_CLOSE`
-    // is the most precise available probe for "the prompt was actually put": no message of
-    // ours is emitted between the last read and the question. The tradeoff is owned here —
-    // a Node release that rewords it breaks this case, and the fix is to re-derive the new
-    // wording rather than to weaken the probe, because a looser match would stop
-    // distinguishing "reached the prompt" from "died earlier for some other reason".
-    expect(run.stderr).toMatch(/readline was closed/);
-    // Nothing was written on the way to the prompt: the sidecar is still absent.
-    expect(await readdir(dir)).not.toContain("orders.jsonl");
+      const run = runImport([csv], { dataDir: dir });
+
+      expectExited(run);
+      expect(run.status).toBe(1);
+      // THE SHELL'S SENTENCE — a consequence, not a rule, and not a readline internal.
+      expect(run.stderr).toContain(
+        "No terminal on stdin: this import is an interview — it asks which reserve funds " +
+          "the batch — and there is nowhere to conduct it, so every question goes " +
+          "unanswered. Run it from a terminal.",
+      );
+      // ONCE, not once per question. Repeating it would bury the flow's refusal in copies.
+      expect(run.stderr.match(/No terminal on stdin/g)).toHaveLength(1);
+      // AND THE FLOW'S OWN SENTENCE, on the flow's own channel, in the flow's own voice —
+      // `no-reserve-declared`, asserted end-to-end for the first time. Two refusals, two
+      // layers, one story: the shell says why there was no answer, the domain says what it
+      // did about it.
+      expect(run.stderr).toContain(
+        "REFUSED — no funding reserve was declared for this batch",
+      );
+      expect(run.stderr).toContain(`Nothing was written to ${join(dir, "orders.jsonl")}.`);
+      // THE INTERNAL IS GONE. This is the regression the whole change exists to kill, and a
+      // readline constructed anywhere on this path would bring it straight back.
+      expect(run.stderr).not.toMatch(/readline was closed/);
+      // Refused means refused: no sidecar, and no staging sibling of one either.
+      expect(await readdir(dir)).not.toContain("orders.jsonl");
+      expect(await litter(dir)).toEqual([]);
+    });
+
+    it("stays SILENT about the terminal on a run that never asks a question", async () => {
+      // THE PAYOFF OF BUILDING LAZILY, stated as behaviour the operator can see. Every
+      // readable rung here is already on file, so nothing is admitted and no question is
+      // ever put — and a shell that announced the missing terminal at STARTUP, rather than
+      // at the first unanswerable question, would scold a run that had nothing to ask.
+      //
+      // The mutation this is pinned against is moving the NOTICE out of `ask` and up to
+      // the shell's opening lines: this case goes red, the case above stays green — which
+      // is exactly the difference between "lazy" and "loud".
+      //
+      // WHAT IT HONESTLY DOES NOT PIN, said out loud so nobody reads more into it: moving
+      // `createInterface` itself back to module scope leaves all nine cases green, because
+      // the `isTTY` guard returns before `rl` is ever touched and a spawned stdin is never
+      // a terminal. The interface's laziness is a STRUCTURAL claim — it is what lets the
+      // `finally` close only what was built — and no test standing outside a TTY can
+      // observe it. The guard, the notice's placement, and the empty-answer composition
+      // are the three things these two cases actually hold down.
+      const dir = await dataDir({
+        "orders.jsonl": `${serializeOrderRecord(placementOnFile())}\n`,
+      });
+      const csv = await exportFile(dir, [RESTATED_ROW]);
+
+      const run = runImport([csv], { dataDir: dir });
+
+      expectExited(run);
+      expect(run.status).toBe(0);
+      expect(run.stderr).not.toMatch(/No terminal on stdin/);
+      expect(run.stderr).not.toMatch(/readline was closed/);
+      // It really did the work — this is a successful import, not a silent early exit.
+      expect(run.stdout).toMatch(/Imported .*: 0 order\(s\) appended/);
+    });
   });
 });

--- a/apps/tui/src/import-orders-cli.ts
+++ b/apps/tui/src/import-orders-cli.ts
@@ -49,9 +49,17 @@ if (!csvPath) {
    * domain then refuses in its own voice. Two sentences, one story: the shell names WHY
    * there is no answer, the flow names WHAT IT DID about it.
    *
-   * The notice is written ONCE per run, not once per question: the operator learns there is
-   * no terminal from the first unanswerable question, and repeating it would bury the
-   * flow's refusal under copies of the shell's.
+   * The notice is written once per run rather than once per question: the operator learns
+   * there is no terminal from the first unanswerable question, and repeating it would bury
+   * the flow's refusal under copies of the shell's. UNTESTED, AND UNTESTABLE FROM A SPAWN —
+   * said out loud so nobody reads the `toldThereIsNoTerminal` flag as pinned behaviour. A
+   * no-terminal run puts exactly ONE question (`import-orders.ts:586` asks the batch
+   * question, gets "", and `:588` refuses), so writing the notice unconditionally leaves
+   * every case in `import-orders-cli.test.ts` green. The flag is kept because it is correct
+   * and costs a boolean, and because the shape of the interview is not fixed: the rung walk
+   * on the far side of the funding wall can put thirty questions, and the day any of them
+   * becomes reachable without a terminal, the difference between one notice and thirty is
+   * the difference between a legible refusal and a wall of the shell shouting over the flow.
    */
   const ask = (question: string): Promise<string> => {
     if (!process.stdin.isTTY) {
@@ -63,6 +71,24 @@ if (!csvPath) {
             "unanswered. Run it from a terminal.\n",
         );
       }
+      // `""` IS HONEST AT EXACTLY ONE CALL SITE, AND THAT IS AN ORDERING DEPENDENCY, not a
+      // property of the empty string. Read as an answer, `""` means different things to the
+      // three questions this flow can put:
+      //
+      //   - `import-orders-funding-declaration.ts:68` (the batch question) reads it as NO
+      //     RESERVE DECLARED, so `declareFunding` returns undefined and the flow refuses at
+      //     `import-orders.ts:588`. This is the refusal that makes the empty answer safe.
+      //   - `import-orders-rung-picks.ts:161` reads it as ACCEPT EVERY PROPOSED RUNG.
+      //   - `import-orders-rung-picks.ts:183` reads it as TAKE THE DEFAULT.
+      //   - `import-orders-funding-declaration.ts:74` reads it as NO PER-RUNG OVERRIDES.
+      //
+      // The last three are ratifications. A no-terminal run never reaches them ONLY because
+      // funding is asked FIRST and refuses the whole batch before any rung question is put.
+      // Reorder the interview — ask rung picks before funding, or make the funding question
+      // skippable — and this same `return ""` silently ratifies every default and the run
+      // WRITES, unattended, with nobody having answered anything. If that ordering ever
+      // moves, this return must become a refusal that the domain cannot mistake for consent
+      // (a sentinel the questions reject, not a blank), and it must move in the same commit.
       return Promise.resolve("");
     }
     rl ??= createInterface({ input: process.stdin, output: process.stdout });

--- a/apps/tui/src/import-orders-cli.ts
+++ b/apps/tui/src/import-orders-cli.ts
@@ -29,7 +29,46 @@ if (!csvPath) {
   process.stderr.write("usage: pnpm orders:import <path/to/open-orders-export.csv>\n");
   process.exitCode = 1;
 } else {
-  const rl = createInterface({ input: process.stdin, output: process.stdout });
+  // THE PROMPT IS BUILT AT THE FIRST QUESTION, NEVER AT STARTUP (#346). `createInterface`
+  // eagerly consumes stdin, so constructing it here — which is where it used to live —
+  // ended a piped stream before any question was put, and the first `ask` rejected with
+  // `readline was closed`: a readline internal, printed verbatim to the operator by the
+  // outer catch below. Memoized, so the several questions of one interview share one
+  // interface, and a run that never asks never builds one.
+  let rl: ReturnType<typeof createInterface> | undefined;
+  let toldThereIsNoTerminal = false;
+
+  /**
+   * The prompt channel — and, on a stdin that is no terminal, the place that says so.
+   *
+   * IT RETURNS RATHER THAN THROWS, DELIBERATELY. Throwing here would unwind through the
+   * outer catch and end the run in the shell, which would leave `no-reserve-declared`
+   * (`import-orders.ts:588`) unreachable forever — the flow's own refusal for a batch
+   * nobody funded, reached only when `declareFunding` gets an empty batch answer. Returning
+   * "" hands the domain the one answer a run with no terminal can honestly give, and the
+   * domain then refuses in its own voice. Two sentences, one story: the shell names WHY
+   * there is no answer, the flow names WHAT IT DID about it.
+   *
+   * The notice is written ONCE per run, not once per question: the operator learns there is
+   * no terminal from the first unanswerable question, and repeating it would bury the
+   * flow's refusal under copies of the shell's.
+   */
+  const ask = (question: string): Promise<string> => {
+    if (!process.stdin.isTTY) {
+      if (!toldThereIsNoTerminal) {
+        toldThereIsNoTerminal = true;
+        process.stderr.write(
+          "No terminal on stdin: this import is an interview — it asks which reserve funds " +
+            "the batch — and there is nowhere to conduct it, so every question goes " +
+            "unanswered. Run it from a terminal.\n",
+        );
+      }
+      return Promise.resolve("");
+    }
+    rl ??= createInterface({ input: process.stdin, output: process.stdout });
+    return rl.question(question);
+  };
+
   try {
     // THE FOLD IS TAKEN, AND ITS DISCARD SUMMARY RENDERED, BEFORE THE IMPORT BEGINS —
     // the same placement and the same argument as `record-fill-cli.ts`. `fundReview()`
@@ -66,7 +105,7 @@ if (!csvPath) {
         // unreadable one costs, which is the proposal and nothing else.
         plansPath: resolvePlansPath(),
         loadPlans,
-        ask: (question) => rl.question(question),
+        ask,
         out: (message) => process.stdout.write(message),
         err: (message) => process.stderr.write(`${message}\n`),
       },
@@ -86,7 +125,10 @@ if (!csvPath) {
       // qualification, each opening on its own gap and naming its own money direction)
       // are the real channel. If this import is ever automated or piped, the exit code
       // becomes the only surface left and this branch must be revisited BEFORE that lands,
-      // not after. (#183 DECIDED this and is closed; the accepted cost and that re-trigger
+      // not after. THAT TRIGGER HAS NOT FIRED: #346 made a piped run REFUSE at the first
+      // question rather than answer it, which is the opposite of automating the import —
+      // the operator is still the only channel, and this 0 still means what it said.
+      // (#183 DECIDED this and is closed; the accepted cost and that re-trigger
       // are recorded in ADR-014, `a skipped export row: not persisted, because it could
       // never be retired`, under `context/adr/`.)
       process.exitCode = 0;
@@ -95,6 +137,9 @@ if (!csvPath) {
     process.stderr.write(`${error instanceof Error ? error.message : String(error)}\n`);
     process.exitCode = 1;
   } finally {
-    rl.close();
+    // ONLY IF ONE WAS EVER BUILT. `?.` is the whole point of the lazy construction above:
+    // a run that never prompted must not construct an interface here just to close it,
+    // which would consume stdin on the way out for no reason at all.
+    rl?.close();
   }
 }

--- a/apps/tui/src/migrate-legacy-log.test.ts
+++ b/apps/tui/src/migrate-legacy-log.test.ts
@@ -268,48 +268,48 @@ describe("migrate-legacy-log — the shell around the one-shot durable-log rewri
     });
 
     /**
-     * KNOWN DEFECT — CHARACTERIZED HERE, NOT BLESSED.
+     * A CONTENTLESS LOG IS THE SAME ANSWER AS A MISSING ONE — the sentence and the
+     * untouched bytes both. Fixed under #345; the two cases below are one seam, and this
+     * is the note that keeps them fixed.
      *
-     * FILED AS #345, which covers this case and the sibling case below. The fix is a
-     * behavior change, so it belongs in its own increment rather than in this tests-only
-     * one.
+     * WHAT WENT WRONG BEFORE. `readOptional` returns `undefined` only on ENOENT, so an
+     * existing but empty (or blank-lines-only) `events.jsonl` read back as `""` and the
+     * early return in `migrateLegacyLog` was NOT taken. `loadGenesis` ran, the line loop
+     * produced no events, and `writeLogImage` was still called — with `"\n"`. The log was
+     * replaced by a single newline byte, while `migratedCount + unchangedCount === 0` sent
+     * the shell down the `touched === 0` branch, so it printed the reassuring "no log"
+     * sentence and exited 0: a lie about a write that happened, on the one tool in the
+     * repo that rewrites the durable log.
      *
-     * This test asserts what the tool OBSERVABLY DOES today, and what it does is wrong:
-     * it reports "No durable log to migrate" about a log it has just OVERWRITTEN.
+     * WHY THE FIX IS NOT IN `readOptional`, AND MUST NOT MOVE THERE. Its ENOENT-only
+     * contract is what every other caller reads it for — "absent" and "present but empty"
+     * are different facts, and the price feed's inbox and the preferences copy both lean
+     * on the distinction. Widening it to fold `""` into `undefined` would silence this
+     * case by destroying the signal that separates an empty log from an unreadable one.
+     * The guard belongs in `migrateLegacyLog`, where "nothing to migrate" is a policy
+     * this tool owns.
      *
-     * The mechanism: `readOptional` returns `undefined` only on ENOENT, so an existing
-     * but empty (or blank-lines-only) `events.jsonl` reads back as `""` and the early
-     * return at `event-store.ts:209-211` is NOT taken. `loadGenesis` runs, the line loop
-     * produces no events, and `writeLogImage` is still called — with `"\n"`. The log is
-     * replaced by a single newline byte, while `migratedCount + unchangedCount === 0`
-     * sends the shell down the `touched === 0` branch and it prints the reassuring
-     * "no log" sentence and exits 0.
-     *
-     * Nothing of value is lost from a log that was already empty, so this is not a live
-     * data-loss incident — but the report is a lie about a write that happened, on the
-     * one tool in the repo that rewrites the durable log, and the same `undefined`-only
-     * ENOENT check is what stands between "empty" and "unreadable". Fixing it is a
-     * behavior change and this increment is tests only; the fix belongs in its own
-     * increment (#345, cited above), with this test INVERTED to assert the log is left
-     * untouched.
+     * BOTH CASES, ONE GUARD. The predicate is "no content once blank lines are
+     * discarded", which is the loop's own rule hoisted above the write — so the
+     * blank-lines-only log below cannot drift back to being handled separately, or at
+     * all.
      */
-    it("KNOWN DEFECT: rewrites an EMPTY log to a single newline while reporting 'No durable log'", async () => {
+    it("leaves an EMPTY log untouched and says 'No durable log to migrate' (exit 0, #345)", async () => {
       const { dir, logPath } = await syntheticDataDir("");
 
       const result = runMigrate({ dataDir: dir, cwd: await workingDir() });
 
       expectExited(result);
       expect(result.status).toBe(0);
-      // What the operator is told:
       expect(result.stdout).toBe(`No durable log to migrate at ${logPath}.\n`);
-      // What actually happened to the file it just told them it did not migrate:
-      expect(await readFile(logPath, "utf8")).toBe("\n");
+      expect(result.stderr).toBe("");
+      // The report and the disk agree: the file it says it did not migrate is byte-for-byte
+      // what it was.
+      expect(await readFile(logPath, "utf8")).toBe("");
       expect(await litter(dir)).toEqual([]);
     });
 
-    // KNOWN DEFECT, same seam and the same follow-up (#345) as the case above: INVERT this
-    // case too when the fix lands, to assert the log is left untouched.
-    it("KNOWN DEFECT (same seam): a blank-lines-only log is collapsed to a single newline", async () => {
+    it("leaves a blank-lines-only log untouched at its original bytes (exit 0, #345)", async () => {
       const { dir, logPath } = await syntheticDataDir("\n\n\n");
 
       const result = runMigrate({ dataDir: dir, cwd: await workingDir() });
@@ -317,9 +317,11 @@ describe("migrate-legacy-log — the shell around the one-shot durable-log rewri
       expectExited(result);
       expect(result.status).toBe(0);
       expect(result.stdout).toBe(`No durable log to migrate at ${logPath}.\n`);
-      // Blank lines are records to neither half, so the loop yields nothing and the
-      // three-byte image is replaced by a one-byte one — again reported as "no log".
-      expect(await readFile(logPath, "utf8")).toBe("\n");
+      expect(result.stderr).toBe("");
+      // Blank lines are records to neither half, so this log carries no content — and the
+      // guard reads it the same way the loop does. All three bytes survive.
+      expect(await readFile(logPath, "utf8")).toBe("\n\n\n");
+      expect(await litter(dir)).toEqual([]);
     });
   });
 

--- a/apps/tui/src/migrate-legacy-log.test.ts
+++ b/apps/tui/src/migrate-legacy-log.test.ts
@@ -323,6 +323,52 @@ describe("migrate-legacy-log — the shell around the one-shot durable-log rewri
       expect(await readFile(logPath, "utf8")).toBe("\n\n\n");
       expect(await litter(dir)).toEqual([]);
     });
+
+    /**
+     * THE ORDERING HALF OF THE #345 GUARD, WHICH THE TWO CASES ABOVE DO NOT PIN. Both of
+     * them plant a valid `genesis.json`, so both stay green whether the guard sits above
+     * `loadGenesis` (`event-store.ts`) or below it. This case is the one that cares WHERE
+     * it sits: with no genesis on disk at all, an empty log exits 0 with the "no log"
+     * sentence only if the guard returns FIRST. Move it below the read and this run exits
+     * 1 naming `genesis.json` instead — which is exactly the mutation this case exists to
+     * catch, and the reason it is worth its spawn.
+     *
+     * IT IS ALSO A BEHAVIOUR CHANGE THIS PR MADE AND NOTHING ELSE RECORDED. Before #345 an
+     * empty log plus a missing genesis DID exit 1 naming `genesis.json`. The change is
+     * deliberate and consistent — the case two blocks up, `says 'No durable log to
+     * migrate' … when the log is absent`, already returns above the genesis read for an
+     * ABSENT log, and #345's whole claim is that a contentless log is the same answer as a
+     * missing one. Two shapes cannot be "one seam" and then take different doors out. This
+     * case is where that consistency is written down as behaviour rather than as a comment.
+     *
+     * The contrast case lives at the bottom of this file (`exits 1 when the data dir has no
+     * genesis to migrate against`): same missing genesis, but a log WITH CONTENT, which
+     * still refuses. Nothing here softens that — a run that has records to migrate still
+     * needs the genesis to cross-reference them against.
+     */
+    it("needs no genesis at all to report an empty log as nothing to migrate (exit 0)", async () => {
+      // NOT `syntheticDataDir` — that helper always plants a genesis, which is the whole
+      // thing this case must NOT have. A bare temp dir holding one empty file.
+      const dir = await tempDir();
+      const logPath = join(dir, "events.jsonl");
+      await writeFile(logPath, "", "utf8");
+      expect(await exists(join(dir, "genesis.json"))).toBe(false);
+
+      const result = runMigrate({ dataDir: dir, cwd: await workingDir() });
+
+      expectExited(result);
+      expect(result.status).toBe(0);
+      expect(result.stdout).toBe(`No durable log to migrate at ${logPath}.\n`);
+      // AND NOTHING ON STDERR: no genesis complaint leaks out alongside the 0. An exit code
+      // that says "fine" over a stderr that names a broken file is the worst of both.
+      expect(result.stderr).toBe("");
+      expect(result.stderr).not.toMatch(/genesis/);
+      // Byte-for-byte: the run that says it migrated nothing wrote nothing, and did not
+      // conjure a genesis on the way past either.
+      expect(await readFile(logPath, "utf8")).toBe("");
+      expect(await exists(join(dir, "genesis.json"))).toBe(false);
+      expect(await litter(dir)).toEqual([]);
+    });
   });
 
   describe("the mapping is read from the CWD, NOT from NUMISMA_DATA_DIR", () => {


### PR DESCRIPTION
Two defects in the TUI's durable-log tooling, file-disjoint and shipped together because they share a package and a test run.

Closes #345 and closes #346.

## #345 — the migration overwrote a log it reported as absent

`migrateLegacyLog` rewrote an existing-but-empty `events.jsonl` to a single newline byte, printed `No durable log to migrate`, and exited 0. `readOptional` returns `undefined` **only** on ENOENT, so `""` is falsy but not `undefined` and slipped past the guard: `loadGenesis` ran, the line loop yielded nothing, and `writeLogImage` was still called with `"\n"` — while `migratedCount + unchangedCount === 0` sent the shell down its "no log" branch. The report was a lie about a write that happened, on the one tool in the repo that rewrites the whole durable log.

The fix is at the guard, not at `readOptional`:

```ts
if (raw === undefined || raw.trim().length === 0) {
```

**`readOptional` is deliberately unchanged.** Its ENOENT-only contract is what lets its other callers distinguish "absent" from "present but empty", and folding `""` into `undefined` there would have quieted this path by destroying the distinction that separates an empty log from an unreadable one. "Nothing to migrate" is a policy this migration owns, so it lives here. That reasoning now survives in the guard comment.

**The empty and blank-lines-only cases are one seam, not two.** The predicate is the line loop's own rule hoisted above the write — the loop trims each line and skips the empty ones, so "no content once blank lines are discarded" is exactly the set of inputs that can never yield a record. An `=== ""` check would have fixed half the defect and left a red pin.

### The two `KNOWN DEFECT` pins are inverted, and that is the deliverable

`migrate-legacy-log.test.ts` carried two tests that deliberately characterized the wrong behaviour, and whose own comments said they must be inverted when this was fixed. Both now assert the log is left byte-for-byte untouched — `""` stays `""`, `"\n\n\n"` stays `"\n\n\n"` — with the same stdout sentence, empty stderr, exit 0, and no litter. The block comment above them is rewritten to record the fixed seam rather than deleted, because the `readOptional` argument is what stops someone "fixing" this in the wrong place later. Both now cite #345, which they previously did not.

## #346 — the funding interview was unreachable without a TTY

`import-orders-cli.ts` constructed its readline interface at module scope, before any prompt was issued. `createInterface` eagerly consumes stdin, so on a piped non-TTY stdin the stream had already ended by the first `ask` and `rl.question` rejected with `readline was closed` — a readline internal, printed verbatim to the operator.

Two changes:

1. **The interface is built at the first question, never at startup**, and memoized so the several questions of one interview share one interface. The `finally` is now `rl?.close()`: a run that never prompted does not construct one on the way out just to close it.
2. **A stdin that is no terminal gets told so, once, in the repo's own voice** rather than leaking a readline internal.

**The refusal returns rather than throws, and that is load-bearing.** Throwing would unwind through the shell's outer `catch` and leave `no-reserve-declared` (`import-orders.ts:588`) unreachable forever — the domain's refusal for a batch nobody funded, reached only when `declareFunding` receives an empty batch answer. Returning `""` hands the domain the one answer a run with no terminal can honestly give, and the domain then refuses in its own voice. Two sentences, one story: the shell names *why* there is no answer, the flow names *what it did* about it. Exit 1, nothing written.

This makes `no-reserve-declared` assertable end-to-end **for the first time** — a refusal the domain layer has always implemented with no way to fire outside a TTY. It is now pinned: the named refusal on stderr, the domain refusal on the flow's channel, exit 1, no `orders.jsonl`, no `.tmp`/`.lock` litter.

**No piped-answer support was added.** #346 calls that a separate product question and does not assume it. It never became necessary — the empty-answer composition covers the case without it. If it is ever wanted, it is its own issue.

The `imported-partial` branch still exits 0 and is untouched. Its fifteen-line rationale names a re-trigger — *"if this import is ever automated or piped, the exit code becomes the only surface left"* — and one sentence was added recording that the trigger has **not** fired: a piped run now refuses at the first question, which is the opposite of automating the import.

## Every new and inverted test was proven able to fail

Mutation applied to production code, red observed, restored:

| Mutation | What went red |
| --- | --- |
| Guard reverted to `raw === undefined` | Both inverted pins, on the file-contents assertion (`expected '\n' to be ''` / `to be '\n\n\n'`) |
| Guard narrowed to `raw === undefined \|\| raw === ""` | Blank-lines pin only; the empty-log pin stayed green — the predicted split, which is what proves the two pins hold different things |
| `isTTY` check deleted | The non-TTY case: `expected 13 to be 1` — the unhandled `readline was closed` rejection returns |
| Non-TTY `ask` throws instead of returning `""` | The `no-reserve-declared` assertion precisely — the refusal never reaches the flow |
| Notice moved to shell startup | The "stays silent when nothing is asked" case |

**One honest negative, recorded rather than papered over.** Moving `createInterface` itself back to module scope *with the guard intact* leaves every case green: the `isTTY` guard returns before `rl` is touched, and a spawned stdin is never a terminal, so no test standing outside a TTY can observe the interface's laziness. Laziness is a structural claim here — it is what lets the `finally` close only what was built — not a tested one. What the new cases do hold down is the guard, the notice's placement, and the return-vs-throw composition. Said plainly because a guard nobody can turn red is worth exactly what it can prove.

## Fixtures

Every fixture is authored — invented ids, an invented instrument, round prices, round balances — and `NUMISMA_DATA_DIR` is set to a throwaway directory on every spawned run. Nothing is seeded from, or shaped by, real output.

## Note for reviewers running the suite in a worktree

`ops/testkit/gitignored-path-globs.test.ts` fails two cases inside any fresh worktree and passes in the main checkout. **It is unrelated to this PR** and reproduces on a clean `a5a0cad`. The cause is that the guard asserts against ambient disk contents: it expects `git ls-files --others --ignored` to report `.claude/` and `apps/web/.tanstack/`, and `--others` only lists paths that physically exist, which in a fresh worktree they do not. The walker's behaviour is correct — a worktree with no build output and no nested worktrees genuinely has nothing to exclude. The test is what is environment-dependent. Filed upward to the board rather than fixed here, since it is another lane's file.
