### PR TITLE
fix(engine): split the fused zero-cost fallback — canonical-order attribution, and a discard for a lot-less leg

### DIFF
--- a/packages/engine/src/contracts.ts
+++ b/packages/engine/src/contracts.ts
@@ -85,12 +85,21 @@ export interface FundReviewData {
 }
 
 /**
- * Why the fold could not apply an event. CLOSED AT TWO MEMBERS — a third reason is a
- * spec change, not a build decision. `position-absent`: the verb named a position the
- * fold has no record of (never opened in this window, or already retired).
+ * Why the fold could not apply an event. A CLOSED VOCABULARY — widening it is a spec
+ * change, not a build decision; it was widened once, deliberately, to three (#329).
+ *
+ * `position-absent`: the verb named a position the fold has no record of (never opened
+ * in this window, or already retired).
+ *
  * `reserve-absent`: a cash leg named a reserve the fold has no record of.
+ *
+ * `provenance-absent`: a cash leg derived from position lots had NO LOTS to derive
+ * from, so there is no cost-basis provenance for the leg to inherit. THIS IS NOT
+ * `reserve-absent` AND THE TWO MUST NEVER BE CONFLATED: here the reserve exists and was
+ * found — what is missing is the attribution the leg would have carried into it.
+ * Reporting a reserve miss that never happened would make the notice lie.
  */
-export type FoldSkipReason = "position-absent" | "reserve-absent";
+export type FoldSkipReason = "position-absent" | "reserve-absent" | "provenance-absent";
 
 /**
  * One event the fold read and then dropped — the Discard Channel's record (PRD #323,

--- a/packages/engine/src/events/fold.ts
+++ b/packages/engine/src/events/fold.ts
@@ -49,6 +49,9 @@ const SKIP_DETAIL: Record<FoldSkipReason, string> = {
   "reserve-absent":
     "The fold has no record of the reserve this event's cash leg names, so that leg was " +
     "read and then dropped. No balance moved.",
+  "provenance-absent":
+    "This event's cash leg has no cost-basis provenance to inherit — the fold has no " +
+    "lots to attribute it across — so the leg was read and then dropped. No balance moved.",
 };
 
 /**
@@ -91,7 +94,10 @@ export function dedupeFoldSkips(skipped: readonly SkippedFoldEvent[]): SkippedFo
  *
  * ZERO-COST LOTS get one delta, not a split: with every cost weight zero there is
  * no cost-basis weight to split by, so the whole delta lands on the canonically
- * first Tier that holds a lot (#329). */
+ * first Tier that holds a lot (#329).
+ *
+ * NO LOTS AT ALL RETURNS AN EMPTY LIST — the leg has no provenance to inherit, so
+ * there is nothing to attribute and the caller must discard it (#329). */
 function tierWeightedDeltas(lots: PositionLot[], total: number, sign: 1 | -1): TierDelta[] {
   const costByTier = new Map<CapitalTier, number>();
   let totalCost = 0;
@@ -102,8 +108,14 @@ function tierWeightedDeltas(lots: PositionLot[], total: number, sign: 1 | -1): T
   }
   const present = TIERS.filter((tier) => costByTier.has(tier));
   if (present.length === 0) {
-    // No lots at all. Left exactly as it was; ruled on separately (#329).
-    return [{ tier: lots[0]?.tier ?? "c1", amount: sign * total }];
+    // NO LOTS ⇒ NO PROVENANCE ⇒ NO DELTA. Any lot at all puts a key in `costByTier`,
+    // so this arm is reachable only when `lots` is empty. It used to return
+    // `[{ tier: lots[0]?.tier ?? "c1", … }]`, which — the `lots[0]` being undefined by
+    // construction — ALWAYS took the `?? "c1"` fallback and minted a full-magnitude c1
+    // delta for a cash movement carrying no provenance whatsoever; `applyToReserve`
+    // then booked it as real c1 capital. Not a bad attribution: an invented one. The
+    // empty list is the discard, and the caller records it (#329).
+    return [];
   }
   if (totalCost === 0) {
     // Zero-cost lots: no cost-basis weight to split by, so the whole delta goes to
@@ -128,7 +140,10 @@ function tierWeightedDeltas(lots: PositionLot[], total: number, sign: 1 | -1): T
 }
 
 /** Open → debit the funding Reserve by the cash leaving, split across the
- * position lots' own Tiers (each Tier pays for what it bought). */
+ * position lots' own Tiers (each Tier pays for what it bought).
+ *
+ * RETURNS `[]` FOR A LOT-LESS OPEN — no lots, no provenance, nothing to attribute.
+ * Callers must treat the empty list as a discard, never as a no-op worth booking. */
 export function reserveDeltasForOpen(lots: PositionLot[], amount: number): TierDelta[] {
   return tierWeightedDeltas(lots, amount, -1);
 }
@@ -141,7 +156,10 @@ export function reserveDeltasForOpen(lots: PositionLot[], amount: number): TierD
  * native and USD weights are proportionally identical, so the split is exact. When
  * `buildClosedPosition` reuses this helper to apportion proceeds against USD cost
  * basis, that native-vs-USD basis mismatch is the source of the documented
- * mixed-`entryFx` per-tier caveat; see that helper's note. Totals stay exact. */
+ * mixed-`entryFx` per-tier caveat; see that helper's note. Totals stay exact.
+ *
+ * RETURNS `[]` FOR A LOT-LESS CLOSE — no lots, no provenance, nothing to attribute.
+ * Callers must treat the empty list as a discard, never as a no-op worth booking. */
 export function reserveDeltasForClose(lots: PositionLot[], proceeds: number): TierDelta[] {
   return tierWeightedDeltas(lots, proceeds, 1);
 }
@@ -264,6 +282,32 @@ export function foldEvents(
       reason,
       detail: SKIP_DETAIL[reason],
     });
+  };
+  /**
+   * Apply one LOT-DERIVED cash leg, or record why it could not be applied.
+   *
+   * PRECEDENCE IS A DECISION: `provenance-absent` wins and the reserve is never
+   * consulted. With no deltas there is nothing to apply, so whether the reserve exists
+   * is moot — recording `reserve-absent` as well would report a reserve miss that never
+   * happened. One event, one finding, on this path.
+   *
+   * Only lot-derived legs route through here. The explicit-tier legs (Deposit,
+   * Withdraw, both Transfer legs) call `applyToReserve` directly: their deltas are
+   * never empty, and routing them here would imply a discard that cannot occur.
+   */
+  const applyTieredLeg = (
+    reserveId: string,
+    deltas: TierDelta[],
+    event: PortfolioEvent,
+    order: number,
+  ): void => {
+    if (deltas.length === 0) {
+      recordSkip(event, order, "provenance-absent");
+      return;
+    }
+    if (!applyToReserve(reserves, reserveId, deltas)) {
+      recordSkip(event, order, "reserve-absent");
+    }
   };
   let usdMxn = genesis.review.usdMxn;
   let latestAsOf = genesis.review.asOf;
@@ -391,9 +435,12 @@ export function foldEvents(
           costAnchors.set(position.instrumentId, anchor);
         }
         // Cash leg: debit the funding reserve. Sufficiency was proven at ingest.
-        if (!applyToReserve(reserves, event.funding.reserveId, reserveDeltasForOpen(position.lots, event.funding.amount))) {
-          recordSkip(event, order, "reserve-absent");
-        }
+        applyTieredLeg(
+          event.funding.reserveId,
+          reserveDeltasForOpen(position.lots, event.funding.amount),
+          event,
+          order,
+        );
         break;
       }
       case "PositionClosed": {
@@ -402,15 +449,12 @@ export function foldEvents(
         // closed position's mix, BEFORE retiring the asset leg. Honest-by-
         // construction: the asset cannot be removed without recording the cash.
         if (closing) {
-          if (
-            !applyToReserve(
-              reserves,
-              event.settlement.reserveId,
-              reserveDeltasForClose(closing.lots, event.settlement.proceeds),
-            )
-          ) {
-            recordSkip(event, order, "reserve-absent");
-          }
+          applyTieredLeg(
+            event.settlement.reserveId,
+            reserveDeltasForClose(closing.lots, event.settlement.proceeds),
+            event,
+            order,
+          );
           // Realized P&L: compute proceeds − cost
           // basis, tag it, and push a finished row onto the closed book INSTEAD of
           // silently dropping the position. Descriptive only — the profit already
@@ -461,15 +505,12 @@ export function foldEvents(
           // The mark the removed units are valued at for the NAV-honesty disclosure:
           // the latest PriceMarked seen so far, else the position's standing mark.
           const markPrice = latestMark.get(trimming.instrumentId) ?? trimming.markPrice;
-          if (
-            !applyToReserve(
-              reserves,
-              event.settlement.reserveId,
-              reserveDeltasForClose(removed, event.settlement.proceeds),
-            )
-          ) {
-            recordSkip(event, order, "reserve-absent");
-          }
+          applyTieredLeg(
+            event.settlement.reserveId,
+            reserveDeltasForClose(removed, event.settlement.proceeds),
+            event,
+            order,
+          );
           closedPositions.push(
             buildClosedPosition(
               trimming,
@@ -529,15 +570,12 @@ export function foldEvents(
               anchor.price = blended;
             }
           }
-          if (
-            !applyToReserve(
-              reserves,
-              event.funding.reserveId,
-              reserveDeltasForOpen([event.lot], event.funding.amount),
-            )
-          ) {
-            recordSkip(event, order, "reserve-absent");
-          }
+          applyTieredLeg(
+            event.funding.reserveId,
+            reserveDeltasForOpen([event.lot], event.funding.amount),
+            event,
+            order,
+          );
         } else {
           recordSkip(event, order, "position-absent");
         }

--- a/packages/engine/src/events/fold.ts
+++ b/packages/engine/src/events/fold.ts
@@ -302,6 +302,12 @@ export function foldEvents(
    * is moot — recording `reserve-absent` as well would report a reserve miss that never
    * happened. One event, one finding, on this path.
    *
+   * AND THE COST IS MEASURABLE, NOT MERELY SEMANTIC: `dedupeFoldSkips` keys on
+   * (`eventId`, `reason`), so two reasons for one event are two DISTINCT records that
+   * both survive dedupe — inflating `discardedEventCount` and emitting two
+   * `formatFoldDiscards` lines for a single drop. The channel would over-report the
+   * very thing it exists to report exactly once.
+   *
    * A RESERVE MISS IS NOT A DISCARD and returns `true`. That asymmetry is INHERITED,
    * not introduced here: a missing reserve has always let the arm carry on, and the
    * cross-ref existence gate rejects an unknown reserve before the fold ever runs, so

--- a/packages/engine/src/events/fold.ts
+++ b/packages/engine/src/events/fold.ts
@@ -87,7 +87,11 @@ export function dedupeFoldSkips(skipped: readonly SkippedFoldEvent[]): SkippedFo
 /** Cost-basis weight of each Tier in a position's lots (the provenance the cash
  * leg inherits). Returns signed `amount` per present Tier summing exactly to
  * `total`, with any float residual folded into the last Tier so the reserve's
- * authoritative `amount` lands exact. */
+ * authoritative `amount` lands exact.
+ *
+ * ZERO-COST LOTS get one delta, not a split: with every cost weight zero there is
+ * no cost-basis weight to split by, so the whole delta lands on the canonically
+ * first Tier that holds a lot (#329). */
 function tierWeightedDeltas(lots: PositionLot[], total: number, sign: 1 | -1): TierDelta[] {
   const costByTier = new Map<CapitalTier, number>();
   let totalCost = 0;
@@ -97,9 +101,20 @@ function tierWeightedDeltas(lots: PositionLot[], total: number, sign: 1 | -1): T
     totalCost += cost;
   }
   const present = TIERS.filter((tier) => costByTier.has(tier));
-  if (present.length === 0 || totalCost === 0) {
-    // Degenerate (zero-cost lots): attribute everything to the first lot's Tier.
+  if (present.length === 0) {
+    // No lots at all. Left exactly as it was; ruled on separately (#329).
     return [{ tier: lots[0]?.tier ?? "c1", amount: sign * total }];
+  }
+  if (totalCost === 0) {
+    // Zero-cost lots: no cost-basis weight to split by, so the whole delta goes to
+    // `present[0]` — the canonically first Tier holding a lot, in c1/c2/c3 order.
+    // Keying on `lots[0].tier` instead made attribution depend on ARRAY INSERTION
+    // ORDER, so two callers with the same lots ordered differently credited
+    // different Tiers (#329). An even split across `present` was rejected: with
+    // every weight zero it would invent a weighting the data does not carry.
+    // `present[0]` is order-independent and matches the old answer whenever
+    // exactly one Tier holds lots — the common shape.
+    return [{ tier: present[0]!, amount: sign * total }];
   }
   const deltas: TierDelta[] = [];
   let allocated = 0;

--- a/packages/engine/src/events/fold.ts
+++ b/packages/engine/src/events/fold.ts
@@ -284,30 +284,48 @@ export function foldEvents(
     });
   };
   /**
-   * Apply one LOT-DERIVED cash leg, or record why it could not be applied.
+   * Apply one LOT-DERIVED cash leg. RETURNS WHETHER THE REST OF THE EVENT MAY RUN.
+   *
+   * THE DISCARD IS TOTAL, WHICH IS WHY THIS IS A GATE AND NOT A VOID CALL. A
+   * lot-derived leg with no deltas has no cost-basis provenance, and an event whose
+   * cash leg cannot be attributed is dropped WHOLE: no closed-book row, no retirement,
+   * no lot mutation, no registration. `false` means the arm must do nothing at all.
+   * Recording the drop and then letting the arm carry on would raise realized P&L by
+   * the full proceeds while crediting NO reserve — the cash would simply vanish, which
+   * is strictly worse than the invented-`c1` attribution this replaced (that at least
+   * conserved the money). The `position-absent` `else` branches in these same arms
+   * already discard the whole event; this is deliberately the SAME semantics, not a
+   * second kind of discard.
    *
    * PRECEDENCE IS A DECISION: `provenance-absent` wins and the reserve is never
    * consulted. With no deltas there is nothing to apply, so whether the reserve exists
    * is moot — recording `reserve-absent` as well would report a reserve miss that never
    * happened. One event, one finding, on this path.
    *
-   * Only lot-derived legs route through here. The explicit-tier legs (Deposit,
-   * Withdraw, both Transfer legs) call `applyToReserve` directly: their deltas are
-   * never empty, and routing them here would imply a discard that cannot occur.
+   * A RESERVE MISS IS NOT A DISCARD and returns `true`. That asymmetry is INHERITED,
+   * not introduced here: a missing reserve has always let the arm carry on, and the
+   * cross-ref existence gate rejects an unknown reserve before the fold ever runs, so
+   * on the gated path it cannot happen at all. Only the provenance case gates.
+   *
+   * Only lot-derived legs route through here. The explicit-tier legs (`Deposit`,
+   * `Withdraw`, both `Transfer` legs) call `applyToReserve` directly: their tiers come
+   * from the event itself rather than from lots, so they have no provenance that could
+   * be missing, and routing them here would imply a discard that cannot occur.
    */
   const applyTieredLeg = (
     reserveId: string,
     deltas: TierDelta[],
     event: PortfolioEvent,
     order: number,
-  ): void => {
+  ): boolean => {
     if (deltas.length === 0) {
       recordSkip(event, order, "provenance-absent");
-      return;
+      return false;
     }
     if (!applyToReserve(reserves, reserveId, deltas)) {
       recordSkip(event, order, "reserve-absent");
     }
+    return true;
   };
   let usdMxn = genesis.review.usdMxn;
   let latestAsOf = genesis.review.asOf;
@@ -403,6 +421,22 @@ export function foldEvents(
     switch (event.type) {
       case "PositionOpened": {
         const { position } = event;
+        // Cash leg FIRST, because it gates the arm. Sufficiency was proven at ingest.
+        // A lot-less open has no provenance for the debit to inherit, and the discard
+        // is total: no registration, no cost anchor, no entry-VWAC fallback mark. The
+        // reserve and the position/close maps are disjoint, so hoisting the leg above
+        // the registration changes nothing an observer can see on the applying path —
+        // it only makes the drop able to stop the arm before it starts.
+        if (
+          !applyTieredLeg(
+            event.funding.reserveId,
+            reserveDeltasForOpen(position.lots, event.funding.amount),
+            event,
+            order,
+          )
+        ) {
+          break;
+        }
         const entryPrice = weightedAverageCost(position.lots);
         positions.set(position.id, {
           id: position.id,
@@ -434,47 +468,49 @@ export function foldEvents(
           pushClose(anchor);
           costAnchors.set(position.instrumentId, anchor);
         }
-        // Cash leg: debit the funding reserve. Sufficiency was proven at ingest.
-        applyTieredLeg(
-          event.funding.reserveId,
-          reserveDeltasForOpen(position.lots, event.funding.amount),
-          event,
-          order,
-        );
         break;
       }
       case "PositionClosed": {
         const closing = positions.get(event.positionId);
+        if (!closing) {
+          recordSkip(event, order, "position-absent");
+          break;
+        }
         // Cash leg: credit the settlement reserve with proceeds, tiered by the
         // closed position's mix, BEFORE retiring the asset leg. Honest-by-
         // construction: the asset cannot be removed without recording the cash.
-        if (closing) {
-          applyTieredLeg(
+        //
+        // AND IT GATES THE REST OF THE ARM. A lot-less position has no provenance for
+        // the proceeds to inherit, so the close is discarded WHOLE — the position stays
+        // open, no row is booked, nothing is retired. Booking the row while the cash
+        // leg dropped would raise realized P&L by the full proceeds against a reserve
+        // that never moved: the R8 failure below, in its other direction.
+        if (
+          !applyTieredLeg(
             event.settlement.reserveId,
             reserveDeltasForClose(closing.lots, event.settlement.proceeds),
             event,
             order,
-          );
-          // Realized P&L: compute proceeds − cost
-          // basis, tag it, and push a finished row onto the closed book INSTEAD of
-          // silently dropping the position. Descriptive only — the profit already
-          // landed in the Reserve above; the blotter records how the fund got here.
-          const settlementCurrency =
-            reserves.get(event.settlement.reserveId)?.currency ?? closing.currency;
-          closedPositions.push(
-            buildClosedPosition(closing, closing.lots, event.asOf, event.settlement.proceeds, settlementCurrency, usdMxn),
-          );
-          // R8 (ledger item 19): THE DELETE LIVES HERE NOW, not after the block. Moving
-          // it in is provably behavior-preserving — `Map.delete` on a key whose `get`
-          // just returned `undefined` is a no-op by definition — and it makes the arm a
-          // clean pair: either the close applies IN FULL (cash leg, closed-book row,
-          // retirement) or it is recorded as discarded and NOTHING happens. Leaving the
-          // delete outside while adding the `else` would be strictly worse than either
-          // shape: the code would announce the drop and then act on its behalf.
-          positions.delete(event.positionId);
-        } else {
-          recordSkip(event, order, "position-absent");
+          )
+        ) {
+          break;
         }
+        // Realized P&L: compute proceeds − cost
+        // basis, tag it, and push a finished row onto the closed book INSTEAD of
+        // silently dropping the position. Descriptive only — the profit already
+        // landed in the Reserve above; the blotter records how the fund got here.
+        const settlementCurrency =
+          reserves.get(event.settlement.reserveId)?.currency ?? closing.currency;
+        closedPositions.push(
+          buildClosedPosition(closing, closing.lots, event.asOf, event.settlement.proceeds, settlementCurrency, usdMxn),
+        );
+        // R8 (ledger item 19): THE DELETE LIVES INSIDE THE APPLYING PATH, not after the
+        // block — reached only once BOTH gates above have passed. The arm is a clean
+        // pair: either the close applies IN FULL (cash leg, closed-book row,
+        // retirement) or it is recorded as discarded and NOTHING happens. Announcing
+        // the drop and then acting on its behalf — pushing the row, retiring the asset
+        // — is the shape this guards against, whichever gate did the announcing.
+        positions.delete(event.positionId);
         break;
       }
       case "PositionTrimmed": {
@@ -505,12 +541,23 @@ export function foldEvents(
           // The mark the removed units are valued at for the NAV-honesty disclosure:
           // the latest PriceMarked seen so far, else the position's standing mark.
           const markPrice = latestMark.get(trimming.instrumentId) ?? trimming.markPrice;
-          applyTieredLeg(
-            event.settlement.reserveId,
-            reserveDeltasForClose(removed, event.settlement.proceeds),
-            event,
-            order,
-          );
+          // Cash leg, AND the gate on the rest of the arm. `splitTierRemoval` yields no
+          // removed lots when the removal names a tier the position holds nothing in, so
+          // the proceeds have no provenance to inherit and the trim is discarded WHOLE:
+          // no partial row, and `trimming.lots` is left exactly as it was. Pushing the
+          // row while the credit dropped would book realized P&L against a reserve that
+          // never moved; mutating the lots on top of that would retire the asset for
+          // cash the fund never received.
+          if (
+            !applyTieredLeg(
+              event.settlement.reserveId,
+              reserveDeltasForClose(removed, event.settlement.proceeds),
+              event,
+              order,
+            )
+          ) {
+            break;
+          }
           closedPositions.push(
             buildClosedPosition(
               trimming,
@@ -570,6 +617,16 @@ export function foldEvents(
               anchor.price = blended;
             }
           }
+          // ROUTED THROUGH THE GATE THOUGH THE DISCARD IS UNREACHABLE HERE, AND THE
+          // RETURN IS DELIBERATELY IGNORED. The array literal `[event.lot]` always
+          // holds exactly one lot, so `reserveDeltasForOpen` always yields exactly one
+          // delta and `provenance-absent` cannot fire on this site — there is nothing
+          // left of the arm to gate anyway, the append happened above. It stays routed
+          // because this IS a lot-derived leg: its tier comes from `event.lot.tier`, so
+          // it belongs on the lot-derived path by kind, not by whether today's argument
+          // happens to be non-empty. Calling `applyToReserve` directly instead would
+          // put a lot-derived leg on the explicit-tier path and quietly lose the
+          // provenance check the day this site learns to add more than one lot.
           applyTieredLeg(
             event.funding.reserveId,
             reserveDeltasForOpen([event.lot], event.funding.amount),

--- a/packages/engine/src/fold.test.ts
+++ b/packages/engine/src/fold.test.ts
@@ -9,7 +9,9 @@ import {
   buildCompositionReport,
   buildEventReference,
   crossReferenceEvent,
+  EVENT_SCHEMA_VERSION,
   foldEvents,
+  parseEvent,
   parseFundReview,
   reserveDeltasForClose,
   reserveDeltasForOpen,
@@ -19,6 +21,7 @@ import {
   type PositionLot,
   type PositionOpenedEvent,
   type PositionClosedEvent,
+  type PositionTrimmedEvent,
   type PriceMarkedEvent,
 } from "./index.js";
 import { describe, expect, it } from "vitest";
@@ -907,16 +910,34 @@ describe("tier-weighted deltas — the zero-cost arm attributes in canonical Tie
   });
 });
 
-describe("tier-weighted deltas — a lot-less cash leg is DISCARDED, not attributed (#329)", () => {
-  // Any lot at all puts a key in `costByTier`, so "no Tier is present" is reachable
-  // ONLY when the lots array is empty. The old code returned a full-magnitude delta on
+describe("a cash leg with no lot provenance discards the WHOLE event (#329)", () => {
+  // Any lot at all puts a key in `costByTier`, so `tierWeightedDeltas` returns an empty
+  // list ONLY when it is handed no lots. The old code returned a full-magnitude delta on
   // the `?? "c1"` fallback — it MINTED c1 capital for a cash movement carrying no
   // provenance whatsoever, and `applyReserveDelta` booked it as real. That is not a bad
-  // attribution, it is an invented one. An empty delta list is the discard; the fold
-  // records it on ADR-020's Discard Channel as `provenance-absent`.
+  // attribution, it is an invented one.
+  //
+  // THE EMPTY LIST IS A DISCARD OF THE EVENT, NOT OF THE LEG. Dropping only the cash
+  // leg and letting the arm carry on is worse than the invented `c1`: the closed-book
+  // row would raise realized P&L by the full proceeds while NO reserve was credited, so
+  // the money would not be misattributed, it would be gone. `provenance-absent` on
+  // ADR-020's Discard Channel therefore means what `position-absent` already means in
+  // these same arms — nothing applied.
+  //
+  // WHICH ROUTE IS REACHABLE. `parseLots` rejects `lots: []`, and the durable log is
+  // parsed line-by-line on load (`loadEventLog`), so a lot-less OPEN cannot reach the
+  // fold through ingest OR through `loadFoldedReview`; it is pinned below as a pure
+  // arm, with the parser guard that makes it unreachable pinned beside it. The credit
+  // legs are a different story: a removal naming a tier the position holds no lots in
+  // is parse-legal (`parse.ts` requires only a positive quantity) and only the
+  // cross-ref sufficiency gate stops it — a gate `loadFoldedReview` does not run, since
+  // it calls `foldEvents` on the durable log directly. That is the migration-shaped
+  // route the conservation tests below use.
 
-  /** Genesis holding one funded reserve and no positions. */
-  function reserveGenesis(): FundReviewData {
+  const DISCARD_GENESIS_RESERVE = 1000;
+
+  /** Genesis with one funded USD reserve and one all-c1 BTC position (3 @ 100). */
+  function trimmableGenesis(): FundReviewData {
     const genesis = emptyGenesis();
     genesis.reserves = [
       {
@@ -926,30 +947,47 @@ describe("tier-weighted deltas — a lot-less cash leg is DISCARDED, not attribu
         executionMode: "live",
         accountId: "binance-usd",
         currency: "USD",
-        amount: 1000,
+        amount: DISCARD_GENESIS_RESERVE,
       },
     ];
-    return genesis;
-  }
-
-  /** A PositionOpened carrying no lots at all — the only shape that reaches the arm. */
-  function lotlessOpen(reserveId: string): PositionOpenedEvent {
-    return opened(
-      "evt-lotless-open",
-      "2026-06-02",
+    genesis.positions = [
       {
-        id: "ghost-core",
+        id: "btc-core",
         portfolioId: "core",
         tempo: "Capital",
         executionMode: "live",
         accountId: "binance-usd",
         instrumentId: "btc-usd",
         direction: "long",
+        markPrice: 120,
         currency: "USD",
-        lots: [],
+        lots: [{ quantity: 3, cost: 100, tier: "c1" }],
       },
-      { reserveId, amount: 400 },
-    );
+    ];
+    return genesis;
+  }
+
+  /** A trim whose removals name `tier`; `c2` on the genesis above removes nothing. */
+  function trimmed(
+    id: string,
+    asOf: string,
+    tier: "c1" | "c2" | "c3",
+    quantity: number,
+    settlement: { reserveId: string; proceeds: number },
+  ): PositionTrimmedEvent {
+    return {
+      id,
+      asOf,
+      type: "PositionTrimmed",
+      positionId: "btc-core",
+      removals: [{ tier, quantity }],
+      settlement,
+    };
+  }
+
+  /** Total realized P&L on the closed book — the figure a partial discard inflates. */
+  function realizedPnl(folded: ReturnType<typeof foldEvents>): number {
+    return (folded.data.closedPositions ?? []).reduce((sum, row) => sum + row.realizedPnlUsd, 0);
   }
 
   it("returns an empty delta list for empty lots on both legs", () => {
@@ -957,10 +995,137 @@ describe("tier-weighted deltas — a lot-less cash leg is DISCARDED, not attribu
     expect(reserveDeltasForClose([], 250)).toEqual([]);
   });
 
-  it("records one provenance-absent skip AND leaves the reserve balance untouched", () => {
-    // Both halves matter. The skip record alone would stay green while the phantom c1
-    // debit still ran; the balance alone would not prove the drop was reported.
-    const folded = foldEvents(reserveGenesis(), [lotlessOpen("desk-usd")]);
+  it("discards a trim naming a tier the position holds no lots in — nothing applies", () => {
+    // THE REACHABLE PRODUCER. `splitTierRemoval` returns `removed: []` when the named
+    // tier's total quantity is zero, so the proceeds have no provenance to inherit.
+    // Every clause here is a distinct way the old partial discard leaked: the row
+    // booked P&L, the mutation retired the asset, the reserve stayed flat while both
+    // happened.
+    const folded = foldEvents(trimmableGenesis(), [
+      trimmed("evt-trim-empty-tier", "2026-06-03", "c2", 1, {
+        reserveId: "desk-usd",
+        proceeds: 130,
+      }),
+    ]);
+
+    expect(folded.skipped).toEqual([
+      {
+        eventId: "evt-trim-empty-tier",
+        index: 0,
+        verb: "PositionTrimmed",
+        reason: "provenance-absent",
+        detail: expect.any(String),
+      },
+    ]);
+    // No partial row, so no realized P&L moved.
+    expect(folded.data.closedPositions ?? []).toEqual([]);
+    expect(realizedPnl(folded)).toBe(0);
+    // The asset leg is untouched: same position, same lots, not retired.
+    expect(folded.data.positions).toHaveLength(1);
+    expect(folded.data.positions[0]!.id).toBe("btc-core");
+    expect(folded.data.positions[0]!.lots).toEqual([{ quantity: 3, cost: 100, tier: "c1" }]);
+    // And the reserve never moved.
+    expect(folded.data.reserves[0]!.amount).toBe(DISCARD_GENESIS_RESERVE);
+  });
+
+  it("discards a close of a position a trim already emptied — the position stays open", () => {
+    // The same door, one verb along: a full-quantity trim is rejected at ingest but is
+    // parse-legal, so a durable log can hold one. It leaves the position open with no
+    // lots, and the close that follows has no provenance for its proceeds. The trim
+    // itself applies in full — it is the BASELINE the close must not move.
+    const applyingTrim = trimmed("evt-trim-all", "2026-06-03", "c1", 3, {
+      reserveId: "desk-usd",
+      proceeds: 360,
+    });
+    const baseline = foldEvents(trimmableGenesis(), [applyingTrim]);
+    expect(baseline.skipped).toEqual([]);
+    expect(baseline.data.reserves[0]!.amount).toBe(DISCARD_GENESIS_RESERVE + 360);
+    expect(realizedPnl(baseline)).toBe(60); // 360 proceeds − 300 cost basis
+    expect(baseline.data.positions[0]!.lots).toEqual([]);
+
+    const folded = foldEvents(trimmableGenesis(), [
+      applyingTrim,
+      closed("evt-close-lotless", "2026-06-04", "btc-core", {
+        reserveId: "desk-usd",
+        proceeds: 500,
+      }),
+    ]);
+
+    expect(folded.skipped).toEqual([
+      {
+        eventId: "evt-close-lotless",
+        index: 1,
+        verb: "PositionClosed",
+        reason: "provenance-absent",
+        detail: expect.any(String),
+      },
+    ]);
+    // Exactly the trim's own row — the close booked nothing. Under the partial discard
+    // this was two rows and 560 of realized P&L against a reserve that never saw the
+    // second 500.
+    expect(folded.data.closedPositions ?? []).toHaveLength(1);
+    expect(realizedPnl(folded)).toBe(60);
+    expect(folded.data.reserves[0]!.amount).toBe(DISCARD_GENESIS_RESERVE + 360);
+    // Not retired: `positions.delete` never ran.
+    expect(folded.data.positions.map((position) => position.id)).toEqual(["btc-core"]);
+  });
+
+  it("reports provenance-absent and NOT reserve-absent when the reserve is also missing", () => {
+    // Precedence is a decision: there is nothing to apply, so whether the reserve
+    // exists is moot, and a reserve miss that never happened must not be reported.
+    // One event, one finding, on this path.
+    const folded = foldEvents(trimmableGenesis(), [
+      trimmed("evt-trim-empty-tier", "2026-06-03", "c2", 1, {
+        reserveId: "no-such-reserve",
+        proceeds: 130,
+      }),
+    ]);
+
+    expect(folded.skipped).toHaveLength(1);
+    expect(folded.skipped[0]!.reason).toBe("provenance-absent");
+  });
+
+  it("keeps the new reason's prose free of figures and of event content", () => {
+    const folded = foldEvents(trimmableGenesis(), [
+      trimmed("evt-trim-empty-tier", "2026-06-03", "c2", 1, {
+        reserveId: "desk-usd",
+        proceeds: 130,
+      }),
+    ]);
+
+    const skip = folded.skipped[0]!;
+    expect(skip.reason).toBe("provenance-absent");
+    expect(skip.detail).not.toMatch(/\d/); // no figure of any kind
+    expect(skip.detail).not.toContain(skip.verb); // the verb has its own field
+    expect(skip.detail).not.toContain(skip.eventId);
+    expect(skip.detail).not.toContain("desk-usd");
+    expect(skip.detail).not.toContain("btc-core");
+    expect(skip.detail.length).toBeGreaterThan(0);
+  });
+
+  it("discards a lot-less open whole — no position, no anchor, no debit", () => {
+    // `foldEvents` is exported and pure, so the open arm must be internally consistent
+    // even though nothing in production can hand it this event (see the parser pin
+    // below). Registering the ghost while dropping its funding debit would put a
+    // position on the read model that no reserve paid for.
+    const folded = foldEvents(trimmableGenesis(), [
+      opened(
+        "evt-lotless-open",
+        "2026-06-02",
+        {
+          id: "ghost-core",
+          portfolioId: "core",
+          tempo: "Capital",
+          executionMode: "live",
+          accountId: "binance-usd",
+          instrumentId: "aapl-usd",
+          direction: "long",
+          currency: "USD",
+          lots: [],
+        },
+        { reserveId: "desk-usd", amount: 400 },
+      ),
+    ]);
 
     expect(folded.skipped).toEqual([
       {
@@ -971,30 +1136,41 @@ describe("tier-weighted deltas — a lot-less cash leg is DISCARDED, not attribu
         detail: expect.any(String),
       },
     ]);
-    expect(folded.data.reserves).toHaveLength(1);
-    expect(folded.data.reserves[0]!.amount).toBe(1000);
+    expect(folded.data.positions.map((position) => position.id)).toEqual(["btc-core"]);
+    expect(folded.data.reserves[0]!.amount).toBe(DISCARD_GENESIS_RESERVE);
+    // No entry-price anchor was seeded for the instrument the ghost named.
+    expect((folded.data.closes ?? []).some((close) => close.instrumentId === "aapl-usd")).toBe(
+      false,
+    );
   });
 
-  it("keeps the new reason's prose free of figures and of event content", () => {
-    const folded = foldEvents(reserveGenesis(), [lotlessOpen("desk-usd")]);
+  it("cannot arrive through ingest: the parser rejects an open with no lots", () => {
+    // WHAT THIS BUYS. It is the reason the test above pins an arm no production route
+    // reaches, and it is the tripwire on that claim: the durable log is parsed on load,
+    // so relaxing `parseLots` would make the lot-less open a LIVE route into the fold
+    // and this test reddens to say so. Everything else in the fixture is valid, so the
+    // empty `lots` is the only thing under test.
+    const result = parseEvent({
+      schemaVersion: EVENT_SCHEMA_VERSION,
+      id: "evt-lotless-open",
+      asOf: "2026-06-02",
+      type: "PositionOpened",
+      position: {
+        id: "ghost-core",
+        portfolioId: "core",
+        tempo: "Capital",
+        executionMode: "live",
+        accountId: "binance-usd",
+        instrumentId: "aapl-usd",
+        direction: "long",
+        currency: "USD",
+        lots: [],
+      },
+      decision: DECISION,
+      funding: { reserveId: "desk-usd", amount: 400 },
+    });
 
-    const skip = folded.skipped[0]!;
-    expect(skip.reason).toBe("provenance-absent");
-    expect(skip.detail).not.toMatch(/\d/); // no figure of any kind
-    expect(skip.detail).not.toContain(skip.verb); // the verb has its own field
-    expect(skip.detail).not.toContain(skip.eventId);
-    expect(skip.detail).not.toContain("desk-usd");
-    expect(skip.detail).not.toContain("ghost-core");
-    expect(skip.detail.length).toBeGreaterThan(0);
-  });
-
-  it("reports provenance-absent and NOT reserve-absent when the reserve is also missing", () => {
-    // Precedence is a decision: there is nothing to apply, so whether the reserve
-    // exists is moot, and a reserve miss that never happened must not be reported.
-    // One event, one finding, on this path.
-    const folded = foldEvents(reserveGenesis(), [lotlessOpen("no-such-reserve")]);
-
-    expect(folded.skipped).toHaveLength(1);
-    expect(folded.skipped[0]!.reason).toBe("provenance-absent");
+    expect(result.kind).toBe("event-error");
+    expect(result).toMatchObject({ path: "position.lots" });
   });
 });

--- a/packages/engine/src/fold.test.ts
+++ b/packages/engine/src/fold.test.ts
@@ -906,3 +906,95 @@ describe("tier-weighted deltas — the zero-cost arm attributes in canonical Tie
     ]);
   });
 });
+
+describe("tier-weighted deltas — a lot-less cash leg is DISCARDED, not attributed (#329)", () => {
+  // Any lot at all puts a key in `costByTier`, so "no Tier is present" is reachable
+  // ONLY when the lots array is empty. The old code returned a full-magnitude delta on
+  // the `?? "c1"` fallback — it MINTED c1 capital for a cash movement carrying no
+  // provenance whatsoever, and `applyReserveDelta` booked it as real. That is not a bad
+  // attribution, it is an invented one. An empty delta list is the discard; the fold
+  // records it on ADR-020's Discard Channel as `provenance-absent`.
+
+  /** Genesis holding one funded reserve and no positions. */
+  function reserveGenesis(): FundReviewData {
+    const genesis = emptyGenesis();
+    genesis.reserves = [
+      {
+        id: "desk-usd",
+        portfolioId: "core",
+        tempo: "Reserve",
+        executionMode: "live",
+        accountId: "binance-usd",
+        currency: "USD",
+        amount: 1000,
+      },
+    ];
+    return genesis;
+  }
+
+  /** A PositionOpened carrying no lots at all — the only shape that reaches the arm. */
+  function lotlessOpen(reserveId: string): PositionOpenedEvent {
+    return opened(
+      "evt-lotless-open",
+      "2026-06-02",
+      {
+        id: "ghost-core",
+        portfolioId: "core",
+        tempo: "Capital",
+        executionMode: "live",
+        accountId: "binance-usd",
+        instrumentId: "btc-usd",
+        direction: "long",
+        currency: "USD",
+        lots: [],
+      },
+      { reserveId, amount: 400 },
+    );
+  }
+
+  it("returns an empty delta list for empty lots on both legs", () => {
+    expect(reserveDeltasForOpen([], 400)).toEqual([]);
+    expect(reserveDeltasForClose([], 250)).toEqual([]);
+  });
+
+  it("records one provenance-absent skip AND leaves the reserve balance untouched", () => {
+    // Both halves matter. The skip record alone would stay green while the phantom c1
+    // debit still ran; the balance alone would not prove the drop was reported.
+    const folded = foldEvents(reserveGenesis(), [lotlessOpen("desk-usd")]);
+
+    expect(folded.skipped).toEqual([
+      {
+        eventId: "evt-lotless-open",
+        index: 0,
+        verb: "PositionOpened",
+        reason: "provenance-absent",
+        detail: expect.any(String),
+      },
+    ]);
+    expect(folded.data.reserves).toHaveLength(1);
+    expect(folded.data.reserves[0]!.amount).toBe(1000);
+  });
+
+  it("keeps the new reason's prose free of figures and of event content", () => {
+    const folded = foldEvents(reserveGenesis(), [lotlessOpen("desk-usd")]);
+
+    const skip = folded.skipped[0]!;
+    expect(skip.reason).toBe("provenance-absent");
+    expect(skip.detail).not.toMatch(/\d/); // no figure of any kind
+    expect(skip.detail).not.toContain(skip.verb); // the verb has its own field
+    expect(skip.detail).not.toContain(skip.eventId);
+    expect(skip.detail).not.toContain("desk-usd");
+    expect(skip.detail).not.toContain("ghost-core");
+    expect(skip.detail.length).toBeGreaterThan(0);
+  });
+
+  it("reports provenance-absent and NOT reserve-absent when the reserve is also missing", () => {
+    // Precedence is a decision: there is nothing to apply, so whether the reserve
+    // exists is moot, and a reserve miss that never happened must not be reported.
+    // One event, one finding, on this path.
+    const folded = foldEvents(reserveGenesis(), [lotlessOpen("no-such-reserve")]);
+
+    expect(folded.skipped).toHaveLength(1);
+    expect(folded.skipped[0]!.reason).toBe("provenance-absent");
+  });
+});

--- a/packages/engine/src/fold.test.ts
+++ b/packages/engine/src/fold.test.ts
@@ -831,23 +831,29 @@ describe("foldEvents — the seed is never mutated (defensive clone)", () => {
   });
 });
 
-describe("tier-weighted deltas — the zero-cost degenerate fallback (pinned, not endorsed)", () => {
-  // PIN OF A DEGENERATE FALLBACK. `tierWeightedDeltas` normally splits a cash
-  // delta across the lots' Tiers by cost-basis weight, but when the lots carry no
-  // cost at all (`totalCost === 0`) there is no weight to split by, and it
-  // attributes the WHOLE delta to `lots[0].tier` — the FIRST LOT'S tier, not the
-  // first Tier in c1/c2/c3 order, and not a split. Coverage rationale §5 names
-  // this arm (`events/fold.ts:47-48`) as an open, reachable branch.
+describe("tier-weighted deltas — the zero-cost arm attributes in canonical Tier order (#329)", () => {
+  // RULED BEHAVIOUR, NOT A PIN. `tierWeightedDeltas` normally splits a cash delta
+  // across the lots' Tiers by cost-basis weight, but when the lots carry no cost
+  // at all (`totalCost === 0`) there is no weight to split by. It attributes the
+  // WHOLE delta to the canonically FIRST Tier that holds a lot — `present[0]`, in
+  // c1/c2/c3 order — never to `lots[0].tier`.
   //
-  // These tests record what the code does today so the behavior cannot change
-  // silently; they are not an argument that attributing everything to one lot's
-  // Tier is the right answer.
+  // WHY ORDER, NOT INSERTION. Keying on `lots[0]` made the answer depend on array
+  // order, so two callers holding the same position with the same lots ordered
+  // differently credited different Tiers. Nothing else in the function behaves
+  // that way: the proportional path iterates `present`, which is already
+  // canonical. `present[0]` is order-independent, and it degenerates to the old
+  // answer whenever exactly one Tier holds lots — the common shape.
+  //
+  // WHY NOT AN EVEN SPLIT across `present`: with every cost weight zero there is
+  // no cost-basis weight to split by, and an even split would invent a weighting
+  // the data does not carry (and drag in residual handling).
 
-  it("attributes the whole close credit to the FIRST lot's Tier when every lot has zero cost", () => {
+  it("attributes the whole close credit to the canonically first present Tier when every lot has zero cost", () => {
     // Zero-cost lots across two Tiers, deliberately ordered c3-then-c1 so the
-    // answer distinguishes "the first lot's tier" (c3) from "the first Tier
-    // present in c1/c2/c3 order" (c1) — and from any proportional split, which
-    // would have to divide by a zero total cost.
+    // answer distinguishes "the first Tier present in c1/c2/c3 order" (c1) from
+    // "the first lot's tier" (c3) — and from any proportional split, which would
+    // have to divide by a zero total cost.
     const zeroCostLots: PositionLot[] = [
       { quantity: 4, cost: 0, tier: "c3" },
       { quantity: 6, cost: 0, tier: "c1" },
@@ -855,7 +861,7 @@ describe("tier-weighted deltas — the zero-cost degenerate fallback (pinned, no
 
     const deltas = reserveDeltasForClose(zeroCostLots, 250);
 
-    expect(deltas).toEqual([{ tier: "c3", amount: 250 }]);
+    expect(deltas).toEqual([{ tier: "c1", amount: 250 }]);
   });
 
   it("debits the same single Tier on the open leg, sign-flipped", () => {
@@ -864,7 +870,23 @@ describe("tier-weighted deltas — the zero-cost degenerate fallback (pinned, no
       { quantity: 1, cost: 0, tier: "c1" },
     ];
 
-    expect(reserveDeltasForOpen(zeroCostLots, 80)).toEqual([{ tier: "c2", amount: -80 }]);
+    expect(reserveDeltasForOpen(zeroCostLots, 80)).toEqual([{ tier: "c1", amount: -80 }]);
+  });
+
+  it("returns the identical delta list however the same zero-cost lots are ordered", () => {
+    // The defect stated as a property: attribution must be a function of WHICH
+    // Tiers hold lots, not of the order the caller happened to build the array in.
+    const c3First: PositionLot[] = [
+      { quantity: 4, cost: 0, tier: "c3" },
+      { quantity: 6, cost: 0, tier: "c2" },
+    ];
+    const c2First: PositionLot[] = [
+      { quantity: 6, cost: 0, tier: "c2" },
+      { quantity: 4, cost: 0, tier: "c3" },
+    ];
+
+    expect(reserveDeltasForClose(c3First, 250)).toEqual(reserveDeltasForClose(c2First, 250));
+    expect(reserveDeltasForOpen(c3First, 80)).toEqual(reserveDeltasForOpen(c2First, 80));
   });
 
   it("splits proportionally the moment ANY lot carries cost — the fallback is the exception", () => {


### PR DESCRIPTION
`tierWeightedDeltas` had one degenerate fallback covering two conditions that are wrong in different ways. This splits them and fixes each on its own terms.

Closes #329.

Three commits: the two original slices, then a third that makes the discard **total** after review found the second slice was losing real money. The third commit is the important one — the story of this PR is in it, not around it.

## The two arms

```ts
const present = TIERS.filter((tier) => costByTier.has(tier));
if (present.length === 0 || totalCost === 0) {
  return [{ tier: lots[0]?.tier ?? "c1", amount: sign * total }];
}
```

**`totalCost === 0` — lots exist, all free.** The whole delta went to `lots[0].tier`: **array insertion order**. Two callers holding the same position with the same lots ordered differently credited different tiers. Nothing else in this file behaves that way — the proportional path iterates `present`, which is already canonical. It now attributes to `present[0]`, the canonically first Tier holding a lot.

An even split across `present` was considered and rejected: with every cost weight zero there is no cost-basis weight to split by, so an even split would invent a weighting the data does not carry. `present[0]` is order-independent — which is exactly the defect being cured — and it degenerates to the old answer whenever one Tier holds the lots, the common shape.

**`present.length === 0` — no lots at all.** Any lot puts a key in `costByTier`, so this arm is reachable **only when `lots` is empty**, which means `lots[0]?.tier ?? "c1"` **always** resolved to the `?? "c1"` fallback. It minted a full-magnitude `c1` delta for a cash movement with no provenance whatsoever, and `applyToReserve` booked it as real c1 capital. That is not a bad attribution; it is an invented one. It is now a **discard**.

## The discard is TOTAL — and the first attempt at it was worse than the bug

The first version of this change dropped only the *cash leg* and let the rest of the arm run. Review caught it, and it was a genuine regression rather than a rough edge.

On `PositionClosed`, that shape recorded the skip and then still pushed a closed-book row carrying the full `settlement.proceeds` and still ran `positions.delete`. On `PositionTrimmed`, it still pushed the partial row and still mutated `trimming.lots`. **Realized P&L rose by the full proceeds while no reserve was ever credited** — the cash simply vanished. The invented-`c1` row this PR removes was wrong, but it at least *conserved the money*; a partial discard does not.

The file already forbade this in its own words. From the R8 comment inside the close arm:

> either the close applies IN FULL (cash leg, closed-book row, retirement) or it is recorded as discarded and NOTHING happens … the code would announce the drop and then act on its behalf.

That sentence was written to forbid precisely the shape the first attempt introduced. So the discard is now total: **no closed-book row, no retirement, no lot mutation, no registration.** `applyTieredLeg` returns a boolean — *may the rest of this event run?* — and each lot-derived arm `break`s on `false`.

This is deliberately the **same** semantics as the `position-absent` `else` branches already in these arms, which discard the whole event too. One discard concept, not two.

**The trade, stated plainly:** a lot-less close now leaves the position **open** rather than retiring it. That is the point. Compare the two failure modes — the old behaviour retired the position, credited full proceeds to realized P&L, and credited no reserve, *invisibly*; the new one leaves a position visibly open with a discard record naming exactly why. **Loud and inspectable beats silent and balanced-looking.**

## The discard goes through ADR-020's existing channel

`foldEvents` already returns `{data, skipped}` with `SkippedFoldEvent`, `SKIP_DETAIL` and `dedupeFoldSkips`. `tierWeightedDeltas` returns `[]`; the arm records the drop with the event's own locator and applies nothing. No new mechanism, and the `(eventId, reason)` dedupe key needed no change.

The four lot-derived call sites route through one `applyTieredLeg` closure. The four explicit-tier legs (Deposit, Withdraw, both Transfer legs) deliberately keep calling `applyToReserve` directly: their tiers come from the event itself rather than from lots, so they have no provenance that could be missing.

`PositionAddedTo` is the fourth lot-derived site and its discard branch is **unreachable** — `[event.lot]` is a one-element array literal, so the empty list cannot occur. It stays routed anyway, with the unreachability stated in code and the return deliberately ignored, because it *is* a lot-derived leg by kind: moving it to the explicit-tier path would silently lose the provenance check the day that site learns to add more than one lot.

### Why a new reason and not `reserve-absent`

The vocabulary was closed at `position-absent` / `reserve-absent`. This is a third kind, and it joins as **`provenance-absent`**.

Mapping it onto `reserve-absent` was the alternative and it was rejected as **dishonest, not merely coarse**. That reason's pinned prose reads *"The fold has no record of the reserve this event's cash leg names"* — which on this path is **a false statement**. The reserve exists and was found. What is missing is the cost-basis provenance the cash leg would inherit. A discard channel whose whole value is that it is stable and quotable cannot afford a notice that lies.

The same standard applies to the new member's own prose, and it is why the total discard matters beyond correctness: `provenance-absent`'s detail ends *"No balance moved."* Under the partial discard that sentence was **false** on the close and trim arms. It is true now.

**Precedence is a decision, not an accident:** when a leg has no lots, `provenance-absent` wins and the reserve is never consulted. There is nothing to apply, so whether the reserve exists is moot; also recording `reserve-absent` would report a miss that never happened. One event, one finding, and it is tested.

## The #299 pin was inverted, not preserved

`fold.test.ts` carried a pin that deliberately froze the old insertion-order behaviour so it could not change silently. It is **designed to go red on this fix**, and it did. It is inverted in the same change: both fixtures now expect `c1`, and the describe no longer reads "pinned, not endorsed" — it states the ruled behaviour and why.

The fixtures' deliberate c3-then-c1 and c2-then-c1 orderings are kept, because that ordering is what lets the test tell canonical order from insertion order. A new test turns the defect into a property: the same zero-cost lots in two array orders must produce the identical delta list.

## Where this can actually fire — corrected twice

The original reachability analysis in this PR was **wrong, and then wrong again after the first correction.** Both versions are worth recording, because the conclusion moved each time.

It first claimed the ingest gate admits a lot-less funding leg the fold discards, citing `crossref.ts:1354` and `:1480`. Then it narrowed to *"only `:1480` is reachable"*, since `:1354` passes `[event.lot]`.

**Neither is reachable.** Both call sites run *after* `parseEvent` — `crossref.ts:621` calls itself the *"Second ingest gate (after `parseEvent`)"*, and `crossReferenceOpen` takes an already-parsed `PositionOpenedEvent`. `parseLots` (`parse.ts:526-528`) rejects an empty `position.lots` outright. So no parsed `PositionOpened` can carry zero lots, and no sufficiency check is ever skipped. There is no guard that stopped guarding.

The one route that survives is a **`PositionTrimmed` whose removals name tiers the position holds no lots in** — `splitTierRemoval` returns `removed: []` when `tierTotal === 0` (`fold.ts:933`). That is also gate-closed (`parse.ts:569` requires a positive quantity, `crossref.ts:1245` rejects on sufficiency), so it is reachable **only** through callers that fold the durable log directly, bypassing both gates: `loadFoldedReview` at `packages/event-store/src/event-store.ts:225` calls `foldEvents` with no parse and no crossref.

**So: migration-shaped and historical, not user-injectable through ingest today.** That bounds the blast radius honestly without pretending the arm is dead — it is exactly why this ships as a recorded discard rather than as deleted code.

Issue #367 was filed on the original false premise and has been **corrected in the open**, with the retraction kept as a comment rather than edited away. It now asks the residual question, which is not about this arm at all: ingest-time validation does not constrain what the durable log already contains.

## Why this is landable without a replay

Two separate measurements, each licensing a different arm. They are **not** one figure.

- **`totalCost === 0`:** zero lots with `cost === 0` across the live ledger — 465 events plus 19 genesis lots, every cost nonzero.
- **`present.length === 0`:** zero calls into `tierWeightedDeltas` with an empty `lots` array, across a full replay of all 465 events.

The second one needed its own measurement because its precondition — no lots at all — never appears in the JSON, so no grep over event shapes could have answered it. Both arms are unreachable on real data today and **this change moves no real balance.**

The roadmap cites 452 events; the correct current figure is **465**. The log grew, the conclusion did not.

**How thin the live evidence is, stated deliberately.** Only 2 events in the whole ledger reach `tierWeightedDeltas` at all, and there is not one `PositionOpened`, `LotAdded` or `PositionTrimmed` event in the log — three of the four lot-derived call sites have never fired on real data. That strengthens the "no balance moves" claim and equally weakens real-data measurement as evidence about future behaviour. The change stands on its reasoning; the measurement bounds today's blast radius, not tomorrow's.

## What the blotter does now

An earlier draft of this body claimed `byTier` could now under-sum `totalRealizedPnlUsd`, because a lot-less close would land in `rows`, `byTempo` and the total but not in `byTier`. **That is no longer true, and the reason is the total discard:** a discarded close produces no row at all, so nothing lands anywhere and every blotter identity still balances. The under-sum was an artifact of the partial discard, and it went away with it.

What a reader should expect instead: a discarded close or trim leaves the position **open**, contributes nothing to the closed book, and appears in `skipped` as `provenance-absent`. `discardedEventCount` is the one live surfaced change.

## This PR knowingly leaves the discard vocabulary split

Making the provenance discard total exposes that **`reserve-absent` has the same partial-discard shape**, and always has. When the settlement reserve is missing, the close arm records the skip and then still pushes the row and still deletes the position — realized P&L rises with no reserve credited, which is the exact failure this PR just fixed, arrived at through a different miss.

**The inconsistency is a sharper problem than the defect**, and it is the reason this is called out rather than left to be discovered. `FoldSkipReason` is a deliberately closed vocabulary — `contracts.ts` says widening it is a spec change, not a build decision. After this PR it has three members and **two different meanings of "discarded"**:

| reason | what the fold does |
|---|---|
| `position-absent` | records the skip, applies nothing |
| `provenance-absent` | records the skip, applies nothing |
| `reserve-absent` | records the skip, **then pushes the row and deletes the position** |

Nothing in the type, the prose, or `SKIP_DETAIL` tells a reader which is which — the distinction lives only in the shape of the call sites. So the next person to add a reason code will inherit one of the two behaviours by whichever site they read first, without knowing a choice was being made. It shows up in the prose too: both members end *"No balance moved."*, and this PR made that true for `provenance-absent` while it remains **false** for `reserve-absent` on the close arm.

**Left unfixed deliberately.** It is pre-existing on `main`, outside #329's scope, and unreachable through ingest for the same reason the rest is (the cross-ref existence gate rejects an unknown reserve first). Fixing it here would widen a PR that has already reversed one premise mid-flight and retracted another. It is documented in the helper's docstring as *inherited rather than chosen*, so the next reader does not mistake it for a decision made here, and it is filed as **#371** — flagged, not smuggled in.

## What did *not* need changing, and why that is load-bearing

There is **no reason→label map anywhere** in the TUI or web discard surfaces — every consumer renders `reason` and `detail` straight off the record. A third vocabulary member therefore reaches every surface with **no code change**, which is why widening the union showed up nowhere in the full suite. That is a property of the ADR-020 design worth stating, not a gap in the search.

One thing it does **not** cover: the existing prose pin in `fold-discard-channel.test.ts:161-169` loops only over the skips its own fixture produces, so it never reaches `provenance-absent`. This PR writes a **separate** prose pin rather than assuming inherited coverage. If anyone later consolidates the two, the new member's prose silently falls out of every pin — so consolidate only by making the loop enumerate the union.

## Tests

Every test added or inverted here was **made to fail on purpose before being trusted** — mutation named, applied, red observed, restored. This board has already shipped two decorative guards that stayed green on the exact regression they existed to catch, and the first version of this PR nearly shipped a third: its four discard tests all pinned a lot-less *open*, a shape `parseLots` forbids, so they exercised an unreachable route while the reachable one went untested. The tests are now re-pointed at the trim route that can actually occur, and driven through `foldEvents` directly — the same door `loadFoldedReview` uses.

The discrimination matters as much as the red. Each mutation below was re-run independently rather than taken on report:

- **Restoring the old invented-`c1` return** reds **all six** discard tests and leaves **all four** zero-cost tests green. The two arms are independently guarded.
- **Recording the skip and letting the arm continue** — the partial discard this PR's third commit fixes — reds **exactly three** tests: the trim conservation test, the emptied-close test, and the lot-less-open test. The precedence and prose tests stay green under it, because they only read the skip record; the conservation tests are what guard the defect.
- **Swapping the two checks in `applyTieredLeg`** reds **only** the precedence test — 1 failed, 41 passed — so that test discriminates rather than duplicating its neighbours.

The parser-shape test earns its place as a tripwire, not a duplicate: it pins that `parseEvent` rejects `lots: []`, which is *the reason* the lot-less open is unreachable. If someone relaxes `parseLots`, that route goes live and this test reddens to say so.

## Suite

Full suite: **2287 passed, 48 skipped, 2 failed.**

One further observation, recorded rather than tidied away: an earlier full-suite run showed a **third** failure, `apps/price-feed/src/schedule-window.test.ts > the launchd fetch window > refuses a mark hour that is not an hour`. It passes 15/15 in isolation and did not reproduce on a second full run. It shells out to a real wrapper script, so parallel contention is the likely mechanism, and this PR's diff is confined to the engine's fold, which that assertion never reaches. Called a **flake, not a pass**, and filed as **#372** so the next lane in that harness has a prior observation to check against.

Both standing failures are in `ops/testkit/gitignored-path-globs.test.ts` — *"still excludes agent worktrees under .claude/ — the bug this closed"* and *"reaches nested .gitignore files, anchored to their own directory"* — and are **not from this change.** That guard derives its globs from `git ls-files --others --ignored`, which lists only ignored paths that exist on disk, so any fresh linked worktree fails them while the main checkout passes 8/8. Pre-existing from #362 and owned by #368, which merges ahead of this one. Nothing in `ops/` is modified here, and every other test in the repo passes.
