### PR TITLE
Make the discovery guard environment-independent: an authored fixture, not live repo state

### DIFF
--- a/ops/testkit/gitignored-path-globs.test.ts
+++ b/ops/testkit/gitignored-path-globs.test.ts
@@ -41,7 +41,13 @@
  * that hold in BOTH the main checkout and a fresh worktree.
  */
 import { execFileSync } from "node:child_process";
-import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import {
+  mkdirSync,
+  mkdtempSync,
+  readFileSync,
+  rmSync,
+  writeFileSync,
+} from "node:fs";
 import { tmpdir } from "node:os";
 import { dirname, join } from "node:path";
 
@@ -55,7 +61,7 @@ import {
   globForIgnoredEntry,
   globsForIgnoredEntries,
 } from "./gitignored-path-globs.ts";
-import { repoFiles } from "./repo-sources.testkit.js";
+import { REPO_ROOT, repoFiles } from "./repo-sources.testkit.js";
 
 /** Whether `path` (repo-root-relative, POSIX) is matched by any of `globs`. */
 function matchesAny(globs: readonly string[], path: string): boolean {
@@ -95,18 +101,63 @@ describe("test discovery", () => {
    * `gitignoredPathGlobs()` returning `[]` would make every other assertion here
    * pass while the original bug came straight back.
    *
-   * WHY THIS LAYER IS ONLY TWO ASSERTIONS WIDE. Anything more specific about the
-   * live repo is a claim about WHICH CHECKOUT the suite is running in.
-   * `node_modules/` is the one ignored directory that exists in the main checkout
-   * and in every linked worktree alike, so it is the only named path this layer
-   * may mention. Everything about the derivation's behaviour — nested
-   * `.gitignore` files, anchoring, escaping, empty directories, and the
+   * WHY NON-EMPTINESS IS THE STRONGEST CLAIM AVAILABLE HERE, AND WHY NO PATH IS
+   * NAMED. An earlier version also asserted `toContain("node_modules/**")`, which
+   * is the exact class this module retires: a claim about WHICH CHECKOUT the suite
+   * is running in. A pnpm store-linked or symlinked `node_modules`, a CI cache
+   * restored outside the tree, or a `--modules-dir` install emits no such entry,
+   * and the guard goes red on completely correct code. `> 0` has none of that
+   * fragility and is still not vacuous: running vitest at all requires an install,
+   * an install puts at least one ignored directory somewhere on disk, and git
+   * reports it — so this holds in the main checkout, in a fresh linked worktree,
+   * and on a cold CI runner alike.
+   *
+   * BUT IT IS NOT THE SAME STRENGTH AS THE TRACKED-TEXT GUARD BELOW, and the
+   * difference is worth being honest about. `.gitignore`'s bytes are identical in
+   * every checkout of a commit, so reading them is environment-independent BY
+   * CONSTRUCTION. `> 0` is an empirical claim about how installs behave — very
+   * robust, not a tautology, and still the same KIND of claim as the
+   * `node_modules/**` one just deleted, only far harder to falsify. It is kept
+   * because the no-op direction genuinely needs a pin and nothing stronger is
+   * available at this layer; if it ever goes red on correct code, delete it rather
+   * than weaken it, because the fixture below is what actually guards the
+   * behaviour. Everything about the derivation's BEHAVIOUR —
+   * nested `.gitignore` files, anchoring, escaping, empty directories, and the
    * deliberate silence about ignored paths that are not on disk — is asserted
    * against the authored fixture repo below, where it holds on every machine.
    */
   it("contributes real globs in any checkout", () => {
     expect(contributedGlobs.length).toBeGreaterThan(0);
-    expect(contributedGlobs).toContain("node_modules/**");
+  });
+
+  /**
+   * THE ONE GUARD LEFT ON THE REAL REPO'S OWN IGNORE RULES, and it is not a
+   * relapse into the live-state class the rest of this file retires. `.gitignore`
+   * is a TRACKED file: at a given commit its bytes are identical in the main
+   * checkout, in every linked worktree, and on every CI runner. Reading its TEXT
+   * is therefore environment-independent by construction — unlike asking git what
+   * it currently ignores ON DISK, which is a fact about one working tree.
+   *
+   * WHAT BREAKS IF THIS LINE GOES AWAY. #362: agent worktrees live under
+   * `.claude/worktrees/`, so without `.claude/` in the root `.gitignore` every
+   * worktree's copy of the tree is collected a second time — the same test files
+   * discovered twice, from two paths. Moving the `.claude/` assertion into the
+   * fixture repo (where it belongs, because that is where it is exercisable in
+   * every checkout) proved the DERIVATION handles the rule, but left nothing at
+   * all watching whether this repo still declares it. Delete the line and the
+   * fixture stays green, the whole suite stays green, and #362 is simply back —
+   * green while running the wrong set of tests, which is the fail-toward-green
+   * mode this entire module exists to prevent.
+   */
+  it("still declares .claude/ in the repo's own tracked .gitignore", () => {
+    // Tracked, not merely present: if `.gitignore` ever stopped being a file git
+    // knows about, reading it off disk would be reading an untracked local file
+    // and the claim would quietly become checkout-specific again.
+    expect(repoFiles()).toContain(".gitignore");
+    const lines = readFileSync(join(REPO_ROOT, ".gitignore"), "utf8")
+      .split("\n")
+      .map((line) => line.trim());
+    expect(lines).toContain(".claude/");
   });
 });
 
@@ -118,17 +169,70 @@ describe("test discovery", () => {
  * (the nested `.gitignore`, in a worktree) or was exercised only by accident of
  * what happened to be sitting on disk.
  *
- * HERMETIC ON PURPOSE. `--exclude-standard` reads `.git/info/exclude` and the
- * user's GLOBAL `core.excludesFile` as well as the repo's `.gitignore` files, so
- * a fixture that did not neutralise both would assert something different on a
- * machine whose owner globally ignores, say, `coverage/`. The repo-local
- * `core.excludesFile` override points at an empty file inside `.git/`, and
- * `.git/info/exclude` is truncated. No commit is made — `--others --ignored`
- * reads the working tree — but the non-ignored files ARE staged, for the reason
- * recorded at the `git add -A` below.
+ * HERMETIC ON PURPOSE, ON TWO AXES. `--exclude-standard` reads `.git/info/exclude`
+ * and the user's GLOBAL `core.excludesFile` as well as the repo's `.gitignore`
+ * files, so a fixture that did not neutralise them would assert something
+ * different on a machine whose owner globally ignores, say, `coverage/`. That is
+ * the CONFIG axis: the repo-local `core.excludesFile` override points at an empty
+ * file inside `.git/`, and `.git/info/exclude` is truncated.
+ *
+ * The second axis is the ENVIRONMENT, and it is the dangerous one. Every git
+ * process here — the fixture's own `git()` helper and the `gitignoredPathGlobs()`
+ * call under test — would otherwise inherit `process.env`. `GIT_DIR`,
+ * `GIT_WORK_TREE` and `GIT_INDEX_FILE` outrank both `-C` and `cwd`, so under
+ * `git bisect run pnpm test`, or inside a hook, or in any wrapper that exports
+ * them, this fixture's `git add -A` would stage the developer's REAL working tree.
+ * `GIT_CONFIG_COUNT`/`GIT_CONFIG_KEY_n`/`GIT_CONFIG_VALUE_n` sit ABOVE repo-local
+ * config in git's precedence order, so they beat the `core.excludesFile` override
+ * the config axis relies on, and `GIT_CONFIG_GLOBAL`/`GIT_CONFIG_SYSTEM` can point
+ * git's config lookup anywhere. So both git surfaces run under `hermeticGitEnv()`,
+ * an ALLOWLIST rather than a denylist of variables to drop — see the note there.
+ *
+ * No commit is made — `--others --ignored` reads the working tree — but the
+ * non-ignored files ARE staged, for the reason recorded at the `git add -A` below.
  */
+/**
+ * The variables a git subprocess in this file is allowed to see, and NOTHING else.
+ *
+ * AN ALLOWLIST, DELIBERATELY — the same argument the module under test makes about
+ * escaping instead of detecting. A denylist of hostile variables (`GIT_DIR`,
+ * `GIT_WORK_TREE`, `GIT_INDEX_FILE`, `GIT_CONFIG_*`, …) would be correct only for
+ * as long as the list is complete, and git's environment surface is large and
+ * growing: `GIT_COMMON_DIR`, `GIT_OBJECT_DIRECTORY`, `GIT_NAMESPACE`,
+ * `GIT_CEILING_DIRECTORIES`, `GIT_ATTR_NOSYSTEM` and more all steer discovery or
+ * config. Naming what may pass THROUGH closes the whole class at once, including
+ * variables git has not shipped yet, and its failure mode is a loud broken
+ * subprocess rather than a quietly redirected one.
+ *
+ * `HOME` is pointed inside the fixture and `GIT_CONFIG_GLOBAL`/`GIT_CONFIG_SYSTEM`
+ * at `/dev/null`, which is belt AND braces with the repo-local `core.excludesFile`
+ * override: the override alone is enough, but only while nothing above it in the
+ * precedence order is set, and this env is exactly what guarantees that.
+ */
+const GIT_ENV_PASSTHROUGH = [
+  "PATH",
+  // Windows needs these three to spawn a process at all; absent elsewhere.
+  "SystemRoot",
+  "SYSTEMROOT",
+  "COMSPEC",
+] as const;
+
+function hermeticGitEnv(home: string): NodeJS.ProcessEnv {
+  const env: NodeJS.ProcessEnv = {
+    HOME: home,
+    GIT_CONFIG_GLOBAL: "/dev/null",
+    GIT_CONFIG_SYSTEM: "/dev/null",
+  };
+  for (const name of GIT_ENV_PASSTHROUGH) {
+    const value = process.env[name];
+    if (value !== undefined) env[name] = value;
+  }
+  return env;
+}
+
 describe("gitignoredPathGlobs against an authored fixture repo", () => {
   let fixtureRoot: string;
+  let fixtureEnv: NodeJS.ProcessEnv;
   let globs: string[];
 
   /** Write one fixture file, creating its parent directories. */
@@ -140,18 +244,30 @@ describe("gitignoredPathGlobs against an authored fixture repo", () => {
 
   /** Run one git command inside the fixture, output discarded. */
   function git(...args: string[]): void {
-    execFileSync("git", ["-C", fixtureRoot, ...args], { stdio: "ignore" });
+    execFileSync("git", ["-C", fixtureRoot, ...args], {
+      stdio: "ignore",
+      env: fixtureEnv,
+    });
   }
 
   beforeAll(() => {
     fixtureRoot = mkdtempSync(join(tmpdir(), "gitignored-path-globs-"));
+    const home = join(fixtureRoot, ".git-home");
+    mkdirSync(home, { recursive: true });
+    fixtureEnv = hermeticGitEnv(home);
     git("init");
-    // Neutralise the ambient environment: an empty global excludes file, and an
-    // empty per-repo exclude. Both live inside `.git/`, so neither is itself a
-    // path `ls-files` can report.
+    // Neutralise the ambient CONFIG: an empty global excludes file, and an empty
+    // per-repo exclude. Both live inside `.git/`, so neither is itself a path
+    // `ls-files` can report. (The ambient ENVIRONMENT is neutralised by
+    // `fixtureEnv` above, which every git process here runs under.)
     writeFileSync(join(fixtureRoot, ".git", "empty-excludes"), "", "utf8");
     git("config", "core.excludesFile", join(fixtureRoot, ".git", "empty-excludes"));
-    writeFileSync(join(fixtureRoot, ".git", "info", "exclude"), "", "utf8");
+    // `init.templateDir` can produce a `.git/` with no `info/` directory at all,
+    // in which case writing straight to `info/exclude` dies ENOENT and errors
+    // every test in this describe.
+    const excludeFile = join(fixtureRoot, ".git", "info", "exclude");
+    mkdirSync(dirname(excludeFile), { recursive: true });
+    writeFileSync(excludeFile, "", "utf8");
 
     // ---- The authored layout. ------------------------------------------
     // Root ignores: two directories that exist and are wholly ignored, one that
@@ -182,11 +298,19 @@ describe("gitignoredPathGlobs against an authored fixture repo", () => {
     // so everything ignored above stays unstaged and therefore still "other".
     git("add", "-A");
 
-    globs = gitignoredPathGlobs(fixtureRoot);
+    // The env matters just as much HERE as in `git()`: `gitignoredPathGlobs`
+    // spawns its own git, and without the seam that process would inherit an
+    // ambient `GIT_DIR` and answer about a different repository entirely while
+    // looking perfectly healthy.
+    globs = gitignoredPathGlobs(fixtureRoot, { env: fixtureEnv });
   });
 
   afterAll(() => {
-    rmSync(fixtureRoot, { recursive: true, force: true });
+    // `mkdtempSync` can throw, leaving `fixtureRoot` undefined; `rmSync` would
+    // then throw ERR_INVALID_ARG_TYPE from the cleanup and bury the real cause.
+    if (fixtureRoot !== undefined) {
+      rmSync(fixtureRoot, { recursive: true, force: true });
+    }
   });
 
   it("derives exactly one anchored glob per ignored path that is on disk", () => {
@@ -256,6 +380,20 @@ describe("gitignoredPathGlobs against an authored fixture repo", () => {
     expect(matchesAny(globs, "{tmp,scratch}/note.test.ts")).toBe(true);
     expect(matchesAny(globs, "tmp/note.test.ts")).toBe(false);
     expect(matchesAny(globs, "scratch/note.test.ts")).toBe(false);
+  });
+
+  /**
+   * THE PRECONDITION ON `root`, MADE LOUD. `git ls-files` descends only from its
+   * cwd and reports relative paths, so a `root` one level down does not fail — it
+   * returns `.tanstack/**` where discovery needed `pkg/web/.tanstack/**`, a glob
+   * that reads correctly and excludes nothing. Prose alone would leave that
+   * silent, and silent-and-plausible is the exact failure this module exists to
+   * close, so the seam refuses instead.
+   */
+  it("refuses a root that is not the repository toplevel", () => {
+    expect(() =>
+      gitignoredPathGlobs(join(fixtureRoot, "pkg", "web"), { env: fixtureEnv }),
+    ).toThrow(/not a repository toplevel/);
   });
 
   /** Over-exclusion, the failure that hides itself, on an authored file list. */

--- a/ops/testkit/gitignored-path-globs.test.ts
+++ b/ops/testkit/gitignored-path-globs.test.ts
@@ -24,13 +24,34 @@
  * written by hand in this file. No expectation is seeded from real `git ls-files`
  * output: a fixture copied from the thing under test agrees with it, wrongness
  * included.
+ *
+ * AND THE DERIVATION ITSELF IS TESTED AGAINST AN AUTHORED FIXTURE REPO, NOT THIS
+ * ONE. A guard that asserts against LIVE repository state gives a different
+ * verdict in every checkout. `gitignoredPathGlobs()` reports only ignored paths
+ * that exist ON DISK, so `.claude/**`, `coverage/**` and `apps/web/.tanstack/**`
+ * are present in the main checkout and absent in a fresh linked worktree — and
+ * this file's first version duly failed two of its eight tests in every worktree,
+ * which is where this board does nearly all of its work. Worse than the false
+ * red: the nested-`.gitignore` assertion was not merely failing there, it was
+ * UNEXERCISABLE, because `apps/web/.tanstack/` cannot exist in a fresh worktree.
+ * The assertion that most needed running was the one that could never run where
+ * the work happens. So the derivation's behaviour is now pinned against a
+ * hand-built git repo in a temp directory, hermetic against the ambient
+ * environment, and the live-repo layer is kept deliberately thin — only claims
+ * that hold in BOTH the main checkout and a fresh worktree.
  */
+import { execFileSync } from "node:child_process";
+import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { dirname, join } from "node:path";
+
 import picomatch from "picomatch";
 import { defaultExclude, defaultInclude } from "vitest/config";
-import { describe, expect, it } from "vitest";
+import { afterAll, beforeAll, describe, expect, it } from "vitest";
 
 import rootConfig from "../../vitest.config.ts";
 import {
+  gitignoredPathGlobs,
   globForIgnoredEntry,
   globsForIgnoredEntries,
 } from "./gitignored-path-globs.ts";
@@ -73,20 +94,180 @@ describe("test discovery", () => {
    * catch it cannot make. What actually needs pinning is the opposite direction:
    * `gitignoredPathGlobs()` returning `[]` would make every other assertion here
    * pass while the original bug came straight back.
+   *
+   * WHY THIS LAYER IS ONLY TWO ASSERTIONS WIDE. Anything more specific about the
+   * live repo is a claim about WHICH CHECKOUT the suite is running in.
+   * `node_modules/` is the one ignored directory that exists in the main checkout
+   * and in every linked worktree alike, so it is the only named path this layer
+   * may mention. Everything about the derivation's behaviour — nested
+   * `.gitignore` files, anchoring, escaping, empty directories, and the
+   * deliberate silence about ignored paths that are not on disk — is asserted
+   * against the authored fixture repo below, where it holds on every machine.
    */
-  it("still excludes agent worktrees under .claude/ — the bug this closed", () => {
+  it("contributes real globs in any checkout", () => {
     expect(contributedGlobs.length).toBeGreaterThan(0);
-    const buried = ".claude/worktrees/probe/apps/web/src/foo.test.ts";
-    expect(matchesAny(contributedGlobs, buried)).toBe(true);
-    // ...and the same path outside the ignored directory stays collectable.
-    expect(matchesAny(contributedGlobs, "apps/web/src/foo.test.ts")).toBe(false);
+    expect(contributedGlobs).toContain("node_modules/**");
+  });
+});
+
+/**
+ * The derivation, run against a git repo authored BY HAND in a temp directory.
+ *
+ * The layout below is the whole point of this file: every behaviour asserted here
+ * is a behaviour that either could not be exercised at all against the live repo
+ * (the nested `.gitignore`, in a worktree) or was exercised only by accident of
+ * what happened to be sitting on disk.
+ *
+ * HERMETIC ON PURPOSE. `--exclude-standard` reads `.git/info/exclude` and the
+ * user's GLOBAL `core.excludesFile` as well as the repo's `.gitignore` files, so
+ * a fixture that did not neutralise both would assert something different on a
+ * machine whose owner globally ignores, say, `coverage/`. The repo-local
+ * `core.excludesFile` override points at an empty file inside `.git/`, and
+ * `.git/info/exclude` is truncated. No commit is made — `--others --ignored`
+ * reads the working tree — but the non-ignored files ARE staged, for the reason
+ * recorded at the `git add -A` below.
+ */
+describe("gitignoredPathGlobs against an authored fixture repo", () => {
+  let fixtureRoot: string;
+  let globs: string[];
+
+  /** Write one fixture file, creating its parent directories. */
+  function write(relative: string, contents: string): void {
+    const target = join(fixtureRoot, relative);
+    mkdirSync(dirname(target), { recursive: true });
+    writeFileSync(target, contents, "utf8");
+  }
+
+  /** Run one git command inside the fixture, output discarded. */
+  function git(...args: string[]): void {
+    execFileSync("git", ["-C", fixtureRoot, ...args], { stdio: "ignore" });
+  }
+
+  beforeAll(() => {
+    fixtureRoot = mkdtempSync(join(tmpdir(), "gitignored-path-globs-"));
+    git("init");
+    // Neutralise the ambient environment: an empty global excludes file, and an
+    // empty per-repo exclude. Both live inside `.git/`, so neither is itself a
+    // path `ls-files` can report.
+    writeFileSync(join(fixtureRoot, ".git", "empty-excludes"), "", "utf8");
+    git("config", "core.excludesFile", join(fixtureRoot, ".git", "empty-excludes"));
+    writeFileSync(join(fixtureRoot, ".git", "info", "exclude"), "", "utf8");
+
+    // ---- The authored layout. ------------------------------------------
+    // Root ignores: two directories that exist and are wholly ignored, one that
+    // exists but is EMPTY, one literal braced name, and one that is NOT on disk.
+    write(".gitignore", ".claude/\nnode_modules/\ncoverage/\nsecrets/\n{tmp,scratch}/\n");
+    write(".claude/worktrees/probe/apps/web/src/foo.test.ts", "// ignored\n");
+    write("node_modules/left-pad/index.js", "// ignored\n");
+    write("{tmp,scratch}/note.test.ts", "// ignored, literally braced\n");
+    mkdirSync(join(fixtureRoot, "coverage"), { recursive: true });
+    // `secrets/` is deliberately never created.
+
+    // A NESTED `.gitignore`, the case a root-only reader cannot see: `.tanstack/`
+    // exists on disk, `.vercel/` does not.
+    write("pkg/web/.gitignore", ".tanstack/\n.vercel/\n");
+    write("pkg/web/.tanstack/cache.json", "{}\n");
+
+    // Untracked-but-not-ignored files, including a test file, all of which must
+    // survive every glob produced.
+    write("pkg/web/src/app.ts", "export const a = 1;\n");
+    write("pkg/web/src/app.test.ts", "// collectable\n");
+    write("README.md", "# fixture\n");
+
+    // STAGE THE NON-IGNORED FILES. No commit is needed, but the index cannot be
+    // left empty: `--directory` collapses a directory that git knows NOTHING
+    // about into a single untracked entry and does not descend into it, so with
+    // an empty index the nested `pkg/web/.gitignore` would never be reached and
+    // the fixture would quietly under-report. `git add -A` honours `.gitignore`,
+    // so everything ignored above stays unstaged and therefore still "other".
+    git("add", "-A");
+
+    globs = gitignoredPathGlobs(fixtureRoot);
   });
 
+  afterAll(() => {
+    rmSync(fixtureRoot, { recursive: true, force: true });
+  });
+
+  it("derives exactly one anchored glob per ignored path that is on disk", () => {
+    expect([...globs].sort()).toEqual(
+      [
+        ".claude/**",
+        "node_modules/**",
+        "pkg/web/.tanstack/**",
+        "\\{tmp,scratch\\}/**",
+      ].sort(),
+    );
+  });
+
+  /**
+   * THE CENTRE OF THIS FIX. `pkg/web/.gitignore` declares `.tanstack/`, and the
+   * glob must be anchored to that directory — `pkg/web/.tanstack/**`, never the
+   * unanchored `**​/.tanstack/**` a text parser would guess at. This is the
+   * assertion that could not run at all in a linked worktree.
+   */
   it("reaches nested .gitignore files, anchored to their own directory", () => {
-    // `apps/web/.gitignore` declares `.tanstack/` and `.vercel/`; the retired
-    // root-only text parser never saw either.
-    expect(contributedGlobs).toContain("apps/web/.tanstack/**");
-    expect(contributedGlobs).toContain("apps/web/.vercel/**");
+    expect(globs).toContain("pkg/web/.tanstack/**");
+    expect(globs).not.toContain("**/.tanstack/**");
+    expect(matchesAny(globs, "pkg/web/.tanstack/cache.json")).toBe(true);
+    // An identically named directory elsewhere is NOT ignored here, and the
+    // anchored glob must leave it collectable.
+    expect(matchesAny(globs, "pkg/api/.tanstack/x.test.ts")).toBe(false);
+  });
+
+  /** The bug this module closed, now exercisable in every checkout. */
+  it("still excludes agent worktrees under .claude/", () => {
+    expect(globs).toContain(".claude/**");
+    const buried = ".claude/worktrees/probe/apps/web/src/foo.test.ts";
+    expect(matchesAny(globs, buried)).toBe(true);
+    // ...and the same path outside the ignored directory stays collectable.
+    expect(matchesAny(globs, "apps/web/src/foo.test.ts")).toBe(false);
+  });
+
+  /**
+   * INTENT, NOT AN OVERSIGHT. An ignore rule for a directory that does not exist
+   * on disk contributes NOTHING, because there is nothing there to exclude. This
+   * is the behaviour that produced the false red in every worktree — `.claude/`
+   * and `apps/web/.tanstack/` simply are not there yet — and it is CORRECT: the
+   * exclude form is safe precisely because it never guesses about paths git has
+   * not seen. Pinned here so nobody "fixes" it by parsing `.gitignore` text again.
+   */
+  it("contributes nothing for an ignored directory that is not on disk", () => {
+    expect(globs.some((glob) => glob.startsWith("secrets"))).toBe(false);
+    expect(globs).not.toContain("pkg/web/.vercel/**");
+    expect(matchesAny(globs, "secrets/a.test.ts")).toBe(false);
+    expect(matchesAny(globs, "pkg/web/.vercel/a.test.ts")).toBe(false);
+  });
+
+  /** `--no-empty-directory`: an ignored directory with nothing in it is not listed. */
+  it("contributes nothing for an ignored directory that is empty", () => {
+    expect(globs).not.toContain("coverage/**");
+    expect(globs.some((glob) => glob.startsWith("coverage"))).toBe(false);
+  });
+
+  /**
+   * The brace hole, pinned end to end through a REAL git round-trip rather than
+   * against a hand-written entry string. `{tmp,scratch}` is one literal directory
+   * to git and two to picomatch; the escaping has to survive the whole path from
+   * `.gitignore` to matcher, not just the pure function.
+   */
+  it("escapes a literal braced directory so it does not brace-expand", () => {
+    expect(globs).toContain("\\{tmp,scratch\\}/**");
+    expect(matchesAny(globs, "{tmp,scratch}/note.test.ts")).toBe(true);
+    expect(matchesAny(globs, "tmp/note.test.ts")).toBe(false);
+    expect(matchesAny(globs, "scratch/note.test.ts")).toBe(false);
+  });
+
+  /** Over-exclusion, the failure that hides itself, on an authored file list. */
+  it("eats none of the fixture's non-ignored files", () => {
+    const collectable = [
+      "pkg/web/src/app.ts",
+      "pkg/web/src/app.test.ts",
+      "pkg/web/.gitignore",
+      "README.md",
+      ".gitignore",
+    ];
+    expect(collectable.filter((file) => matchesAny(globs, file))).toEqual([]);
   });
 });
 

--- a/ops/testkit/gitignored-path-globs.ts
+++ b/ops/testkit/gitignored-path-globs.ts
@@ -90,11 +90,27 @@ export function globsForIgnoredEntries(
  * `--directory --no-empty-directory` collapses a wholly-ignored directory to one
  * entry instead of listing every file inside it (15 entries here, not tens of
  * thousands of `node_modules` files), and `-z` keeps paths with spaces intact.
- * `cwd: REPO_ROOT` is imported rather than re-derived — the walker and discovery
- * agreeing on one root is the point, and inside a linked worktree that root is the
- * worktree's own.
+ * The default root is `REPO_ROOT`, imported rather than re-derived — the walker
+ * and discovery agreeing on one root is the point, and inside a linked worktree
+ * that root is the worktree's own.
+ *
+ * WHY `root` IS A PARAMETER. It is the seam that makes this derivation testable
+ * without depending on WHICH CHECKOUT the suite happens to be running in. Git
+ * lists only ignored paths that EXIST ON DISK — correct, and the reason the
+ * exclude form is safe — but it also means the answer is a fact about one working
+ * tree rather than about the repo. A fresh linked worktree has no `.claude/`, no
+ * `coverage/`, no `apps/web/.tanstack/`, so a guard asserting against the live
+ * result was green in the main checkout and red in every worktree; worse, the
+ * assertion that most needed exercising — that the derivation reaches NESTED
+ * `.gitignore` files and anchors them to their own directory — could never run
+ * where this board actually does its work. Point `root` at an AUTHORED fixture
+ * repo instead and the behaviour under test (nested ignores, anchoring, escaping
+ * through a real git round-trip, `--no-empty-directory`, and the deliberate
+ * silence about ignored paths that do not exist on disk) is pinned identically on
+ * every machine. The default is unchanged, so `vitest.config.ts` calls this
+ * exactly as it did before.
  */
-export function gitignoredPathGlobs(): string[] {
+export function gitignoredPathGlobs(root: string = REPO_ROOT): string[] {
   const listing = execFileSync(
     "git",
     [
@@ -106,7 +122,7 @@ export function gitignoredPathGlobs(): string[] {
       "--no-empty-directory",
       "-z",
     ],
-    { cwd: REPO_ROOT, encoding: "utf8", maxBuffer: 64 * 1024 * 1024 },
+    { cwd: root, encoding: "utf8", maxBuffer: 64 * 1024 * 1024 },
   );
   return globsForIgnoredEntries(
     listing.split("\0").filter((entry) => entry !== ""),

--- a/ops/testkit/gitignored-path-globs.ts
+++ b/ops/testkit/gitignored-path-globs.ts
@@ -49,8 +49,47 @@
  * one will look for the other; the missing suffix is the honest part.
  */
 import { execFileSync } from "node:child_process";
+import { realpathSync } from "node:fs";
 
 import { REPO_ROOT } from "./repo-sources.testkit.js";
+
+/**
+ * Throw unless `root` is the TOPLEVEL of a git repository.
+ *
+ * Compared through `realpathSync` on both sides because git answers with the
+ * resolved path: on macOS a `mkdtemp` root is `/var/folders/…` and git calls the
+ * same directory `/private/var/folders/…`. Comparing the raw strings there would
+ * reject every legitimate temp-directory fixture, which is the only caller that
+ * passes `root` at all.
+ */
+function assertRepositoryToplevel(
+  root: string,
+  env: NodeJS.ProcessEnv | undefined,
+): void {
+  let toplevel: string;
+  try {
+    toplevel = execFileSync("git", ["rev-parse", "--show-toplevel"], {
+      cwd: root,
+      encoding: "utf8",
+      stdio: ["ignore", "pipe", "ignore"],
+      ...(env === undefined ? {} : { env }),
+    }).trim();
+  } catch (cause) {
+    throw new Error(
+      `gitignored-path-globs: ${root} is not inside a git repository, so ` +
+        `\`git ls-files\` cannot say what is ignored there.`,
+      { cause },
+    );
+  }
+  if (realpathSync(toplevel) !== realpathSync(root)) {
+    throw new Error(
+      `gitignored-path-globs: ${root} is not a repository toplevel (that is ` +
+        `${toplevel}). \`git ls-files\` reports paths relative to its cwd, so a ` +
+        `subdirectory root yields globs anchored to the wrong base — they look ` +
+        `right and exclude nothing. Pass the toplevel.`,
+    );
+  }
+}
 
 /**
  * Glob metacharacters picomatch honours, each escapable with a backslash.
@@ -109,8 +148,34 @@ export function globsForIgnoredEntries(
  * silence about ignored paths that do not exist on disk) is pinned identically on
  * every machine. The default is unchanged, so `vitest.config.ts` calls this
  * exactly as it did before.
+ *
+ * `root` MUST BE A REPOSITORY TOPLEVEL, AND THAT IS CHECKED, NOT ASSUMED.
+ * `git ls-files` reports paths relative to its cwd and descends only from there,
+ * so pointing `root` at a SUBDIRECTORY of a repo does not fail — it returns
+ * plausible-looking globs anchored to the wrong base. Handed `apps/web`, it
+ * reports `.tanstack/**` where discovery needs `apps/web/.tanstack/**`, and that
+ * glob silently excludes nothing (or, worse, excludes an unrelated root-level
+ * directory of the same name). Fail-toward-green again, in the one module whose
+ * entire purpose is to close that mode — so a non-toplevel `root` throws. The
+ * check is skipped when `root` is the default, which is itself the output of
+ * `git rev-parse --show-toplevel`: nothing to re-derive, and no subprocess added
+ * to the config-load path that runs before every single test invocation.
+ *
+ * `options.env` REPLACES THE ENVIRONMENT OF THE GIT SUBPROCESS, and exists for the
+ * same reason `root` does. Git reads `GIT_DIR`, `GIT_WORK_TREE` and
+ * `GIT_INDEX_FILE` from the environment and they OUTRANK `cwd`, while
+ * `GIT_CONFIG_COUNT`/`GIT_CONFIG_KEY_n`/`GIT_CONFIG_VALUE_n` outrank even
+ * repo-local config — so a fixture that pins `root` but inherits `process.env` is
+ * only hermetic on a machine that happens not to export any of them (a `git
+ * bisect run`, a hook, or a CI wrapper is not such a machine). Omitting the option
+ * inherits `process.env` exactly as before, so the `vitest.config.ts` call site is
+ * byte-identical in behaviour.
  */
-export function gitignoredPathGlobs(root: string = REPO_ROOT): string[] {
+export function gitignoredPathGlobs(
+  root: string = REPO_ROOT,
+  options: { readonly env?: NodeJS.ProcessEnv } = {},
+): string[] {
+  if (root !== REPO_ROOT) assertRepositoryToplevel(root, options.env);
   const listing = execFileSync(
     "git",
     [
@@ -122,7 +187,12 @@ export function gitignoredPathGlobs(root: string = REPO_ROOT): string[] {
       "--no-empty-directory",
       "-z",
     ],
-    { cwd: root, encoding: "utf8", maxBuffer: 64 * 1024 * 1024 },
+    {
+      cwd: root,
+      encoding: "utf8",
+      maxBuffer: 64 * 1024 * 1024,
+      ...(options.env === undefined ? {} : { env: options.env }),
+    },
   );
   return globsForIgnoredEntries(
     listing.split("\0").filter((entry) => entry !== ""),


### PR DESCRIPTION
Closes #365.

The guard on test discovery asserted against **live repository state**, so it gave a different verdict in every checkout. `gitignoredPathGlobs()` derives its globs from

```
git ls-files --others --ignored --exclude-standard --directory --no-empty-directory -z
```

which lists only ignored paths that **exist on disk**. Two assertions in `gitignored-path-globs.test.ts` read `rootConfig.test.exclude` and required specific entries — `apps/web/.tanstack/**`, `apps/web/.vercel/**`, and a `.claude/` match — to be among them. A fresh linked worktree has none of those directories, so those globs are never contributed, and the guard went red on correct code.

## The production mechanism was right; the test was wrong

Nothing ignored on disk means nothing to exclude. That is the correct answer, not a bug — and the derivation is otherwise sound: repo-root-anchored, nested-`.gitignore`-aware, escaping intact. The defect was entirely in what the guard chose to assert against.

That makes this the exact defect class **#355** was filed to retire — a guard whose verdict depends on which checkout it runs in. #362 fixed it for the repo-wide source walker and reintroduced it one layer up, inside the guard shipped to protect that fix.

## Three environments, three answers, one commit

| environment | ignored dirs on disk | verdict at `a5a0cad` |
|---|---|---|
| main checkout (local) | `.claude/`, `coverage/`, `.vercel/`, `apps/web/.tanstack/`, `apps/web/.vercel/`, `.env*` | 8/8 pass |
| linked worktree | `node_modules/` only (6 globs) | 2 fail |
| CI, fresh clone | 7 globs | 2 fail |

CI was already red on this before #362 merged, and has been red on `main` ever since — every open lane's PR check inherits it. On the runner, the only reason any `apps/web` ignored output exists at all is that `pnpm --filter @numisma/web build` runs immediately before `pnpm test`, so the verdict depended on **CI step ordering** as well as on the checkout. `.claude/` can never exist on a runner, so that assertion had no state in which it could pass there.

## The second-order problem: unexercisable, not merely failing

In a worktree `apps/web/.tanstack/` **cannot** exist, so the nested-`.gitignore` assertion had no passing state — nothing verified that the derivation reaches nested `.gitignore` files and anchors them to their own directory. This board does nearly all of its work in worktrees, so the guard could not verify what it exists to verify exactly where it counts. What stayed green was the load-bearing "eats no test file" assertion, which an empty glob list satisfies — the fail-toward-green mode the module's own header warns about.

## The fix: assert the derivation against an authored fixture

`gitignoredPathGlobs()` takes an optional derivation root (`gitignoredPathGlobs(root = REPO_ROOT)`); the default is unchanged, so `vitest.config.ts` is untouched. The git flags are unchanged — the mechanism was never the problem. The parameter is the seam that lets the guard drive the derivation against a repository it authored rather than the one it happens to be running in.

The tests build a hermetic fixture repo in a temp directory with a known layout: a root `.gitignore`, a **nested** `.gitignore` in a subdirectory, directories that exist and directories that do not, an empty ignored directory, and a literal `{tmp,scratch}` directory that pins escaping through a real git round-trip. The fixture sets its own `core.excludesFile`, so a developer's global excludes cannot change the answer.

This turns the two dead assertions into live ones and adds the coverage nothing had:

- nested `.gitignore` reached **and anchored to its own directory** — the assertion that was unexercisable in a worktree, now exercised in every checkout
- `.claude/` excluded, with a buried test path matching and a sibling path outside it not matching
- a rule for a directory that **does not exist on disk** contributes nothing — pinned as intent, since that correct behaviour is what produced the false red
- an ignored-but-empty directory contributes nothing (`--no-empty-directory`)
- escaping survives the real git round-trip, not just the pure function

The live-repo layer is now deliberately thin: the load-bearing "eats no test file git knows about" assertion stays, plus a smoke that holds in a worktree, the main checkout and CI alike. Nothing left in the suite asserts the presence of a directory that only some checkouts have.

## The guard is not decorative

A guard that cannot fail is what produced this, so the replacement was mutation-tested against the glob derivation. Each mutation was applied to `gitignored-path-globs.ts`, observed red, and restored (the restored file is byte-identical to the reviewed one, `shasum c006e540…`):

| mutation | red |
|---|---|
| ignore the injected root — `cwd: root` → `cwd: REPO_ROOT`, i.e. reintroduce the exact defect this PR fixes | 4 failed / 14 |
| drop `--directory --no-empty-directory` | 6 failed / 14 |
| stop escaping metacharacters — `entry.replace(GLOB_METACHARACTERS, …)` → `entry` | 5 failed / 14 |
| unanchor — emit `**/<last segment>/**` instead of the real path | 8 failed / 14 |

The first is the one that matters: reintroducing the environment dependence turns the fixture suite red, which is precisely what the old guard could not do.

## Verification

| run | result |
|---|---|
| this test, linked worktree (bare) | 14/14 |
| this test, worktree with the main checkout's ignored dirs reconstructed on disk | 14/14 |
| **control** — pre-fix code, same reconstructed shape | 8/8, matching the main checkout exactly, which confirms the reconstruction is faithful and the only variable is on-disk state |
| full suite, worktree | 153 files passed, 4 skipped; 2287 tests passed, 48 skipped; 0 failures |
| `pnpm typecheck` (six projects + `tsconfig.ops.json`) | clean |

The control run is the load-bearing one: the same commit that is 8/8 in a main-shaped tree is 2-failed in a bare worktree, and after this change it is 14/14 in both.
