### PR TITLE
The operator notice's twin property: bound the data half, take the job half off 5b

### DIFF
--- a/apps/price-feed/src/operator-notice-cli.ts
+++ b/apps/price-feed/src/operator-notice-cli.ts
@@ -11,10 +11,19 @@
  * already drives.
  *
  * ZERO-ARGUMENT, AND IT MUST STAY THAT WAY. An unattended step that takes a date is
- * a step that eventually writes the wrong one. The window is the derivation's own
- * default — the launchd era floor and a ceiling of yesterday — which is exactly what
- * the TUI's liveness banner uses, and this notice is that banner's push twin: the
- * two must not describe different windows.
+ * a step that eventually writes the wrong one. The window is the composer's own
+ * default — `defaultGapReportSince` and a ceiling of yesterday — which is exactly
+ * what the TUI's liveness banner uses, and this notice is that banner's push twin:
+ * the two must not describe different windows.
+ *
+ * THE TWIN PROPERTY BINDS THE WINDOW, NOT THE RENDERING, and the distinction is
+ * load-bearing: `operator-notice.ts` rules that the banner ENUMERATES venue-dark
+ * days while the notice COUNTS them, so the two surfaces are ALREADY REQUIRED to
+ * render one finding differently. A recency bound on the notice's venue-dark count
+ * (`MAX_NOTICE_VENUE_DARK_DAYS`) is therefore a rendering decision and no breach of
+ * the sentence above — the derivation still walks the whole shared window on both
+ * surfaces. Read the other way, this claim makes the notice unfixable, which is how
+ * #381 read it. Nothing here is retired.
  *
  * NO ENVIRONMENT OF ITS OWN. The notice is resolved from the SAME data dir as
  * `gap-report.json` and `job-heartbeat.json`, through the one rule in ADR-006

--- a/apps/price-feed/src/wrapper-harness/fake-bin.testkit.ts
+++ b/apps/price-feed/src/wrapper-harness/fake-bin.testkit.ts
@@ -67,13 +67,28 @@ import { join } from "node:path";
  *   itself. Case 3, and the exact historical shape: the grandchild outlived the group
  *   TERM while holding the inherited write end of the log pipe, so `tee` never saw EOF
  *   and both sat in the run's process group holding launchd's per-label job slot.
+ * - `writes-operator-notice` — copies an authored payload over an authored target path,
+ *   then succeeds. The ONLY behavior that has an effect outside the case's bookkeeping,
+ *   and it exists for one reason (#376): step 5b is now a real writer of
+ *   `operator-notice.txt` and the EXIT trap is a second one, so "the trap replaced what 5b
+ *   wrote" is a claim about ORDERING between two writers that a fake succeeding silently
+ *   cannot express. Both the path and the body come from files
+ *   ({@link armFakeOperatorNoticeWrite}) rather than from this module, so the fake stays a
+ *   dumb copier and the AUTHORED text lives beside the case that asserts it.
  */
 export type FakeBehavior =
   | "succeeds"
   | "hangs"
   | "exits-127"
   | "ignores-term"
-  | "hangs-with-term-deaf-grandchild";
+  | "hangs-with-term-deaf-grandchild"
+  | "writes-operator-notice";
+
+/** The file holding the absolute path `writes-operator-notice` copies ONTO. */
+export const FAKE_NOTICE_TARGET_NAME = "operator-notice-target";
+
+/** The file holding the authored body `writes-operator-notice` copies FROM. */
+export const FAKE_NOTICE_PAYLOAD_NAME = "operator-notice-payload";
 
 /**
  * The authored TERM-deaf child's filename. It is matched against `ps` output, so case 3
@@ -211,6 +226,28 @@ case "\${BEHAVIOR}" in
     "\${CASE_DIR}/bin/${TERM_DEAF_CHILD_NAME}" &
     printf 'fake pnpm: %s hanging after forking a TERM-deaf grandchild (authored fixture)\\n' "\${COMMAND}"
     hang_until_released
+    exit 0
+    ;;
+  writes-operator-notice)
+    # STANDS IN FOR STEP 5b'S WRITE, and it is a plain copy on purpose: the harness never
+    # runs the real notice CLI, so the only thing this may claim to be is "a writer that
+    # put authored bytes at that path before the run went on". What those bytes MEAN is
+    # the asserting case's business, not this fake's.
+    #
+    # FAIL CLOSED, LOUDLY. A missing payload or target would otherwise leave this behaving
+    # exactly like \`succeeds\` — and the case that armed it would then "prove" the trap
+    # replaced a file nobody ever wrote, which is the one way it could pass while
+    # asserting nothing.
+    if [[ ! -f "\${CASE_DIR}/${FAKE_NOTICE_TARGET_NAME}" || ! -f "\${CASE_DIR}/${FAKE_NOTICE_PAYLOAD_NAME}" ]]; then
+      printf 'fake pnpm: %s was told to write the operator notice with no authored payload\\n' "\${COMMAND}" >&2
+      exit 96
+    fi
+    NOTICE_TARGET="$(cat "\${CASE_DIR}/${FAKE_NOTICE_TARGET_NAME}")"
+    if ! cat "\${CASE_DIR}/${FAKE_NOTICE_PAYLOAD_NAME}" > "\${NOTICE_TARGET}"; then
+      printf 'fake pnpm: %s could not write the authored notice to %s\\n' "\${COMMAND}" "\${NOTICE_TARGET}" >&2
+      exit 96
+    fi
+    printf 'fake pnpm: %s wrote the authored notice payload (authored fixture)\\n' "\${COMMAND}"
     exit 0
     ;;
   *)

--- a/apps/price-feed/src/wrapper-harness/operator-notice.testkit.ts
+++ b/apps/price-feed/src/wrapper-harness/operator-notice.testkit.ts
@@ -27,6 +27,11 @@
 import { existsSync, readFileSync, writeFileSync } from "node:fs";
 import { join } from "node:path";
 import { OPERATOR_NOTICE_FILENAME } from "@numisma/event-store";
+import {
+  FAKE_NOTICE_PAYLOAD_NAME,
+  FAKE_NOTICE_TARGET_NAME,
+  setFakeBehavior,
+} from "./fake-bin.testkit.js";
 
 /** Authored instants for the seeds below. Never a captured value. */
 const AUTHORED_SEED_STARTED_AT = "2001-02-03T04:00:00Z";
@@ -105,16 +110,30 @@ export function seedHeartbeatOutcome(dataDir: string, outcome: SeededOutcome): v
 }
 
 /**
- * THE SENTINEL NOTICE — an authored file standing in for one a previous run's step 5b left
- * behind, naming a loss that is still real.
+ * THE SENTINEL NOTICE — an authored file standing in for one a step 5b left behind, naming
+ * a loss that is still real.
  *
  * The date and the command are shaped like the notice's own lost-day pair, but the date is
- * an authored one this repo has never run on: the case asserts this text survives BYTE FOR
- * BYTE, so it must be impossible for any real derivation to have produced it.
+ * an authored one this repo has never run on: the cases assert this text either survives
+ * BYTE FOR BYTE or is gone ENTIRELY, so it must be impossible for any real derivation to
+ * have produced it.
+ *
+ * It serves both 5b's: seeded on disk it is the PREVIOUS run's notice (what step 0 must
+ * leave alone), and written by the fake mid-run it is THIS run's notice (what the EXIT
+ * trap must replace when the run dies afterwards).
  */
 export const AUTHORED_SENTINEL_NOTICE =
   "Numisma: 2001-02-03 is a LOST DAY (authored harness fixture, not a real finding).\n" +
   "Numisma: 2001-02-03 — recover with: pnpm prices:fetch --as-of=2001-02-03\n";
+
+/**
+ * The shortest span of {@link AUTHORED_SENTINEL_NOTICE} nothing else could have written.
+ *
+ * The case that asserts the sentinel is GONE needs a needle rather than the whole hay:
+ * `not.toContain` on the full two-line body would also pass if a writer had kept the first
+ * line and dropped the second, which is precisely the half-append this channel refuses.
+ */
+export const AUTHORED_SENTINEL_FRAGMENT = "is a LOST DAY (authored harness fixture";
 
 /** Put the sentinel notice on disk where step 0 would find it. */
 export function seedOperatorNotice(dataDir: string, body: string): void {
@@ -153,3 +172,40 @@ export function readOperatorNotice(dataDir: string): string | undefined {
 export function expectedFailureFragment(outcome: SeededOutcome): string {
   return `exit ${outcome.exitCode} at step '${outcome.lastStep}'`;
 }
+
+/**
+ * ARM THE FAKE `pnpm operator-notice` TO ACTUALLY WRITE (#376).
+ *
+ * Until this existed the fake succeeded without touching anything, so every notice on disk
+ * at the end of a run was step 0's by elimination. The EXIT trap now writes the same file
+ * too, which turns "who wrote last" into a real question — and answering it needs a step 5b
+ * that leaves bytes behind.
+ *
+ * BEHAVIOR AND FIXTURES ARE SET TOGETHER, deliberately: the behavior fails closed on a
+ * missing payload, and a caller that could arm one without the other would be able to
+ * produce that failure from a test rather than from the fake.
+ *
+ * THE TARGET IS DERIVED FROM {@link OPERATOR_NOTICE_FILENAME}, not retyped — the same
+ * imported constant the rest of this module resolves its path from, so the fake writes
+ * where both the wrapper's bash and the real CLI would.
+ */
+export function armFakeOperatorNoticeWrite(caseDir: string, dataDir: string, body: string): void {
+  writeFileSync(join(caseDir, FAKE_NOTICE_TARGET_NAME), operatorNoticeFixturePath(dataDir), "utf8");
+  writeFileSync(join(caseDir, FAKE_NOTICE_PAYLOAD_NAME), body, "utf8");
+  setFakeBehavior(caseDir, "operator-notice", "writes-operator-notice");
+}
+
+/**
+ * WHICH OF THE TWO BASH WRITERS PRODUCED THE FILE STANDING ON DISK.
+ *
+ * Step 0 and the EXIT trap share `write_operator_failure_notice` and therefore share the
+ * FAILED line VERBATIM — that is the point of the shared writer, and it is also why the
+ * failure line alone cannot say who wrote. The one thing the two callers vary is the scope
+ * line's tail, which names the run that will replace the file: from step 0 the run that is
+ * starting, from the trap the one after it. So these two fragments are the only
+ * discriminator the channel has, and asserting on them is asserting on the seam.
+ */
+export const STEP_0_SCOPE_TAIL = "the run now starting replaces this file";
+
+/** The trap's tail — see {@link STEP_0_SCOPE_TAIL}. */
+export const EXIT_TRAP_SCOPE_TAIL = "the next run replaces this file";

--- a/apps/price-feed/src/wrapper-harness/run-daily-fetch.test.ts
+++ b/apps/price-feed/src/wrapper-harness/run-daily-fetch.test.ts
@@ -1954,9 +1954,16 @@ describe.runIf(decision.run)("wrapper harness — the real wrapper, armed", () =
    *
    * THE RUN SUCCEEDS, so this is the no-writer case end to end (#376): step 0 has no
    * breadcrumb to speak from, the EXIT trap's branch is gated on a non-zero exit, and the
-   * unarmed fake at 5b writes nothing. On a fresh machine's FIRST healthy run the file must
-   * therefore not exist at all — the strongest form of "say nothing, write nothing" the
-   * channel has.
+   * unarmed fake at 5b writes nothing. IN THIS HARNESS, therefore, no writer touches the
+   * file and it must not exist at all — the strongest form of "say nothing, write nothing"
+   * the two BASH writers have.
+   *
+   * SAID PRECISELY, BECAUSE THE PRODUCTION SENTENCE IS THE OPPOSITE: with a real toolchain
+   * a fresh machine's first healthy run DOES create `operator-notice.txt`, empty, because
+   * `writeOperatorNoticeFile` always writes including the empty case — that unconditional
+   * write is the self-clearing contract. What this case isolates is the bash half: with 5b
+   * inert, `undefined` vs `""` separates "no bash writer spoke" from "step 0 truncated
+   * unconditionally", and only the first is correct.
    */
   it(
     `case 9c — no heartbeat means no notice, ${RUNS_PER_CASE} consecutive times`,

--- a/apps/price-feed/src/wrapper-harness/run-daily-fetch.test.ts
+++ b/apps/price-feed/src/wrapper-harness/run-daily-fetch.test.ts
@@ -138,8 +138,12 @@ import {
 import {
   AUTHORED_CLEAN_OUTCOME,
   AUTHORED_FAILED_OUTCOME,
+  AUTHORED_SENTINEL_FRAGMENT,
   AUTHORED_SENTINEL_NOTICE,
   AUTHORED_WEDGED_OUTCOME,
+  EXIT_TRAP_SCOPE_TAIL,
+  STEP_0_SCOPE_TAIL,
+  armFakeOperatorNoticeWrite,
   expectedFailureFragment,
   readOperatorNotice,
   seedHeartbeatOutcome,
@@ -1772,14 +1776,28 @@ describe.runIf(decision.run)("wrapper harness — the real wrapper, armed", () =
   // the suite header already gives about `launchctl` — this harness delivers the signal,
   // not the sender.
   //
-  // ALL FOUR RUN OUT OF THE MARK WINDOW, so no run stamps itself and the heartbeat
-  // assertions stay about step 0 rather than about the carry-forward contract cases 6 and
-  // 8 own. And all four end the run EARLY — before step 5b — on purpose: a run that
-  // reached 5b would have the fake `pnpm operator-notice` succeed without writing anything,
-  // and the file's final contents would then be step 0's by default rather than by proof.
-  // Ending early is also the only shape production actually produces here, which is the
-  // trap this board has paid for before: a guard that pins a shape the real producer never
-  // emits is a guard that cannot fail.
+  // ALL FIVE RUN OUT OF THE MARK WINDOW, so no run stamps itself and the heartbeat
+  // assertions stay about the notice rather than about the carry-forward contract cases 6
+  // and 8 own.
+  //
+  // ── THERE ARE NOW TWO BASH WRITERS, AND THAT SETS THESE CASES' SHAPE (#376) ──────────
+  // The EXIT trap writes this same file, through the same shared function, on any non-zero
+  // exit — because a notice that carries only DATA findings is EMPTY on a run whose data
+  // was clean and which then died at `backfill`, and an empty notice reads as health for as
+  // long as it takes the next fire to notice. The trap is therefore the LAST writer on
+  // every failing run, which is exactly what 9e asserts.
+  //
+  // The consequence for 9a-9c is that step 0's own write is no longer observable at the end
+  // of a run that FAILED: the trap has overwritten it by then, correctly. So those three
+  // now run to COMPLETION and read the file afterwards. That is not a weaker vehicle, it is
+  // two claims for the price of one — the notice standing at the end of a clean run can
+  // only be what step 0 left there, AND the trap's zero-exit restraint (it must not
+  // truncate, `:>`, or otherwise touch the file when the run succeeded) is what makes that
+  // sentence true. A trap that cleared the file unconditionally fails all three at once.
+  //
+  // WHICH WRITER WROTE IS ASSERTED THROUGH THE SCOPE TAIL, never through the FAILED line:
+  // the two callers share that line verbatim on purpose, and `STEP_0_SCOPE_TAIL` /
+  // `EXIT_TRAP_SCOPE_TAIL` are the only place they differ.
 
   /**
    * CASE 9a · THE PREVIOUS RUN FAILED, SO THE NOTICE SAYS SO — naming BOTH fields.
@@ -1788,6 +1806,13 @@ describe.runIf(decision.run)("wrapper harness — the real wrapper, armed", () =
    * PATH problem on this machine and exit 124 at `timeout:backfill` is a wedged network
    * call, and a notice that could not tell them apart would send the operator to the wrong
    * place on the one channel that reaches them unasked.
+   *
+   * THE RUN ITSELF IS HEALTHY, and since #376 that is the only shape in which this claim
+   * can be read at all: on a failing run the EXIT trap overwrites step 0's lines with this
+   * run's own failure, which is the whole point of the trap. A clean run leaves the trap
+   * silent, so the file still holds what step 0 put there — a notice about the PREVIOUS run
+   * standing over a successful one, which is exactly what production does until step 5b
+   * replaces it.
    */
   it(
     `case 9a — a FAILED previous heartbeat is written into the notice, ${RUNS_PER_CASE} consecutive times`,
@@ -1796,10 +1821,6 @@ describe.runIf(decision.run)("wrapper harness — the real wrapper, armed", () =
         const options = markCaseOptions("out", CASE_OPTIONS);
         const dirs = makeCaseDir(options);
         seedHeartbeatOutcome(dirs.dataDir, AUTHORED_FAILED_OUTCOME);
-        // THIS run dies at `prices-fetch`, which is a DIFFERENT step from the seeded
-        // `resolve-tools`. Without that difference "step 0 reported the previous run" and
-        // "something reported this one" would be the same observation.
-        setFakeBehavior(dirs.caseDir, "prices:fetch", "exits-127");
         const label = `case 9a run ${run}/${RUNS_PER_CASE}`;
 
         const record = await launchWrapper({
@@ -1812,9 +1833,9 @@ describe.runIf(decision.run)("wrapper harness — the real wrapper, armed", () =
         });
 
         assertTriple(record, dirs.caseDir, {
-          exitCode: 127,
-          lastStep: "prices-fetch",
-          pnpmReached: ["prices:fetch"],
+          exitCode: 0,
+          lastStep: "complete",
+          pnpmReached: WRAPPER_PNPM_COMMANDS,
           mark: options.mark,
           label,
         });
@@ -1832,13 +1853,18 @@ describe.runIf(decision.run)("wrapper harness — the real wrapper, armed", () =
         expect(notice ?? "", `${label}: the notice's lines do not begin \`Numisma: \``).toMatch(
           /^Numisma: /,
         );
-        // AND IT IS THE PREVIOUS RUN'S OUTCOME, NOT THIS ONE'S. This run died at
-        // `prices-fetch`; a notice naming that step would mean step 0 had somehow read a
-        // heartbeat written after it, which is the one thing its placement rules out.
+        // AND IT WAS STEP 0 THAT WROTE IT. The FAILED line is shared verbatim with the EXIT
+        // trap, so only the scope tail can say which caller produced the file — and a trap
+        // that had written here on a ZERO exit would have replaced a real notice with one
+        // about a run that succeeded.
         expect(
           notice ?? "",
-          `${label}: the notice named THIS run's step — step 0 cannot know it`,
-        ).not.toContain("prices-fetch");
+          `${label}: the notice standing after a CLEAN run is not step 0's — something else wrote it`,
+        ).toContain(STEP_0_SCOPE_TAIL);
+        expect(
+          notice ?? "",
+          `${label}: the EXIT trap wrote a notice on a run that exited 0`,
+        ).not.toContain(EXIT_TRAP_SCOPE_TAIL);
       }
     },
     600_000,
@@ -1858,10 +1884,16 @@ describe.runIf(decision.run)("wrapper harness — the real wrapper, armed", () =
    * exists to end. Self-clearing is step 5b's job alone, because step 5b runs only once the
    * day's work is actually done.
    *
-   * So: an authored sentinel notice, a CLEAN heartbeat, and a run that dies before 5b. The
+   * So: an authored sentinel notice, a CLEAN heartbeat, and a run that finishes. The
    * sentinel must survive BYTE FOR BYTE — `toBe`, never `toContain`, because a step 0 that
    * appended to it rather than truncating it would also be wrong and `toContain` would
    * shrug.
+   *
+   * AND IT IS NOW THE SAME CASE FOR THE EXIT TRAP (#376). Two writers of one file are held
+   * to one restraint here: the run exits 0, so the trap's notice branch must not fire, and
+   * a trap that wrote unconditionally would delete this sentinel just as surely as a step 0
+   * that truncated. `pnpm operator-notice` is deliberately left UNARMED, so the fake writes
+   * nothing at 5b and the bytes on disk at the end can only be the seed.
    */
   it(
     `case 9b — a CLEAN previous heartbeat leaves the notice untouched, ${RUNS_PER_CASE} consecutive times`,
@@ -1871,7 +1903,6 @@ describe.runIf(decision.run)("wrapper harness — the real wrapper, armed", () =
         const dirs = makeCaseDir(options);
         seedOperatorNotice(dirs.dataDir, AUTHORED_SENTINEL_NOTICE);
         seedHeartbeatOutcome(dirs.dataDir, AUTHORED_CLEAN_OUTCOME);
-        setFakeBehavior(dirs.caseDir, "prices:fetch", "exits-127");
         const label = `case 9b run ${run}/${RUNS_PER_CASE}`;
 
         const record = await launchWrapper({
@@ -1884,23 +1915,24 @@ describe.runIf(decision.run)("wrapper harness — the real wrapper, armed", () =
         });
 
         assertTriple(record, dirs.caseDir, {
-          exitCode: 127,
-          lastStep: "prices-fetch",
-          pnpmReached: ["prices:fetch"],
+          exitCode: 0,
+          lastStep: "complete",
+          pnpmReached: WRAPPER_PNPM_COMMANDS,
           mark: options.mark,
           label,
         });
 
-        // THE RUN REALLY DID DIE BEFORE 5b, stated rather than assumed: if it had reached
-        // the notice step, the fake would have "succeeded" without writing and the survival
-        // below would prove nothing about step 0's restraint.
+        // THE RUN REALLY DID REACH 5b, stated rather than assumed: the unarmed fake writing
+        // nothing there is what makes the survival below attributable to the two bash
+        // writers rather than to a run that stopped before anything could write.
         expect(
           existsSync(join(dirs.caseDir, "sentinels", sentinelNameFor("operator-notice"))),
-          `${label}: the run reached step 5b, so this case cannot say what step 0 did`,
-        ).toBe(false);
+          `${label}: the run never reached step 5b, so this case cannot say what it proves`,
+        ).toBe(true);
         expect(
           readOperatorNotice(dirs.dataDir),
-          `${label}: step 0 rewrote or truncated a notice a HEALTHY previous run had left — ` +
+          `${label}: a notice a HEALTHY previous run had left was rewritten or truncated — ` +
+            "by step 0 at the start, or by the EXIT trap on a run that exited 0; either way " +
             "an empty file over a real lost day reads as health",
         ).toBe(AUTHORED_SENTINEL_NOTICE);
       }
@@ -1919,6 +1951,12 @@ describe.runIf(decision.run)("wrapper harness — the real wrapper, armed", () =
    * The assertion is `toBeUndefined`, and the distinction from `""` is the case: an empty
    * notice is the healthy SELF-CLEARED state, and a step 0 that truncated unconditionally
    * would produce exactly that and sail past a reader which flattened the two.
+   *
+   * THE RUN SUCCEEDS, so this is the no-writer case end to end (#376): step 0 has no
+   * breadcrumb to speak from, the EXIT trap's branch is gated on a non-zero exit, and the
+   * unarmed fake at 5b writes nothing. On a fresh machine's FIRST healthy run the file must
+   * therefore not exist at all — the strongest form of "say nothing, write nothing" the
+   * channel has.
    */
   it(
     `case 9c — no heartbeat means no notice, ${RUNS_PER_CASE} consecutive times`,
@@ -1927,7 +1965,6 @@ describe.runIf(decision.run)("wrapper harness — the real wrapper, armed", () =
         const options = markCaseOptions("out", CASE_OPTIONS);
         const dirs = makeCaseDir(options);
         // Deliberately no seed of any kind — `makeCaseDir` leaves a fresh data dir.
-        setFakeBehavior(dirs.caseDir, "prices:fetch", "exits-127");
         const label = `case 9c run ${run}/${RUNS_PER_CASE}`;
 
         const record = await launchWrapper({
@@ -1940,17 +1977,18 @@ describe.runIf(decision.run)("wrapper harness — the real wrapper, armed", () =
         });
 
         assertTriple(record, dirs.caseDir, {
-          exitCode: 127,
-          lastStep: "prices-fetch",
-          pnpmReached: ["prices:fetch"],
+          exitCode: 0,
+          lastStep: "complete",
+          pnpmReached: WRAPPER_PNPM_COMMANDS,
           mark: options.mark,
           label,
         });
 
         expect(
           readOperatorNotice(dirs.dataDir),
-          `${label}: step 0 invented a failure report on a machine with no breadcrumb — ` +
-            "cry-wolf on day one, from the one channel whose only asset is being believed",
+          `${label}: a failure report was invented on a machine with no breadcrumb and a ` +
+            "run that succeeded — cry-wolf on day one, from the one channel whose only " +
+            "asset is being believed",
         ).toBeUndefined();
       }
     },
@@ -1971,8 +2009,16 @@ describe.runIf(decision.run)("wrapper harness — the real wrapper, armed", () =
    * the fake bin: the isolation contract still passes (every entry is absolute and inside
    * the case dir), the real `pnpm` is in neither the prepend nor the inherited launchd
    * PATH, and the wrapper's own `command -v pnpm` guard is what ends the run. That the
-   * notice is on disk afterwards is the proof that step 0 ran BEFORE that guard and
+   * notice is on disk afterwards is the proof that the channel ran BEFORE that guard and
    * survived it.
+   *
+   * WHICH OF THE TWO BASH WRITERS IS ON TRIAL HERE CHANGED WITH #376, and the case is
+   * sharper for it. Both write on this path — step 0 about the SEEDED wedged run, then the
+   * EXIT trap about THIS run's exit 127 — and the trap is last. So the file at the end must
+   * name `resolve-tools`, not the seed, and that single assertion carries two facts: the
+   * notice channel still speaks with no toolchain at all, and the trap is the writer that
+   * stands. Step 0's own bytes are unobservable from here for the same reason; 9a is where
+   * they are read.
    */
   it(
     `case 9d — the notice survives an unresolvable toolchain, ${RUNS_PER_CASE} consecutive times`,
@@ -2013,12 +2059,110 @@ describe.runIf(decision.run)("wrapper harness — the real wrapper, armed", () =
         const notice = readOperatorNotice(dirs.dataDir);
         expect(
           notice,
-          `${label}: with the toolchain gone there is no other writer — step 0 said nothing`,
+          `${label}: with the toolchain gone there is no node-shaped writer — the bash ` +
+            "channel said nothing at all",
         ).toBeDefined();
         expect(
           notice ?? "",
-          `${label}: the notice does not name the previous wedged run`,
-        ).toContain(expectedFailureFragment(AUTHORED_WEDGED_OUTCOME));
+          `${label}: the notice does not name THIS run's refusal, which is the failure the ` +
+            "operator has to act on",
+        ).toContain(expectedFailureFragment({ exitCode: 127, lastStep: "resolve-tools" }));
+        expect(
+          notice ?? "",
+          `${label}: the standing notice is not the EXIT trap's — the trap writes last on ` +
+            "every failing run, including this one, where nothing node-shaped ever ran",
+        ).toContain(EXIT_TRAP_SCOPE_TAIL);
+        // AND THE SEED IS GONE. Step 0 wrote it moments earlier; a notice still naming the
+        // PREVIOUS wedged run would mean the trap never fired on an `exit 127` — the exact
+        // path the whole pure-bash argument is built on.
+        expect(
+          notice ?? "",
+          `${label}: the notice still names the PREVIOUS wedged run — the EXIT trap did not ` +
+            "fire on the toolchain refusal",
+        ).not.toContain(expectedFailureFragment(AUTHORED_WEDGED_OUTCOME));
+      }
+    },
+    600_000,
+  );
+
+  /**
+   * CASE 9e · THE NEW SEAM — TWO WRITERS, ONE FILE, ORDERING MATTERS (#376).
+   *
+   * Since the job half came off step 5b, the notice carries DATA findings only. So a 23:00
+   * fire whose data is genuinely clean writes an EMPTY notice at 23:04 and then wedges at
+   * `backfill` at 23:49: the 08:00 terminal prints nothing, step 0 does not speak until the
+   * 18:00 fire, and an all-clear stands over a known-failed run for nineteen hours — on the
+   * channel that exists because a lost day reached no one. The EXIT trap closes that by
+   * writing the same file, through the same shared function, on a non-zero exit.
+   *
+   * THE FAKE `pnpm operator-notice` ACTUALLY WRITES HERE, and that is what makes this a
+   * case rather than a restatement of 9d. Everywhere else the fake succeeds silently, so
+   * "the trap wrote" and "nobody else wrote" are the same observation. Armed with an
+   * authored payload, 5b leaves bytes on disk mid-run and the run then dies AFTER it — so
+   * the assertion is about ORDER: the trap's lines are there and the payload is not.
+   *
+   * THAT THE PAYLOAD IS DISCARDED IS THE RULED TRADE, NOT AN ACCIDENT. Those lines were
+   * true — but from the trap's position they are unmaintainable text of unknown vintage,
+   * and the wrapper's own step 0 comment already ruled that a bounded currently-true
+   * message beats a preserved one nothing can retire. The same bytes were discarded before
+   * this change too, by step 0 at the NEXT fire; all that moves is when the operator finds
+   * out. The `not.toContain` below is that ruling, written where it can go red.
+   *
+   * NOTHING HERE GOES NEAR THE REAL CLI. The payload is authored, the target path comes
+   * from the same imported `OPERATOR_NOTICE_FILENAME` the rest of this module uses, and the
+   * pnpm sentinel proves the fake — not a real toolchain — is what ran.
+   */
+  it(
+    `case 9e — the EXIT trap REPLACES step 5b's notice when the run dies after it, ${RUNS_PER_CASE} consecutive times`,
+    async () => {
+      for (let run = 1; run <= RUNS_PER_CASE; run += 1) {
+        const options = markCaseOptions("out", CASE_OPTIONS);
+        const dirs = makeCaseDir(options);
+        // No heartbeat seed: step 0 must stay SILENT, so the only writers in this run are
+        // 5b and the trap and the ordering claim cannot be satisfied by a leftover.
+        armFakeOperatorNoticeWrite(dirs.caseDir, dirs.dataDir, AUTHORED_SENTINEL_NOTICE);
+        // The step AFTER the notice, which is the whole geometry of the hole: everything
+        // 5b knows was already written, and the run then failed.
+        setFakeBehavior(dirs.caseDir, "backfill", "exits-127");
+        const label = `case 9e run ${run}/${RUNS_PER_CASE}`;
+
+        const record = await launchWrapper({
+          caseDir: dirs.caseDir,
+          wrapperPath: WRAPPER_PATH,
+          env: caseEnv(dirs, options),
+          groupLeader: true,
+          settleDeadlineMs: SETTLE_DEADLINE_MS,
+          maxWaitMs: 60_000,
+        });
+
+        assertTriple(record, dirs.caseDir, {
+          exitCode: 127,
+          lastStep: "backfill",
+          pnpmReached: WRAPPER_PNPM_COMMANDS,
+          mark: options.mark,
+          label,
+        });
+
+        const notice = readOperatorNotice(dirs.dataDir);
+        expect(
+          notice,
+          `${label}: no notice at all after a run that died past 5b — the file the fake ` +
+            "wrote is gone and nothing replaced it",
+        ).toBeDefined();
+        expect(
+          notice ?? "",
+          `${label}: the notice does not name THIS run's failure, so the terminal prints an ` +
+            "all-clear over a run that died at backfill",
+        ).toContain(expectedFailureFragment({ exitCode: 127, lastStep: "backfill" }));
+        expect(
+          notice ?? "",
+          `${label}: the standing notice is not the EXIT trap's`,
+        ).toContain(EXIT_TRAP_SCOPE_TAIL);
+        expect(
+          notice ?? "",
+          `${label}: step 5b's lines are still there — the trap APPENDED rather than ` +
+            "replacing, which puts two vintages in one voice",
+        ).not.toContain(AUTHORED_SENTINEL_FRAGMENT);
       }
     },
     600_000,

--- a/apps/tui/src/gap-lines.ts
+++ b/apps/tui/src/gap-lines.ts
@@ -49,7 +49,9 @@ import {
  * the window's tail is where the still-actionable damage is.
  *
  * Exported because the test must DRIVE the bound rather than restate it; the same
- * reason `MAX_WINDOW_DAYS` is exported from `gap-report-core.ts`.
+ * reason `MAX_WINDOW_DAYS` is exported from `@numisma/event-store` — a constant this
+ * app now has a real relationship to, since `liveness-lines.ts` takes its window
+ * floor from `defaultGapReportSince`, which is that width applied.
  */
 export const MAX_GAP_LINES = 7;
 
@@ -65,8 +67,9 @@ export const MAX_GAP_LINES = 7;
  * and by D7 fires on ~9-10 market holidays a year. The starving line is the one whose
  * own text says *the day is not lost*.
  *
- * It is not a rare shape either: this app passes no `since`, so the floor is the fixed
- * `LAUNCHD_ERA_START` and the window grows by a day every day. On holidays alone the
+ * It is not a rare shape either: this app passes no `since`, so the floor is
+ * `defaultGapReportSince` — the era start until 2027-08-08 and a rolling 400-day floor
+ * after it — and the window grows by a day every day until then. On holidays alone the
  * venue-dark side crosses the cap within about a year, permanently, on the one surface
  * that is read daily and the only automatic one that names permanent data loss.
  *
@@ -88,8 +91,9 @@ export function formatGapCheckFailure(error: unknown): string {
  * Derive the lost days and render them.
  *
  * EMPTY MEANS CLEAN — the caller stays quiet, which is the whole point of putting
- * this on a channel the operator sees every single day. The window's floor defaults
- * to the launchd era and its ceiling is pinned to yesterday by the derivation, so
+ * this on a channel the operator sees every single day. The window's floor is filled
+ * in by `loadLivenessLines` (`defaultGapReportSince`) when the caller supplies none,
+ * and its ceiling is pinned to yesterday by the derivation, so
  * this can never accuse the day still in progress.
  *
  * Bounded to {@link MAX_GAP_LINES} — see that constant. A CLEAN WINDOW STILL

--- a/apps/tui/src/liveness-lines.test.ts
+++ b/apps/tui/src/liveness-lines.test.ts
@@ -8,7 +8,13 @@ import { mkdtemp, rm, writeFile } from "node:fs/promises";
 import { tmpdir } from "node:os";
 import { resolve } from "node:path";
 import type { PortfolioEvent } from "@numisma/engine";
-import { heartbeatPath, resolveEventStorePaths, type EventStorePaths } from "@numisma/event-store";
+import {
+  LAUNCHD_ERA_START,
+  defaultGapReportSince,
+  heartbeatPath,
+  resolveEventStorePaths,
+  type EventStorePaths,
+} from "@numisma/event-store";
 import { afterEach, describe, expect, it } from "vitest";
 import { loadLivenessLines } from "./liveness-lines.js";
 
@@ -135,6 +141,32 @@ describe("loadLivenessLines", () => {
       "Numisma: the daily price job FAILED on 2026-08-04 — exit 1 at step 'post-check'. " +
         "Nothing pushed this to you; that is why it is here.",
     ]);
+  });
+
+  /**
+   * THE FLOOR THE BANNER INHERITS. `app.ts` passes no window, which is the only call
+   * shape production makes, and the banner is the operator notice's PULL twin — the
+   * twin property binds the WINDOW, so a floor either surface picks for itself is the
+   * defect. Asserted past 2027-08-08 as well, where the fixed era start and the
+   * rolling 400-day floor are genuinely different days; before that they agree and the
+   * case would pass on the regression it exists to catch.
+   */
+  it("takes defaultGapReportSince as its floor when the caller supplies none", async () => {
+    const paths = await store({ events: healthyDay("2026-08-04") });
+    expect(await loadLivenessLines(paths, NOW)).toEqual(
+      await loadLivenessLines(paths, NOW, { since: defaultGapReportSince(NOW) }),
+    );
+
+    const later = new Date("2027-09-01T12:00:00Z");
+    expect(defaultGapReportSince(later)).not.toBe(LAUNCHD_ERA_START);
+    expect(await loadLivenessLines(paths, later)).toEqual(
+      await loadLivenessLines(paths, later, { since: defaultGapReportSince(later) }),
+    );
+    // Observably different from the floor it used to take: the wider era window
+    // withholds more days, and the tail line counts them.
+    expect(await loadLivenessLines(paths, later)).not.toEqual(
+      await loadLivenessLines(paths, later, { since: LAUNCHD_ERA_START }),
+    );
   });
 
   it("never throws, whatever it finds on disk", async () => {

--- a/apps/tui/src/liveness-lines.ts
+++ b/apps/tui/src/liveness-lines.ts
@@ -20,7 +20,12 @@
  * neither can throw — a liveness report that stops the dashboard mounting is worse
  * than no liveness report at all.
  */
-import { loadHeartbeatLines, type EventStorePaths, type GapWindow } from "@numisma/event-store";
+import {
+  defaultGapReportSince,
+  loadHeartbeatLines,
+  type EventStorePaths,
+  type GapWindow,
+} from "@numisma/event-store";
 import { loadGapLines } from "./gap-lines.js";
 
 /**
@@ -29,6 +34,16 @@ import { loadGapLines } from "./gap-lines.js";
  * `now` is passed ONCE and shared: the heartbeat's staleness threshold and the gap
  * report's ceiling are the same rule (`dueThrough`), so evaluating them against two
  * different clock reads is the one way they could contradict each other.
+ *
+ * THE FLOOR NOBODY SUPPLIED IS `defaultGapReportSince` — the same floor
+ * `pnpm gap-report` and the operator notice take. `app.ts` passes no window at all,
+ * so before this the banner floored at the FIXED `LAUNCHD_ERA_START` while the
+ * command floored 400 days back from yesterday, and the two started describing
+ * different windows on 2027-08-08. Defaulting HERE rather than at `app.ts` is what
+ * makes the shared floor structural: the notice's `loadOperatorNoticeLines` does the
+ * identical thing at its own composer, so the twin binding survives a new caller
+ * that never read this comment. Nothing observable changes until 2027-08-08, which
+ * is the whole reason it had to be written before then.
  */
 export async function loadLivenessLines(
   paths: EventStorePaths,
@@ -37,7 +52,7 @@ export async function loadLivenessLines(
 ): Promise<string[]> {
   const [heartbeat, gaps] = await Promise.all([
     loadHeartbeatLines(paths, now),
-    loadGapLines(paths, { ...window, now }),
+    loadGapLines(paths, { ...window, since: window.since ?? defaultGapReportSince(now), now }),
   ]);
   return [...heartbeat, ...gaps];
 }

--- a/apps/web/src/push/gap-report-core.ts
+++ b/apps/web/src/push/gap-report-core.ts
@@ -47,7 +47,8 @@
  * structurally rather than trusting it to stay true.
  */
 import {
-  boundedEraFloor,
+  MAX_WINDOW_DAYS,
+  defaultGapReportSince,
   formatGapReport,
   formatGapSummary,
   gapReportPath,
@@ -60,46 +61,22 @@ import {
 } from "@numisma/event-store";
 
 /**
- * The widest window the command will report on, in calendar days (a bit over a
- * year). The CEILING is already pinned to yesterday by `computeGapReport` — which
- * clamps rather than defaults, so no `--until` can push it forward — but nothing
- * bounds how far back a `--since` may reach, and `--since 1970-01-01` would print
- * one line per calendar day for twenty thousand of them. A report nobody can read
- * is a report nobody reads.
- */
-export const MAX_WINDOW_DAYS = 400;
-
-/**
- * The floor a run that did not ask for one gets: `LAUNCHD_ERA_START`, or
- * `MAX_WINDOW_DAYS` back from the ceiling — WHICHEVER IS LATER.
+ * BOTH OF THESE NOW LIVE IN `@numisma/event-store`, beside `boundedEraFloor` — the
+ * function {@link defaultGapReportSince} is a one-line application of. They moved
+ * because the TUI banner and the operator notice inherit this same floor, and
+ * neither the package nor `apps/tui` can import from `apps/web`; the alternative
+ * was a second copy of the width. The reasoning is in full on the constants there.
  *
- * WITHOUT THIS CLAMP THE TWO CONSTANTS COLLIDE ON A DATE. `computeGapReport`
- * defaults the floor to the era start, which is a FIXED day and not a rolling one,
- * so the default window grows by one day every day; the cap above refuses anything
- * over 400. The zero-argument run — the only one the 18:00 job makes — therefore
- * starts THROWING on 2027-08-08 and throws every night after, with no remedy short
- * of a code change. A job that goes permanently red on a date nobody wrote down is
- * the same skim-inducing failure the era floor itself was chosen to avoid, arriving
- * through the scheduler instead of through the report.
+ * They are RE-EXPORTED here rather than dropped so every existing importer keeps
+ * reading them from the command that gave them their name — and so this module's
+ * `--since` validation below is read against the same width the derivation's
+ * default floor was clamped to. One constant, one window, one place to change it.
  *
- * THE CAP STILL BITES, and only where it was aimed: an explicit `--since
- * 1970-01-01` is an operator asking for twenty thousand lines and still gets the
- * refusal. This clamp only fills in the floor nobody supplied.
- *
- * THE COST, SAID PLAINLY: once the era is older than the window, a lost day
- * eventually ages out of the default report. That is the right trade for a finding
- * that is PERMANENT and unfixable — a day lost in 2026 is not actionable in 2028,
- * and `--since` still reaches it — but it does mean the default report is a
- * trailing window, not a complete history, from 2027-08-08 on.
- *
- * The calendar arithmetic and the era start stay in `@numisma/event-store`; only
- * the WIDTH is this command's, because readability is this command's reason. That
- * split is also what keeps this module's one-import property intact — see the
+ * The re-export is a bare `export {}` over the module's single import, not a second
+ * `export … from`, which keeps this module's one-import property intact — see the
  * structural test in `gap-report-core.test.ts`.
  */
-export function defaultGapReportSince(now: Date): string {
-  return boundedEraFloor(now, MAX_WINDOW_DAYS);
-}
+export { MAX_WINDOW_DAYS, defaultGapReportSince };
 
 export interface GapReportArgs {
   since: string | undefined;

--- a/docs/price-feed-ops.md
+++ b/docs/price-feed-ops.md
@@ -953,10 +953,11 @@ pressure the channel exists to apply. The date is repeated inside the command li
 on purpose, so a line that reaches you alone — grepped, quoted into a standup,
 wrapped by a narrow terminal — still says which day it recovers.
 
-**Venue-dark days are COUNTED on one line and never enumerated**:
+**Venue-dark days are COUNTED on one line, never enumerated, and only the RECENT
+ones are counted at all**:
 
 ```text
-Numisma: 3 venue-day(s) dark — not lost days: the feed ran and the days are anchored. Enumerate them with pnpm gap-report.
+Numisma: 3 venue-day(s) dark in the last 7 days — not lost days: the feed ran and the days are anchored, and the venue was silent or the market was closed for a holiday. Enumerate them with pnpm gap-report.
 ```
 
 The asymmetry is deliberate and it is the decision this channel lives or dies on.
@@ -968,6 +969,33 @@ schedule, inside the fix. So the notice carries the number and names
 `pnpm gap-report`, which enumerates them on demand. (The TUI banner *does*
 enumerate them, correctly — a pulled surface has a different noise budget. The
 two renderings differ on purpose and must not be unified.)
+
+**The count is not your running total — it is bounded to the last
+`MAX_NOTICE_VENUE_DARK_DAYS` days** (seven, in
+`packages/event-store/src/operator-notice.ts`), which is why the line names the
+window out loud. Counting *all* of them would have re-created, in one line, the
+permanence the enumeration was refused for: the store's oldest venue-dark day is
+a holiday no command can clear, so an unbounded count is a line that prints
+forever and an "empty means healthy" notice that can never be empty again. Under
+the bound the count **self-extinguishes by age** instead: a market holiday is
+counted for a week and then goes quiet, and a recent venue outage's day drops off
+the same way once the marks land or the week passes. Seven keeps the channel
+empty roughly four days in five on a healthy store; the docstring on the constant
+carries the arithmetic and the recorded flip trigger (three, if ~70 noisy days a
+year still proves too many).
+
+Two consequences worth holding on to when you read the line:
+
+- **An empty notice does not mean every venue-dark day you ever had was
+  cleared.** It means none fell in the last seven days. Nothing was cleared —
+  venue-dark days are still permanent, and the derivation still knows all of
+  them.
+- **`pnpm gap-report` will usually enumerate MORE than the notice counted**, and
+  that is the design, not a disagreement: the report walks the whole window, the
+  notice only admits the recent tail. The bound is presentation-only and applied
+  at the leaf — the derivation window is never narrowed to achieve it, because
+  that would age out **lost** days too, which is the one outcome this channel
+  exists to prevent.
 
 **A `lost days were NOT checked (…)` line** means the **derivation itself broke** —
 the checker, not the data:

--- a/docs/price-feed-ops.md
+++ b/docs/price-feed-ops.md
@@ -766,11 +766,29 @@ Every surface this repo has is **pull-only**. The TUI banner derives the lost da
 live and correctly, and says so only to someone who opens the TUI; the dashboard
 only to someone who opens the dashboard; `gap-report.json` only to someone who
 opens the file. On 2026-08-14/15 all three were right the whole time and nobody
-looked for three days, at the machine. Step 5b of the wrapper
-(`pnpm operator-notice`) closes that by writing the same two signals — the job
-heartbeat and the gap findings — into one well-known plain-text file. This section
-is the other half: getting your shell to read it. It adds no detection; it is a
+looked for three days, at the machine. The wrapper closes that by writing one
+well-known plain-text file that your shell prints unasked. This section is the
+other half: getting your shell to read it. It adds no detection; it is a
 transport.
+
+**Three writers, one file, and each speaks for a different failure** (#376):
+
+| Writer | When | What it says |
+| --- | --- | --- |
+| Step 5b (`pnpm operator-notice`) | every run that reaches it | the **data** findings only — lost days and the venue-dark count. Rewritten in full, so a healthy run truncates it to empty |
+| The wrapper's `EXIT` trap | any run that exits **non-zero** | this run **FAILED**, with its exit code and the step it died at. Replaces whatever stood there |
+| Step 0 | at the start of a run, when the **previous** heartbeat says that run did not finish clean | the same FAILED sentence, about the previous run |
+
+The two bash writers share one function and one wording (`write_operator_failure_notice`
+in `ops/price-feed/run-daily-fetch.sh`), so there is exactly one phrasing of "the job
+failed" to learn. They differ in one clause — which run will replace the file. The trap
+is what stops an all-clear standing over a known-failed run overnight: a run whose data
+was clean writes an *empty* notice at 5b and may still die at `backfill` minutes later.
+Step 0 remains as the backstop for the one death the trap cannot report — a `SIGKILL`,
+an OOM kill, a power loss — where no trap runs at all.
+
+**On a run that exits 0 the trap touches the file not at all**, which is what lets
+step 5b's findings (or an untouched previous notice) stand.
 
 **The file.** `operator-notice.txt`, in the resolved data dir beside the durable
 log, next to `gap-report.json` and `job-heartbeat.json`
@@ -886,7 +904,8 @@ A clean machine prints nothing on a new shell. That is the whole contract, and i
 is why there is nothing to configure and nothing to maintain:
 
 - The file is **rewritten in full on every run**, including the healthy case,
-  where it is truncated to empty. The channel self-clears.
+  where step 5b truncates it to empty. The channel self-clears. A failing run is
+  rewritten in full too, by the `EXIT` trap — never appended to.
 - **No rotation and no history.** It is a notice, not a log. One fixed name, one
   current state.
 - **No dismissal state anywhere in the design** — so there is none to get wrong,
@@ -894,14 +913,31 @@ is why there is nothing to configure and nothing to maintain:
 
 ### What it means when it does print
 
-Lines arrive in one order, always: **the job first, the data second** — a failed
-run is *why* days went missing, and reading the consequence before the reason is
-the wrong way round on a channel scanned in two seconds.
+You are reading **either a job report or a data report, never both mixed** — the
+file has one writer at a time and the last one to write wins.
 
-**Job lines** (from `job-heartbeat.json`) name a run that failed and the step it
-died at, a breadcrumb dated ahead of today (a wrong machine clock), or a job that
-has not completed since some date. These are the wrapper-level failures; triage
-them with the sections above.
+**A job report** is two lines from bash, and it is the whole file when it is
+there:
+
+```text
+Numisma: the previous daily price job run FAILED — exit 124 at step 'timeout:backfill'. Nothing pushed this to you; that is why it is here.
+Numisma: written by the wrapper in pure bash, so it says nothing about lost days yet — the next run replaces this file wholesale if it reaches its own notice step.
+```
+
+The exit code and the step are the triage — `exit 127 at step 'resolve-tools'` is
+a `PATH` problem on this machine, `exit 124 at step 'timeout:backfill'` is a wedged
+call the watchdog ended — and the sections above are where to take them. The second
+line is the bound: a job report says **nothing** about lost days, so read it as
+"the run failed", never as "and the data is fine". Run `pnpm gap-report` for that.
+The next run's step 5b replaces this file with the data report below.
+
+Note what a job report *never* carries any more (#376): the future-dated
+breadcrumb and the "has not completed since" staleness line. Both live on in the
+TUI banner, which reads the same heartbeat live; neither is actionable on the one
+channel that arrives unasked, because the run printing it has usually just fixed
+the thing it names.
+
+**A data report** is what step 5b writes, and it is everything below.
 
 **Lost days are ENUMERATED, one per day, each followed by its own recovery
 command**:

--- a/ops/price-feed/run-daily-fetch.sh
+++ b/ops/price-feed/run-daily-fetch.sh
@@ -445,8 +445,10 @@ if [[ -n "$PREVIOUS_EXIT_CODE" && -n "$PREVIOUS_LAST_STEP" ]]; then
     # true, and on the outage above step 5b is precisely what is not running. A stale
     # enumeration standing under a fresh FAILED line is a channel telling the operator two
     # things of different vintages in one voice, which is the credibility spend this whole
-    # design refuses. So: one bounded, currently-true message, and `NOTICE_SCOPE_LINE` above
-    # says out loud that lost days are not in it. The cost is real and it is accepted.
+    # design refuses. So: one bounded, currently-true message, and the scope line in
+    # `write_operator_failure_notice` (`notice_scope_line`, defined with the writer near the
+    # top of this file) says out loud that lost days are not in it. The cost is real and it
+    # is accepted.
     #
     # THE TAIL IS "the run now starting" BECAUSE THAT IS WHERE THIS CALLER STANDS — the run
     # this file is about is over, and the one that will replace this text has not reached
@@ -1070,10 +1072,15 @@ pnpm gap-report -- --write
 #     run died at `prices-fetch`, this run is landing the missed days right now —
 #     the file is right and the sentence is wrong, and the run writing it is the run
 #     that just fixed it. So the channels split by LANGUAGE: this notice is the DATA
-#     half, and the job half is bash that knows its own run — step 0 today, correctly
-#     scoped to the PREVIOUS run and reaching the two paths this step never sees at
-#     all. The TUI banner keeps all three heartbeat triggers; it is a live PULL
-#     surface, read at the moment the operator looks. Writing an in-progress
+#     half, and the job half is bash — two writers of this same file, reaching the two
+#     paths this step never sees at all. The PRIMARY one is the EXIT trap, which calls
+#     `write_operator_failure_notice` from inside the failing run and is therefore
+#     scoped to THIS run at the moment it dies. Step 0 is the BACKSTOP: it reads the
+#     previous run's breadcrumb, so it is deliberately scoped to the PREVIOUS run, and
+#     what it covers alone is a death with no trap at all — SIGKILL, OOM, power loss —
+#     plus a run that dies before the trap is installed. Step 0's own block above says
+#     this in the same words. The TUI banner keeps all three heartbeat triggers; it
+#     is a live PULL surface, read at the moment the operator looks. Writing an in-progress
 #     heartbeat before this line instead was refused on `write_heartbeat`'s own cost:
 #     its first act after capturing $? is a SIGKILL of the watchdog and a reap of its
 #     sleep, so an early write would leave this step AND `backfill`, the longest one,

--- a/ops/price-feed/run-daily-fetch.sh
+++ b/ops/price-feed/run-daily-fetch.sh
@@ -174,6 +174,61 @@ HEARTBEAT_FILE="$DATA_DIR/job-heartbeat.json"
 # before line 59 runs and therefore cannot split anything.
 OPERATOR_NOTICE_FILE="$DATA_DIR/operator-notice.txt"
 
+# --- THE ONE FAILED-NOTICE WRITER, SHARED BY BOTH BASH SITES (#376) ----------
+# TWO SITES WRITE "the job failed" INTO THIS FILE and there is exactly one wording for it.
+# Step 0 speaks about the run that ENDED before this one; the EXIT trap speaks about the
+# run that is ending right now. Left as two `printf`s they would drift into two dialects of
+# one sentence on the one channel the operator reads in two seconds — which is the
+# vocabulary split this codebase refuses everywhere else (step 0's own comment already
+# borrows `formatHeartbeatWarning`'s voice for exactly this reason). So: one function, one
+# wording, and the only thing a caller may vary is named below.
+#
+# THE FAILED LINE IS VERBATIM FROM BOTH SITES, INCLUDING "the previous … run". That reads
+# correctly from the trap too, and not by luck: nothing `cat`s this file during the run
+# that wrote it. The operator meets it at the next shell prompt, by which time the run the
+# trap described is, in fact, the previous one.
+#
+# WHAT DIFFERS IS THE SCOPE LINE'S TAIL — WHICH RUN WILL REPLACE THIS FILE. From step 0
+# that is "the run now starting"; from the trap the starting run is already over, so it is
+# "the next run". That is the whole of the argument, and it is an argument rather than a
+# whole line so the two cannot drift.
+#
+# `$1` exit code · `$2` step name · `$3` the tail above.
+#
+# IT CANNOT FAIL ITS CALLER. Both call sites are places where an error would cost more than
+# the notice: step 0 runs under `set -euo pipefail` before the toolchain is even resolved,
+# and the trap must never replace the exit code it was installed to record. Every command
+# is guarded and the function returns 0 unconditionally.
+#
+# DEFINED HERE, BESIDE THE PATH IT WRITES, AND THAT PLACEMENT IS LOAD-BEARING: it must
+# exist before step 0 runs and before `trap write_heartbeat EXIT` is installed, and both of
+# those are further down. It reads `$OPERATOR_NOTICE_FILE`, assigned one line above, so the
+# `set -u`-inside-a-trap hazard this file documents for `MARK_WINDOW` cannot reach it —
+# there is no path on which the trap can fire before line 175 has run.
+write_operator_failure_notice() {
+  notice_exit_code="$1"
+  notice_last_step="$2"
+  notice_replacing_run="$3"
+  # `formatHeartbeatWarning`'s voice and its closing clause, deliberately — the operator
+  # must not have to learn two vocabularies for one job. What is dropped is the DATE it ran
+  # on, because that is a clock read neither caller makes; what is added is line two, which
+  # bounds the claim so a reader never mistakes this for a lost-day report.
+  notice_failed_line="Numisma: the previous daily price job run FAILED — exit"
+  notice_failed_line="$notice_failed_line $notice_exit_code at step '$notice_last_step'."
+  notice_failed_line="$notice_failed_line Nothing pushed this to you; that is why it is here."
+  notice_scope_line="Numisma: written by the wrapper in pure bash, so it says nothing about"
+  notice_scope_line="$notice_scope_line lost days yet — $notice_replacing_run replaces this file"
+  notice_scope_line="$notice_scope_line wholesale if it reaches its own notice step."
+  # OVERWRITE, NEVER APPEND, and one `printf` for both lines so it stays that way: the
+  # notice has exactly one well-known name and no history, and a file that accumulated
+  # would be a log nobody reads. Guarded because a full or read-only data dir must cost a
+  # notice, never the run.
+  printf '%s\n%s\n' "$notice_failed_line" "$notice_scope_line" \
+    > "$OPERATOR_NOTICE_FILE" 2>/dev/null || true
+  return 0
+}
+# ----------------------------------------------------------------------------
+
 # --- was this run even CAPABLE of marking? (#185 S2) -------------------------
 # `RunAtLoad true` means this script now fires at ANY hour — a 09:00 login is an
 # ordinary trigger. Such a run stores quotes and emits ZERO marks (the mark-instant
@@ -302,13 +357,24 @@ fi
 
 # --- 0) did the PREVIOUS run finish? (#357 slice 3) --------------------------
 # THE ONE STEP THAT RUNS BEFORE THE TOOLCHAIN EXISTS, and that is its whole reason to be.
-# Step 5b writes this same file through `pnpm operator-notice` and says everything this
-# says and more — but only on a run that GETS to step 5b. The two failures this channel was
-# built for are exactly the runs that do not: an unresolvable `pnpm` or `node` (the two
+# Step 5b writes this same file through `pnpm operator-notice` and — since #376 — says only
+# what the DATA says, on a run that gets there at all. The failures this channel was built
+# for are exactly the runs that do not get there: an unresolvable `pnpm` or `node` (the two
 # `exit 127`s further down) and a run that died partway. On either, every node-shaped
 # writer in this repo is unreachable, so the one thing left that can speak must depend on
 # nothing that could itself be the missing thing. `sed` and a `printf` into a file depend on
 # nothing — the same argument, verbatim, that makes `write_heartbeat` above pure bash.
+#
+# WHAT THIS STEP IS *AFTER* #376, SAID PLAINLY BECAUSE AN EARLIER VERSION OF THIS COMMENT
+# CLAIMED MORE. It is no longer the only bash channel for a partway death: the EXIT trap now
+# calls `write_operator_failure_notice` too, on a non-zero exit, so a run that dies at step
+# 3 reports itself the moment it dies rather than waiting for the NEXT fire to notice. That
+# leaves step 0 as a BACKSTOP re-asserting a fact the trap has usually already written —
+# and the residue it covers alone is real and unreachable from anywhere else: a death with
+# no trap at all. SIGKILL to this shell, an OOM kill, a power loss. On those the heartbeat
+# is the previous run's and nothing has spoken, so this step is the only thing that ever
+# will. On every other path it writes the same sentence twice, one run apart, which is the
+# cheapest possible form of that insurance.
 #
 # IT IS A PURE EQUALITY READ OF TWO FIELDS: NO DATE MATH, NO THRESHOLD, NO CLOCK. That is a
 # decision, not an unfinished implementation. "Too long since the last good run" is
@@ -361,21 +427,6 @@ if [[ -n "$PREVIOUS_EXIT_CODE" && -n "$PREVIOUS_LAST_STEP" ]]; then
   # exact false all-clear it was built to end. Self-clearing belongs to step 5b ALONE,
   # which runs only once the day's work is actually done.
   if [[ "$PREVIOUS_EXIT_CODE" != "0" || "$PREVIOUS_LAST_STEP" != "complete" ]]; then
-    # `formatHeartbeatWarning`'s voice and its closing clause, deliberately — the operator
-    # must not have to learn two vocabularies for one job. What is dropped is the DATE it
-    # ran on, because that is a clock read this step does not make; what is added is line
-    # two, which bounds the claim so a reader never mistakes this for a lost-day report.
-    NOTICE_FAILED_LINE="Numisma: the previous daily price job run FAILED — exit"
-    NOTICE_FAILED_LINE="$NOTICE_FAILED_LINE $PREVIOUS_EXIT_CODE at step '$PREVIOUS_LAST_STEP'."
-    NOTICE_FAILED_LINE="$NOTICE_FAILED_LINE Nothing pushed this to you; that is why it is here."
-    NOTICE_SCOPE_LINE="Numisma: written by the wrapper before the toolchain was resolved, so it"
-    NOTICE_SCOPE_LINE="$NOTICE_SCOPE_LINE says nothing about lost days yet — the run now starting replaces"
-    NOTICE_SCOPE_LINE="$NOTICE_SCOPE_LINE this file wholesale if it reaches its own notice step."
-    # OVERWRITE, NEVER APPEND, and one `printf` for both lines so it stays that way: the
-    # notice has exactly one well-known name and no history, and a file that accumulated
-    # would be a log nobody reads. Guarded because a full or read-only data dir must cost a
-    # notice, never the run.
-    #
     # THE TRADE THIS `>` MAKES, RECORDED BECAUSE IT CUTS AGAINST THE BLOCK ABOVE. The clean
     # branch refuses to touch the file precisely because the previous run's step 5b may have
     # named real lost days — and this branch then deletes those same lines. Across a
@@ -396,8 +447,11 @@ if [[ -n "$PREVIOUS_EXIT_CODE" && -n "$PREVIOUS_LAST_STEP" ]]; then
     # things of different vintages in one voice, which is the credibility spend this whole
     # design refuses. So: one bounded, currently-true message, and `NOTICE_SCOPE_LINE` above
     # says out loud that lost days are not in it. The cost is real and it is accepted.
-    printf '%s\n%s\n' "$NOTICE_FAILED_LINE" "$NOTICE_SCOPE_LINE" \
-      > "$OPERATOR_NOTICE_FILE" 2>/dev/null || true
+    #
+    # THE TAIL IS "the run now starting" BECAUSE THAT IS WHERE THIS CALLER STANDS — the run
+    # this file is about is over, and the one that will replace this text has not reached
+    # its notice step yet. The trap's call passes "the next run" for the mirror reason.
+    write_operator_failure_notice "$PREVIOUS_EXIT_CODE" "$PREVIOUS_LAST_STEP" "the run now starting"
   fi
 fi
 # ----------------------------------------------------------------------------
@@ -530,6 +584,42 @@ write_heartbeat() {
     printf '{\n  "schemaVersion": 2,\n  "startedAt": "%s",\n  "finishedAt": "%s",\n  "exitCode": %d,\n  "lastStep": "%s",\n  "markWindow": %s\n}\n' \
       "$STARTED_AT" "$HEARTBEAT_FINISHED_AT" "$HEARTBEAT_STATUS" "$HEARTBEAT_LAST_STEP" "$MARK_WINDOW" \
       > "$HEARTBEAT_FILE" 2>/dev/null || true
+  fi
+  # --- and the OPERATOR NOTICE, on a non-zero exit only (#376) --------------
+  # THE FALSE ALL-CLEAR THIS CLOSES. Since #376 took the job half off step 5b, the notice is
+  # a pure data channel: a 23:00 fire whose data really is clean writes an EMPTY notice at
+  # 23:04, then wedges at `backfill` at 23:49. The 08:00 terminal prints nothing at all, and
+  # step 0 does not speak until 18:00 — nineteen hours of an all-clear standing over a run
+  # that is known to have failed, on the channel built because a lost day reached no one.
+  # The heartbeat above already holds the whole diagnosis by then; it is simply not the file
+  # the operator's shell prints.
+  #
+  # ON A ZERO EXIT THIS TOUCHES THE FILE NOT AT ALL. Not a truncate, not a `:>`, nothing —
+  # the same restraint as step 0's clean branch and for the same reason: step 5b has already
+  # written the truth about this run's data, and clearing it here would delete a real
+  # lost-day enumeration minutes after the only writer that could produce it.
+  #
+  # `$HEARTBEAT_LAST_STEP`, NOT `$LAST_STEP` — the DECORATED name the breadcrumb just
+  # recorded. `timeout:backfill` is the whole diagnosis in one field, and the notice and the
+  # heartbeat naming one failure two different ways is the same vocabulary split this
+  # channel's shared writer exists to prevent.
+  #
+  # THE TRADE, INHERITED AND RESTATED SO IT IS NOT REDISCOVERED: on a run that dies AFTER
+  # 5b, this `>` discards the lost-day enumeration 5b wrote minutes ago. That content is not
+  # stale — but from here it is unmaintainable text of unknown vintage, exactly as step 0's
+  # `>` comment above already ruled, and a bounded currently-true message beats a preserved
+  # one nothing can retire. What changes is only WHEN the same content is discarded: here,
+  # at the moment of failure, instead of at the next fire up to nineteen hours later. Same
+  # loss, operator informed a day sooner. Appending under 5b's lines is rejected for the
+  # reason that comment gives at length.
+  #
+  # Guarded like everything else in this trap, and reached only under the `[[ -d "$DATA_DIR"
+  # ]]` return above: a failure here must never replace the exit code the trap exists to
+  # record, and this runs on every exit path including both `exit 127`s, where
+  # `write_operator_failure_notice` is reachable because it is defined beside
+  # `$OPERATOR_NOTICE_FILE` far above either of them.
+  if [[ "$HEARTBEAT_STATUS" -ne 0 ]]; then
+    write_operator_failure_notice "$HEARTBEAT_STATUS" "$HEARTBEAT_LAST_STEP" "the next run" || true
   fi
   return 0
 }

--- a/ops/price-feed/run-daily-fetch.sh
+++ b/ops/price-feed/run-daily-fetch.sh
@@ -966,9 +966,28 @@ pnpm gap-report -- --write
 #     dashboard only to someone who opens the dashboard, gap-report.json only to
 #     someone who opens the file. On 2026-08-14/15 all three were right the whole
 #     time and nobody looked for three days, at the machine. This step writes the
-#     same two signals into one well-known file the shell profile cats, so the next
-#     new terminal is where the loss arrives. No new derivation: it composes
-#     primitives `pnpm gap-report` already uses.
+#     DATA findings into one well-known file the shell profile cats, so the next new
+#     terminal is where the loss arrives. No new derivation: it composes primitives
+#     `pnpm gap-report` already uses.
+#
+#     IT SAYS NOTHING ABOUT THE JOB, AND THAT IS #376's RULING. The notice composed
+#     the heartbeat lines here until then, and this is the one moment they are
+#     guaranteed to be misread: the EXIT trap is EXIT-ONLY, so at 5b the breadcrumb
+#     still holds the PREVIOUS run's bytes — exactly what step 0 read at the top of
+#     this same run. Not staler, identically sourced and DIFFERENTLY SCOPED: step 0
+#     says the PREVIOUS run failed, `formatHeartbeatWarning` says "the daily price
+#     job FAILED", present tense, about the job. On a recovery run — the previous
+#     run died at `prices-fetch`, this run is landing the missed days right now —
+#     the file is right and the sentence is wrong, and the run writing it is the run
+#     that just fixed it. So the channels split by LANGUAGE: this notice is the DATA
+#     half, and the job half is bash that knows its own run — step 0 today, correctly
+#     scoped to the PREVIOUS run and reaching the two paths this step never sees at
+#     all. The TUI banner keeps all three heartbeat triggers; it is a live PULL
+#     surface, read at the moment the operator looks. Writing an in-progress
+#     heartbeat before this line instead was refused on `write_heartbeat`'s own cost:
+#     its first act after capturing $? is a SIGKILL of the watchdog and a reap of its
+#     sleep, so an early write would leave this step AND `backfill`, the longest one,
+#     with no timeout at all.
 #
 #     AFTER step 5, and that placement is the whole reliability argument. By here the
 #     toolchain has been resolved (step 1), the fetch, the ingest and the commit have

--- a/packages/event-store/src/gap-report.ts
+++ b/packages/event-store/src/gap-report.ts
@@ -259,13 +259,66 @@ export function dueThrough(now: Date, timeZone: string = REPORT_TIME_ZONE): stri
  * is 2027-08-08, and the cost is the 18:00 job going permanently red at its last
  * step, long after anyone remembers why.
  *
- * The WIDTH lives with the caller that has the reason for it (readability, a line
- * budget, a screen); the ERA START and the calendar arithmetic live here, with the
- * derivation they belong to. Neither has to know the other's constant.
+ * IT STAYS PARAMETERIZED: a caller with its own reason for its own width (a line
+ * budget, a screen) passes it, and the ERA START and the calendar arithmetic live
+ * here, with the derivation they belong to. What no longer lives with a caller is
+ * the DEFAULT width — {@link MAX_WINDOW_DAYS} below — because more than one surface
+ * now inherits it.
  */
 export function boundedEraFloor(now: Date, maxDays: number): string {
   const widest = addDays(dueThrough(now), -(maxDays - 1));
   return widest > LAUNCHD_ERA_START ? widest : LAUNCHD_ERA_START;
+}
+
+/**
+ * The widest window the gap report will report on, in calendar days (a bit over a
+ * year). The CEILING is already pinned to yesterday by `computeGapReport` — which
+ * clamps rather than defaults, so no `--until` can push it forward — but nothing
+ * bounds how far back a `--since` may reach, and `--since 1970-01-01` would print
+ * one line per calendar day for twenty thousand of them. A report nobody can read
+ * is a report nobody reads.
+ */
+export const MAX_WINDOW_DAYS = 400;
+
+/**
+ * The floor a run that did not ask for one gets: `LAUNCHD_ERA_START`, or
+ * `MAX_WINDOW_DAYS` back from the ceiling — WHICHEVER IS LATER.
+ *
+ * WITHOUT THIS CLAMP THE TWO CONSTANTS COLLIDE ON A DATE. `computeGapReport`
+ * defaults the floor to the era start, which is a FIXED day and not a rolling one,
+ * so the default window grows by one day every day; the cap above refuses anything
+ * over 400. The zero-argument run — the only one the 18:00 job makes — therefore
+ * starts THROWING on 2027-08-08 and throws every night after, with no remedy short
+ * of a code change. A job that goes permanently red on a date nobody wrote down is
+ * the same skim-inducing failure the era floor itself was chosen to avoid, arriving
+ * through the scheduler instead of through the report.
+ *
+ * THE CAP STILL BITES, and only where it was aimed: an explicit `--since
+ * 1970-01-01` is an operator asking for twenty thousand lines and still gets the
+ * refusal. This clamp only fills in the floor nobody supplied.
+ *
+ * THE COST, SAID PLAINLY: once the era is older than the window, a lost day
+ * eventually ages out of the default report. That is the right trade for a finding
+ * that is PERMANENT and unfixable — a day lost in 2026 is not actionable in 2028,
+ * and `--since` still reaches it — but it does mean the default report is a
+ * trailing window, not a complete history, from 2027-08-08 on.
+ *
+ * ── WHY THE WIDTH LIVES HERE AND NOT WITH THE COMMAND ─────────────────────────
+ * It used to live in `apps/web/src/push/gap-report-core.ts`, on the reasoning that
+ * only the WIDTH was that command's because readability was that command's reason.
+ * Readability is STILL the width's reason; what changed is who inherits it. The TUI
+ * banner and the operator notice take this same floor, so the width is three
+ * surfaces' rule rather than one command's.
+ *
+ * Neither this package nor `apps/tui` can import from `apps/web`, so the only
+ * alternative to moving it down is a SECOND COPY of the width — the exact failure
+ * `packages/engine/src/price-feed/venue-calendar.ts:12-20` records: *"two copies
+ * compile happily while disagreeing… and the visible result is two health surfaces
+ * contradicting each other about the same day."* Same shape and same reason as the
+ * #266 D4 move that brought `venue-calendar.ts` down into the engine.
+ */
+export function defaultGapReportSince(now: Date): string {
+  return boundedEraFloor(now, MAX_WINDOW_DAYS);
 }
 
 /**

--- a/packages/event-store/src/index.ts
+++ b/packages/event-store/src/index.ts
@@ -22,9 +22,11 @@ export {
 // async shell (`gap-report-io.js`).
 export {
   LAUNCHD_ERA_START,
+  MAX_WINDOW_DAYS,
   REPORT_TIME_ZONE,
   boundedEraFloor,
   computeGapReport,
+  defaultGapReportSince,
   dueThrough,
   formatGapReport,
   formatGapSummary,

--- a/packages/event-store/src/index.ts
+++ b/packages/event-store/src/index.ts
@@ -57,10 +57,11 @@ export {
   writeGapReportFile,
 } from "./gap-report-io.js";
 
-// The operator notice (#357): the liveness banner's PUSH twin. The same two signals
-// the TUI prints, composed into a file the shell profile cats on every new terminal
-// — because every other surface in this repo is pull-only, and a lost day nobody
-// goes looking for stays lost. It adds no derivation: the composition is pure
+// The operator notice (#357): the liveness banner's PUSH twin. The DATA half of what
+// the TUI prints — the gap findings only; the job half is the wrapper's bash (#376,
+// see `operator-notice.ts`) — composed into a file the shell profile cats on every new
+// terminal, because every other surface in this repo is pull-only, and a lost day
+// nobody goes looking for stays lost. It adds no derivation: the composition is pure
 // (`operator-notice.js`) and the disk touch is its one shell
 // (`operator-notice-io.js`).
 export {

--- a/packages/event-store/src/operator-notice-io.test.ts
+++ b/packages/event-store/src/operator-notice-io.test.ts
@@ -3,11 +3,17 @@
  *
  * Everything written here is SYNTHETIC and hand-authored — invented instrument
  * marks with round prices, a hand-built heartbeat. Nothing is seeded from a real
- * run's output. What is asserted is the shell's four jobs and nothing more: the
- * path it picks, that a clean window leaves an EMPTY file, that a dirty one carries
- * both signals in cause-then-effect order, that it OVERWRITES rather than appends
- * or merges, and — the one case the rest of the file cannot reach — what it writes
- * WHEN NO WINDOW IS PASSED, which is the only call shape production ever makes.
+ * run's output. What is asserted is the shell's jobs and nothing more: the path it
+ * picks, that a clean window leaves an EMPTY file, that a dirty one enumerates the
+ * lost days, that it OVERWRITES rather than appends or merges, and — the one case
+ * the rest of the file cannot reach — what it writes WHEN NO WINDOW IS PASSED,
+ * which is the only call shape production ever makes.
+ *
+ * THE HEARTBEAT FIXTURE IS HERE TO PROVE A SILENCE. Since #376 the notice is purely
+ * the DATA channel, so a FAILED breadcrumb on disk must reach the file in no form at
+ * all — see the two cases below that seed one. The job half lives in the wrapper's
+ * bash, and all three heartbeat triggers live on in the TUI banner, whose own suite
+ * is untouched by this ruling.
  */
 import { mkdtemp, readFile, rm, stat, writeFile } from "node:fs/promises";
 import { tmpdir } from "node:os";
@@ -101,17 +107,40 @@ describe("writeOperatorNotice", () => {
     expect((await stat(written)).size).toBe(0);
   });
 
-  it("carries the heartbeat's cause before the lost days it explains", async () => {
+  /**
+   * THE #376 CASE, PINNED POSITIVELY RATHER THAN BY OMISSION.
+   *
+   * A breadcrumb describing a FAILED previous run sits on disk — the exact bytes
+   * step 0 read at the top of this same run — and the window is clean, because the
+   * run composing the notice has just landed the marks. The notice must be EMPTY.
+   * Anything else is the false FAILED on the recovery path: a sentence in the
+   * present tense, about the job, written by the run that already fixed it.
+   *
+   * If anyone re-adds a job half to the composer, this is the case that goes red.
+   */
+  it("says NOTHING about the job when a FAILED breadcrumb sits beside a clean window", async () => {
+    const paths = await store(CRYPTO_MARKS);
+    await seedFailedHeartbeat(paths, "2026-08-14T18:30:00-06:00");
+    const written = await writeOperatorNotice(paths, { now: NOW, window: WINDOW });
+    expect(await readFile(written, "utf8")).toBe("");
+  });
+
+  it("carries the lost days a FAILED breadcrumb does not get to speak about", async () => {
     const paths = await store([]);
     await seedFailedHeartbeat(paths, "2026-08-14T18:30:00-06:00");
     const written = await writeOperatorNotice(paths, { now: NOW, window: WINDOW });
-    const lines = (await readFile(written, "utf8")).trimEnd().split("\n");
-    expect(lines[0]).toContain("FAILED on 2026-08-14");
-    expect(lines.some((line) => line.includes("NO DATA"))).toBe(true);
+    const body = await readFile(written, "utf8");
+    const lines = body.trimEnd().split("\n");
+    // The data half is untouched by the job half's removal: the days are still named
+    // and each still carries its own move.
+    expect(lines[0]).toContain("NO DATA");
     expect(lines).toContain(
       "Numisma: 2026-08-16 — recover with: pnpm prices:fetch --as-of=2026-08-16",
     );
-    expect(await readFile(written, "utf8")).toMatch(/\n$/);
+    // And the breadcrumb on disk reaches the file in no form at all.
+    expect(lines.every((line) => !line.includes("daily price job"))).toBe(true);
+    expect(lines.every((line) => !line.includes("FAILED"))).toBe(true);
+    expect(body).toMatch(/\n$/);
   });
 
   it("OVERWRITES a previous run's notice rather than appending to it", async () => {

--- a/packages/event-store/src/operator-notice-io.test.ts
+++ b/packages/event-store/src/operator-notice-io.test.ts
@@ -15,6 +15,7 @@ import { dirname, join } from "node:path";
 import type { PortfolioEvent } from "@numisma/engine";
 import { afterEach, describe, expect, it } from "vitest";
 import { resolveEventStorePaths, type EventStorePaths } from "./event-store.js";
+import { LAUNCHD_ERA_START, defaultGapReportSince } from "./gap-report.js";
 import { HEARTBEAT_FILENAME } from "./heartbeat.js";
 import { MAX_NOTICE_LOST_DAYS } from "./operator-notice.js";
 import {
@@ -135,9 +136,10 @@ describe("writeOperatorNotice", () => {
  *
  * Every other test on this page passes `WINDOW`, two days wide, and that is exactly
  * how the ninety-line notice shipped: `operator-notice-cli.ts` passes NO window, so
- * the run gets the derivation's own floor (`LAUNCHD_ERA_START`) and a ceiling of
- * yesterday — a window that is forty-odd days wide today and one day wider every
- * day. A narrow explicit window cannot reach {@link MAX_NOTICE_LOST_DAYS} at all, so
+ * the run gets the composer's own floor (`defaultGapReportSince` — the era start
+ * today, a rolling 400-day floor from 2027-08-08) and a ceiling of yesterday — a
+ * window that is forty-odd days wide today and one day wider every day until then.
+ * A narrow explicit window cannot reach {@link MAX_NOTICE_LOST_DAYS} at all, so
  * the cap was proved only against hand-built `GapReport`s in `operator-notice.test.ts`
  * and never against the path that produced the defect. This closes that: the store is
  * real files, the composer runs end to end, and the argument list is the CLI's.
@@ -181,6 +183,50 @@ describe("writeOperatorNotice, called the way the CLI calls it", () => {
     // plus the one tail. Anything the notice adds beyond that is not lost-day noise.
     expect(lines.filter((line) => line.includes("lost")).length).toBeLessThanOrEqual(
       MAX_NOTICE_LOST_DAYS * 2 + 1,
+    );
+  });
+});
+
+/**
+ * THE FLOOR THE NOTICE SHARES WITH THE COMMAND IT TELLS THE OPERATOR TO RUN.
+ *
+ * The notice ends its venue-dark and its withheld-lost lines with "enumerate them
+ * with pnpm gap-report" — the BARE command, no `--since`. That promise is only kept
+ * if both surfaces open the same window, and the fix could not be made at the pointer:
+ * `pnpm gap-report --since=<era floor>` is an instruction the command REFUSES from
+ * 2027-08-08, because era-floor → yesterday crosses `MAX_WINDOW_DAYS` on exactly that
+ * date. Not "the default won't show it" — no invocation can.
+ *
+ * SO THE ASSERTION IS AGAINST `defaultGapReportSince` ITSELF, which is expressible at
+ * all only because that constant moved down into this package. And it is made TWICE:
+ * once at today's clock, where the two candidate floors happen to agree and the test
+ * proves only the binding, and once past 2027-08-08, where they actually diverge —
+ * which is where the whole date-bomb lives and the only place a regression would show.
+ */
+describe("the notice's default floor", () => {
+  it("is defaultGapReportSince, not a floor of its own", async () => {
+    const paths = await store(CRYPTO_MARKS);
+    expect(await loadOperatorNoticeLines(paths, NOW)).toEqual(
+      await loadOperatorNoticeLines(paths, NOW, { since: defaultGapReportSince(NOW) }),
+    );
+  });
+
+  it("is STILL defaultGapReportSince on a clock where the two old floors diverge", async () => {
+    const paths = await store(CRYPTO_MARKS);
+    const later = new Date("2027-09-01T20:00:00-06:00");
+
+    // The premise of the case: past this date the fixed era start and the rolling
+    // 400-day floor are different days. Driven, so the date is not restated.
+    expect(defaultGapReportSince(later)).not.toBe(LAUNCHD_ERA_START);
+
+    expect(await loadOperatorNoticeLines(paths, later)).toEqual(
+      await loadOperatorNoticeLines(paths, later, { since: defaultGapReportSince(later) }),
+    );
+    // And it is genuinely observable: the era floor opens a wider window, so it
+    // withholds more lost days. A test that could not tell the two apart would pass
+    // on the very regression it exists to catch.
+    expect(await loadOperatorNoticeLines(paths, later)).not.toEqual(
+      await loadOperatorNoticeLines(paths, later, { since: LAUNCHD_ERA_START }),
     );
   });
 });

--- a/packages/event-store/src/operator-notice-io.ts
+++ b/packages/event-store/src/operator-notice-io.ts
@@ -15,7 +15,7 @@
 import { writeFile } from "node:fs/promises";
 import { dirname, join } from "node:path";
 import type { EventStorePaths } from "./event-store.js";
-import type { GapWindow } from "./gap-report.js";
+import { defaultGapReportSince, type GapWindow } from "./gap-report.js";
 import { loadGapReport } from "./gap-report-io.js";
 import { loadHeartbeatLines } from "./heartbeat-io.js";
 import { formatOperatorNotice, type NoticeGapFindings } from "./operator-notice.js";
@@ -48,6 +48,24 @@ export function operatorNoticePath(paths: EventStorePaths): string {
  * heartbeat's staleness threshold and the gap report's ceiling are the same rule
  * (`dueThrough`), so evaluating them against two different clock reads is the one
  * way the two halves of one notice could contradict each other.
+ *
+ * ── THE FLOOR NOBODY SUPPLIED IS `defaultGapReportSince`, NOT THE ERA START ───
+ * A caller with no `since` gets the SAME floor `pnpm gap-report` gives itself —
+ * `LAUNCHD_ERA_START` or `MAX_WINDOW_DAYS` back from yesterday, whichever is later.
+ * That matters because THIS NOTICE TELLS THE OPERATOR TO RUN THAT COMMAND. Left on
+ * the derivation's fixed era floor, the two diverge on 2027-08-08 — `gap-report.json`
+ * and `operator-notice.txt` are written into one directory minutes apart from two
+ * different windows — and the cheap repair is refused by the code: a notice that
+ * printed `pnpm gap-report --since=<era floor>` would be naming a window wider than
+ * `MAX_WINDOW_DAYS`, which that command rejects outright. So it is not "the default
+ * won't show it" but "no invocation can".
+ *
+ * THE DEFAULT LIVES HERE, AT THE COMPOSER, AND NOT AT THE CLI. `apps/tui`'s
+ * `loadLivenessLines` does the identical thing for the identical reason. Putting it
+ * in the two shells instead would make the twin property a CONVENTION two apps have
+ * to remember; here it is structural, and a third caller inherits it for free.
+ * Today this changes nothing observable — the era start is later than 400 days back
+ * until 2027-08-08 — which is exactly why it has to be written down now.
  */
 export async function loadOperatorNoticeLines(
   paths: EventStorePaths,
@@ -56,7 +74,11 @@ export async function loadOperatorNoticeLines(
 ): Promise<string[]> {
   const [heartbeatLines, findings] = await Promise.all([
     loadHeartbeatLines(paths, now),
-    loadGapFindings(paths, { ...window, now }),
+    loadGapFindings(paths, {
+      ...window,
+      since: window.since ?? defaultGapReportSince(now),
+      now,
+    }),
   ]);
   return formatOperatorNotice(heartbeatLines, findings);
 }

--- a/packages/event-store/src/operator-notice-io.ts
+++ b/packages/event-store/src/operator-notice-io.ts
@@ -116,6 +116,14 @@ async function loadGapFindings(
  * being replaced wholesale is correct. The single `writeFile` with no `flag` is what
  * makes that non-negotiable in code rather than in a comment.
  *
+ * AND SINCE #376 THE STALENESS RUNS THE OTHER WAY TOO, WHICH IS FINE FOR THE SAME
+ * REASON. The wrapper's EXIT trap is a THIRD writer of this file and the only one that
+ * writes AFTER this one — on a non-zero exit it replaces whatever landed here with the
+ * failure of the run that just died. So this writer's output is what is stale in that
+ * direction: it describes data findings from a run that then failed, and a report of the
+ * failure is what the operator can act on today. Every writer of this file overwrites,
+ * none of them merge, and the last one to speak is the one with the newest fact.
+ *
  * NOT ATOMIC, AND IT DOES NOT CREATE THE DIRECTORY — both accepted, for
  * `writeGapReportFile`'s reasons unchanged. This is a small single-writer file in a
  * directory that by construction already holds the log it was derived from, and a

--- a/packages/event-store/src/operator-notice-io.ts
+++ b/packages/event-store/src/operator-notice-io.ts
@@ -6,18 +6,16 @@
  * RESOLVED {@link EventStorePaths}, so the caller's `NUMISMA_DATA_DIR` resolution is
  * honoured rather than re-derived, and one store resolution serves the process.
  *
- * IT CANNOT REJECT. Both halves already refuse to throw — `loadHeartbeatLines`
- * treats an unreadable breadcrumb as absent, and the gap derivation's failure is
- * caught here and rendered AS A LINE rather than swallowed. The write itself is the
- * one operation left that can fail, and it is left to the caller: the CLI entry that
- * runs inside the wrapper decides what a disk failure means for the run.
+ * IT CANNOT REJECT. The gap derivation's failure is caught here and rendered AS A
+ * LINE rather than swallowed. The write itself is the one operation left that can
+ * fail, and it is left to the caller: the CLI entry that runs inside the wrapper
+ * decides what a disk failure means for the run.
  */
 import { writeFile } from "node:fs/promises";
 import { dirname, join } from "node:path";
 import type { EventStorePaths } from "./event-store.js";
 import { defaultGapReportSince, type GapWindow } from "./gap-report.js";
 import { loadGapReport } from "./gap-report-io.js";
-import { loadHeartbeatLines } from "./heartbeat-io.js";
 import { formatOperatorNotice, type NoticeGapFindings } from "./operator-notice.js";
 
 /**
@@ -42,12 +40,22 @@ export function operatorNoticePath(paths: EventStorePaths): string {
 }
 
 /**
- * Derive both signals for ONE instant and render the notice. Empty means healthy.
+ * Derive the data findings for ONE instant and render the notice. Empty means healthy.
  *
- * `now` IS PASSED ONCE AND SHARED, for `liveness-lines.ts`' reason verbatim: the
- * heartbeat's staleness threshold and the gap report's ceiling are the same rule
- * (`dueThrough`), so evaluating them against two different clock reads is the one
- * way the two halves of one notice could contradict each other.
+ * ONE AWAIT, BECAUSE THERE IS ONE SIGNAL. This composed the heartbeat lines
+ * alongside the gap findings until #376; `operator-notice.ts`' header holds the
+ * ruling and the reason re-adding the second await is not a small convenience.
+ * `loadHeartbeatLines` is untouched and still has the TUI banner, a LIVE PULL
+ * surface, as its consumer.
+ *
+ * `now` IS STILL READ ONCE AND PASSED IN, but no longer for `liveness-lines.ts`'
+ * reason: with the heartbeat gone there is no second half here to contradict. The
+ * reason now is REPRODUCIBILITY AND SCOPE — `now` fixes the window's ceiling
+ * (`dueThrough`) and its floor (`defaultGapReportSince`) from one clock read, so the
+ * floor and the ceiling of a single notice can never straddle a midnight, and a test
+ * can name the instant instead of racing it. THE CALLER OWNS THE CLOCK: the CLI
+ * reads it once and hands it to this composer and to nothing else, which is what
+ * lets the wrapper's step 5b be a pure function of the store plus one instant.
  *
  * ── THE FLOOR NOBODY SUPPLIED IS `defaultGapReportSince`, NOT THE ERA START ───
  * A caller with no `since` gets the SAME floor `pnpm gap-report` gives itself —
@@ -72,15 +80,12 @@ export async function loadOperatorNoticeLines(
   now: Date,
   window: Omit<GapWindow, "now"> = {},
 ): Promise<string[]> {
-  const [heartbeatLines, findings] = await Promise.all([
-    loadHeartbeatLines(paths, now),
-    loadGapFindings(paths, {
-      ...window,
-      since: window.since ?? defaultGapReportSince(now),
-      now,
-    }),
-  ]);
-  return formatOperatorNotice(heartbeatLines, findings);
+  const findings = await loadGapFindings(paths, {
+    ...window,
+    since: window.since ?? defaultGapReportSince(now),
+    now,
+  });
+  return formatOperatorNotice(findings);
 }
 
 /** The one `try` in the module — the derivation's failure, carried as data. */

--- a/packages/event-store/src/operator-notice.test.ts
+++ b/packages/event-store/src/operator-notice.test.ts
@@ -96,7 +96,7 @@ describe("the notice's lost-day cap", () => {
 
   it("names EVERY lost day at the realistic outage shape, each with its own command", () => {
     const lost = lostRun(REALISTIC_LOST_DAYS);
-    const lines = formatOperatorNotice([], findings(lost, []));
+    const lines = formatOperatorNotice(findings(lost, []));
 
     // The cap must never hide the debt it exists to surface: nothing withheld, and
     // every single day still individually remediable from the notice alone.
@@ -110,7 +110,7 @@ describe("the notice's lost-day cap", () => {
 
   it("enumerates EXACTLY the cap with no tail line", () => {
     const lost = lostRun(MAX_NOTICE_LOST_DAYS);
-    const lines = formatOperatorNotice([], findings(lost, []));
+    const lines = formatOperatorNotice(findings(lost, []));
 
     expect(lines).toHaveLength(MAX_NOTICE_LOST_DAYS * 2);
     expect(lines.join("\n")).not.toContain("withheld");
@@ -121,7 +121,7 @@ describe("the notice's lost-day cap", () => {
 
   it("withholds and COUNTS the moment one day more than the cap arrives", () => {
     const lost = lostRun(MAX_NOTICE_LOST_DAYS + 1);
-    const lines = formatOperatorNotice([], findings(lost, []));
+    const lines = formatOperatorNotice(findings(lost, []));
 
     expect(lines).toHaveLength(MAX_NOTICE_LOST_DAYS * 2 + 1);
     expect(lines.at(-1)).toBe(
@@ -134,7 +134,7 @@ describe("the notice's lost-day cap", () => {
     const lost = lostRun(MAX_NOTICE_LOST_DAYS + withheld);
     const shown = lost.slice(withheld);
     const hidden = lost.slice(0, withheld);
-    const joined = formatOperatorNotice([], findings(lost, [])).join("\n");
+    const joined = formatOperatorNotice(findings(lost, [])).join("\n");
 
     for (const { date } of shown) {
       expect(joined).toContain(RECOVERY(date));
@@ -150,7 +150,6 @@ describe("the notice's lost-day cap", () => {
 
   it("puts the withheld tail after the shown days and before the venue-dark count", () => {
     const lines = formatOperatorNotice(
-      [],
       findings(lostRun(MAX_NOTICE_LOST_DAYS + 2), [
         { date: "2026-08-11", source: "binance", expected: 4 },
       ]),
@@ -175,11 +174,11 @@ describe("the notice's lost-day cap", () => {
  */
 describe("the notice's venue-dark recency bound", () => {
   it("says NOTHING AT ALL about a venue-dark day older than the window", () => {
-    expect(formatOperatorNotice([], findings([], [dark(NEWEST_REFUSED)]))).toEqual([]);
+    expect(formatOperatorNotice(findings([], [dark(NEWEST_REFUSED)]))).toEqual([]);
   });
 
   it("still counts the OLDEST day the window admits", () => {
-    expect(formatOperatorNotice([], findings([], [dark(OLDEST_ADMITTED)]))).toEqual([
+    expect(formatOperatorNotice(findings([], [dark(OLDEST_ADMITTED)]))).toEqual([
       VENUE_DARK(1),
     ]);
   });
@@ -189,7 +188,7 @@ describe("the notice's venue-dark recency bound", () => {
       dark(daysBeforeUntil(offset)),
     );
     const outside = [dark(NEWEST_REFUSED), dark(daysBeforeUntil(MAX_NOTICE_VENUE_DARK_DAYS + 30))];
-    expect(formatOperatorNotice([], findings([], [...outside, ...inside]))).toEqual([
+    expect(formatOperatorNotice(findings([], [...outside, ...inside]))).toEqual([
       VENUE_DARK(MAX_NOTICE_VENUE_DARK_DAYS),
     ]);
   });
@@ -199,7 +198,7 @@ describe("the notice's venue-dark recency bound", () => {
     // window to achieve it would age 2026-08-14/15 out of the notice, which is the one
     // outcome this channel exists to prevent.
     const stale = { date: NEWEST_REFUSED, reason: "no-anchor" as const };
-    expect(formatOperatorNotice([], findings([stale], [dark(NEWEST_REFUSED)]))).toEqual([
+    expect(formatOperatorNotice(findings([stale], [dark(NEWEST_REFUSED)]))).toEqual([
       `Numisma: ${NEWEST_REFUSED} — NO DATA. No event of any kind carries this date; the day is lost.`,
       RECOVERY(NEWEST_REFUSED),
     ]);
@@ -210,33 +209,33 @@ describe("the notice's venue-dark recency bound", () => {
       kind: "report",
       report: { ...report([], [dark(UNTIL)]), since: UNTIL, calendarDays: 1 },
     };
-    expect(formatOperatorNotice([], narrow)).toEqual([VENUE_DARK(1)]);
+    expect(formatOperatorNotice(narrow)).toEqual([VENUE_DARK(1)]);
   });
 });
 
 describe("formatOperatorNotice", () => {
   it("says nothing at all when the job is healthy and the window is clean", () => {
-    expect(formatOperatorNotice([], CLEAN)).toEqual([]);
+    expect(formatOperatorNotice(CLEAN)).toEqual([]);
   });
 
-  it("puts the heartbeat's cause before the data's effect", () => {
-    const lines = formatOperatorNotice(
-      ["Numisma: the price feed has not completed since 2026-08-13."],
-      findings([{ date: "2026-08-14", reason: "no-anchor" }], []),
-    );
-    expect(lines[0]).toBe("Numisma: the price feed has not completed since 2026-08-13.");
-    expect(lines.slice(1).some((line) => line.includes("2026-08-14"))).toBe(true);
-  });
-
-  it("still speaks for a failed job on a clean window", () => {
-    expect(formatOperatorNotice(["Numisma: the last run exited 127."], CLEAN)).toEqual([
-      "Numisma: the last run exited 127.",
-    ]);
+  /**
+   * #376's ruling, pinned at the SIGNATURE.
+   *
+   * This composer took `heartbeatLines` first, and at the wrapper's step 5b that half
+   * was written by a run that knows its own status and reads someone else's. The
+   * arity is the ruling made mechanical: a job half cannot come back without editing
+   * this line, and `operator-notice-io.test.ts` pins the same absence against a real
+   * FAILED breadcrumb on disk. The TUI banner keeps all three triggers — it reads the
+   * same primitive live, which is the one context where "the job failed" is a
+   * currently-true sentence.
+   */
+  it("TAKES THE FINDINGS AND NOTHING ELSE — the job is not this channel's to report", () => {
+    expect(formatOperatorNotice).toHaveLength(1);
+    expect(formatOperatorNotice(CLEAN)).toEqual([]);
   });
 
   it("ENUMERATES each lost day and names its own recovery command", () => {
     const lines = formatOperatorNotice(
-      [],
       findings(
         [
           { date: "2026-08-14", reason: "no-anchor" },
@@ -261,7 +260,7 @@ describe("formatOperatorNotice", () => {
       { date: "2026-08-11", source: "twelvedata", expected: 6 },
       { date: "2026-08-11", source: "binance", expected: 4 },
     ];
-    const lines = formatOperatorNotice([], findings([], entries));
+    const lines = formatOperatorNotice(findings([], entries));
     expect(lines).toEqual([VENUE_DARK(3)]);
     // The accumulating rows must not reach the notice at all: no date and no venue
     // name from the venue-dark side may appear anywhere in it.
@@ -276,7 +275,7 @@ describe("formatOperatorNotice", () => {
     // `venue-calendar.ts` accepts the holiday false positive ONLY on the condition
     // that every surface rendering this expectation says so in its own message. The
     // line must carry the clause, not merely the count.
-    const [line] = formatOperatorNotice([], findings([], [dark("2026-08-12")]));
+    const [line] = formatOperatorNotice(findings([], [dark("2026-08-12")]));
     expect(line).toContain("the market was closed for a holiday");
     // And it must name its own scope: a count whose window is invisible reads as total.
     expect(line).toContain(`in the last ${MAX_NOTICE_VENUE_DARK_DAYS} days`);
@@ -286,7 +285,6 @@ describe("formatOperatorNotice", () => {
   it("carries both kinds, lost first, when the window has both", () => {
     expect(
       formatOperatorNotice(
-        [],
         findings(
           [{ date: "2026-08-15", reason: "no-marks" }],
           [{ date: "2026-08-11", source: "binance", expected: 4 }],
@@ -302,7 +300,6 @@ describe("formatOperatorNotice", () => {
   it("pairs each recovery command with ITS OWN lost date, not the first one", () => {
     const dates = ["2026-08-02", "2026-08-14", "2026-08-15"];
     const lines = formatOperatorNotice(
-      [],
       findings(
         dates.map((date) => ({ date, reason: "no-anchor" }) as LostDay),
         [],
@@ -317,23 +314,17 @@ describe("formatOperatorNotice", () => {
   });
 
   it("reports a BROKEN check as a line rather than swallowing it", () => {
-    const lines = formatOperatorNotice([], {
+    const lines = formatOperatorNotice({
       kind: "failed",
       error: new Error("log line 12 quarantined"),
     });
     expect(lines).toEqual(["Numisma: lost days were NOT checked (log line 12 quarantined)."]);
   });
 
-  it("keeps the heartbeat lines even when the gap check itself broke", () => {
+  it("says the check broke and NOTHING BESIDE IT on a non-Error throw", () => {
     expect(
-      formatOperatorNotice(["Numisma: the last run exited 127."], {
-        kind: "failed",
-        error: "no such file",
-      }),
-    ).toEqual([
-      "Numisma: the last run exited 127.",
-      "Numisma: lost days were NOT checked (no such file).",
-    ]);
+      formatOperatorNotice({ kind: "failed", error: "no such file" }),
+    ).toEqual(["Numisma: lost days were NOT checked (no such file)."]);
   });
 });
 

--- a/packages/event-store/src/operator-notice.test.ts
+++ b/packages/event-store/src/operator-notice.test.ts
@@ -9,16 +9,20 @@
 import { describe, expect, it } from "vitest";
 import {
   MAX_NOTICE_LOST_DAYS,
+  MAX_NOTICE_VENUE_DARK_DAYS,
   formatNoticeCheckFailure,
   formatOperatorNotice,
   type NoticeGapFindings,
 } from "./operator-notice.js";
 import type { GapReport, LostDay, VenueDarkDay } from "./gap-report.js";
 
+/** The report ceiling every fixture here shares — the instant the recency bound anchors at. */
+const UNTIL = "2026-08-16";
+
 function report(lost: readonly LostDay[], venueDark: readonly VenueDarkDay[]): GapReport {
   return {
     since: "2026-08-01",
-    until: "2026-08-16",
+    until: UNTIL,
     calendarDays: 16,
     anchorsChecked: 14,
     lost: [...lost],
@@ -50,6 +54,33 @@ function lostRun(count: number): LostDay[] {
 
 const RECOVERY = (date: string) =>
   `Numisma: ${date} — recover with: pnpm prices:fetch --as-of=${date}`;
+
+/**
+ * The venue-dark line, with BOTH numbers driven off the bound: the count the line
+ * reports and the window it names. Restating "7" here would let the sentence and the
+ * constant drift apart, which is the whole reason the constant is exported.
+ */
+const VENUE_DARK = (count: number) =>
+  `Numisma: ${count} venue-day(s) dark in the last ${MAX_NOTICE_VENUE_DARK_DAYS} days — ` +
+  `not lost days: the feed ran and the days are anchored, and the venue was silent or ` +
+  `the market was closed for a holiday. Enumerate them with pnpm gap-report.`;
+
+/**
+ * `offset` days before the report's ceiling — 0 is `until` itself. Driven off the
+ * ceiling rather than authored, so a case can say "the oldest day the bound admits"
+ * instead of a literal a reader has to do arithmetic on.
+ */
+function daysBeforeUntil(offset: number): string {
+  return new Date(Date.parse(`${UNTIL}T00:00:00Z`) - offset * 86_400_000)
+    .toISOString()
+    .slice(0, 10) as string;
+}
+
+/** The oldest venue-dark day the bound still admits, and the newest it does not. */
+const OLDEST_ADMITTED = daysBeforeUntil(MAX_NOTICE_VENUE_DARK_DAYS - 1);
+const NEWEST_REFUSED = daysBeforeUntil(MAX_NOTICE_VENUE_DARK_DAYS);
+
+const dark = (date: string): VenueDarkDay => ({ date, source: "twelvedata", expected: 6 });
 
 /**
  * The realistic near-term outage this cap was sized against: 08-14/08-15 unrecovered
@@ -128,10 +159,58 @@ describe("the notice's lost-day cap", () => {
     expect(lines.at(-2)).toBe(
       "Numisma: 2 earlier lost day(s) withheld — enumerate them with pnpm gap-report.",
     );
-    expect(lines.at(-1)).toBe(
-      "Numisma: 1 venue-day(s) dark — not lost days: the feed ran and the days are " +
-        "anchored. Enumerate them with pnpm gap-report.",
+    expect(lines.at(-1)).toBe(VENUE_DARK(1));
+  });
+});
+
+/**
+ * THE CASE #381 NAMES — the one that would have caught this shape at authoring time.
+ *
+ * The notice must be able to reach EMPTY on the real store, and before the bound it
+ * could not: 2026-07-03 is observed US Independence Day, `owesMarkOn` is holiday-blind
+ * by #266 D7, so that day is a permanent venue-dark finding no command will ever
+ * clear. Every number here is driven off {@link MAX_NOTICE_VENUE_DARK_DAYS} — the
+ * boundary is pinned from BOTH sides, so neither widening nor narrowing the bound can
+ * pass silently, and only removing it turns these red.
+ */
+describe("the notice's venue-dark recency bound", () => {
+  it("says NOTHING AT ALL about a venue-dark day older than the window", () => {
+    expect(formatOperatorNotice([], findings([], [dark(NEWEST_REFUSED)]))).toEqual([]);
+  });
+
+  it("still counts the OLDEST day the window admits", () => {
+    expect(formatOperatorNotice([], findings([], [dark(OLDEST_ADMITTED)]))).toEqual([
+      VENUE_DARK(1),
+    ]);
+  });
+
+  it("counts only the days inside the window when both sides are present", () => {
+    const inside = Array.from({ length: MAX_NOTICE_VENUE_DARK_DAYS }, (_unused, offset) =>
+      dark(daysBeforeUntil(offset)),
     );
+    const outside = [dark(NEWEST_REFUSED), dark(daysBeforeUntil(MAX_NOTICE_VENUE_DARK_DAYS + 30))];
+    expect(formatOperatorNotice([], findings([], [...outside, ...inside]))).toEqual([
+      VENUE_DARK(MAX_NOTICE_VENUE_DARK_DAYS),
+    ]);
+  });
+
+  it("leaves the LOST half untouched — a lost day is permanent and never ages out", () => {
+    // The bound is presentation-only AND venue-dark-only. Narrowing the derivation
+    // window to achieve it would age 2026-08-14/15 out of the notice, which is the one
+    // outcome this channel exists to prevent.
+    const stale = { date: NEWEST_REFUSED, reason: "no-anchor" as const };
+    expect(formatOperatorNotice([], findings([stale], [dark(NEWEST_REFUSED)]))).toEqual([
+      `Numisma: ${NEWEST_REFUSED} — NO DATA. No event of any kind carries this date; the day is lost.`,
+      RECOVERY(NEWEST_REFUSED),
+    ]);
+  });
+
+  it("filters nothing when the report itself is narrower than the bound", () => {
+    const narrow: NoticeGapFindings = {
+      kind: "report",
+      report: { ...report([], [dark(UNTIL)]), since: UNTIL, calendarDays: 1 },
+    };
+    expect(formatOperatorNotice([], narrow)).toEqual([VENUE_DARK(1)]);
   });
 });
 
@@ -175,23 +254,33 @@ describe("formatOperatorNotice", () => {
   });
 
   it("COUNTS venue-dark days on one line and never enumerates them", () => {
-    const dark: VenueDarkDay[] = [
-      { date: "2026-07-03", source: "twelvedata", expected: 6 },
+    // All three inside the recency window, so this case is about the RENDERING and
+    // nothing else — the bound has its own describe block above.
+    const entries: VenueDarkDay[] = [
+      { date: "2026-08-12", source: "twelvedata", expected: 6 },
       { date: "2026-08-11", source: "twelvedata", expected: 6 },
       { date: "2026-08-11", source: "binance", expected: 4 },
     ];
-    const lines = formatOperatorNotice([], findings([], dark));
-    expect(lines).toEqual([
-      "Numisma: 3 venue-day(s) dark — not lost days: the feed ran and the days are " +
-        "anchored. Enumerate them with pnpm gap-report.",
-    ]);
-    // The permanent, accumulating rows must not reach the notice at all: no date and
-    // no venue name from the venue-dark side may appear anywhere in it.
+    const lines = formatOperatorNotice([], findings([], entries));
+    expect(lines).toEqual([VENUE_DARK(3)]);
+    // The accumulating rows must not reach the notice at all: no date and no venue
+    // name from the venue-dark side may appear anywhere in it.
     const joined = lines.join("\n");
-    for (const entry of dark) {
+    for (const entry of entries) {
       expect(joined).not.toContain(entry.date);
       expect(joined).not.toContain(entry.source);
     }
+  });
+
+  it("names the holiday the derivation cannot rule out, as #266 D7 requires", () => {
+    // `venue-calendar.ts` accepts the holiday false positive ONLY on the condition
+    // that every surface rendering this expectation says so in its own message. The
+    // line must carry the clause, not merely the count.
+    const [line] = formatOperatorNotice([], findings([], [dark("2026-08-12")]));
+    expect(line).toContain("the market was closed for a holiday");
+    // And it must name its own scope: a count whose window is invisible reads as total.
+    expect(line).toContain(`in the last ${MAX_NOTICE_VENUE_DARK_DAYS} days`);
+    expect(line).toContain("pnpm gap-report");
   });
 
   it("carries both kinds, lost first, when the window has both", () => {
@@ -206,8 +295,7 @@ describe("formatOperatorNotice", () => {
     ).toEqual([
       "Numisma: 2026-08-15 — NO MARKS. The day is anchored but no price mark landed on it; the day is lost.",
       "Numisma: 2026-08-15 — recover with: pnpm prices:fetch --as-of=2026-08-15",
-      "Numisma: 1 venue-day(s) dark — not lost days: the feed ran and the days are " +
-        "anchored. Enumerate them with pnpm gap-report.",
+      VENUE_DARK(1),
     ]);
   });
 

--- a/packages/event-store/src/operator-notice.ts
+++ b/packages/event-store/src/operator-notice.ts
@@ -96,9 +96,14 @@
  * right now — the three heartbeat triggers come apart:
  *
  *   - `exitCode !== 0`: true of N−1 and NOT ACTIONABLE, because the run writing the
- *     line just fixed it. Step 0 already carries this, correctly scoped, and step 0
+ *     line just fixed it. The bash already carries this, correctly scoped, and it
  *     reaches the two paths 5b never sees at all (an unresolvable `pnpm`/`node`, and
- *     a run that died partway).
+ *     a run that died partway). Since the wrapper's EXIT trap began calling
+ *     `write_operator_failure_notice`, the PRIMARY carrier is the trap, and it speaks
+ *     about THIS run at the moment it dies rather than about N−1 on the next fire —
+ *     which is why the FAILED sentence stopped being anti-correlated with the truth
+ *     of the run composing it. Step 0 is now the BACKSTOP for the same fact (see
+ *     below).
  *   - STALENESS: true of N−1 and NOT ACTIONABLE — run N recorded the day minutes
  *     earlier. Not lost but UPGRADED: every case it fires on, the lost-day half
  *     names better, with the day's own dated `pnpm prices:fetch --as-of=` line —
@@ -119,8 +124,22 @@
  * running with no timeout. It buys back only the future-dated trigger.
  *
  * SO THE CHANNELS SPLIT BY LANGUAGE: this notice is purely the DATA channel, and the
- * job channel is purely bash — the wrapper's step 0, which knows its own run's scope
- * because it is inside it. `formatHeartbeatWarning`,
+ * job channel is purely bash. That bash is now TWO WRITERS OF ONE FILE, and which one
+ * speaks is the difference between reporting a death and remembering one:
+ *
+ *   - THE WRAPPER'S `EXIT` TRAP is the PRIMARY writer. It fires inside the failing run
+ *     on a non-zero exit, so it knows its own run's status and its own run's scope
+ *     because it is inside it, and a run that dies at step 3 reports itself the moment
+ *     it dies instead of waiting for the next fire.
+ *   - THE WRAPPER'S STEP 0 is the BACKSTOP. It reads the previous run's breadcrumb at
+ *     the top of the next run, so it is deliberately scoped to run N−1 — inside run N,
+ *     speaking about N−1. On every ordinary failure it re-asserts what the trap already
+ *     wrote, one run apart. The residue it covers ALONE is the death with no trap at
+ *     all — SIGKILL to the shell, an OOM kill, a power loss — plus the run that dies
+ *     before the trap is installed. On those nothing else in this repo ever speaks.
+ *
+ * `run-daily-fetch.sh`'s own step 0 and step 5b blocks say the same thing; the three
+ * must be kept in agreement. `formatHeartbeatWarning`,
  * `loadHeartbeatLines` and `heartbeat.ts` are UNTOUCHED and the TUI banner keeps all
  * three triggers: it is a LIVE PULL surface reading the same primitive at the moment
  * the operator looks, which is the one context in which "the job failed" is a
@@ -175,8 +194,11 @@ export function formatNoticeCheckFailure(error: unknown): string {
  * THE MOST LOST DAYS THIS CHANNEL WILL ENUMERATE before it withholds the rest.
  *
  * Everything above enumerates correctly and unusably. The CLI passes no window, so
- * production gets the derivation's default (~90 days): smoke-run against a store with
- * no log at all, this composer wrote NINETY LINES on first contact. A notice that long
+ * production gets the COMPOSER's floor — `loadOperatorNoticeLines` fills in
+ * `defaultGapReportSince(now)`, which is the era start today and a rolling 400-day
+ * floor from 2027-08-08, so `computeGapReport`'s own `LAUNCHD_ERA_START` default is
+ * never reached from this path. Measured against that floor: smoke-run against a
+ * store with no log at all, this composer wrote NINETY LINES on first contact. A notice that long
  * on a channel that prints on every new terminal trains its reader to skip it on day
  * one — which reproduces #357 INSIDE the fix for #357. The bound is the one property
  * that did not survive rerouting off the TUI's `loadLivenessLines` (D3 chose it partly
@@ -376,6 +398,21 @@ function formatWithheldLostDays(withheld: number): string {
  * resolve to and is reproducible in a test besides. A report narrower than the bound
  * simply filters nothing — no clamp is needed, because the floor only ever moves
  * earlier than the report's own.
+ *
+ * THE ARITHMETIC, CHECKED AND RECORDED SO IT IS NOT RE-DERIVED: `floor = until − 6`
+ * with `date >= floor` is `[until − 6, until]`, exactly seven calendar days inclusive,
+ * pinned from both sides off the constant by `operator-notice.test.ts`'
+ * `OLDEST_ADMITTED` / `NEWEST_REFUSED` pair. Two residual wrinkles, both
+ * PRESENTATION-ONLY and both accepted:
+ *
+ *   - "in the last 7 days" is measured from `until`, which is YESTERDAY, so the window
+ *     the operator reads as "the last 7 days" is `[today − 7, today − 1]`: a day dark
+ *     exactly seven days before the morning they read it is still counted, and today
+ *     never is (it cannot be — it is not due yet). Fixing the wording would cost either
+ *     a clock read in this pure half or the clumsier "in the 7 days ending <until>".
+ *   - A caller handing in a report NARROWER than the bound still gets "in the last 7
+ *     days", naming a window the report did not open. Unreachable from the zero-argument
+ *     CLI; the test pins the filter-nothing behaviour deliberately.
  */
 function formatVenueDarkCount(report: GapReport): string[] {
   const floor = addDays(report.until, -(MAX_NOTICE_VENUE_DARK_DAYS - 1));

--- a/packages/event-store/src/operator-notice.ts
+++ b/packages/event-store/src/operator-notice.ts
@@ -5,17 +5,17 @@
  * failed on 2026-08-14/15 was not detection but ARRIVAL: the TUI named both lost
  * days correctly, live, the whole time, and nobody opened the TUI for three days
  * while sitting at the machine. Every surface in this repo is PULL-ONLY. This
- * module composes the same two signals into a file the shell profile cats on every
- * new terminal, so the first moment the operator is back is unmissable. It adds no
+ * module composes the DATA findings into a file the shell profile cats on every new
+ * terminal, so the first moment the operator is back is unmissable. It adds no
  * derivation of any kind.
  *
  * ── WHY IT LIVES HERE AND NOT IN THE TUI ──────────────────────────────────────
- * It sits beside the primitives it composes — `loadHeartbeatLines`,
- * `loadGapReport`, `formatLostDays` are all already exported from this package.
- * The alternative, reaching into `apps/tui`'s `loadLivenessLines`, is AN APP
- * IMPORTING AN APP: `gap-lines.ts` records that a prototype did exactly that
- * through a computed specifier `tsc` could not follow, and that both the bridge and
- * its hand-written interface were deleted for it.
+ * It sits beside the primitives it composes — `loadGapReport` and `formatLostDays`
+ * are both already exported from this package. The alternative, reaching into
+ * `apps/tui`'s `loadLivenessLines`, is AN APP IMPORTING AN APP: `gap-lines.ts`
+ * records that a prototype did exactly that through a computed specifier `tsc`
+ * could not follow, and that both the bridge and its hand-written interface were
+ * deleted for it.
  *
  * ── IT IS NOT THE BANNER, AND MUST NOT BE UNIFIED WITH IT ─────────────────────
  * The notice and the TUI banner do NOT share a rendering, deliberately. The banner
@@ -72,11 +72,60 @@
  *     above ({@link MAX_NOTICE_VENUE_DARK_DAYS}), which is what stops the count
  *     itself from becoming the permanent line the enumeration was refused for.
  *
- * ── ORDER IS THE CAUSE, THEN THE EFFECT ───────────────────────────────────────
- * Heartbeat lines (the job) first, data findings second — the same order, and for
- * the same reason, as `liveness-lines.ts`: a failed run is WHY the days went
- * missing, and reading the consequence before the reason is the wrong way round on
- * a channel scanned in two seconds.
+ * ── IT DOES NOT SPEAK FOR THE JOB, AND THAT IS THE ADMISSION RULE AGAIN ───────
+ * This composer once opened with the heartbeat lines — the job's status first, the
+ * data findings second, cause before effect, the ordering `liveness-lines.ts` still
+ * keeps and still needs. That ordering is gone from here because ITS FIRST TERM IS
+ * GONE. The heartbeat half was composed at step 5b of the wrapper, and 5b is the
+ * one moment it is guaranteed to be misread.
+ *
+ * THE MECHANISM, STATED CORRECTLY, because the obvious statement of it is wrong and
+ * every remedy that chases freshness buys the wrong thing. The EXIT trap is
+ * EXIT-ONLY, so at 5b the breadcrumb still holds run N−1's bytes EXACTLY AS STEP 0
+ * SAW THEM AT THE TOP OF THIS SAME RUN. The two read the same file. 5b is not
+ * STALER — it is identically sourced and DIFFERENTLY SCOPED. Step 0 says "the
+ * PREVIOUS daily price job run FAILED" and adds a scope line; `formatHeartbeatWarning`
+ * says "the daily price job FAILED on <date>", present tense, about the job. On a
+ * recovery run the file is right and the sentence is wrong.
+ *
+ * Said the way it is worth remembering: **5b's job half was written by a run that
+ * knows its own status and reads someone else's.**
+ *
+ * PRICED AGAINST THE ADMISSION RULE, on the recovery run that motivated this — N−1
+ * died at `prices-fetch` three days ago and run N is landing three days of marks
+ * right now — the three heartbeat triggers come apart:
+ *
+ *   - `exitCode !== 0`: true of N−1 and NOT ACTIONABLE, because the run writing the
+ *     line just fixed it. Step 0 already carries this, correctly scoped, and step 0
+ *     reaches the two paths 5b never sees at all (an unresolvable `pnpm`/`node`, and
+ *     a run that died partway).
+ *   - STALENESS: true of N−1 and NOT ACTIONABLE — run N recorded the day minutes
+ *     earlier. Not lost but UPGRADED: every case it fires on, the lost-day half
+ *     names better, with the day's own dated `pnpm prices:fetch --as-of=` line —
+ *     dated, actionable, self-extinguishing, which the staleness line is not. The
+ *     one case it caught that the gap half does not is "marks landed from a manual
+ *     fetch but the job never ran", and under the admission rule that is not
+ *     actionable: the data is there.
+ *   - FUTURE-DATED: the only real loss, and it is small. That breadcrumb is
+ *     overwritten by every run's own EXIT trap, so the anomaly is ALREADY visible
+ *     only between N−1's death and N's finish. It survives on the TUI, live.
+ *
+ * Two of the three are ANTI-CORRELATED with the truth of the run composing them.
+ *
+ * THE ALTERNATIVE IS REFUSED BY THE BASH, NOT BY TASTE. "Write an in-progress
+ * heartbeat before 5b" would make the file describe THIS run — and `write_heartbeat`'s
+ * first act after capturing `$?` is a SIGKILL of the watchdog plus a `pgrep -P` reap
+ * of its `sleep`, so an early write would leave 5b AND `backfill`, the longest step,
+ * running with no timeout. It buys back only the future-dated trigger.
+ *
+ * SO THE CHANNELS SPLIT BY LANGUAGE: this notice is purely the DATA channel, and the
+ * job channel is purely bash — the wrapper's step 0, which knows its own run's scope
+ * because it is inside it. `formatHeartbeatWarning`,
+ * `loadHeartbeatLines` and `heartbeat.ts` are UNTOUCHED and the TUI banner keeps all
+ * three triggers: it is a LIVE PULL surface reading the same primitive at the moment
+ * the operator looks, which is the one context in which "the job failed" is a
+ * currently-true sentence. If `loadHeartbeatLines` ends up with only the banner as a
+ * consumer, THAT IS CORRECT AND NOT A CLEANUP OPPORTUNITY.
  *
  * ── EMPTY MEANS HEALTHY ───────────────────────────────────────────────────────
  * A clean window returns NO LINES, and the shell writes an EMPTY FILE — not an "all
@@ -208,22 +257,20 @@ export const MAX_NOTICE_LOST_DAYS = 10;
 export const MAX_NOTICE_VENUE_DARK_DAYS = 7;
 
 /**
- * The heartbeat lines, then the data findings, for one instant. EMPTY when there is
- * nothing to say.
+ * The data findings for one instant. EMPTY when there is nothing to say.
  *
- * `heartbeatLines` arrives already rendered (`loadHeartbeatLines`) rather than being
- * derived here, for the same reason the report does: this half owns COMPOSITION and
- * nothing else.
+ * ONE ARGUMENT, AND THE MISSING ONE IS THE POINT. This took `heartbeatLines` first
+ * until #376; the header records why the job half came off this channel and why
+ * re-adding it is not a small convenience. The findings arrive already derived
+ * rather than being computed here, for the reason this half exists at all: it owns
+ * COMPOSITION and nothing else, so every rendering decision — including the broken
+ * one — is exercised by a synchronous test with no disk.
  */
-export function formatOperatorNotice(
-  heartbeatLines: readonly string[],
-  findings: NoticeGapFindings,
-): string[] {
+export function formatOperatorNotice(findings: NoticeGapFindings): string[] {
   if (findings.kind === "failed") {
-    return [...heartbeatLines, formatNoticeCheckFailure(findings.error)];
+    return [formatNoticeCheckFailure(findings.error)];
   }
   return [
-    ...heartbeatLines,
     ...formatLostDayFindings(findings.report),
     ...formatVenueDarkCount(findings.report),
   ];

--- a/packages/event-store/src/operator-notice.ts
+++ b/packages/event-store/src/operator-notice.ts
@@ -32,6 +32,29 @@
  * that constant was not a decision — it is where the bound went missing, and the
  * constant's own comment records how.
  *
+ * ── THE ADMISSION RULE: A MOVE THE OPERATOR CAN MAKE TODAY ────────────────────
+ * **A line earns this notice only if there is a move the operator can make today
+ * that deletes it.** That is the rule the whole channel is judged against, and it
+ * is the rule the ENUMERATE/COUNT split below was already reaching for without
+ * saying: that split bounded the VOLUME of what gets printed and left the
+ * ADMISSION open, which is how a line that no move can ever delete ended up
+ * printing on every new terminal forever. "Something is wrong" is not the bar. A
+ * notice that offers zero moves has spent the operator's attention and returned
+ * nothing, and it does that on the mornings when nothing is wrong — which is most
+ * of them.
+ *
+ * A VENUE-DARK DAY IS ADMITTED ONLY WHEN RECENT, and that is this rule applied
+ * rather than an exception to it. A real outage's day IS actionable: once the
+ * provider is back, `pnpm prices:fetch --as-of=<date>` lands the marks and the day
+ * then LEAVES `venueDark` entirely — `computeGapReport` re-derives the finding from
+ * the marks on every run — so the line self-extinguishes exactly like a lost day.
+ * A US market holiday's never will; no command will ever clear one, because there
+ * was nothing to fetch. The derivation cannot tell those two apart (`owesMarkOn`
+ * is holiday-blind by #266 D7, deliberately), so RECENCY IS THE ONLY PROXY IT HAS
+ * — and it is a proxy with the property that actually matters here: **the line
+ * leaves on its own even when the operator can do nothing.** See
+ * {@link MAX_NOTICE_VENUE_DARK_DAYS}.
+ *
  * ── ENUMERATE `lost`, COUNT `venueDark` ───────────────────────────────────────
  * The split is the decision this channel lives or dies on, and the data already
  * carries it (`venueDark` is its own key, never folded into `lost`):
@@ -44,8 +67,10 @@
  *     holidays and no command will ever clear one. Enumerated on a channel that
  *     prints on every new terminal, that is cry-wolf channel death arriving on a
  *     schedule, inside the fix. So it gets ONE LINE CARRYING A NUMBER, in
- *     `formatGapSummary`'s existing wording, and the notice names the command that
- *     enumerates them on demand.
+ *     `formatGapSummary`'s voice, and the notice names the command that enumerates
+ *     them on demand — and that line is BOUNDED BY RECENCY under the admission rule
+ *     above ({@link MAX_NOTICE_VENUE_DARK_DAYS}), which is what stops the count
+ *     itself from becoming the permanent line the enumeration was refused for.
  *
  * ── ORDER IS THE CAUSE, THEN THE EFFECT ───────────────────────────────────────
  * Heartbeat lines (the job) first, data findings second — the same order, and for
@@ -65,6 +90,7 @@
  * indistinguishable from one saying "all clear", which is the exact failure this
  * whole increment exists to remove. `gap-lines.ts`'s reasoning, verbatim.
  */
+import { addDays } from "@numisma/engine";
 import {
   formatLostDays,
   type GapReport,
@@ -135,6 +161,53 @@ export function formatNoticeCheckFailure(error: unknown): string {
 export const MAX_NOTICE_LOST_DAYS = 10;
 
 /**
+ * HOW RECENT A VENUE-DARK DAY MUST BE to earn a place on this channel at all.
+ *
+ * This is the ADMISSION RULE in the header made numeric, and it is the constant
+ * that makes "empty means healthy" REACHABLE ON THE REAL STORE. Without it the
+ * notice can never be empty again: the store's one venue-dark day is 2026-07-03,
+ * observed US Independence Day, and `owesMarkOn` is holiday-blind by #266 D7, so
+ * that day is a standing finding no command will ever clear. A channel that always
+ * says something is a channel that is never read.
+ *
+ * WHY SEVEN, against the failure shape and not an aesthetic. The holiday case is
+ * not one line — it is ONE EPISODE PER HOLIDAY, N DAYS LONG, about ten times a
+ * year, forever. N therefore sets what fraction of the year this channel is
+ * non-empty ON A PERFECTLY HEALTHY STORE: 30 days spends ~300 of them and leaves
+ * the notice quiet ~18% of the year; 14 spends ~140; SEVEN spends ~70 and keeps
+ * the channel EMPTY FOUR DAYS IN FIVE. Anything in the 14–30 range converts a
+ * permanent line into a line present most of the year, which trains the identical
+ * skim — it does not restore the contract, it slows its collapse.
+ *
+ * Seven is also the SHORTEST window that survives the absence pattern this
+ * codebase already plans around: {@link MAX_NOTICE_LOST_DAYS}' own comment names
+ * "Fri 2026-08-21 through Sun 08-23 are away days". Below seven, a Friday outage
+ * over a long weekend depends on the operator opening a shell on exactly the right
+ * Monday; above seven the episodes start merging around Thanksgiving and
+ * Christmas. RECORDED FLIP TRIGGER: if ~70 noisy days a year still proves too
+ * many, THREE is defensible — a real outage still reaches the TUI banner and
+ * `pnpm gap-report` intact. 14 and 30 are not.
+ *
+ * THE BOUND IS PRESENTATION-ONLY AND APPLIED AT THE LEAF, exactly like
+ * {@link MAX_NOTICE_LOST_DAYS}: `computeGapReport` still walks the whole window and
+ * still knows every venue-dark day. NARROWING THE DERIVATION WINDOW TO ACHIEVE
+ * THIS IS FORBIDDEN — it would narrow the `lost` half too, and lost days are
+ * PERMANENT, so 2026-08-14/15 would age out of the notice: the one outcome this
+ * channel exists to prevent.
+ *
+ * THE TUI BANNER DOES NOT TAKE THIS BOUND, and that is not an oversight. The
+ * banner is a PULL surface, deliberately scanned when opened, and it already has
+ * the ceiling its own docstring asked for (`MAX_GAP_LINES` / `RESERVED_LOST_LINES`).
+ * The twin property this notice shares with it binds the WINDOW, not the RENDERING
+ * — `operator-notice-cli.ts` says so — and a recency bound is a rendering decision,
+ * the same kind of decision as the banner enumerating what this notice counts.
+ *
+ * Exported because the test must DRIVE the bound rather than restate it — the same
+ * reason {@link MAX_NOTICE_LOST_DAYS} and the TUI's `MAX_GAP_LINES` are exported.
+ */
+export const MAX_NOTICE_VENUE_DARK_DAYS = 7;
+
+/**
  * The heartbeat lines, then the data findings, for one instant. EMPTY when there is
  * nothing to say.
  *
@@ -198,6 +271,14 @@ function formatLostDayFindings(report: GapReport): string[] {
  * It is written in `formatVenueDarkCount`'s voice, with its `(s)` house form and its
  * `pnpm gap-report` pointer, for the same reason: one finding, one vocabulary. A count
  * the operator cannot expand is a dead end, and that command already expands it.
+ *
+ * THE BARE COMMAND REALLY DOES ENUMERATE THESE, and that is a property of the floor
+ * this notice takes rather than of this sentence: `loadOperatorNoticeLines` defaults
+ * to `defaultGapReportSince`, so the window these days were withheld from and the
+ * window `pnpm gap-report` opens are the same one. See `formatVenueDarkCount` below
+ * for why naming a `--since` here instead would produce an instruction that command
+ * REFUSES, and why this pointer was promising an enumeration it could not deliver
+ * until the two floors were bound together.
  */
 function formatWithheldLostDays(withheld: number): string {
   return `Numisma: ${withheld} earlier lost day(s) withheld — enumerate them with pnpm gap-report.`;
@@ -209,17 +290,56 @@ function formatWithheldLostDays(withheld: number): string {
  *
  * The sentence is `formatGapSummary`'s venue-dark clause, in its voice and with its
  * `(s)` house form, so the two surfaces do not develop two vocabularies for one
- * finding. It names `pnpm gap-report` because a count the operator cannot expand is
- * a dead end, and expanding it on demand is exactly what that command already does.
- * Omitted entirely at zero: a channel that prints "0 venue-day(s) dark" on a clean
- * day has broken the empty-means-healthy contract.
+ * finding. Omitted entirely at zero — a channel that prints "0 venue-day(s) dark" on
+ * a clean day has broken the empty-means-healthy contract — and ZERO AFTER FILTERING
+ * IS THE SAME ZERO, which is precisely what makes that contract reachable on the real
+ * store rather than only in a fixture.
+ *
+ * ── IT CARRIES THE HOLIDAY CLAUSE, BECAUSE #266 D7 REQUIRES IT ────────────────
+ * `packages/engine/src/price-feed/venue-calendar.ts` accepts that a US market holiday
+ * reads as venue-dark ON THE CONDITION that *"every surface that renders this
+ * expectation is required to say so in its own message, so a holiday reads as a
+ * holiday."* `formatVenueDarkDays` honours it; this line did not, and the store's one
+ * venue-dark day is 2026-07-03, observed Independence Day — the known false positive,
+ * pinned into a push channel with the sentence that would explain it stripped out.
+ * That was a defect independent of any window and the clause is not optional here.
+ *
+ * ── AND IT NAMES ITS OWN WINDOW ───────────────────────────────────────────────
+ * The count is over {@link MAX_NOTICE_VENUE_DARK_DAYS} days, not over the report, so
+ * the line SAYS SO: a count whose scope is invisible is a count the reader assumes is
+ * total. The number in the text is derived from the constant rather than restated, so
+ * retuning the bound moves the sentence with it. `pnpm gap-report` is the record; the
+ * notice is not.
+ *
+ * ── THE `pnpm gap-report` POINTER IS SAFE TO KEEP ─────────────────────────────
+ * It points at the BARE command, with no `--since`, and that only works because
+ * `loadOperatorNoticeLines` now defaults its floor to `defaultGapReportSince` — the
+ * same floor that command uses. Before that, the notice floored at
+ * `LAUNCHD_ERA_START` while the command floored 400 days back, so from 2027-08-08 the
+ * two describe different windows; and the obvious repair — printing
+ * `pnpm gap-report --since=${report.since}` — produces an instruction the command
+ * REFUSES, because era-floor → yesterday crosses `MAX_WINDOW_DAYS` on exactly that
+ * date. Not "the default won't show it" but "no invocation can". Same for
+ * `formatWithheldLostDays`' pointer above; both are correct by construction now, and
+ * both stop being correct the moment either surface picks its own floor again.
+ *
+ * ── THE WINDOW IS ANCHORED AT `report.until`, NOT AT `now` ────────────────────
+ * This half is PURE and reads no clock; `report.until` is already clamped to
+ * yesterday by the derivation, which is the same instant a clock read here would
+ * resolve to and is reproducible in a test besides. A report narrower than the bound
+ * simply filters nothing — no clamp is needed, because the floor only ever moves
+ * earlier than the report's own.
  */
 function formatVenueDarkCount(report: GapReport): string[] {
-  if (report.venueDark.length === 0) {
+  const floor = addDays(report.until, -(MAX_NOTICE_VENUE_DARK_DAYS - 1));
+  const recent = report.venueDark.filter(({ date }) => date >= floor);
+  if (recent.length === 0) {
     return [];
   }
   return [
-    `Numisma: ${report.venueDark.length} venue-day(s) dark — not lost days: the feed ` +
-      `ran and the days are anchored. Enumerate them with pnpm gap-report.`,
+    `Numisma: ${recent.length} venue-day(s) dark in the last ` +
+      `${MAX_NOTICE_VENUE_DARK_DAYS} days — not lost days: the feed ran and the days ` +
+      `are anchored, and the venue was silent or the market was closed for a holiday. ` +
+      `Enumerate them with pnpm gap-report.`,
   ];
 }


### PR DESCRIPTION
Closes #381. Closes #376.

Two defects filed against the operator notice from opposite sides — a channel that can never be empty, and a channel that can be empty while a run is failing. They were grilled together on 2026-08-18 (`codebase-grill`, nine nodes, nine locked decisions, zero parked) because both turned out to be consequences of one unstated contract. The ruling is on both issue bodies as a comment; the remedy menus in the original bodies are superseded.

## The rule both halves fell out of

**A line earns this notice only if there is a move the operator can make today that deletes it.** That is what the existing ENUMERATE-`lost` / COUNT-`venueDark` split was already reaching for — it bounded the **volume** of what gets printed and left the **admission** open. The volume was never the problem.

Traced against a healthy store on 2026-08-19 — 2026-07-03 dark on record, previous run exited 1 at `post-check`, current run clean — the notice printed two lines and offered zero moves. Under the admission rule it is **empty**.

## Four commits

**1 — `refactor(event-store)`: the window width moves beside the era floor.** `MAX_WINDOW_DAYS` and `defaultGapReportSince` come down into `@numisma/event-store`; `gap-report-core.ts` re-exports them, so no importer changes. Behaviour-identical, and it is the seam the other three stand on: the package and `apps/tui` cannot import from `apps/web`, and the alternative was a second copy of 400 — the exact failure `venue-calendar.ts:12-20` records. Same shape as the #266 move that brought `venue-calendar.ts` into the engine.

**2 — the data half (#381).** `MAX_NOTICE_VENUE_DARK_DAYS = 7`, presentation-only at the leaf exactly like `MAX_NOTICE_LOST_DAYS`; `computeGapReport` still walks the whole window, because narrowing the derivation would narrow the **lost** half too and lost days are permanent. A venue-dark day is admitted only when recent, and that is the admission rule applied rather than an exception to it: a real outage's day is recoverable by `pnpm prices:fetch --as-of=<date>` and then leaves `venueDark`, because the report re-derives the finding from marks every run; a US market holiday's never will. Recency is the only proxy the derivation has, and it has the property that matters — the line leaves on its own even when the operator can do nothing.

The line also regains the holiday clause #266 D7 requires of every surface rendering this expectation. The store's one venue-dark day is 2026-07-03, observed Independence Day — the known false positive, pinned into a push channel with the sentence that would explain it stripped out. And it names its own window, because a count whose scope is invisible is a count the reader assumes is total.

Both twins now default their floor to `defaultGapReportSince`. The notice tells the operator to run `pnpm gap-report`; on the fixed era floor those diverge on 2027-08-08, and the cheap repair is refused by the code — a `--since=<era floor>` names a window wider than `MAX_WINDOW_DAYS`, which that command rejects outright. So it was not "the default won't show it" but "no invocation can". The default lives at both composers rather than at the two shells, so the twin binding is structural.

**The twin property is not retired.** It binds the **window**, not the **rendering** — the banner enumerates, the notice counts, and `operator-notice.ts` already required them to render this finding differently. That sentence is now in the CLI's header, because its absence is what made #381 read as unfixable.

**3 — the job half (#376).** All three heartbeat triggers come off step 5b; `formatOperatorNotice` loses its `heartbeatLines` argument. A correction to how the issue states the mechanism: the trap is EXIT-only, so at 5b the file holds run N−1's breadcrumb **exactly as step 0 saw it** — the two read the same bytes. 5b is not staler, it is identically sourced and differently scoped, and on the recovery path the file is right and the sentence is wrong. Two of the three triggers were anti-correlated with the truth of the run composing them: 5b's job half was written by a run that knows its own status and reads someone else's. `formatHeartbeatWarning`, `loadHeartbeatLines` and the TUI are untouched — the banner keeps all three triggers, and that their suites pass unedited is the evidence.

**4 — the bash.** The EXIT trap writes the notice too, on a non-zero exit only, closing the ~19-hour all-clear that commit 3 would otherwise leave standing over a run that dies after 5b. On a zero exit it does not touch the file. Step 0 and the trap share one writer function and one wording; only the scope line's tail varies by argument. Step 0 is kept as the only cover for a trap-less death.

## Assurance

- **Unit, the case #381 named:** a venue-dark day older than the window yields an **empty** notice, with every number driven off `MAX_NOTICE_VENUE_DARK_DAYS` rather than restated — plus the boundary from both sides, a mixed window, and a guard that the **lost** half is untouched by the bound.
- **Unit, the shared floor:** the notice's floor and `defaultGapReportSince` are the same value, asserted at a clock past 2027-08-08 where the two old floors genuinely differ. Commit 1 is what makes that expressible.
- **Unit, the silence:** a FAILED breadcrumb on disk beside a clean window produces an **empty file**. That is #376's false-FAILED-on-the-recovery-path case, and it goes red the instant anyone re-adds the argument.
- **Harness, real bash — case 9e:** the fake `pnpm operator-notice` writes an authored sentinel, the run dies at `backfill`, and the trap's FAILED lines must have replaced it. Two writers, one file, ordering matters. Cases 9a–9c now run to completion, which is the only shape in which step 0's own bytes survive to be read — and that buys the zero-exit restraint in the same three cases.

`pnpm typecheck` clean. `pnpm test` armed: **160 passed | 3 skipped** files, **2476 passed | 19 skipped** tests. `NUMISMA_WRAPPER_TEST=always pnpm test:wrapper`: **61 passed**. `shellcheck` and `bash -n` clean on the wrapper.

No ADR — the twin property is not being retired, and the constant move has the #266 precedent, which took none either. The docstrings that already carry this reasoning are where the ruling landed.

## Known residue, not closed here

Step 0's unique cover — a trap-less death by SIGKILL, OOM or power loss — has no harness case; producing one needs an external kill of the wrapper shell plus new residue handling. It is named in step 0's rewritten comment block.
