### PR TITLE
fix(data-dir): route every dataDir door through one predicate, pinned by one table

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,7 +28,7 @@ six members are versioned together at the monorepo version.
 
 | Package                                                    | Runtime                                    | Owns                                                                                                                                                                                                                                                                                       |
 | ---------------------------------------------------------- | ------------------------------------------ | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ |
-| [`@numisma/engine`](./packages/engine/README.md)           | Node-compatible, IO-free, no Bun/openTUI   | The pure fund domain: parsing untrusted input, validating events, folding genesis + log into the `CompositionReport` read model, the shared formatters, the pure half of the two-plane price model, and the whole Orders model. Exposes `.`, `./format`, and `./calendar` subpath exports. |
+| [`@numisma/engine`](./packages/engine/README.md)           | Node-compatible, IO-free, no Bun/openTUI   | The pure fund domain: parsing untrusted input, validating events, folding genesis + log into the `CompositionReport` read model, the shared formatters, the pure half of the two-plane price model, and the whole Orders model. Exposes `.`, `./format`, `./calendar`, and `./testkit` subpath exports. |
 | [`@numisma/event-store`](./packages/event-store/README.md) | Node-compatible                            | The durable log's **read** path — path resolution, genesis load, log load with quarantine, `loadFoldedReview` — plus the gap-report and job-heartbeat sidecars. Consumed by both the TUI and the web push. Exposes `.` and the `./testkit` subpath export.                                                                                 |
 | [`@numisma/preferences`](./packages/preferences/README.md) | Node-compatible                            | Sidecar file IO for `preferences.jsonl` (profit-split policy) and `orders.jsonl` (resting claims). Append-only, validated on load, cross-process locked for orders.                                                                                                                        |
 | [`@numisma/tui`](./apps/tui/README.md)                     | Bun + openTUI (dashboard); Node for CLIs   | The local access surface: the durable log's **write** half (ingest / dedup / atomic append / archive / legacy migration), startup orchestration, the interactive dashboard, the three Orders CLIs, and the smoke renders.                                                                  |
@@ -41,9 +41,10 @@ lives in `@numisma/event-store`, the **write/ingest** path (inbox detection,
 dedup persistence, atomic append, archive) and startup orchestration stay in
 `@numisma/tui`, and sidecar IO lives in `@numisma/preferences`. Every app
 consumes its libraries through a package's declared entry points — the root
-plus the three deliberate subpath exports (`@numisma/engine/format`,
-`@numisma/engine/calendar`, `@numisma/event-store/testkit`) — never an
-undeclared deep import; `pnpm typecheck` mechanically bars those.
+plus the four deliberate subpath exports (`@numisma/engine/format`,
+`@numisma/engine/calendar`, `@numisma/engine/testkit`,
+`@numisma/event-store/testkit`) — never an undeclared deep import; `pnpm
+typecheck` mechanically bars those.
 
 ## Documentation
 

--- a/apps/price-feed/src/paths.test.ts
+++ b/apps/price-feed/src/paths.test.ts
@@ -13,9 +13,10 @@
  * Every fixture is an authored string. Nothing here touches a filesystem — this is pure
  * path algebra — so no test in this file can reach a real data dir.
  */
-import { join, resolve } from "node:path";
+import { dirname, join, resolve } from "node:path";
 import { describe, expect, it } from "vitest";
 import { PRICE_STORE_DIR_SEGMENT } from "@numisma/engine";
+import { assertDataDirContract } from "@numisma/engine/testkit";
 import { resolvePriceFeedPaths } from "./paths.js";
 
 describe("resolvePriceFeedPaths — a BLANK dataDir is REFUSED before it can be laundered", () => {
@@ -88,4 +89,19 @@ describe("resolvePriceFeedPaths — a BLANK dataDir is REFUSED before it can be 
     const spaced = resolve("/tmp/numisma authored root 348");
     expect(resolvePriceFeedPaths(spaced).log).toBe(join(spaced, "events.jsonl"));
   });
+});
+
+// The LAUNDERING door runs the same table as the other four (#369). It is the door the
+// table most needs, because its failure mode is invisible at the boundary it delegates
+// across: it used to `resolve()` its argument first, which turns every value the upstream
+// resolver refuses into one it accepts. `resolve("data")` is `<cwd>/data` — absolute,
+// valid-looking, and a different store on every CWD.
+//
+// It is also the one door with NO `undefined` arm: its `dataDir` is required, so there is
+// no default for a caller to fall into. The table asserts that absence rather than
+// skipping it, so a later edit that adds a default has to come back through here.
+assertDataDirContract({
+  name: "resolvePriceFeedPaths",
+  subject: /a price-feed data directory|NUMISMA_DATA_DIR/,
+  root: (dataDir) => dirname(resolvePriceFeedPaths(dataDir).log),
 });

--- a/apps/price-feed/src/paths.test.ts
+++ b/apps/price-feed/src/paths.test.ts
@@ -13,9 +13,10 @@
  * Every fixture is an authored string. Nothing here touches a filesystem — this is pure
  * path algebra — so no test in this file can reach a real data dir.
  */
+import { homedir } from "node:os";
 import { dirname, join, resolve } from "node:path";
 import { describe, expect, it } from "vitest";
-import { PRICE_STORE_DIR_SEGMENT } from "@numisma/engine";
+import { INBOX_PATH_SEGMENTS, PRICE_STORE_DIR_SEGMENT } from "@numisma/engine";
 import { assertDataDirContract } from "@numisma/engine/testkit";
 import { resolvePriceFeedPaths } from "./paths.js";
 
@@ -100,8 +101,49 @@ describe("resolvePriceFeedPaths — a BLANK dataDir is REFUSED before it can be 
 // It is also the one door with NO `undefined` arm: its `dataDir` is required, so there is
 // no default for a caller to fall into. The table asserts that absence rather than
 // skipping it, so a later edit that adds a default has to come back through here.
+//
+// The root is read back off `pricesDir`, NOT off `log`. `log`, `genesis` and `inbox` are
+// all built by the delegated `resolveEventStorePaths`, so a table driven through any of
+// them measures the EVENT-STORE door's normalization a second time and says nothing about
+// this one. `pricesDir` is the only field this function assembles from its own `base`, so
+// it is the only field through which the table can see this door at all: a regression
+// that fed `join(dataDir, PRICE_STORE_DIR_SEGMENT)` the raw argument would keep every
+// delegated field correct and split the price marks off to `<cwd>/~/scratch/prices`,
+// invisibly, if the table kept reading `log`.
 assertDataDirContract({
   name: "resolvePriceFeedPaths",
-  subject: /a price-feed data directory|NUMISMA_DATA_DIR/,
-  root: (dataDir) => dirname(resolvePriceFeedPaths(dataDir).log),
+  subject: /a price-feed data directory/,
+  root: (dataDir) => dirname(resolvePriceFeedPaths(dataDir).pricesDir),
+});
+
+describe("resolvePriceFeedPaths — all four locations agree on ONE base", () => {
+  // The table drives this door through `pricesDir` alone (see above), which proves this
+  // function's own normalization but not that its own half and its delegated half landed
+  // on the SAME root. That agreement is the whole reason this function exists rather than
+  // each caller assembling four paths itself, and it is exactly what a split would break:
+  // marks written under one root while the log, genesis and inbox live under another is
+  // not a crash, it is a fund whose prices silently stop reaching its positions.
+  //
+  // The two inputs are the two the argument doors used to get wrong. `~/…` is #369's
+  // ruling (three doors produced `<cwd>/~/…`), and a padded absolute path is the trim's
+  // new reach at the argument doors — the one whose halves would disagree if only one of
+  // them normalized.
+  const assertOneBase = (dataDir: string, base: string): void => {
+    const paths = resolvePriceFeedPaths(dataDir);
+    expect(paths.pricesDir).toBe(join(base, PRICE_STORE_DIR_SEGMENT));
+    expect(paths.genesis).toBe(join(base, "genesis.json"));
+    expect(paths.log).toBe(join(base, "events.jsonl"));
+    expect(paths.inbox).toBe(join(base, ...INBOX_PATH_SEGMENTS));
+  };
+
+  it("a `~` path expands once, for the price store and the delegated log alike", () => {
+    // `homedir()` at runtime — never a `/Users/...` literal, which ADR-006 forbids and
+    // which would publish the operator's directory layout in a public repo.
+    assertOneBase("~/scratch/numisma-authored-price-root", join(homedir(), "scratch", "numisma-authored-price-root"));
+  });
+
+  it("a whitespace-padded path is trimmed once, not by one half only", () => {
+    const root = resolve("/tmp/numisma-authored-price-root-369");
+    assertOneBase(`  ${root}  `, root);
+  });
 });

--- a/apps/price-feed/src/paths.ts
+++ b/apps/price-feed/src/paths.ts
@@ -5,8 +5,8 @@
  * the tui consumes — so price-feed and tui agree by construction rather than by
  * two copies of one convention.
  */
-import { join, resolve } from "node:path";
-import { PRICE_STORE_DIR_SEGMENT } from "@numisma/engine";
+import { join } from "node:path";
+import { PRICE_STORE_DIR_SEGMENT, normalizeDataDirOverride } from "@numisma/engine";
 import { resolveEventStorePaths } from "@numisma/event-store";
 
 export interface PriceFeedPaths {
@@ -27,32 +27,38 @@ export interface PriceFeedPaths {
 /**
  * Resolve the price-feed's on-disk locations from one data root.
  *
- * A blank or whitespace-only `dataDir` is REFUSED (#348), and the refusal has to live
- * HERE rather than being inherited. This function calls `resolve()` on its argument
- * BEFORE handing it to `resolveEventStorePaths`, and `resolve("")` is the process's CWD
- * — an absolute, perfectly valid-looking path. So a blank laundered through this
- * function arrived at the hardened resolver already disguised, its own guard never
- * fired, and the pair produced exactly the `<cwd>/events.jsonl` that resolver's error
- * message says must never happen. Measured before this guard, not theorised.
+ * The guard has to live HERE rather than being inherited, and that is the whole reason
+ * this function is one of the doors #348 and #369 both had to reach. It used to call
+ * `resolve()` on its argument BEFORE handing it to `resolveEventStorePaths`, which
+ * LAUNDERS every value the upstream resolver refuses into one it accepts: `resolve("")`
+ * is the process's CWD and `resolve("data")` is `<cwd>/data`, both absolute and both
+ * indistinguishable at the boundary from a deliberate root. The upstream guard saw a
+ * valid-looking path and passed it, and the pair produced exactly the
+ * `<cwd>/events.jsonl` that resolver's error message says can never happen. Measured
+ * before the blank guard, not theorised — and the relative arm laundered the same way
+ * until #369.
+ *
+ * Validating through the shared `normalizeDataDirOverride` is what makes that
+ * structurally impossible rather than fixed twice: the value is checked as the caller
+ * WROTE it, before any `resolve()` can disguise it.
  *
  * `dataDir` is REQUIRED here and there is deliberately no default, so unlike the
- * resolvers upstream this one has no `undefined` → default arm to preserve: every
- * caller (`cli.ts`, `fetch-prices.ts`) passes `config.dataDir`, which is
- * `resolveDataDir()` — already absolute and already blank-refused. The guard is
- * therefore unreachable from the real callers by construction, which is the point: it
- * exists so that stays true.
+ * resolvers upstream this one has no `undefined` → default arm to preserve — which is
+ * why its refusal points only at "pass an absolute path" and not at a way to reach a
+ * default it does not have. Every caller (`cli.ts`, `fetch-prices.ts`) passes
+ * `config.dataDir`, which is `resolveDataDir()` — already absolute and already
+ * validated. The guard is therefore unreachable from the real callers by construction,
+ * which is the point: it exists so that stays true.
  */
 export function resolvePriceFeedPaths(dataDir: string): PriceFeedPaths {
-  if (dataDir.trim() === "") {
-    throw new Error(
-      `a price-feed data directory must not be empty (got "${dataDir}"). ` +
-        `An empty value is not "unset": it resolves to the process's working ` +
-        `directory, which would scatter the price store, the inbox and a phantom ` +
-        `event log into whatever directory the fetch happened to start in. ` +
-        `Pass an absolute path.`,
-    );
-  }
-  const base = resolve(dataDir);
+  const base = normalizeDataDirOverride(dataDir, {
+    subject: "a price-feed data directory",
+    blankHeadline: "a price-feed data directory must not be empty",
+    blankConsequence:
+      "it resolves to the process's working directory, which would scatter the price " +
+      "store, the inbox and a phantom event log into whatever directory the fetch " +
+      "happened to start in.",
+  });
   // Reading the log refreshes its derived `events.jsonl.quarantine` lane, which is
   // shared with `pnpm spine` and the tui and is not the log itself (R6 holds).
   // `pricesDir` is assembled here because the event store has no equivalent for it.

--- a/context/adr/ADR-006-private-sibling-data-repo-commit-per-ingest.md
+++ b/context/adr/ADR-006-private-sibling-data-repo-commit-per-ingest.md
@@ -76,6 +76,23 @@ the `captureIngestCommit` seam wired into `ingestInbox` — is the `@numisma/tui
   split-brain onto two stores — and must be **rejected with a loud error** (require absolute
   or `~`). price-feed and tui must keep agreeing on the sub-paths (`inbox/transactions.json`,
   `prices/`, `genesis.json`, `events.jsonl`); a resolver split here silently breaks ingest.
+- **The rule binds every DOOR, not just the env knob, and `~` expands at all of them (#369).**
+  The `NUMISMA_DATA_DIR` variable is one of five entry points for a data root; the other four
+  are caller-supplied `dataDir` arguments (`resolveEventStorePaths`, `resolvePreferencesPath`,
+  `resolveSidecarPath`, `resolvePriceFeedPaths`). Stating the invariant only for the env knob
+  left the arguments to four hand-written copies of it, and they drifted: two accepted a bare
+  `"data"` and produced `<cwd>/data/…` silently — the exact split-brain this bullet forbids —
+  and the five disagreed on `~` three ways (expanded, refused as non-absolute, or turned into
+  a directory literally *named* `~`). The predicate is therefore **one shared function**
+  (`normalizeDataDirOverride`), and the `undefined` → default arm stays per-door because the
+  defaults genuinely differ. **`~` is honored at every door**, not only at the env knob: the
+  hazard the rule guards is *CWD-dependence*, and `~/x` has none — it is absolute and
+  homedir-derived, which is this bullet's own invariant verbatim. The counter-argument (`~` is
+  a shell affordance and `node:path` has no notion of it) loses because an env-only tilde rule
+  would need a mode flag on the shared predicate, restoring the per-door divergence the shared
+  predicate exists to remove. `~user` is **not** supported syntax and is refused as relative.
+  One input→outcome table (`@numisma/engine/testkit`) is run against all five doors, so a
+  one-sided edit fails a test rather than reaching production.
 - **The best-effort commit contract has three clauses and a fixed ordering.** The append is
   *already durable* (atomic temp-and-rename) before the capture runs; the capture then
   **never throws / never blocks / never corrupts** it. Ordering is fixed: **append →

--- a/docs/codebase-map.md
+++ b/docs/codebase-map.md
@@ -37,9 +37,10 @@ placeholder convention itself, are documented in
 **The dependency rule:** apps depend on packages, never the reverse; packages
 depend on `@numisma/engine` and never on each other beyond that. Every consumer
 imports through a package's **declared** entry points only — the root plus the
-three deliberate subpath exports (`@numisma/engine/format`,
-`@numisma/engine/calendar`, `@numisma/event-store/testkit`) — never an
-undeclared deep path into a package's `src/`. `pnpm typecheck` enforces both
+four deliberate subpath exports (`@numisma/engine/format`,
+`@numisma/engine/calendar`, `@numisma/engine/testkit`,
+`@numisma/event-store/testkit`) — never an undeclared deep path into a
+package's `src/`. `pnpm typecheck` enforces both
 the public surfaces and the no-deep-import boundary — it is a real gate, not a
 formality.
 

--- a/docs/durable-log-ops.md
+++ b/docs/durable-log-ops.md
@@ -90,7 +90,12 @@ The `NUMISMA_DATA_DIR` env var is the **single** knob that moves every plane (th
 event-store, the price-feed config, and the preferences sidecar). The resolution rule
 lives once, pure and IO-free, in `@numisma/engine` (`packages/engine/src/data-dir.ts`):
 
-- unset / empty / whitespace → the `<fund>` default (`~/Dev/<fund>/data`);
+- unset → the `<fund>` default (`~/Dev/<fund>/data`);
+- empty / whitespace-only → **rejected loudly** (#348): an empty value is a
+  MISCONFIGURED knob, not an absent one, and silently falling through to the
+  default would send every write to the real ledger instead of the store the
+  deployment meant to configure — unset the variable to choose the default
+  deliberately;
 - `~` or `~/…` → `~`-expanded against `homedir()`, then made absolute;
 - an absolute path → normalized;
 - a **relative** path → **rejected loudly** (a relative value would resolve

--- a/packages/engine/README.md
+++ b/packages/engine/README.md
@@ -109,7 +109,7 @@ imports the shared kernel rather than re-copying cross-concern helpers.
 | `orders/fill.ts`       | `TornFillAct`, `LadderPosition`, `FundingTier`, `OpenLadderTarget`, `AddLadderTarget`, `LadderTarget`, `FillActInput`, `FillAct`, `fillEventId`, `parseFillEventId`, `reconcileFillActs`, `resolveLadderPosition`, `deriveFundingTier`, `buildFillAct` | `S8`: the fill act's pure half — builds the paired `orderFilled` sidecar record and the `PositionOpened`/`PositionAddedTo` event together, so a caller can never write half of one. |
 | `durable-log.ts`       | `HeadDigest`, `IngestCommitInput`, `deriveHeadDigest`, `formatIngestCommitMessage` | Pure derivations for the git-backed durable event log's shell: a compact, schema-v2 Head Digest derived from the whole `FoldedReview` envelope (so a reader can trust a head — including its `discardedEventCount` — without replaying the log; ADR-020), and a deterministic ingest commit message. |
 | `calendar.ts`          | `addDays`, `daysBetween`   | Calendar-date arithmetic over the `asOf`-as-`YYYY-MM-DD` convention. Import-free (browser-safe by construction); also reachable via the `@numisma/engine/calendar` subpath. |
-| `data-dir.ts`          | `resolveDataDir`           | The one resolver for the durable ledger's data root: honors `NUMISMA_DATA_DIR`, else defaults to the sibling `<fund>` repo's `data/`. Pure string/env computation (`homedir()`, `node:path`) — no fs, no clock. |
+| `data-dir.ts`          | `resolveDataDir`, `normalizeDataDirOverride`, `DataDirVoice` | The one resolver for the durable ledger's data root: honors `NUMISMA_DATA_DIR`, else defaults to the sibling `<fund>` repo's `data/`. `normalizeDataDirOverride` is the ONE implementation of ADR-006's rule for a PRESENT value (blank refused, `~` expanded, absolute normalized, relative refused), which the four caller-supplied data-dir doors in the other packages route through so no door can be softer or harder than the env knob (#369); `DataDirVoice` carries the per-door refusal prose #348 deliberately wrote. Pure string/env computation (`homedir()`, `node:path`) — no fs, no clock. |
 
 Dependency direction: `contracts.ts` → (`internal.ts`, `price-journey.ts`) →
 `parse.ts` / `compose/*` / `events/*` / `price-feed/*` / `orders/*` / `format.ts`
@@ -128,10 +128,19 @@ folded state too, but only transitively — through `compose/canonical.js`, whic
 `parseFundReview` (to re-validate genesis) and the composition read model;
 `contracts.ts` depends on nothing else in the package, so there are no cycles.
 
-Two subpath exports exist beside the package root: `@numisma/engine/format`
-(the shared formatters, standalone) and `@numisma/engine/calendar` (the
+Three subpath exports exist beside the package root: `@numisma/engine/format`
+(the shared formatters, standalone), `@numisma/engine/calendar` (the
 import-free calendar arithmetic, for browser-side consumers that cannot pull in
-the rest of the package) — see `package.json`'s `exports` map.
+the rest of the package), and `@numisma/engine/testkit` — see `package.json`'s
+`exports` map.
+
+`./testkit` is TEST SCAFFOLDING, not domain code: it exports the one
+input→outcome table for ADR-006's `dataDir` rule (`data-dir-contract.testkit.ts`)
+so all five data-dir doors can be driven against a single copy of it from their
+own packages (#369). It is deliberately kept OUT of the `.` entry point, and out
+of `index.ts` entirely, so it is unreachable from production code — a subpath
+export is what lets four packages share one table without the table becoming
+part of the engine's domain surface.
 
 > Note: the behavioral suite is split to mirror the modules —
 > `fund-composition-{parse,tiers,warnings,dashboard}.test.ts` over a shared

--- a/packages/engine/package.json
+++ b/packages/engine/package.json
@@ -6,6 +6,7 @@
   "exports": {
     ".": "./src/index.ts",
     "./format": "./src/format.ts",
+    "./testkit": "./src/data-dir-contract.testkit.ts",
     "./calendar": "./src/calendar.ts"
   },
   "types": "./src/index.ts",

--- a/packages/engine/src/data-dir-contract.testkit.ts
+++ b/packages/engine/src/data-dir-contract.testkit.ts
@@ -148,6 +148,14 @@ export interface DataDirDoor {
    * The door's own voice, so the shared predicate is proven NOT to have flattened the
    * per-door error messages #348 deliberately wrote (a Reserve floor served from a file
    * nothing writes, vs a SECOND genesis seeded beside the job's CWD).
+   *
+   * It must match THIS door's subject and nothing else. An alternation that also admits
+   * another door's wording — `/a sidecar data directory|NUMISMA_DATA_DIR/` — disarms the
+   * assertion against the one regression `DataDirVoice` exists to prevent: a door that
+   * stopped calling `normalizeDataDirOverride` with its own voice and started delegating
+   * to `resolveDataDir({ NUMISMA_DATA_DIR: dataDir })` would emit the ENGINE's message,
+   * every root row would still land on the same path, and the whole table would stay
+   * green while the operator lost the sentence naming which artifact was at stake.
    */
   subject: RegExp;
   /**
@@ -197,25 +205,18 @@ export function assertDataDirContract(door: DataDirDoor): void {
       });
     }
 
-    it("never resolves against the process CWD — the whole point of the table", () => {
-      // The refusal rows above are each asserted individually; this is the class-level
-      // statement, and it names the two paths #369 measured coming out of the permissive
-      // doors so a regression reads as itself rather than as a generic mismatch.
-      for (const forbidden of [process.cwd(), join(process.cwd(), "data")]) {
-        for (const testCase of DATA_DIR_CONTRACT_CASES) {
-          let produced: string | undefined;
-          try {
-            produced = door.root(testCase.input);
-          } catch {
-            continue;
-          }
-          expect(
-            produced,
-            `${door.name}(${JSON.stringify(testCase.input)}) resolved to a CWD-derived root (${forbidden})`,
-          ).not.toBe(forbidden);
-        }
-      }
-    });
+    // There is deliberately NO extra "never resolves against the process CWD" case here.
+    // One used to sit at this spot, looping every row and asserting the produced root was
+    // neither `process.cwd()` nor `<cwd>/data`. It could not fail: every input that could
+    // have produced either of those two paths is a refusal row above, and each of those
+    // rows already asserts the door RETURNS NOTHING — a strictly stronger claim than "the
+    // thing it returned was not this particular path". A test that cannot go red while
+    // its neighbours are green is worse than no test, because its name advertises a
+    // class-level guarantee it is not actually holding. The guarantee is real and is held
+    // by the rows themselves: the `throws-relative` rows are exactly the CWD-dependent
+    // spellings #369 measured coming out of the permissive doors (`data` → `<cwd>/data`,
+    // `~/scratch` → `<cwd>/~/scratch`), and the `root` rows pin the absolute path each
+    // accepted input must land on, which no CWD-derived answer can equal.
 
     const defaultArm = door.defaultArm;
     if (defaultArm === undefined) {

--- a/packages/engine/src/data-dir-contract.testkit.ts
+++ b/packages/engine/src/data-dir-contract.testkit.ts
@@ -1,0 +1,238 @@
+/**
+ * The ONE input→outcome table for ADR-006's `dataDir` rule, and the driver that runs it
+ * against a door (TEST INPUT ONLY).
+ *
+ * #369's defect was not that a resolver was wrong. It was that FIVE doors each carried a
+ * hand-written copy of one contract, and two of them had already drifted apart from the
+ * other three on two of the table's inputs — silently, because nothing exercised the same
+ * inputs against all of them. `normalizeDataDirOverride` collapsed the five predicates
+ * into one; this collapses the five test suites' overlapping coverage into one table, so
+ * the fix cannot be half-undone by a one-sided edit. A door that stops routing through the
+ * shared predicate fails HERE, in its own package, naming the input it disagreed on.
+ *
+ * A table alone would not have caught the original drift — the four packages could each
+ * have kept their own copy of it, which is exactly what they had. What makes this load-
+ * bearing is that there is ONE copy, imported: `@numisma/engine/testkit`. Every package
+ * with a door already depends on `@numisma/engine`, so no new dependency edge is drawn to
+ * get it, and the doors live in four different packages precisely because no single
+ * package can import all five (the dependency graph forbids it, correctly).
+ *
+ * Doors report their ROOT, not their final path — `dirname(…)` on the door's side. The
+ * table is about the data root and nothing else; which leaf a door appends
+ * (`events.jsonl`, `preferences.jsonl`, `orders.jsonl`) is that door's own business and
+ * is already pinned by its own suite.
+ *
+ * NO `/Users/...` LITERAL APPEARS HERE, and none may. `~` expectations are computed from
+ * `os.homedir()` at runtime — ADR-006 forbids the hardcoded form, and a committed one
+ * would publish the operator's real directory layout in a public repo.
+ *
+ * Coverage-excluded by `vitest.config.ts`'s `.testkit.ts` glob: it is exercised by the
+ * tests that import it, not product code to measure.
+ */
+import { homedir } from "node:os";
+import { isAbsolute, join, resolve } from "node:path";
+import { describe, expect, it } from "vitest";
+
+/** One row of the table: an input, and the outcome EVERY door must produce for it. */
+export type DataDirContractCase =
+  | {
+      input: string;
+      outcome: "throws-blank";
+      /** Why this row exists — read by whoever it fails on. */
+      why: string;
+    }
+  | { input: string; outcome: "throws-relative"; why: string }
+  | {
+      input: string;
+      outcome: "root";
+      /** The root every door must land on, computed at runtime — never a literal. */
+      root: () => string;
+      why: string;
+    };
+
+/**
+ * The table. Every door must agree on every row.
+ *
+ * The `undefined` row is deliberately NOT here — it is the one input whose correct answer
+ * genuinely differs per door (the engine's is the accumulus root; the three delegating
+ * doors' is `resolveDataDir()`; price-feed's argument is required and has no `undefined`
+ * arm at all). It is driven separately, per door, by `defaultArm` below.
+ */
+export const DATA_DIR_CONTRACT_CASES: readonly DataDirContractCase[] = [
+  {
+    input: "",
+    outcome: "throws-blank",
+    why: "the value an unset shell variable expands to (#348) — a MISCONFIGURED knob, not an absent one",
+  },
+  {
+    input: "   ",
+    outcome: "throws-blank",
+    why: "blank's most common spelling; `resolve(\"   \")` makes a directory NAMED three spaces, which `=== \"\"` waves through",
+  },
+  {
+    input: "\t\n",
+    outcome: "throws-blank",
+    why: "the other whitespace spelling",
+  },
+  {
+    input: "~",
+    outcome: "root",
+    root: () => resolve(homedir()),
+    why: "a bare tilde is the home directory itself",
+  },
+  {
+    input: "~/scratch",
+    outcome: "root",
+    root: () => resolve(join(homedir(), "scratch")),
+    why: "#369's ruling: `~` expands at EVERY door, not only at the env knob — it is absolute and homedir-derived, ADR-006's invariant verbatim. Three doors used to produce `<cwd>/~/scratch`, a directory literally named `~`",
+  },
+  {
+    input: "~/scratch/nested",
+    outcome: "root",
+    root: () => resolve(join(homedir(), "scratch", "nested")),
+    why: "expansion is of the leading segment only; the rest of the path rides along",
+  },
+  {
+    input: "~scratch",
+    outcome: "throws-relative",
+    why: "`~user` (another user's home) is NOT supported syntax — it must be REFUSED, not silently become `<cwd>/~scratch`. The tilde arm is `~` or `~/`, nothing else",
+  },
+  {
+    input: "/tmp/numisma-authored-contract-root",
+    outcome: "root",
+    root: () => resolve("/tmp/numisma-authored-contract-root"),
+    why: "the ordinary accepted case — without it, a door that threw on EVERYTHING would pass every refusal row above",
+  },
+  {
+    input: "/tmp/numisma authored contract root",
+    outcome: "root",
+    root: () => resolve("/tmp/numisma authored contract root"),
+    why: "the predicate is `trim() === \"\"`, not \"has no spaces\" — a real macOS path carries spaces, and refusing those would be a new bug wearing this fix's clothes",
+  },
+  {
+    input: "  /tmp/numisma-authored-contract-root  ",
+    outcome: "root",
+    root: () => resolve("/tmp/numisma-authored-contract-root"),
+    why: "surrounding whitespace is trimmed, so a padded env value resolves to the same store as the bare one rather than to a sibling",
+  },
+  {
+    input: "/tmp/numisma-authored-contract-root/../numisma-authored-contract-root",
+    outcome: "root",
+    root: () => resolve("/tmp/numisma-authored-contract-root"),
+    why: "an absolute path is NORMALIZED, so two spellings of one directory cannot become two stores",
+  },
+  {
+    input: "data",
+    outcome: "throws-relative",
+    why: "#369's headline case: `pnpm prices:fetch` (CWD = repo root) and a package script (CWD = package dir) would land on two different stores. Two doors used to produce `<cwd>/data` silently",
+  },
+  {
+    input: "./data",
+    outcome: "throws-relative",
+    why: "the explicitly-relative spelling — same hazard, and the one an author is likeliest to think is safe",
+  },
+  {
+    input: "../data",
+    outcome: "throws-relative",
+    why: "escaping upward is still CWD-anchored, so it splits the same way",
+  },
+];
+
+/** A data-dir door: anything that turns a caller-supplied value into a data ROOT. */
+export interface DataDirDoor {
+  /** How the door is named when a row fails on it. */
+  name: string;
+  /** Resolve a PRESENT value to its data ROOT (the door strips its own leaf). */
+  root(dataDir: string): string;
+  /**
+   * The door's own voice, so the shared predicate is proven NOT to have flattened the
+   * per-door error messages #348 deliberately wrote (a Reserve floor served from a file
+   * nothing writes, vs a SECOND genesis seeded beside the job's CWD).
+   */
+  subject: RegExp;
+  /**
+   * The `undefined` arm, when the door has one: what it resolves to with nothing
+   * configured, and what that must equal. Absent for `resolvePriceFeedPaths`, whose
+   * `dataDir` is REQUIRED — it has no default to fall through to, by design.
+   */
+  defaultArm?: { actual: () => string; expected: () => string };
+}
+
+/**
+ * Run the whole table against one door. Call it from the door's own package.
+ *
+ * Pure path algebra throughout — no row touches a filesystem, so no case here can reach
+ * a real data dir.
+ */
+export function assertDataDirContract(door: DataDirDoor): void {
+  describe(`${door.name} — the shared dataDir contract table (#369)`, () => {
+    for (const testCase of DATA_DIR_CONTRACT_CASES) {
+      it(`${JSON.stringify(testCase.input)} → ${testCase.outcome} — ${testCase.why}`, () => {
+        if (testCase.outcome === "root") {
+          expect(door.root(testCase.input)).toBe(testCase.root());
+          return;
+        }
+
+        // A door that RETURNS a path where the table says refuse must fail with the
+        // offending path in the message, not with a bare "expected a throw" that leaves
+        // the reader to work out which wrong store it just pointed at.
+        let produced: string | undefined;
+        try {
+          produced = door.root(testCase.input);
+        } catch {
+          produced = undefined;
+        }
+        expect(
+          produced,
+          `${door.name} must REFUSE ${JSON.stringify(testCase.input)} rather than resolve it`,
+        ).toBeUndefined();
+
+        // And the refusal must be this door's own, not some incidental downstream error.
+        expect(() => door.root(testCase.input)).toThrow(door.subject);
+        expect(() => door.root(testCase.input)).toThrow(
+          testCase.outcome === "throws-blank"
+            ? /must not be empty|set to an empty value/
+            : /absolute path or start with "~\/"/,
+        );
+      });
+    }
+
+    it("never resolves against the process CWD — the whole point of the table", () => {
+      // The refusal rows above are each asserted individually; this is the class-level
+      // statement, and it names the two paths #369 measured coming out of the permissive
+      // doors so a regression reads as itself rather than as a generic mismatch.
+      for (const forbidden of [process.cwd(), join(process.cwd(), "data")]) {
+        for (const testCase of DATA_DIR_CONTRACT_CASES) {
+          let produced: string | undefined;
+          try {
+            produced = door.root(testCase.input);
+          } catch {
+            continue;
+          }
+          expect(
+            produced,
+            `${door.name}(${JSON.stringify(testCase.input)}) resolved to a CWD-derived root (${forbidden})`,
+          ).not.toBe(forbidden);
+        }
+      }
+    });
+
+    const defaultArm = door.defaultArm;
+    if (defaultArm === undefined) {
+      it("has no `undefined` arm — its dataDir is REQUIRED, by design", () => {
+        // Not a skipped row: the ABSENCE is the contract. `resolvePriceFeedPaths` takes a
+        // required argument precisely so there is no default for a caller to fall into,
+        // and this asserts the table knows that rather than having forgotten the door.
+        expect(door.defaultArm).toBeUndefined();
+      });
+      return;
+    }
+
+    it("`undefined` → the door's own default, which is absolute and never CWD-derived", () => {
+      const actual = defaultArm.actual();
+      expect(actual).toBe(defaultArm.expected());
+      expect(isAbsolute(actual)).toBe(true);
+      expect(actual).not.toBe(process.cwd());
+    });
+  });
+}

--- a/packages/engine/src/data-dir-contract.testkit.ts
+++ b/packages/engine/src/data-dir-contract.testkit.ts
@@ -113,7 +113,10 @@ export const DATA_DIR_CONTRACT_CASES: readonly DataDirContractCase[] = [
     input: "  /tmp/numisma-authored-contract-root  ",
     outcome: "root",
     root: () => resolve("/tmp/numisma-authored-contract-root"),
-    why: "surrounding whitespace is trimmed, so a padded env value resolves to the same store as the bare one rather than to a sibling",
+    why:
+      "surrounding whitespace is trimmed, so a padded env value resolves to the same store as the bare one rather than to a sibling. " +
+      "This row is NEW reach at the four argument doors: they used to `resolve()` the raw string, so `\"/tmp/a b \"` became `/tmp/a b /events.jsonl` — a SIBLING directory whose name ends in a space. " +
+      "The padded value is RETARGETED onto the intended root, not refused, because the env knob has always trimmed and a door that refused what the knob accepts is the drift this table exists to make unreachable",
   },
   {
     input: "/tmp/numisma-authored-contract-root/../numisma-authored-contract-root",

--- a/packages/engine/src/data-dir.test.ts
+++ b/packages/engine/src/data-dir.test.ts
@@ -11,6 +11,7 @@ import { homedir } from "node:os";
 import { isAbsolute, join, resolve } from "node:path";
 import { describe, expect, it } from "vitest";
 import { resolveDataDir } from "./data-dir.js";
+import { assertDataDirContract } from "./data-dir-contract.testkit.js";
 
 const ACCUMULUS_DEFAULT = join(homedir(), "Dev", "accumulus", "data");
 
@@ -101,4 +102,18 @@ describe("resolveDataDir — the single durable-ledger data-root resolver", () =
       }
     }
   });
+});
+
+// The `NUMISMA_DATA_DIR` env knob is a data-dir DOOR like the four caller-supplied ones,
+// so it runs the same table. The rows above are this door's own history — the #348 blank
+// refusal, the D6 relative refusal, the message wording an operator reads — and they stay;
+// the table is what proves this door and the other four still answer identically.
+assertDataDirContract({
+  name: "resolveDataDir (NUMISMA_DATA_DIR)",
+  subject: /NUMISMA_DATA_DIR/,
+  root: (dataDir) => resolveDataDir({ NUMISMA_DATA_DIR: dataDir }),
+  defaultArm: {
+    actual: () => resolveDataDir({}),
+    expected: () => ACCUMULUS_DEFAULT,
+  },
 });

--- a/packages/engine/src/data-dir.ts
+++ b/packages/engine/src/data-dir.ts
@@ -96,6 +96,20 @@ export interface DataDirVoice {
  * started. No door wanted that arm; it was what "call `resolve()` and hope" happened
  * to do.
  *
+ * WHAT THE TRIM RETARGETS, AND WHY THAT IS NOT A REFUSAL. The `trim()` is not only the
+ * blank predicate's input — the trimmed string is what gets resolved, so surrounding
+ * whitespace is stripped from every accepted value too. At the env knob that has always
+ * been true; at the four ARGUMENT doors it is new reach, and it changes one pathological
+ * but legal case rather than rejecting it: `resolveEventStorePaths("/tmp/a b ")` used to
+ * yield `/tmp/a b /events.jsonl` — a SIBLING directory whose name ends in a space, beside
+ * the one the caller plainly meant — and now yields `/tmp/a b/events.jsonl`. The value is
+ * RETARGETED, not refused, and that is the right call for the same reason the rest of
+ * this function exists: a trailing-space directory is never what a caller or a launchd
+ * plist intends, the env knob already silently landed on the intended root, and a door
+ * that refused a value the knob accepts would be a fifth disagreement in the very
+ * function written to leave none. Interior whitespace is untouched — `/tmp/a b` is a real
+ * macOS path and stays one.
+ *
  * Expansion is `os.homedir()` at RUNTIME. Never a `/Users/...` literal, in this file or
  * in any test that pins it — ADR-006 forbids the literal, and a committed one would leak
  * the operator's real directory layout into a public repo.

--- a/packages/engine/src/data-dir.ts
+++ b/packages/engine/src/data-dir.ts
@@ -4,6 +4,12 @@
 // `config.ts` — the exact duplication ADR-001's realized note (#58) celebrated
 // removing with a contract test — so it lives here as the single copy.
 //
+// It also holds the ONE implementation of the rule itself
+// (`normalizeDataDirOverride`), which the four caller-supplied data-dir doors in
+// the other packages route through. #369 filed those four for having four
+// hand-written copies of one contract that had already drifted apart on two of
+// its four inputs.
+//
 // This is pure string/env computation: `homedir()` reads a process-derived value
 // (like `$HOME`) and the `node:path` helpers are pure — no fs, no clock, no IO —
 // so it belongs in the engine alongside `INBOX_PATH_SEGMENTS` /
@@ -23,27 +29,113 @@ function accumulusDataDirDefault(): string {
 }
 
 /**
+ * The wording each door uses when it refuses a value. The RULE is shared and lives in
+ * `normalizeDataDirOverride` below; only the VOICE is per-door, because the cost of the
+ * mistake genuinely differs by door and #348 deliberately spent that difference — the
+ * preferences resolver names a Reserve floor served from a file nothing writes, the
+ * event-store resolver names a SECOND genesis seeded beside the job's CWD. An operator
+ * reading either message has to be able to tell which artifact is at stake, so the
+ * message is parameterised and the predicate is not.
+ */
+export interface DataDirVoice {
+  /**
+   * How this door names the knob when it refuses a RELATIVE value: `NUMISMA_DATA_DIR`,
+   * `a sidecar data directory`.
+   */
+  subject: string;
+  /** The BLANK refusal's opening clause, in this door's own voice. */
+  blankHeadline: string;
+  /** What silently accepting a blank would have cost HERE, in this door's own terms. */
+  blankConsequence: string;
+  /**
+   * How the caller deliberately reaches the default instead — omitted by the one door
+   * (`resolvePriceFeedPaths`) whose `dataDir` is REQUIRED and therefore has no
+   * `undefined` → default arm to point at.
+   */
+  blankRemedy?: string;
+}
+
+/**
+ * The ONE implementation of ADR-006's `dataDir` rule, applied to a value that is
+ * PRESENT. Five doors take a data root — the `NUMISMA_DATA_DIR` env knob and four
+ * caller-supplied arguments — and #369 filed them for disagreeing about two of the
+ * four inputs. They now disagree about none, because there is one predicate.
+ *
+ * The table, whole:
+ *
+ *   | input                  | outcome                                      |
+ *   | ---------------------- | -------------------------------------------- |
+ *   | `undefined`            | the door's own default (NOT this function)    |
+ *   | `""` / whitespace-only | THROW — misconfigured, not absent (#348)      |
+ *   | `~` or `~/…`           | expand against `homedir()`, then `resolve()`  |
+ *   | an absolute path       | `resolve()`                                   |
+ *   | a relative path        | THROW — CWD-dependent, split-brain (#369)     |
+ *
+ * `undefined` is deliberately NOT handled here: the five doors have genuinely different
+ * defaults (the engine's is the accumulus root; the sidecar/store doors' is
+ * `resolveDataDir()`; price-feed's argument is required and has no default at all), and
+ * folding that difference in would mean a parameter whose value varies per door — which
+ * is the drift seam this function exists to close, rebuilt one level up. Each door keeps
+ * its own `undefined` arm and routes every PRESENT value through here.
+ *
+ * WHY `~` EXPANDS AT EVERY DOOR AND NOT ONLY AT THE ENV KNOB (#369's ruling). The hazard
+ * the rule guards is CWD-DEPENDENCE, and `~/scratch` has none: it is absolute and
+ * homedir-derived, verbatim the invariant ADR-006 states. The counter-argument — `~` is a
+ * shell affordance, `node:path` has no notion of it, so a TypeScript caller writing it is
+ * likelier confused than deliberate — is real but loses, for two reasons. First, the
+ * argument boundary is not purely programmatic: `resolvePriceFeedPaths(config.dataDir)`
+ * is fed a value that ORIGINATED as `NUMISMA_DATA_DIR` in a launchd plist, which cannot
+ * expand `~` itself (ADR-006); it arrives pre-expanded today only because of the order
+ * the plumbing happens to run in, not because of any contract. Second, and decisively:
+ * an env-only tilde rule would need an `allowTilde` flag here, making one function carry
+ * two behaviours and splitting the contract table into a column that varies per door.
+ * That is #369's defect rebuilt inside #369's fix.
+ *
+ * Before this, `~/scratch` at the three permissive doors produced
+ * `<cwd>/~/scratch` — a directory literally NAMED `~`, beside wherever the process
+ * started. No door wanted that arm; it was what "call `resolve()` and hope" happened
+ * to do.
+ *
+ * Expansion is `os.homedir()` at RUNTIME. Never a `/Users/...` literal, in this file or
+ * in any test that pins it — ADR-006 forbids the literal, and a committed one would leak
+ * the operator's real directory layout into a public repo.
+ */
+export function normalizeDataDirOverride(raw: string, voice: DataDirVoice): string {
+  const trimmed = raw.trim();
+  if (trimmed === "") {
+    const remedy =
+      voice.blankRemedy === undefined
+        ? "Pass an absolute path."
+        : `${voice.blankRemedy}, or pass an absolute path.`;
+    throw new Error(
+      `${voice.blankHeadline} (got "${raw}"). ` +
+        `An empty value is not "unset": ${voice.blankConsequence} ${remedy}`,
+    );
+  }
+  if (trimmed === "~" || trimmed.startsWith("~/")) {
+    return resolve(join(homedir(), trimmed.slice(1)));
+  }
+  if (!isAbsolute(trimmed)) {
+    throw new Error(
+      `${voice.subject} must be an absolute path or start with "~/" (got "${trimmed}"). ` +
+        `A relative value resolves differently depending on the working directory, ` +
+        `so it is rejected to prevent a split-brain ledger.`,
+    );
+  }
+  return resolve(trimmed);
+}
+
+/**
  * Resolve the durable ledger's data root, honoring the `NUMISMA_DATA_DIR` env var —
  * the SINGLE knob that moves EVERY plane (the tui event-store, the price-feed
  * config, and the preferences sidecar), so one override steers them all and no
  * plane can drift onto a divergent ghost ledger.
  *
- * Resolution rule (must stay byte-identical across planes):
- *   - UNSET (`undefined`)                → the accumulus default (`~/Dev/accumulus/data`).
- *     Nobody configured this knob, so the default is the answer.
- *   - PRESENT but empty or whitespace-only → REJECTED loudly (#348). A set-but-empty
- *     env var is a MISCONFIGURED knob, not an absent one — `NUMISMA_DATA_DIR="${SCRATCH}"`
- *     with `SCRATCH` unset is exactly how it happens — and the cost of guessing which
- *     one it meant is a write to the REAL ledger. The relative-path arm below already
- *     refuses a present-but-unusable value for this reason; empty is the same class of
- *     mistake with a worse blast radius (relative lands on a wrong-but-scratch dir,
- *     empty lands on the operator's real accumulus data).
- *   - `~` or `~/…`                       → `~`-expanded against `homedir()`, then made absolute.
- *   - an absolute path                   → normalized via `resolve()`.
- *   - a RELATIVE path (e.g. `data`)      → REJECTED loudly (D6). A relative value
- *     resolves differently depending on the process CWD — `pnpm prices:fetch`
- *     (CWD = repo root) vs a package's own script (CWD = package dir) would land on
- *     two different stores — so it must fail loud rather than silently split-brain.
+ * The `undefined` arm is this function's own: nobody configured the knob, so the
+ * accumulus default is the answer. Every PRESENT value goes through the shared
+ * `normalizeDataDirOverride` above — blank refused (#348), `~` expanded, absolute
+ * normalized, relative refused (D6) — which is the same predicate the four
+ * caller-supplied doors use, so the planes cannot drift apart on any input.
  *
  * `env` is injectable so callers (and the drift/contract test) can resolve against a
  * given environment without mutating the real `process.env`. price-feed reads at
@@ -53,28 +145,15 @@ export function resolveDataDir(
   env: Record<string, string | undefined> = process.env,
 ): string {
   const fromEnv = env.NUMISMA_DATA_DIR;
-  if (fromEnv !== undefined) {
-    const raw = fromEnv.trim();
-    if (raw === "") {
-      throw new Error(
-        `NUMISMA_DATA_DIR is set to an empty value (got "${fromEnv}"). ` +
-          `An empty value is not "unset": accepting it would silently send every write ` +
-          `to the REAL default ledger instead of the store this deployment meant to ` +
-          `configure. Unset NUMISMA_DATA_DIR to choose the default deliberately, or ` +
-          `give it an absolute path.`,
-      );
-    }
-    if (raw === "~" || raw.startsWith("~/")) {
-      return resolve(join(homedir(), raw.slice(1)));
-    }
-    if (!isAbsolute(raw)) {
-      throw new Error(
-        `NUMISMA_DATA_DIR must be an absolute path or start with "~/" (got "${raw}"). ` +
-          `A relative value resolves differently depending on the working directory, ` +
-          `so it is rejected to prevent a split-brain ledger.`,
-      );
-    }
-    return resolve(raw);
+  if (fromEnv === undefined) {
+    return accumulusDataDirDefault();
   }
-  return accumulusDataDirDefault();
+  return normalizeDataDirOverride(fromEnv, {
+    subject: "NUMISMA_DATA_DIR",
+    blankHeadline: "NUMISMA_DATA_DIR is set to an empty value",
+    blankConsequence:
+      "accepting it would silently send every write to the REAL default ledger " +
+      "instead of the store this deployment meant to configure.",
+    blankRemedy: "Unset NUMISMA_DATA_DIR to choose the default deliberately",
+  });
 }

--- a/packages/engine/src/index.ts
+++ b/packages/engine/src/index.ts
@@ -449,7 +449,8 @@ export {
 // `NUMISMA_DATA_DIR` env override with an absolute, homedir-derived accumulus
 // default. Shared by the tui event-store, the price-feed config, and the
 // preferences sidecar so every plane resolves the same store.
-export { resolveDataDir } from "./data-dir.js";
+export { normalizeDataDirOverride, resolveDataDir } from "./data-dir.js";
+export type { DataDirVoice } from "./data-dir.js";
 
 // Shared formatters (the engine's one source of truth for the cents-precision /
 // padding conventions, consumed by the TUI) + the CLI composition renderer.

--- a/packages/event-store/src/event-store.test.ts
+++ b/packages/event-store/src/event-store.test.ts
@@ -6,9 +6,10 @@
 // skewed NAV), and a fixed log self-heals its stale quarantine lane. A small
 // explicit genesis fixture makes the cases legible.
 import { mkdir, mkdtemp, readFile, rm, stat, writeFile } from "node:fs/promises";
-import { resolve } from "node:path";
+import { dirname, resolve } from "node:path";
 import { tmpdir } from "node:os";
-import { deriveHeadDigest } from "@numisma/engine";
+import { deriveHeadDigest, resolveDataDir } from "@numisma/engine";
+import { assertDataDirContract } from "@numisma/engine/testkit";
 import {
   loadEventLog,
   loadFoldedReview,
@@ -387,4 +388,18 @@ describe("resolveEventStorePaths — a BLANK dataDir is REFUSED, not defaulted a
     const explicit = resolve("/tmp/numisma-explicit-store-348");
     expect(resolveEventStorePaths(explicit).log).toBe(resolve(explicit, "events.jsonl"));
   });
+});
+
+// The event-store door runs the SAME table as the other four (#369). This is the door
+// where a one-sided edit costs most — it owns `genesis.json` and the append-only
+// `events.jsonl` — and it is one of the two that used to resolve a bare `"data"` to
+// `<cwd>/data/events.jsonl` without a word.
+assertDataDirContract({
+  name: "resolveEventStorePaths",
+  subject: /an event-store data directory|NUMISMA_DATA_DIR/,
+  root: (dataDir) => dirname(resolveEventStorePaths(dataDir).log),
+  defaultArm: {
+    actual: () => dirname(resolveEventStorePaths().log),
+    expected: () => resolveDataDir(),
+  },
 });

--- a/packages/event-store/src/event-store.test.ts
+++ b/packages/event-store/src/event-store.test.ts
@@ -396,7 +396,7 @@ describe("resolveEventStorePaths — a BLANK dataDir is REFUSED, not defaulted a
 // `<cwd>/data/events.jsonl` without a word.
 assertDataDirContract({
   name: "resolveEventStorePaths",
-  subject: /an event-store data directory|NUMISMA_DATA_DIR/,
+  subject: /an event-store data directory/,
   root: (dataDir) => dirname(resolveEventStorePaths(dataDir).log),
   defaultArm: {
     actual: () => dirname(resolveEventStorePaths().log),

--- a/packages/event-store/src/event-store.ts
+++ b/packages/event-store/src/event-store.ts
@@ -19,11 +19,12 @@
  *     the log still loads. The fold path then refuses to run on a partial log.
  */
 import { mkdir, readFile, rm, writeFile } from "node:fs/promises";
-import { dirname, join, resolve } from "node:path";
+import { dirname, join } from "node:path";
 import {
   INBOX_PATH_SEGMENTS,
   dedupeFoldSkips,
   foldEvents,
+  normalizeDataDirOverride,
   parseEvent,
   parseFundReview,
   resolveDataDir,
@@ -72,28 +73,34 @@ export function quarantineLogPath(logPath: string): string {
 /**
  * Resolve every on-disk location of one event store from its root.
  *
- * No `dataDir` → the shared `resolveDataDirDefault()`. A blank or whitespace-only
- * `dataDir` → REFUSED, loudly (#348). This is written as an explicit `undefined` check
- * rather than as a default PARAMETER because a JS default fires on `undefined` and on
- * nothing else: `""` used to sail past it into `resolve("")`, which is the process's
- * CWD. That is the arm ADR-006 exists to forbid, and it is worst here of anywhere —
- * this resolver owns `genesis.json` and the append-only `events.jsonl`, so a caller
- * that got its env expansion wrong would not read a stale ledger, it would find NO
- * ledger, seed a second one beside whatever directory the job started in, and append
- * to that. `undefined` means nobody configured this and takes the default; `""` means
- * somebody configured it and got it wrong, which is not a thing to guess at.
+ * No `dataDir` → the shared `resolveDataDirDefault()`. A PRESENT `dataDir` goes through
+ * the shared `normalizeDataDirOverride` (#369) — blank refused, `~` expanded, absolute
+ * normalized, relative refused — the same predicate the engine's env knob and the
+ * sidecar / preferences / price-feed doors use, so no door can be softer than another.
+ * Until #369 this one accepted a bare `"data"` and produced `<cwd>/data/events.jsonl`.
+ *
+ * The `undefined` arm is written as an explicit check rather than as a default PARAMETER
+ * because a JS default fires on `undefined` and on nothing else: `""` used to sail past
+ * it into `resolve("")`, which is the process's CWD. That is the arm ADR-006 exists to
+ * forbid, and it is worst here of anywhere — this resolver owns `genesis.json` and the
+ * append-only `events.jsonl`, so a caller that got its env expansion wrong would not read
+ * a stale ledger, it would find NO ledger, seed a second one beside whatever directory
+ * the job started in, and append to that. `undefined` means nobody configured this and
+ * takes the default; `""` means somebody configured it and got it wrong, which is not a
+ * thing to guess at.
  */
 export function resolveEventStorePaths(dataDir?: string): EventStorePaths {
-  if (dataDir !== undefined && dataDir.trim() === "") {
-    throw new Error(
-      `an event-store data directory must not be empty (got "${dataDir}"). ` +
-        `An empty value is not "unset": resolving it would land on the process's ` +
-        `working directory and seed a SECOND genesis and event log there, splitting ` +
-        `the ledger away from the real one. Pass no data directory at all to use the ` +
-        `default deliberately, or pass an absolute path.`,
-    );
-  }
-  const base = resolve(dataDir ?? resolveDataDirDefault());
+  const base =
+    dataDir === undefined
+      ? resolveDataDirDefault()
+      : normalizeDataDirOverride(dataDir, {
+          subject: "an event-store data directory",
+          blankHeadline: "an event-store data directory must not be empty",
+          blankConsequence:
+            "resolving it would land on the process's working directory and seed a " +
+            "SECOND genesis and event log there, splitting the ledger away from the real one.",
+          blankRemedy: "Pass no data directory at all to use the default deliberately",
+        });
   return {
     genesis: join(base, "genesis.json"),
     log: join(base, "events.jsonl"),

--- a/packages/preferences/src/data-dir-doors.test.ts
+++ b/packages/preferences/src/data-dir-doors.test.ts
@@ -1,0 +1,48 @@
+/**
+ * This package's two data-dir DOORS, driven through the shared contract table (#369).
+ *
+ * `resolveSidecarPath` and `resolvePreferencesPath` are separate doors, not one: the
+ * sidecar resolver is what `plans.jsonl`, `orders.jsonl` and `reconciliations.jsonl`
+ * reach the data root through, while the preferences resolver has its own because its
+ * `undefined` arm and its refusal wording are its own. Before #369 they DISAGREED — the
+ * sidecar door refused `~/x` as non-absolute while the preferences door silently produced
+ * `<cwd>/~/x`, and the preferences door accepted a bare `"data"` the sidecar door refused.
+ * One table over both is what makes that state unreachable rather than merely fixed.
+ *
+ * The per-door suites (`plans-reliable`, `preferences-reliable`) keep their own #348
+ * blank-refusal cases: those pin each door's error PROSE, which is deliberately different
+ * per door and is not the table's business. This file pins that the two doors compute the
+ * same ROOT from the same input.
+ *
+ * Pure path algebra — nothing here touches a filesystem, so no case can reach a real
+ * data dir.
+ */
+import { dirname } from "node:path";
+import { resolveDataDir } from "@numisma/engine";
+import { assertDataDirContract } from "@numisma/engine/testkit";
+import { resolvePreferencesPath } from "./preferences.js";
+import { resolveSidecarPath } from "./sidecar-io.js";
+
+// The file name is incidental to the table — the door reports the ROOT it resolved, and
+// which leaf a sidecar appends is pinned by that sidecar's own suite.
+const SIDECAR_PROBE_FILE = "orders.jsonl";
+
+assertDataDirContract({
+  name: "resolveSidecarPath",
+  subject: /a sidecar data directory|NUMISMA_DATA_DIR/,
+  root: (dataDir) => dirname(resolveSidecarPath(SIDECAR_PROBE_FILE, dataDir)),
+  defaultArm: {
+    actual: () => dirname(resolveSidecarPath(SIDECAR_PROBE_FILE)),
+    expected: () => resolveDataDir(),
+  },
+});
+
+assertDataDirContract({
+  name: "resolvePreferencesPath",
+  subject: /a preferences data directory|NUMISMA_DATA_DIR/,
+  root: (dataDir) => dirname(resolvePreferencesPath(dataDir)),
+  defaultArm: {
+    actual: () => dirname(resolvePreferencesPath()),
+    expected: () => resolveDataDir(),
+  },
+});

--- a/packages/preferences/src/data-dir-doors.test.ts
+++ b/packages/preferences/src/data-dir-doors.test.ts
@@ -29,7 +29,7 @@ const SIDECAR_PROBE_FILE = "orders.jsonl";
 
 assertDataDirContract({
   name: "resolveSidecarPath",
-  subject: /a sidecar data directory|NUMISMA_DATA_DIR/,
+  subject: /a sidecar data directory/,
   root: (dataDir) => dirname(resolveSidecarPath(SIDECAR_PROBE_FILE, dataDir)),
   defaultArm: {
     actual: () => dirname(resolveSidecarPath(SIDECAR_PROBE_FILE)),
@@ -39,7 +39,7 @@ assertDataDirContract({
 
 assertDataDirContract({
   name: "resolvePreferencesPath",
-  subject: /a preferences data directory|NUMISMA_DATA_DIR/,
+  subject: /a preferences data directory/,
   root: (dataDir) => dirname(resolvePreferencesPath(dataDir)),
   defaultArm: {
     actual: () => dirname(resolvePreferencesPath()),

--- a/packages/preferences/src/preferences.ts
+++ b/packages/preferences/src/preferences.ts
@@ -29,10 +29,11 @@
  *     non-monotonic file replays deterministically).
  */
 import { appendFile, mkdir, readFile } from "node:fs/promises";
-import { dirname, join, resolve } from "node:path";
+import { dirname, join } from "node:path";
 import {
   defaultProfitPolicyEntry,
   isIsoCalendarDate,
+  normalizeDataDirOverride,
   resolveDataDir,
   type LoadedPreferences,
   type PreferenceSkipReason,
@@ -49,30 +50,37 @@ import {
  * `loadPreferences(resolvePreferencesPath())` live, via `loadReserveFloorAsOf` →
  * `buildGlanceForAnchor` — so the split-brain hazard this resolver prevents is live, not
  * hypothetical: a CWD-relative read here would silently serve the phone a Reserve floor
- * from a different file than the one the fund appends to (ADR-004). An explicit `dataDir`
- * is still honored verbatim for callers (e.g. tests) that pass one.
+ * from a different file than the one the fund appends to (ADR-004).
  *
- * A blank or whitespace-only `dataDir` is REFUSED (#348), and the refusal is the reason
- * this is written as an explicit `undefined` check rather than as a default PARAMETER.
- * A JS default parameter fires on `undefined` and on nothing else, so `""` used to sail
- * straight past it into `resolve("")` — which is the process's CWD, the one arm ADR-006
- * exists to forbid. The phone's Reserve floor would then be read from
- * `<wherever-the-job-started>/preferences.jsonl`, a file nobody writes, and the answer
- * would be a plausible wrong number rather than an error. `undefined` still means nobody
+ * An explicit `dataDir` goes through the shared `normalizeDataDirOverride` (#369) rather
+ * than through a fourth hand-written copy of the rule. That matters most HERE, because
+ * this is the door that drifted furthest: until #369 it accepted a bare `"data"` and
+ * silently produced `<cwd>/data/preferences.jsonl`, so the phone's Reserve floor came
+ * from wherever the job started — a plausible wrong number rather than an error, which is
+ * the worst possible failure shape for this particular file.
+ *
+ * The blank arm is written as an explicit `undefined` check rather than as a default
+ * PARAMETER, and that is load-bearing (#348). A JS default parameter fires on `undefined`
+ * and on nothing else, so `""` used to sail straight past it into `resolve("")` — the
+ * process's CWD, the one arm ADR-006 exists to forbid. `undefined` still means nobody
  * configured this and still takes the default; `""` means somebody configured it and got
  * the expansion wrong, and that is not something this resolver may guess at.
  */
 export function resolvePreferencesPath(dataDir?: string): string {
-  if (dataDir !== undefined && dataDir.trim() === "") {
-    throw new Error(
-      `a preferences data directory must not be empty (got "${dataDir}"). ` +
-        `An empty value is not "unset": resolving it would land on the process's ` +
-        `working directory, serving a Reserve floor from a file nothing writes. ` +
-        `Pass no data directory at all to use the default deliberately, or pass an ` +
-        `absolute path.`,
-    );
+  if (dataDir === undefined) {
+    return join(resolveDataDir(), "preferences.jsonl");
   }
-  return join(resolve(dataDir ?? resolveDataDir()), "preferences.jsonl");
+  return join(
+    normalizeDataDirOverride(dataDir, {
+      subject: "a preferences data directory",
+      blankHeadline: "a preferences data directory must not be empty",
+      blankConsequence:
+        "resolving it would land on the process's working directory, serving a " +
+        "Reserve floor from a file nothing writes.",
+      blankRemedy: "Pass no data directory at all to use the default deliberately",
+    }),
+    "preferences.jsonl",
+  );
 }
 
 const SPLIT_BASES: readonly SplitBasis[] = ["highWaterMark", "perClose"];

--- a/packages/preferences/src/sidecar-io.ts
+++ b/packages/preferences/src/sidecar-io.ts
@@ -13,18 +13,22 @@
  */
 import { mkdir, open, readFile, rename, rm, writeFile } from "node:fs/promises";
 import { setTimeout as delay } from "node:timers/promises";
-import { dirname, isAbsolute, join, resolve } from "node:path";
-import { resolveDataDir } from "@numisma/engine";
+import { dirname, join } from "node:path";
+import { normalizeDataDirOverride, resolveDataDir } from "@numisma/engine";
 
 /**
  * Resolve `<dataDir>/<fileName>` under ADR-006's invariant: ABSOLUTE and
  * homedir-derived, NEVER CWD-relative.
  *
- * The cases, and why each is what it is:
+ * The `undefined` arm is this resolver's own — nobody configured a directory, so the
+ * shared engine `resolveDataDir()` (the `NUMISMA_DATA_DIR` env knob, or the accumulus
+ * default) is the answer. Every PRESENT value goes through the shared
+ * `normalizeDataDirOverride`, which is the SAME predicate the engine's env knob and the
+ * event-store / preferences / price-feed doors use, so this resolver cannot be either
+ * the softer or the harder door around the others (#369).
  *
- *   - **No override at all (`undefined`)** → the shared engine `resolveDataDir()`
- *     (the `NUMISMA_DATA_DIR` env knob, or the accumulus default). Nobody configured
- *     a directory, so the shared one is the answer.
+ * The two arms that predicate decides, and why each is what it is:
+ *
  *   - **A blank or whitespace-only override (`""`)** → THROWN, loudly (#348).
  *
  *     Three arms were weighed for `""`, and the record of all three lives here so
@@ -33,8 +37,9 @@ import { resolveDataDir } from "@numisma/engine";
  *       1. `""` → `resolve("")` → the process's CWD. **Rejected, and the rejection
  *          still stands.** A durable, git-tracked artifact written relative to
  *          whatever directory a script happened to start in is a split-brain ledger
- *          waiting to happen. NEVER reintroduce `resolve("")` here — the throw below
- *          is what keeps this arm shut now that `""` no longer has a landing spot.
+ *          waiting to happen. NEVER reintroduce `resolve("")` here — the shared
+ *          refusal is what keeps this arm shut now that `""` no longer has a landing
+ *          spot.
  *       2. `""` → the shared default, silently. **What this resolver did until #348.**
  *          Its argument: `""` is exactly the value an unset shell variable expands to
  *          (`${VAR:-}`) at the one call site most likely to produce it. That is true,
@@ -48,34 +53,30 @@ import { resolveDataDir } from "@numisma/engine";
  *          value for exactly that reason. An empty value is the same class of mistake
  *          with a worse blast radius: relative lands on a wrong-but-scratch dir, empty
  *          lands on the real ledger.
- *   - **An absolute override** → honored verbatim (normalized). Tests pass one.
  *   - **A relative override** → THROWN, loudly. It resolves differently depending
- *     on the working directory, so silently accepting it splits the store; the
- *     engine's `resolveDataDir` refuses the same value for the same reason and this
- *     resolver must not be the softer door around it.
+ *     on the working directory, so silently accepting it splits the store.
+ *
+ * And the arm this resolver CHANGED in #369: `~/x` used to be refused here as
+ * non-absolute while the engine's env knob expanded it. Both now expand it. `~/x` is
+ * absolute and homedir-derived — ADR-006's invariant verbatim — and it carries none of
+ * the CWD-dependence the rule exists to refuse; the full ruling is recorded on
+ * `normalizeDataDirOverride`.
  */
 export function resolveSidecarPath(fileName: string, dataDir?: string): string {
   if (dataDir === undefined) {
     return join(resolveDataDir(), fileName);
   }
-  const raw = dataDir.trim();
-  if (raw === "") {
-    throw new Error(
-      `a sidecar data directory must not be empty (got "${dataDir}"). ` +
-        `An empty value is not "unset": accepting it would silently send every write ` +
-        `to the REAL default ledger instead of the directory the caller meant to pass. ` +
-        `Pass no data directory at all to use the default deliberately, or pass an ` +
-        `absolute path.`,
-    );
-  }
-  if (!isAbsolute(raw)) {
-    throw new Error(
-      `a sidecar data directory must be an absolute path (got "${raw}"). ` +
-        `A relative value resolves differently depending on the working directory, ` +
-        `so it is rejected to prevent a split-brain ledger.`,
-    );
-  }
-  return join(resolve(raw), fileName);
+  return join(
+    normalizeDataDirOverride(dataDir, {
+      subject: "a sidecar data directory",
+      blankHeadline: "a sidecar data directory must not be empty",
+      blankConsequence:
+        "accepting it would silently send every write to the REAL default ledger " +
+        "instead of the directory the caller meant to pass.",
+      blankRemedy: "Pass no data directory at all to use the default deliberately",
+    }),
+    fileName,
+  );
 }
 
 /**


### PR DESCRIPTION
The last ruling on the board. Two data-dir resolvers silently accepted a relative `"data"` and resolved it against the process CWD while two refused it loudly — and one of the permissive two owns `genesis.json` and `events.jsonl`.

## The fifth door

The issue named four. There were five: `resolvePriceFeedPaths` called `resolve()` on its argument **before** delegating to `resolveEventStorePaths`, so `"data"` arrived at the hardened resolver already disguised as `<cwd>/data` — absolute, valid-looking, and a different store on every CWD. That is the same laundering #348 measured for blank, on the relative arm. Folding it in was the difference between fixing the bug and moving it one file over.

## The tilde ruling

The five doors disagreed on `~` **three** ways:

| door | `~/scratch` before | after |
| --- | --- | --- |
| `resolveDataDir` (env) | expands | expands |
| `resolveSidecarPath` | throws — non-absolute | expands |
| `resolvePreferencesPath` | `<cwd>/~/scratch` | expands |
| `resolveEventStorePaths` | `<cwd>/~/scratch` | expands |
| `resolvePriceFeedPaths` | `<cwd>/~/scratch` | expands |

**`~` expands at every door.** The hazard the rule guards is CWD-dependence, and `~/x` has none — it is absolute and homedir-derived, which is ADR-006's invariant verbatim.

The counter-argument, recorded so it is not re-litigated: `~` is a shell affordance, `node:path` has no notion of it, so a TypeScript caller writing it is likelier confused than deliberate. It loses on two counts. The argument boundary is not purely programmatic — `resolvePriceFeedPaths(config.dataDir)` is fed a value that originated as `NUMISMA_DATA_DIR` in a launchd plist, which cannot expand `~` itself; it arrives pre-expanded only because of the order the plumbing runs in, not because of any contract. And decisively: an env-only rule needs an `allowTilde` flag on the shared predicate, making one function carry two behaviours and splitting the table into a column that varies per door — this issue's defect rebuilt inside its own fix.

`~user` is **not** supported syntax and is refused as relative rather than silently becoming `<cwd>/~user`. Expansion is `os.homedir()` at runtime; no `/Users/...` literal enters the tree, in the source or in the tests.

## The shape

One predicate — `normalizeDataDirOverride` in `@numisma/engine` — for every **present** value: blank refused (#348), `~` expanded, absolute normalized, relative refused. The `undefined` → default arm stays per-door on purpose: the five defaults genuinely differ (accumulus root / `resolveDataDir()` / no default at all), and folding that in would mean a parameter whose value varies per door.

Per-door error prose is preserved verbatim through a `DataDirVoice`. #348 deliberately spent that difference — the preferences door names a Reserve floor served from a file nothing writes, the event-store door names a SECOND genesis seeded beside the job's CWD — and a shared predicate must not flatten it. Every existing message assertion still passes unchanged.

One input→outcome table (`@numisma/engine/testkit`) runs against all five doors from their own packages. No single package can import all five — the dependency graph forbids it, correctly — and none needed a new edge, since every package with a door already depends on `@numisma/engine`.

## Verification

`pnpm verify` green: 2546 passed, 51 skipped, typecheck clean, TUI startup smoke passes.

The table was mutation-checked, not just observed passing: reverting `resolveEventStorePaths` to its pre-fix `resolve(dataDir ?? default)` body fails **15 rows**, each naming the input it disagreed on.

## What this closes

Closes #369.