### PR TITLE
fix(tui): a rejected question is a missing answer, not a dead run

### DIFF
--- a/apps/tui/src/import-orders-cli.ts
+++ b/apps/tui/src/import-orders-cli.ts
@@ -55,6 +55,27 @@ if (!csvPath) {
    * unattended, with nobody having answered anything. If that ordering ever moves, this
    * must become a refusal that the domain cannot mistake for consent (a sentinel the
    * questions reject, not a blank), and it must move in the same commit.
+   *
+   * AND THERE IS A SECOND DOOR INTO THOSE THREE RATIFICATIONS THAT IS NOT A REORDER:
+   * CTRL-D. The prompt channel resolves `""` for an ABANDONED question too, and for the
+   * whole rest of the interview after it, because the abort closes the interface (#370,
+   * clause 4 of `prompt-channel.ts`). That is what makes the FIRST question's Ctrl-D come
+   * back as `no-reserve-declared` in the domain's own voice instead of readline's
+   * `Aborted with Ctrl+D`, and it is the fix #370 asked for. But it also means the three
+   * ratifications above are reachable with blanks after ANY question — the ordering
+   * argument above covers the no-terminal path only, and the paragraph above predicted
+   * exactly this outcome by the one route it did not anticipate.
+   *
+   * WHAT STOPS THE WRITE ANYWAY, since the sentinel is not built yet: the channel LATCHES
+   * the abandonment (`prompt.aborted`), this shell hands that latch to the flow as
+   * `promptAbandoned`, and `importBitgetOpenOrders` refuses as `interview-abandoned`
+   * before `appendOrders` rather than appending. The guarantee is positional-independent —
+   * if the terminal was abandoned, nothing is written — so it does not depend on WHICH
+   * question caught the Ctrl-D, and it survives a reorder of this interview even though
+   * the sentence above does not. `import-orders.test.ts` pins both halves: the first
+   * question still refuses as `no-reserve-declared`, and an interview abandoned after it
+   * never reaches `appendOrders`. The sentinel remains owed; it would move the refusal to
+   * the abandoned question instead of catching it at the door.
    */
   const prompt = createPromptChannel({
     isTTY: Boolean(process.stdin.isTTY),
@@ -104,6 +125,8 @@ if (!csvPath) {
         plansPath: resolvePlansPath(),
         loadPlans,
         ask,
+        // THE LATCH, not a value: read at the write door, long after this bag is built.
+        promptAbandoned: () => prompt.aborted(),
         out: (message) => process.stdout.write(message),
         err: (message) => process.stderr.write(`${message}\n`),
       },

--- a/apps/tui/src/import-orders.test.ts
+++ b/apps/tui/src/import-orders.test.ts
@@ -2097,3 +2097,96 @@ describe("an import nobody can answer refuses at the FIRST question and writes n
     expect(await readOrDefault(setup.ordersPath, "<<absent>>")).toBe("<<absent>>");
   });
 });
+
+/**
+ * THE OTHER DOOR INTO THOSE RATIFYING QUESTIONS: CTRL-D, WHICH IS NOT A REORDER.
+ *
+ * The case above pins the ORDERING argument — funding is asked first and refuses, so a
+ * run with no terminal never reaches a ratification. That argument covers the no-terminal
+ * path only. `prompt-channel.ts` clause 4 resolves `""` for an ABANDONED question too,
+ * and for every question after it, because the abort closes the interface. So an operator
+ * who types a real reserve, sees the override question, realises the reserve is the wrong
+ * one and presses Ctrl-D used to get: the override blank read as "no overrides", the
+ * rung-pick blank read as ACCEPT EVERY PROPOSAL, and `appendOrders` called with
+ * `planId`/`rungId` joins nobody declared — durably, in an append-only file, attributed
+ * to the reserve they were in the act of taking back. Before #370's channel change the
+ * same keystroke ended the run with nothing on disk.
+ *
+ * THE ASSERTION IS AT THIS SEAM RATHER THAN THE CHANNEL'S, because this is the layer
+ * where the behaviour changed — the channel returning `""` was never the defect. No pty,
+ * no spawn: `ask` is injected, and `promptAbandoned` is the channel's latch as a
+ * predicate. The guarantee it pins is positional-independent — if the terminal was
+ * abandoned, nothing is written — so it holds for a Ctrl-D at the LAST question too,
+ * which is the case a latch that only re-answered later questions would still leak.
+ */
+describe("an interview abandoned at the terminal writes NOTHING (#370, clause 4)", () => {
+  /** Answers the funding question once, then `""` forever — what the channel really does. */
+  function abandonAfterFirstAnswer(setup: Harness): { appended: number } {
+    const calls = { appended: 0 };
+    let abandoned = false;
+    let answered = 0;
+    setup.io.ask = async (question) => {
+      setup.asked.push(question);
+      if (answered === 0) {
+        answered += 1;
+        return "reserve-a";
+      }
+      abandoned = true;
+      return "";
+    };
+    setup.io.promptAbandoned = () => abandoned;
+    setup.io.appendOrders = async () => {
+      calls.appended += 1;
+    };
+    return calls;
+  }
+
+  it("refuses as interview-abandoned and never reaches appendOrders", async () => {
+    const setup = await harness({ plans: [planLadder()] });
+    const calls = abandonAfterFirstAnswer(setup);
+
+    const outcome = await importBitgetOpenOrders({ csvPath: setup.csvPath, io: setup.io });
+
+    // THE PIN. Without the write-door check this is `imported / appended: 2`, carrying
+    // declared rung joins the operator never accepted.
+    expect(calls.appended).toBe(0);
+    expect(outcome).toMatchObject({ status: "rejected", reason: "interview-abandoned" });
+    // The operator gets the refusal contract's literal second sentence, not a stack.
+    expect(
+      setup.errors.some(
+        (message) => message.startsWith("REFUSED —") && message.includes("Nothing was written"),
+      ),
+    ).toBe(true);
+    // And the interview really did get past the refusing question — otherwise this case
+    // would be passing for the reason the case above already covers.
+    expect(setup.asked.length).toBeGreaterThan(1);
+    expect(setup.asked[0]).toContain("Funding reserve for this batch");
+  });
+
+  it("still lets a Ctrl-D at the FIRST question refuse as no-reserve-declared", async () => {
+    // #370's actual fix, unregressed: the channel's first rejecting question resolves
+    // `""`, the domain reads that as NO RESERVE DECLARED, and the operator gets the
+    // domain's own words rather than `Aborted with Ctrl+D`. The latch is true here too,
+    // but the funding refusal fires long before the write door, so it is that refusal —
+    // the specific one #370 names — the operator sees, not the new one.
+    const setup = await harness({ answers: [""], plans: [planLadder()] });
+    setup.io.promptAbandoned = () => true;
+
+    const outcome = await importBitgetOpenOrders({ csvPath: setup.csvPath, io: setup.io });
+
+    expect(outcome).toMatchObject({ status: "rejected", reason: "no-reserve-declared" });
+    expect(setup.asked).toHaveLength(1);
+    expect(await readOrDefault(setup.ordersPath, "<<absent>>")).toBe("<<absent>>");
+  });
+
+  it("writes normally when the terminal was never abandoned", async () => {
+    // The predicate defaults to absent for every existing caller and fixture; present and
+    // false must behave identically, or the guard would be a new failure mode of its own.
+    const setup = await harness({ answers: ["reserve-a", "n", ""], plans: [planLadder()] });
+    setup.io.promptAbandoned = () => false;
+
+    const outcome = await importBitgetOpenOrders({ csvPath: setup.csvPath, io: setup.io });
+
+    expect(outcome).toMatchObject({ status: "imported", appended: 2 });
+  });
+});

--- a/apps/tui/src/import-orders.ts
+++ b/apps/tui/src/import-orders.ts
@@ -110,6 +110,27 @@ export interface OrdersImportIo {
   loadPlans: (path: string) => Promise<LoadedPlans>;
   /** Ask the operator one question; the answer is returned trimmed by the caller. */
   ask: (question: string) => Promise<string>;
+  /**
+   * WHETHER THE TERMINAL CONDUCTING THIS INTERVIEW WAS ABANDONED — optional, and absent
+   * means "it was not". Every caller that has no terminal to abandon (every fixture, and
+   * any future non-interactive driver) is unaffected by omitting it.
+   *
+   * WHY THE FLOW NEEDS A SECOND CHANNEL AT ALL. `ask` can only answer with a string, and
+   * the shell's prompt channel resolves `""` when a question is abandoned by Ctrl-D — it
+   * must, because that is what lets the FIRST question's blank come back as this flow's
+   * own `no-reserve-declared` refusal instead of a readline internal on the operator's
+   * screen (#370). But `""` is a RATIFICATION at three of this flow's questions: the
+   * funding override, and the rung-pick prompt at both of its sites. A Ctrl-D pressed
+   * after the funding declaration therefore used to race through them and land
+   * `planId`/`rungId` joins nobody declared, in an append-only file. The string cannot
+   * carry the difference, so the fact travels beside it.
+   *
+   * CHECKED AT THE WRITE DOOR, WHICH IS WHY THE GUARANTEE IS POSITIONAL-INDEPENDENT: if
+   * the terminal was abandoned, nothing is written — regardless of which question caught
+   * the Ctrl-D, including the last one. A latch that only changed later ANSWERS would
+   * still leak the interview whose final question was the abandoned one.
+   */
+  promptAbandoned?: () => boolean;
   out: (message: string) => void;
   err: (message: string) => void;
 }
@@ -121,6 +142,13 @@ export type OrdersImportRejection =
   | "unreadable-sidecar"
   | "unreadable-sidecar-lines"
   | "no-reserve-declared"
+  /**
+   * THE OPERATOR ABANDONED THE INTERVIEW AT THE TERMINAL — Ctrl-D — and the answers
+   * behind that point are blanks nobody typed. See {@link OrdersImportIo.promptAbandoned}
+   * for why the flow cannot see this in the answers themselves, and `prompt-channel.ts`
+   * for the latch that carries it.
+   */
+  | "interview-abandoned"
   /**
    * A row names a claim already on file and DISAGREES with it in a way that would leave
    * the file claiming LESS than the venue still holds (#174).
@@ -667,6 +695,25 @@ export async function importBitgetOpenOrders(
   const fresh: OrderRecord[] = [...records, ...observations].filter(
     (record) => !currentOnFile.has(appendKey(record)),
   );
+  // THE WRITE DOOR, AND THE LAST THING CHECKED BEFORE IT. An abandoned terminal makes
+  // every answer after the abandonment a blank nobody typed, and three of this flow's
+  // questions read a blank as consent — so the refusal cannot live at any one question,
+  // it has to live here, where every path that writes passes. Positional-independent: it
+  // does not matter which question caught the Ctrl-D, including the last one.
+  //
+  // A REFUSAL, NOT A THROW, and in the established vocabulary — the operator gets the
+  // same `REFUSED — ... Nothing was written` contract as `write-failed`, and the second
+  // sentence is literally true because nothing has been appended at this point.
+  if (io.promptAbandoned?.() === true) {
+    return reject(
+      io,
+      "interview-abandoned",
+      `the interview was abandoned at the terminal (Ctrl-D), so the answers after that ` +
+        `point were blanks nobody typed — and three of this import's questions read a ` +
+        `blank as consent. Nothing about this batch is attributable to a declaration the ` +
+        `operator made, so none of it is written. Run the import again`,
+    );
+  }
   try {
     await io.appendOrders(io.ordersPath, fresh);
   } catch (error) {

--- a/apps/tui/src/prompt-channel.test.ts
+++ b/apps/tui/src/prompt-channel.test.ts
@@ -20,8 +20,30 @@
  * CI is ubuntu while development is darwin.)
  *
  * So the channel takes `isTTY` as a VALUE and the interface as a FACTORY, and the thing
- * under test here is the channel rather than Node's terminal handling. Symptom 1 remains
- * open in #370 and gets its own decision; nothing below claims to cover it.
+ * under test here is the channel rather than Node's terminal handling.
+ *
+ * WHAT THE SYMPTOM 1 CASES BELOW DO AND DO NOT COVER. Symptom 1 is Ctrl-D at a REAL
+ * terminal, where `isTTY` is true, the guard does not fire, and `rl.question()` rejects.
+ * The channel's answer to that rejection is pinned here — and ONLY the channel's answer.
+ * There is no pty, no spawn and no child process anywhere in this file: nothing below
+ * presses Ctrl-D, and nothing below is end-to-end coverage of a terminal delivering one.
+ * What is pinned is: given a `question()` that rejects with the shape Node really
+ * produces, this channel resolves with `""`.
+ *
+ * THAT SHAPE WAS MEASURED, NOT ASSUMED — node v24.14.0, `node:readline/promises` over an
+ * in-process `PassThrough` pair with `terminal: true`, a pending `question()`, and a raw
+ * `\x04` byte written to the input:
+ *
+ *     name "AbortError", code "ABORT_ERR", message "Aborted with Ctrl+D"
+ *
+ * That message is the string #370 reports the operator seeing, printed by the shell's
+ * outer catch. The same measurement recorded the OTHER rejection a caller can provoke: a
+ * question put after the interface has closed rejects with code `ERR_USE_AFTER_CLOSE`,
+ * message "readline was closed" — the readline internal symptom 2 removed from the
+ * operator's screen. Both are reproduced by the authored fakes below. (It also recorded a
+ * non-rejection: plain stream EOF and `rl.close()` leave a pending `question()` unsettled
+ * forever rather than rejecting. Nothing here depends on that, but it is why a bare
+ * `.catch()` is the whole fix and no timeout is part of it.)
  *
  * Every fake is authored. Nothing here touches `process`, stdin, or a real readline.
  */
@@ -52,11 +74,57 @@ function fakeInterface(answers: string[]): PromptInterface & {
   };
 }
 
+/**
+ * Node's Ctrl-D rejection, reproduced from the measurement in this file's header rather
+ * than from the docs: an `AbortError` carrying `ABORT_ERR` and Node's own wording. This
+ * is the error that reached the operator through the shells' outer catch in #370.
+ */
+function abortedWithCtrlD(): Error {
+  const error: Error & { code?: string } = new Error("Aborted with Ctrl+D");
+  error.name = "AbortError";
+  error.code = "ABORT_ERR";
+  return error;
+}
+
+/** The other measured rejection: any question put after the interface has closed. */
+function usedAfterClose(): Error {
+  const error: Error & { code?: string } = new Error("readline was closed");
+  error.code = "ERR_USE_AFTER_CLOSE";
+  return error;
+}
+
+/**
+ * A readline stand-in that behaves the way the measured one does once Ctrl-D lands: the
+ * question in flight rejects with the abort, and every question after it rejects with
+ * `ERR_USE_AFTER_CLOSE`, because the interface is closed from that moment on. `close()`
+ * still counts, because the shell calls it in its `finally` either way.
+ */
+function ctrlDInterface(): PromptInterface & { asked: string[]; closed: number } {
+  const asked: string[] = [];
+  const state = { closed: 0 };
+  return {
+    asked,
+    get closed() {
+      return state.closed;
+    },
+    question: async (query: string) => {
+      asked.push(query);
+      throw asked.length === 1 ? abortedWithCtrlD() : usedAfterClose();
+    },
+    close: () => {
+      state.closed += 1;
+    },
+  };
+}
+
 /** The channel plus the two things a caller can observe about how it was built. */
-function channelOn(isTTY: boolean, answers: string[] = []) {
+function channelOn(
+  isTTY: boolean,
+  answers: string[] = [],
+  rl: PromptInterface & { asked: string[]; closed: number } = fakeInterface(answers),
+) {
   const errors: string[] = [];
   let built = 0;
-  const rl = fakeInterface(answers);
   const channel = createPromptChannel({
     isTTY,
     createInterface: () => {
@@ -177,5 +245,64 @@ describe("on a stdin that is no terminal the channel says so and returns an empt
     harness.channel.close();
 
     expect(harness.rl.closed).toBe(0);
+  });
+});
+
+describe("on a terminal where the question is aborted the channel ends the ANSWER, not the run", () => {
+  // #370, SYMPTOM 1. At a real terminal `isTTY` is true, so the no-terminal guard never
+  // fires; Ctrl-D makes `rl.question()` reject, and before this decision that rejection
+  // unwound through the shell's outer catch — `import-orders-cli.ts` and
+  // `record-fill-cli.ts` both print `error.message` there — putting Node's own wording,
+  // "Aborted with Ctrl+D", on the operator's screen and ending the run. The consequence
+  // the issue names: the domain's refusal, `REFUSED — no funding reserve was declared for
+  // this batch`, was never reached. Resolving with `""` is the same answer the
+  // no-terminal path gives, and it lets the domain refuse in its own voice.
+  it("RESOLVES with '' when the question rejects with Node's measured Ctrl-D abort", async () => {
+    const harness = channelOn(true, [], ctrlDInterface());
+
+    await expect(harness.channel.ask("funding reserve? ")).resolves.toBe("");
+
+    // It really did reach readline — this is the terminal path, not the guard.
+    expect(harness.built).toBe(1);
+    expect(harness.rl.asked).toEqual(["funding reserve? "]);
+  });
+
+  // Ctrl-D closes the interface, so the interview does not stop at the aborted question:
+  // whatever the flow asks next reaches a closed readline and rejects with
+  // `ERR_USE_AFTER_CLOSE` — the readline internal #370's symptom 2 took off the
+  // operator's screen. It must not come back through this door. Every later question
+  // answers `""` too, which is what carries a nineteen-question interview all the way to
+  // the domain's refusal instead of ending it at the first one.
+  it("keeps answering '' for the rest of the interview once the interface is closed", async () => {
+    const harness = channelOn(true, [], ctrlDInterface());
+
+    expect(await harness.channel.ask("first? ")).toBe("");
+    expect(await harness.channel.ask("second? ")).toBe("");
+    expect(await harness.channel.ask("third? ")).toBe("");
+
+    expect(harness.rl.asked).toEqual(["first? ", "second? ", "third? "]);
+    // Still one interface. An abort is not a reason to build another one.
+    expect(harness.built).toBe(1);
+  });
+
+  // Nothing is written to the error sink: the abort is not the shell's news to report.
+  // The domain's refusal is the message the operator gets, and it arrives on its own.
+  it("says nothing of its own about the abort", async () => {
+    const harness = channelOn(true, [], ctrlDInterface());
+
+    await harness.channel.ask("a? ");
+
+    expect(harness.errors).toEqual([]);
+  });
+
+  // The shells close in a `finally`, so `close()` runs on this path too. It was built,
+  // so it closes — once, and without throwing, even though readline is already closed.
+  it("still closes the interface it built", async () => {
+    const harness = channelOn(true, [], ctrlDInterface());
+
+    await harness.channel.ask("a? ");
+    harness.channel.close();
+
+    expect(harness.rl.closed).toBe(1);
   });
 });

--- a/apps/tui/src/prompt-channel.test.ts
+++ b/apps/tui/src/prompt-channel.test.ts
@@ -306,3 +306,62 @@ describe("on a terminal where the question is aborted the channel ends the ANSWE
     expect(harness.rl.closed).toBe(1);
   });
 });
+
+/**
+ * THE ABANDONMENT LATCH — the fact `""` cannot carry.
+ *
+ * Clause 4 must resolve `""` (that is what lets the domain refuse in its own voice), and
+ * `""` is a RATIFICATION at several questions of both shells' interviews. The string
+ * therefore cannot tell a flow whether an answer was typed or abandoned, so the channel
+ * remembers it beside the string. What the flow does with it is the flow's business and
+ * is pinned where that behaviour lives — `import-orders.test.ts` drives
+ * `importBitgetOpenOrders` with an abandoning `ask` and asserts nothing is appended.
+ * What is pinned HERE is only the latch: when it is set, when it is not, and that it
+ * never clears.
+ */
+describe("the channel remembers that a question was abandoned", () => {
+  it("is false before anything is asked", () => {
+    expect(channelOn(true).channel.aborted()).toBe(false);
+  });
+
+  it("is false after a question that was actually answered", async () => {
+    const harness = channelOn(true, ["reserve-a"]);
+
+    expect(await harness.channel.ask("funding reserve? ")).toBe("reserve-a");
+
+    expect(harness.channel.aborted()).toBe(false);
+  });
+
+  it("latches on the rejecting question, WITHOUT changing what it resolves", async () => {
+    const harness = channelOn(true, [], ctrlDInterface());
+
+    // Both halves in one case on purpose: a latch that suppressed clause 4's `""` would
+    // put `Aborted with Ctrl+D` back on the operator's screen, which is the whole defect
+    // #370 removed.
+    expect(await harness.channel.ask("funding reserve? ")).toBe("");
+    expect(harness.channel.aborted()).toBe(true);
+  });
+
+  it("never clears for the rest of the interview", async () => {
+    const harness = channelOn(true, [], ctrlDInterface());
+
+    await harness.channel.ask("first? ");
+    await harness.channel.ask("second? ");
+    await harness.channel.ask("third? ");
+
+    expect(harness.channel.aborted()).toBe(true);
+  });
+
+  // The no-terminal path never asks readline anything, so no question was ABANDONED —
+  // it was unaskable. That path is governed by each shell's ordering argument, and its
+  // first question refuses on `""` before any write door is reached. Latching here would
+  // report an abandonment that did not happen and would attribute the wrong refusal to a
+  // piped run.
+  it("stays false on a stdin that is no terminal", async () => {
+    const harness = channelOn(false);
+
+    await harness.channel.ask("a? ");
+
+    expect(harness.channel.aborted()).toBe(false);
+  });
+});

--- a/apps/tui/src/prompt-channel.ts
+++ b/apps/tui/src/prompt-channel.ts
@@ -5,10 +5,10 @@
  * It exists because the shape #346 gave the import shell was right and was NOT shared:
  * `record-fill-cli.ts` still built its interface at module scope, so a piped run printed
  * `readline was closed` — a readline internal, verbatim, to the operator (#370, symptom 2).
- * Two shells needing the identical three decisions is a real seam rather than a
- * hypothetical one, so the mechanism moved here and the shells kept their wiring.
+ * Two shells needing the identical decisions is a real seam rather than a hypothetical
+ * one, so the mechanism moved here and the shells kept their wiring.
  *
- * The three decisions, all of which were previously duplicated or missing:
+ * The decisions, all of which were previously duplicated or missing:
  *
  *   1. THE INTERFACE IS BUILT AT THE FIRST QUESTION, NEVER AT STARTUP. `createInterface`
  *      eagerly consumes stdin, so constructing it up front ends a piped stream before any
@@ -31,17 +31,53 @@
  *      `recordFill` reaches nineteen `ask` sites once the ones it delegates to
  *      `authorLadderTarget` and `resolveFunding` are counted, and the import shell's rung
  *      walk can put one question per rung.
+ *   4. A QUESTION THAT REJECTS RESOLVES WITH "" TOO (#370, symptom 1). At a REAL terminal
+ *      `isTTY` is true, so clause 2's guard never fires; Ctrl-D then makes
+ *      `rl.question()` reject, and that rejection used to unwind through each shell's
+ *      outer catch, which prints `error.message` — putting Node's own wording, "Aborted
+ *      with Ctrl+D" (measured: `AbortError`, code `ABORT_ERR`), on the operator's screen
+ *      and ending the run there. So the domain's refusal, the message the operator
+ *      actually needs, was never reached. Clause 2's reasoning applies unchanged: a
+ *      question with no answer has one honest answer, `""`, and the domain refuses in its
+ *      own voice. This clause is only the second door into the same decision.
+ *
+ *      WHY THE CATCH IS WIDE AND NOT NARROWED TO THE ABORT. `.catch(() => "")` swallows
+ *      every rejection, which is deliberate. Two rejections were measured and BOTH mean
+ *      the same thing: `ABORT_ERR` (Ctrl-D) and `ERR_USE_AFTER_CLOSE` / "readline was
+ *      closed", which is what every question AFTER the Ctrl-D gets, because the abort
+ *      closes the interface. Narrowing to `ABORT_ERR` would therefore fix the first
+ *      question and hand the operator the readline internal on the second — the exact
+ *      string clause 1 exists to keep off the screen. And the generalisation holds past
+ *      what was measured: whatever makes a question reject, no answer arrived, and the
+ *      domain must be allowed to say so. A rejected question is a missing ANSWER, never a
+ *      run that cannot continue — the shells' outer catch is for the domain's failures,
+ *      not for the prompt's.
  *
  * WHAT `""` MEANS IS THE CALLER'S PROBLEM, AND IT IS AN ORDERING DEPENDENCY. Read as an
  * answer, `""` means different things to different questions — a refusal at one, "take the
- * default" at another. It is safe only while the FIRST question a no-terminal run reaches
- * is one that refuses on it. Each shell states that dependency at its own construction
- * site and each pins it, because neither this module nor the other shell can see it.
+ * default" at another. It is safe only while the FIRST question a run reaches unanswerable
+ * is one that refuses on it. That dependency now governs BOTH paths, and clause 4 WIDENS
+ * IT. Clause 2 only ever reaches the FIRST question — a no-terminal run is refused there
+ * and never gets further, which is why each shell's construction site can argue safety
+ * from the ordering alone. Clause 4 lands wherever the operator presses Ctrl-D, which is
+ * any question in the interview and every question after it. Both shells enumerate their
+ * questions and both name the ones that read `""` as a silent ratification rather than a
+ * refusal — six of `record-fill`'s nineteen, three of the import shell's. Those are now
+ * reachable by Ctrl-D, and the sentence "only the first is ever reached" is true of the
+ * no-terminal path only. This is the accepted residual of #370: it buys the domain's
+ * refusal at the first question, which is where Ctrl-D is actually pressed, at the price
+ * of a mid-interview Ctrl-D ratifying a default. The durable fix is the one both
+ * construction sites already name — a sentinel the questions reject rather than a blank —
+ * and it belongs to whichever increment makes an unanswered question distinguishable from
+ * an empty one. Each shell states the dependency at its own site and each pins it, because
+ * neither this module nor the other shell can see it.
  *
  * EVERYTHING IS INJECTED — `isTTY` as a value, the interface as a factory, the error sink
  * as a function — so the channel is testable with no terminal, no process and no spawn.
- * That is the whole reason the pty question #370 opens with does not have to be answered
- * to fix symptom 2: the thing under test is this channel, not Node's terminal handling.
+ * That is the whole reason the pty question #370 opens with does not have to be answered:
+ * the thing under test is this channel, not Node's terminal handling. The cost is stated
+ * plainly in `prompt-channel.test.ts` — the suite pins what this channel does with a
+ * rejecting `question()`, and does NOT cover a real terminal delivering a real Ctrl-D.
  */
 
 /** The readline surface this channel uses — structural, so a test can hand it a fake. */
@@ -93,7 +129,9 @@ export function createPromptChannel(io: PromptChannelIo): PromptChannel {
         return Promise.resolve("");
       }
       rl ??= io.createInterface();
-      return rl.question(question);
+      // CLAUSE 4. A rejected question is an ANSWER that did not arrive, not a run that
+      // cannot continue. See the module docstring for why the catch is this wide.
+      return rl.question(question).catch(() => "");
     },
     close: (): void => {
       rl?.close();

--- a/apps/tui/src/prompt-channel.ts
+++ b/apps/tui/src/prompt-channel.ts
@@ -64,13 +64,36 @@
  * questions and both name the ones that read `""` as a silent ratification rather than a
  * refusal — six of `record-fill`'s nineteen, three of the import shell's. Those are now
  * reachable by Ctrl-D, and the sentence "only the first is ever reached" is true of the
- * no-terminal path only. This is the accepted residual of #370: it buys the domain's
- * refusal at the first question, which is where Ctrl-D is actually pressed, at the price
- * of a mid-interview Ctrl-D ratifying a default. The durable fix is the one both
- * construction sites already name — a sentinel the questions reject rather than a blank —
- * and it belongs to whichever increment makes an unanswered question distinguishable from
- * an empty one. Each shell states the dependency at its own site and each pins it, because
- * neither this module nor the other shell can see it.
+ * no-terminal path only.
+ *
+ * SO CLAUSE 4 DOES NOT SHIP ALONE. A mid-interview Ctrl-D in `orders:import` was measured
+ * reaching `import-orders.ts`'s `appendOrders` with `planId`/`rungId` joins nobody
+ * declared — the batch attributed to a reserve the operator was in the act of taking back
+ * — where the same keystroke previously ended the run with nothing on disk. Two things
+ * stand between the widened `""` and a durable write now:
+ *
+ *   - THIS CHANNEL LATCHES THE ABANDONMENT (`aborted` below). The rejecting question
+ *     still resolves `""` — clause 4 is unchanged, and the first-question Ctrl-D still
+ *     ends in the domain's own refusal — but the channel REMEMBERS that a question was
+ *     abandoned, so the fact survives the string that cannot carry it.
+ *   - AND THE FLOW REFUSES AT ITS WRITE DOOR. `import-orders.ts` takes the latch as an
+ *     injected predicate and refuses as `interview-abandoned` before `appendOrders`.
+ *     THAT GUARANTEE IS POSITIONAL-INDEPENDENT — if the terminal was abandoned, nothing
+ *     is written — so it holds no matter which question caught the Ctrl-D, INCLUDING the
+ *     last question of an interview, which a latch that only re-answered later questions
+ *     would still leak. `record-fill` reaches its own writes only through
+ *     `Write BOTH? [y/N]`, on which `isAffirmative("")` is false, so an abandoned run
+ *     there abandons at that gate; its construction site now says so.
+ *
+ * THE SENTINEL IS STILL OWED. What the latch does NOT buy is an unanswered question
+ * distinguishable from an empty one AT THE QUESTION: every ratifying question in between
+ * still reads the blank as consent, and the operator still watches a batch be ratified
+ * before the write door refuses it. A sentinel the questions reject rather than a blank
+ * would move the refusal to the question that was actually abandoned, and would remove
+ * the ordering dependency instead of merely surviving it. Both construction sites still
+ * name it, and it belongs to whichever increment makes that distinction. Each shell states
+ * the dependency at its own site and each pins it, because neither this module nor the
+ * other shell can see it.
  *
  * EVERYTHING IS INJECTED — `isTTY` as a value, the interface as a factory, the error sink
  * as a function — so the channel is testable with no terminal, no process and no spawn.
@@ -108,6 +131,24 @@ export interface PromptChannelIo {
 export interface PromptChannel {
   ask: (question: string) => Promise<string>;
   /**
+   * WHETHER ANY QUESTION IN THIS RUN WAS ABANDONED — a latch, set the first time a
+   * `question()` rejects and never cleared. Readable without touching module state,
+   * because it is a closure over this channel's own interview and nothing else.
+   *
+   * IT DOES NOT CHANGE WHAT `ask` RESOLVES. Clause 4 stands exactly as written: the
+   * rejecting question still resolves `""`, so a Ctrl-D at the FIRST question still lets
+   * the domain refuse in its own voice rather than printing a readline internal — that is
+   * #370's actual fix and this latch must not regress it. What the latch adds is a fact
+   * the flow can consult BEFORE it writes: an answer of `""` that came from an abandoned
+   * terminal is not an answer at all, and no shell can tell the two apart from the string.
+   *
+   * THE NO-TERMINAL PATH DOES NOT SET IT. Clause 2 never asks readline anything, so no
+   * question was abandoned there; that path is still governed by the ordering argument
+   * each construction site makes, and the first question refuses on `""` before any write
+   * door is reached.
+   */
+  aborted: () => boolean;
+  /**
    * Closes the interface IF ONE WAS EVER BUILT. The `?.` is the whole point of the lazy
    * construction: a run that never prompted must not build an interface here just to
    * close it, which would consume stdin on the way out for no reason at all.
@@ -118,8 +159,10 @@ export interface PromptChannel {
 export function createPromptChannel(io: PromptChannelIo): PromptChannel {
   let rl: PromptInterface | undefined;
   let toldThereIsNoTerminal = false;
+  let aQuestionWasAbandoned = false;
 
   return {
+    aborted: () => aQuestionWasAbandoned,
     ask: (question: string): Promise<string> => {
       if (!io.isTTY) {
         if (!toldThereIsNoTerminal) {
@@ -131,7 +174,11 @@ export function createPromptChannel(io: PromptChannelIo): PromptChannel {
       rl ??= io.createInterface();
       // CLAUSE 4. A rejected question is an ANSWER that did not arrive, not a run that
       // cannot continue. See the module docstring for why the catch is this wide.
-      return rl.question(question).catch(() => "");
+      // THE LATCH IS SET HERE AND NOWHERE ELSE — see `PromptChannel.aborted`.
+      return rl.question(question).catch(() => {
+        aQuestionWasAbandoned = true;
+        return "";
+      });
     },
     close: (): void => {
       rl?.close();

--- a/apps/tui/src/record-fill-cli.ts
+++ b/apps/tui/src/record-fill-cli.ts
@@ -72,6 +72,31 @@ const paths = resolveEventStorePaths();
  * cannot mistake for consent (a sentinel the questions reject, not a blank), and it must
  * move in the same commit. `record-fill.test.ts` pins the ordering itself — one question
  * asked, and it is the rung pick — so the move is loud rather than silent.
+ *
+ * CTRL-D IS A SECOND DOOR INTO THOSE SIX RATIFICATIONS, AND IT IS NOT A REORDER. The
+ * prompt channel resolves `""` for an ABANDONED question and for every question after it,
+ * because the abort closes the interface (#370, clause 4 of `prompt-channel.ts`). So the
+ * sentence "only the first is ever reached" is true of the NO-TERMINAL path only. Press
+ * Ctrl-D anywhere in this nineteen-question interview and the run races through whatever
+ * is left of it, ratifying the six — the remaining quantity, the per-rung book default,
+ * no cancellations, the reserve's tempo, the proposed cash figure, and the lot appended
+ * to an existing Position.
+ *
+ * WHAT STOPS THIS ACT WRITING ANYWAY IS ITS FINAL GATE, and that was verified rather than
+ * assumed: every writer of the act sits BEHIND `Write BOTH? [y/N]` (`record-fill.ts:900`),
+ * on which `isAffirmative("")` is false, so an abandoned run reaches that gate and
+ * ABANDONS — `writeLogImage` and `appendOrders` are inside the two-file act just past it,
+ * and the advisory trail's `appendReconciliation` is reached only through
+ * `reconcileRecordedFill`, called once after the act is already durable. Nothing writes
+ * ahead of the gate. `Confirm these derived verdicts? [y/N]` sits earlier and abandons on
+ * a blank as well, so most abandoned runs stop before even reaching the final one.
+ *
+ * THAT IS A PROPERTY OF THIS SHELL, NOT OF THE CHANNEL, and it is why this act needs no
+ * equivalent of the import shell's `interview-abandoned` refusal — the import flow has no
+ * terminal gate at all, so it takes the channel's abandonment latch and refuses at its
+ * write door instead. If a writer here is ever moved AHEAD of `Write BOTH?`, or that gate
+ * is ever rephrased so that silence means yes, this argument dies with it and this act
+ * must take the latch too.
  */
 const prompt = createPromptChannel({
   isTTY: Boolean(process.stdin.isTTY),

--- a/context/adr/ADR-004-preferences-sidecar.md
+++ b/context/adr/ADR-004-preferences-sidecar.md
@@ -213,8 +213,10 @@ Each was verified against the code before being corrected here.
    `preferences.ts` for a reason of its own and rewrote the docstring; it now
    states the read path is **ALREADY WIRED** and the split-brain hazard live, not
    hypothetical, and its test-side twin says the same. The string this item
-   originally quoted no longer exists anywhere in the repo — quoted above only as
-   the historical claim being corrected.
+   originally quoted no longer exists **in the source** — `preferences.ts` carries
+   no "latent" anywhere. It survives only in the ADR record: quoted above as the
+   historical claim being corrected, and in `context/adr/INDEX.md`'s summary of
+   this same correction. That is the record doing its job, and it stays.
 
    **The chain is named by its functions, not by line numbers**, which is the
    practice this ADR adopts everywhere after correction 2's original citations went

--- a/context/adr/ADR-004-preferences-sidecar.md
+++ b/context/adr/ADR-004-preferences-sidecar.md
@@ -199,29 +199,40 @@ Each was verified against the code before being corrected here.
    in place. **The split the bullet asserts is intact**; only the runtime
    package's name is wrong, which is exactly why it survived this long.
 
-2. **`preferences.ts`'s own "latent today (no runtime caller)" is false.** The
-   docstring on `resolvePreferencesPath`
-   (`packages/preferences/src/preferences.ts:~39`) says the resolver is *"latent
-   today (no runtime caller), but becomes silent split-brain the moment the
-   sidecar is wired into the read path."* **That moment has already passed.** The
-   web push path reads it live: `apps/web/src/push/push-core.ts:130` —
-   `loadPreferences(resolvePreferencesPath())` inside `loadReserveFloorAsOf` —
-   reached from `buildGlanceForAnchor` (`:142`), which `apps/web/src/push/push.ts:73`
-   and `apps/web/src/push/backfill-core.ts:175` both call. The comment's own
-   hazard is therefore **live, not hypothetical**, and the resolver is load-bearing
-   today. The claim is corrected here; **the comment itself is left untouched by
-   this increment**, which changes no code at all — it is a one-line fix owed to
-   the next change that opens that file. *(**The debt is PAID, 2026-08-13 — spec
-   #320.** Slice 1 opened `preferences.ts` for a reason of its own and rewrote
-   that docstring: it now states the read path is already wired and the
-   split-brain hazard live, not latent. Nothing above is withdrawn — the chain it
-   names still holds and is still the reason the resolver is load-bearing — but
-   the line numbers this item cites have all moved since it was written, so read
-   the chain by its function names: `loadPreferences(resolvePreferencesPath())`
-   inside `loadReserveFloorAsOf`, reached from `buildGlanceForAnchor`, which the
-   push and the backfill both call. That chain is now also where the sidecar's
-   discards are carried out to the run's operator channel and emitted **after**
-   the upsert lands — ADR-020's fifth clause.)*
+2. **`preferences.ts`'s own "latent today (no runtime caller)" WAS false, and the
+   comment has since been rewritten.** When this correction was written, the
+   docstring on `resolvePreferencesPath` said the resolver was *"latent today (no
+   runtime caller), but becomes silent split-brain the moment the sidecar is wired
+   into the read path."* That moment had already passed: the web push path was
+   reading it live. The correction recorded the claim as false and deliberately
+   **left the comment standing** — a one-line fix owed to the next change that
+   opened the file.
+
+   **That debt is PAID (2026-08-13, spec #320)**, so this item is now a record of
+   a correction that has landed rather than one still owed. Slice 1 opened
+   `preferences.ts` for a reason of its own and rewrote the docstring; it now
+   states the read path is **ALREADY WIRED** and the split-brain hazard live, not
+   hypothetical, and its test-side twin says the same. The string this item
+   originally quoted no longer exists anywhere in the repo — quoted above only as
+   the historical claim being corrected.
+
+   **The chain is named by its functions, not by line numbers**, which is the
+   practice this ADR adopts everywhere after correction 2's original citations went
+   stale twice: `packages/preferences/src/preferences.ts` exports
+   `resolvePreferencesPath`; `apps/web/src/push/push-core.ts` calls
+   `loadPreferences(resolvePreferencesPath())` inside **`loadReserveFloorAsOf`**,
+   which **`buildGlanceForAnchor`** calls, which both the push
+   (`apps/web/src/push/push.ts`) and the backfill
+   (`apps/web/src/push/backfill-core.ts`) call. Note where the boundary sits:
+   `push.ts` and `backfill-core.ts` name **`buildGlanceForAnchor` only** — neither
+   mentions `loadPreferences` or `resolvePreferencesPath`, and `push-core.ts` is
+   the only non-test file under `apps/web/src` that does. So the resolver is load-bearing today
+   and the hazard it prevents is live, but the sidecar read is reached through one
+   door, not three.
+
+   That same chain is where the sidecar's discards are carried out to the run's
+   operator channel and emitted **after** the upsert lands — ADR-020's fifth
+   clause.
 
 3. **ADR-003's body only ever reaches NINE verbs**, so *"ADR-003 stays at ten
    verbs"* cites the wrong document. The count is genuinely **ten**. But ADR-003's


### PR DESCRIPTION
What actually closes #370 is the fix below to symptom 1. What actually closes #378 is the ADR-004 rewrite below.

## #370, symptom 1 — a rejected question is a missing answer, not a dead run

At a real terminal `isTTY` is true, so the prompt channel's no-terminal guard never fires. Ctrl-D makes `rl.question()` reject, and before this fix that rejection unwound straight through each shell's outer catch — `import-orders-cli.ts` and `record-fill-cli.ts` both print `error.message` there — putting Node's own wording, `Aborted with Ctrl+D`, on the operator's screen and ending the run. The domain's refusal, `REFUSED — no funding reserve was declared for this batch`, was never reached.

The fix is one line, `rl.question(q).catch(() => "")` in `apps/tui/src/prompt-channel.ts` — clause 4, the second door into the decision clause 2 already made. A rejected question is an ANSWER that did not arrive, not a run that cannot continue, so the channel resolves it with `""`, the same honest answer the no-terminal path already gives, and the domain refuses in its own voice instead of Node.

### The Node contract, measured rather than assumed

node v24.14.0, `node:readline/promises` over an in-process `PassThrough` pair with `terminal: true`, a raw `\x04` byte written to a pending `question()`:

```
name "AbortError", code "ABORT_ERR", message "Aborted with Ctrl+D"
```

The same measurement found the second rejection a caller can provoke: a question put after the interface has closed rejects `ERR_USE_AFTER_CLOSE` / "readline was closed" — the readline internal symptom 2 already removed from the operator's screen. It also found what does NOT reject: plain stream EOF and `rl.close()` leave a pending `question()` unsettled forever rather than rejecting anything.

That's why the catch is wide rather than narrowed to `ABORT_ERR`. The abort closes the interface, so every question asked after it hits `ERR_USE_AFTER_CLOSE`. Narrowing the catch would fix the first question and hand the operator the readline internal on the second — the exact string clause 1 exists to keep off the screen.

### What the tests cover, and what they don't

There is no pty, no spawn and no child process anywhere in `prompt-channel.test.ts`. It pins what the channel does with a `question()` that rejects with the measured shape above — nothing more. It is NOT end-to-end coverage of a real terminal delivering a real Ctrl-D.

That's deliberate. The issue's proposed `script -q /dev/null` harness was measured and rejected earlier: with piped stdin it delivers Ctrl-D to the pty before the child even starts, so a raw `\x04`, a blank line, and a real answer all collapse to the identical `AbortError`. It cannot express the blank-line-versus-Ctrl-D contrast the issue's own argument rests on, and an assertion built on it would pass for the wrong reason.

### The accepted residual — flagging this for review, not burying it

`""` is only safe as an answer while the FIRST question a run reaches unanswerable is one that refuses on it. The no-terminal path only ever reaches the first question, so ordering alone made it safe. Ctrl-D doesn't respect that ordering — it lands wherever the operator presses it, and every question after it also answers `""`, including the questions both shells' own enumeration reads as a silent ratification rather than a refusal: six of `record-fill`'s nineteen, three of the import shell's.

Open question for review: whether a mid-interview Ctrl-D can now reach a durable write with ratified defaults where it previously aborted the run outright. The module docstring records this as an accepted residual. The durable fix is the sentinel both construction sites already name — something the questions reject rather than a blank they can't distinguish from a real answer.

## #378 — ADR-004's correction 2 asserted a comment that no longer exists

ADR-004's "three stale claims" item 2 quoted `preferences.ts`'s docstring as still saying the resolver is "latent today (no runtime caller)", and said "the comment itself is left untouched by this increment." Spec #320 rewrote that docstring — the quoted string exists nowhere in the repo anymore, and the debt the correction described as owed has been paid.

Rewritten to post-#320 tense: what was wrong when the correction was written, and what's true now, kept separate rather than blurred. The chain is renamed by FUNCTION instead of pinned line numbers, so it can't go stale a fourth time: `loadPreferences(resolvePreferencesPath())` inside `loadReserveFloorAsOf`, called by `buildGlanceForAnchor`, called by both `push.ts` and `backfill-core.ts`.

A grep against that chain turned up a correction to the ADR's own claim: `push.ts` and `backfill-core.ts` call `buildGlanceForAnchor` only — neither names `loadPreferences` or `resolvePreferencesPath` directly. `push-core.ts` is the only non-test file under `apps/web/src` that does. The sidecar read is reached through one door, not the three the ADR implied. Agrees with `context/adr/INDEX.md:8`, which is unchanged.

## Verification

- `pnpm vitest run apps/tui/src/prompt-channel.test.ts` — red first (4 failed | 9 passed), then 13 passed.
- `pnpm typecheck` clean across all seven projects.
- Full `pnpm test`: 162 files passed / 3 skipped, 2547 passed / 51 skipped, 29.08s. Neither known red present — `ops/testkit/gitignored-path-globs` (#365/#368) passed, and `apps/price-feed/src/schedule-window.test.ts` (#372) did not flake. The 3 skipped files are the Postgres suites gated on `NUMISMA_TEST_DATABASE_URL`.

Closes #370. Closes #378.
