### PR TITLE
fix(price-feed): give the wrapper harness's case dirs an end

### DIFF
--- a/apps/price-feed/src/wrapper-harness/case-dir-disposal.test.ts
+++ b/apps/price-feed/src/wrapper-harness/case-dir-disposal.test.ts
@@ -11,12 +11,18 @@
  * real case dir, and no assertion depends on a wrapper having run.
  */
 
-import { existsSync, mkdirSync, mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import { chmodSync, existsSync, mkdirSync, mkdtempSync, rmSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
-import { afterEach, describe, expect, it } from "vitest";
+import { afterAll, afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
-import { CASE_DIR_PREFIX, disposeCaseDir, KEEP_CASE_DIRS_ENV } from "./case-dir.testkit.js";
+import { CONTRACT_MARK_CONFIG } from "./mark-window.testkit.js";
+import {
+  CASE_DIR_PREFIX,
+  disposeCaseDir,
+  KEEP_CASE_DIRS_ENV,
+  makeCaseDir,
+} from "./case-dir.testkit.js";
 
 /** Dirs this file made, removed whatever the assertions did or did not do to them. */
 const minted: string[] = [];
@@ -31,10 +37,32 @@ function mintCaseDir(): string {
   return dir;
 }
 
+/**
+ * THE OPT-OUT IS RESET BEFORE EACH CASE, NOT ONLY AFTER ONE. This file documents a variable
+ * a human exports while debugging, so a human who is doing exactly that runs the suite with
+ * it already in the environment — and an `afterEach`-only reset leaves the FIRST case in
+ * this file inheriting it, which turns the disposal cases red for a reason that has nothing
+ * to do with the code. The ambient value is put back at the end rather than deleted, because
+ * this process does not own the shell it was started from.
+ */
+const ambientKeep = process.env[KEEP_CASE_DIRS_ENV];
+
+beforeEach(() => {
+  delete process.env[KEEP_CASE_DIRS_ENV];
+});
+
 afterEach(() => {
   delete process.env[KEEP_CASE_DIRS_ENV];
   while (minted.length > 0) {
     rmSync(minted.pop() as string, { recursive: true, force: true });
+  }
+});
+
+afterAll(() => {
+  if (ambientKeep === undefined) {
+    delete process.env[KEEP_CASE_DIRS_ENV];
+  } else {
+    process.env[KEEP_CASE_DIRS_ENV] = ambientKeep;
   }
 });
 
@@ -101,6 +129,38 @@ describe("disposeCaseDir", () => {
     }
   });
 
+  /**
+   * CLEANUP DOES NOT GET A VOTE ON THE VERDICT. `rmSync` throws once it exhausts its
+   * retries, and this runs from `onTestFinished`, so a throw here would redden a case that
+   * had already passed — the timeout cases end with the wrapper's strays still writing
+   * inside the case dir, which is exactly how that race is lost. The refusal above still
+   * throws, because that one means the caller is wrong; this one means the filesystem was
+   * busy, which is not a fact about the code under test.
+   *
+   * The unremovable directory is authored, not waited for: a case dir the process may
+   * traverse but not write makes the recursive unlink fail with `EACCES` on the first try,
+   * every time, with no race to lose. Root ignores those bits, so the case states that it
+   * is not describing a root run rather than passing vacuously in one.
+   */
+  it.skipIf(process.getuid?.() === 0)(
+    "warns and returns when the removal fails, so a green case stays green",
+    () => {
+      const dir = mintCaseDir();
+      chmodSync(dir, 0o500);
+      const warn = vi.spyOn(console, "warn").mockImplementation(() => {});
+
+      try {
+        expect(() => disposeCaseDir(dir, { failed: false })).not.toThrow();
+        expect(existsSync(dir), "the removal was supposed to have failed").toBe(true);
+        expect(warn, "a directory left on disk without a word is the silent leak").toHaveBeenCalledTimes(1);
+        expect(String(warn.mock.calls[0]?.[0]), "the warning does not name the directory").toContain(dir);
+      } finally {
+        warn.mockRestore();
+        chmodSync(dir, 0o700);
+      }
+    },
+  );
+
   // ── THE PATH GUARD ────────────────────────────────────────────────────────────────
   //
   // A recursive delete that can be pointed anywhere is not acceptable in a testkit, so it
@@ -116,15 +176,28 @@ describe("disposeCaseDir", () => {
       expect(existsSync(stranger), "the guard threw and deleted the directory anyway").toBe(true);
     });
 
-    it("refuses a correctly-prefixed path that is not in the temp dir", () => {
-      const outsideRoot = mkdtempSync(join(tmpdir(), CASE_DIR_PREFIX));
-      minted.push(outsideRoot);
+    it("refuses a case dir's own child, prefixed or not, because that is not a case dir", () => {
+      const parent = mkdtempSync(join(tmpdir(), CASE_DIR_PREFIX));
+      minted.push(parent);
       // Prefix-correct in its own basename, but one level deeper than a case dir ever is.
-      const impostor = join(outsideRoot, `${CASE_DIR_PREFIX}deeper`);
+      const impostor = join(parent, `${CASE_DIR_PREFIX}deeper`);
       mkdirSync(impostor, { recursive: true });
 
       expect(() => disposeCaseDir(impostor, { failed: false })).toThrow(/refused to remove/);
       expect(existsSync(impostor)).toBe(true);
+    });
+
+    // The case above is still INSIDE the temp tree, and the three literal paths below either
+    // miss the prefix or are relative. This is the one that hands the guard an absolute,
+    // correctly-prefixed, existing directory whose parent is not the temp dir at all — the
+    // shape a caller would produce by building a case dir path against the wrong root.
+    it("refuses a correctly-prefixed directory that lives outside the temp tree", () => {
+      const stranger = join(process.cwd(), `${CASE_DIR_PREFIX}outside-the-temp-tree`);
+      mkdirSync(stranger, { recursive: true });
+      minted.push(stranger);
+
+      expect(() => disposeCaseDir(stranger, { failed: false })).toThrow(/refused to remove/);
+      expect(existsSync(stranger), "the guard threw and deleted the directory anyway").toBe(true);
     });
 
     for (const path of ["/", "/tmp", "relative/numisma-wrapper-case-x", ""]) {
@@ -141,5 +214,77 @@ describe("disposeCaseDir", () => {
 
       expect(() => disposeCaseDir("/", { failed: true })).toThrow(/refused to remove/);
     });
+  });
+});
+
+/**
+ * ── THE WIRING, NOT THE DISPOSER ──────────────────────────────────────────────────────
+ *
+ * Everything above tests `disposeCaseDir` as a pure function, which leaves the part that
+ * actually fixes #390 — the `onTestFinished` registration inside `makeCaseDir` — pinned by
+ * nothing. Delete those lines and a disposer suite that tests only the function stays fully
+ * green while every one of the ~40 call sites leaks again, exactly as before.
+ *
+ * So these cases observe the registration from OUTSIDE the test that triggers it. One case
+ * mints a dir and stashes its path; the NEXT case asserts the path is gone. Vitest runs the
+ * cases of a file sequentially and in source order, so "the next case" is a fact about the
+ * runner rather than luck, and by the time it executes, the minting case's
+ * `onTestFinished` callbacks have already run.
+ *
+ * These are the only cases in this file that call the real `makeCaseDir`, so they are also
+ * the only ones that pay for its `git init` and its fake bin. Two of them is the price of
+ * the seam not being deletable in silence.
+ */
+describe("makeCaseDir registers its own disposal", () => {
+  const CASE_OPTIONS = {
+    maxRunSeconds: 5,
+    watchdogGraceSeconds: 1,
+    mark: CONTRACT_MARK_CONFIG,
+  } as const;
+
+  /** Written by the minting case, read by the case after it. */
+  let dirOfPassingCase: string | undefined;
+  let dirOfSkippedCase: string | undefined;
+
+  // A backstop, not the assertion: if the registration is missing, the observing case fails
+  // AND the dir it caught is still on disk, so this file must not become the leak it pins.
+  afterAll(() => {
+    for (const dir of [dirOfPassingCase, dirOfSkippedCase]) {
+      if (dir !== undefined) {
+        rmSync(dir, { recursive: true, force: true });
+      }
+    }
+  });
+
+  it("mints a case dir, and this case does nothing whatever to remove it", () => {
+    const dirs = makeCaseDir(CASE_OPTIONS);
+    dirOfPassingCase = dirs.caseDir;
+
+    expect(existsSync(dirs.caseDir), "makeCaseDir did not produce a directory").toBe(true);
+  });
+
+  it("and the case above ended green, so its directory is already gone", () => {
+    expect(dirOfPassingCase, "the minting case did not run before this one").toBeDefined();
+    expect(
+      existsSync(dirOfPassingCase as string),
+      "makeCaseDir minted a dir and nothing removed it when the owning case passed — the " +
+        "self-registration is gone and #390 is back",
+    ).toBe(false);
+  });
+
+  it("mints a case dir and then skips itself mid-body", (context) => {
+    const dirs = makeCaseDir(CASE_OPTIONS);
+    dirOfSkippedCase = dirs.caseDir;
+
+    context.skip();
+  });
+
+  it("and the skipped case's directory is gone too, because a skip has no evidence", () => {
+    expect(dirOfSkippedCase, "the skipping case did not run before this one").toBeDefined();
+    expect(
+      existsSync(dirOfSkippedCase as string),
+      "a skipped case kept its directory: its body stopped before it asserted anything, so " +
+        "there is no post-mortem to preserve and this is a permanent leak",
+    ).toBe(false);
   });
 });

--- a/apps/price-feed/src/wrapper-harness/case-dir-disposal.test.ts
+++ b/apps/price-feed/src/wrapper-harness/case-dir-disposal.test.ts
@@ -1,0 +1,145 @@
+/**
+ * THE DISPOSER'S OWN TESTS — the one piece of the harness that DELETES, tested apart from
+ * everything it deletes for.
+ *
+ * `disposeCaseDir` is a recursive `rm`. Every other module in this directory fails toward
+ * refusing; this one, if it were wrong about which path it was handed, would fail toward
+ * removing a directory nobody asked it to remove. So its guard is tested first and by
+ * name, with paths that are deliberately NOT case dirs.
+ *
+ * Every directory here is minted by this file and torn down by this file. Nothing reads a
+ * real case dir, and no assertion depends on a wrapper having run.
+ */
+
+import { existsSync, mkdirSync, mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { afterEach, describe, expect, it } from "vitest";
+
+import { CASE_DIR_PREFIX, disposeCaseDir, KEEP_CASE_DIRS_ENV } from "./case-dir.testkit.js";
+
+/** Dirs this file made, removed whatever the assertions did or did not do to them. */
+const minted: string[] = [];
+
+function mintCaseDir(): string {
+  const dir = mkdtempSync(join(tmpdir(), CASE_DIR_PREFIX));
+  minted.push(dir);
+  // A file and a nested directory, so "it was removed" means the RECURSIVE removal
+  // happened and not merely an `rmdir` of something that was already empty.
+  mkdirSync(join(dir, "logs"), { recursive: true });
+  writeFileSync(join(dir, "logs", "run.log"), "authored fixture\n", "utf8");
+  return dir;
+}
+
+afterEach(() => {
+  delete process.env[KEEP_CASE_DIRS_ENV];
+  while (minted.length > 0) {
+    rmSync(minted.pop() as string, { recursive: true, force: true });
+  }
+});
+
+describe("disposeCaseDir", () => {
+  it("removes a passing case's directory, contents and all", () => {
+    const dir = mintCaseDir();
+
+    disposeCaseDir(dir, { failed: false });
+
+    expect(existsSync(dir), "a passing case left its directory behind").toBe(false);
+  });
+
+  it("is a no-op on a directory that is already gone, so a second call cannot throw", () => {
+    const dir = mintCaseDir();
+    disposeCaseDir(dir, { failed: false });
+
+    expect(() => disposeCaseDir(dir, { failed: false })).not.toThrow();
+  });
+
+  // THE WHOLE REASON THE DISPOSER TAKES A FLAG. These cases assert on files the wrapper
+  // wrote — the per-run log, the heartbeat, the sentinels. Deleting them on the way out of
+  // a red case deletes the evidence of the red.
+  it("KEEPS a failing case's directory, because the post-mortem reads it", () => {
+    const dir = mintCaseDir();
+
+    disposeCaseDir(dir, { failed: true });
+
+    expect(existsSync(join(dir, "logs", "run.log")), "the failure evidence was deleted").toBe(true);
+  });
+
+  describe(`the ${KEEP_CASE_DIRS_ENV} opt-out`, () => {
+    it("keeps a PASSING case's directory when it is set", () => {
+      const dir = mintCaseDir();
+      process.env[KEEP_CASE_DIRS_ENV] = "1";
+
+      disposeCaseDir(dir, { failed: false });
+
+      expect(existsSync(dir), "the opt-out was set and the directory went anyway").toBe(true);
+    });
+
+    // The grammar, pinned: a human typed this variable to keep dirs, so anything that is
+    // not an explicit off-word keeps them. Nothing in the suite sets it, so a value the
+    // table does not name can only have come from that human.
+    for (const value of ["1", "true", "yes", "always", "please", " keep "]) {
+      it(`treats \`${value}\` as keep`, () => {
+        const dir = mintCaseDir();
+        process.env[KEEP_CASE_DIRS_ENV] = value;
+
+        disposeCaseDir(dir, { failed: false });
+
+        expect(existsSync(dir)).toBe(true);
+      });
+    }
+
+    for (const value of ["", "0", "false", "no", "OFF"]) {
+      it(`treats \`${value}\` as off, so the dir still goes`, () => {
+        const dir = mintCaseDir();
+        process.env[KEEP_CASE_DIRS_ENV] = value;
+
+        disposeCaseDir(dir, { failed: false });
+
+        expect(existsSync(dir)).toBe(false);
+      });
+    }
+  });
+
+  // ── THE PATH GUARD ────────────────────────────────────────────────────────────────
+  //
+  // A recursive delete that can be pointed anywhere is not acceptable in a testkit, so it
+  // refuses everything that is not a direct child of the temp dir carrying the harness's
+  // own prefix. It THROWS rather than returning quietly: a disposer handed the wrong path
+  // has a caller that is wrong, and that must be read, not swallowed.
+  describe("the path guard", () => {
+    it("refuses a temp-dir sibling that does not carry the harness prefix", () => {
+      const stranger = mkdtempSync(join(tmpdir(), "not-a-numisma-case-"));
+      minted.push(stranger);
+
+      expect(() => disposeCaseDir(stranger, { failed: false })).toThrow(/refused to remove/);
+      expect(existsSync(stranger), "the guard threw and deleted the directory anyway").toBe(true);
+    });
+
+    it("refuses a correctly-prefixed path that is not in the temp dir", () => {
+      const outsideRoot = mkdtempSync(join(tmpdir(), CASE_DIR_PREFIX));
+      minted.push(outsideRoot);
+      // Prefix-correct in its own basename, but one level deeper than a case dir ever is.
+      const impostor = join(outsideRoot, `${CASE_DIR_PREFIX}deeper`);
+      mkdirSync(impostor, { recursive: true });
+
+      expect(() => disposeCaseDir(impostor, { failed: false })).toThrow(/refused to remove/);
+      expect(existsSync(impostor)).toBe(true);
+    });
+
+    for (const path of ["/", "/tmp", "relative/numisma-wrapper-case-x", ""]) {
+      it(`refuses \`${path}\``, () => {
+        expect(() => disposeCaseDir(path, { failed: false })).toThrow(/refused to remove/);
+      });
+    }
+
+    // AND IT REFUSES BEFORE IT ASKS WHETHER TO KEEP. Otherwise the opt-out would be a way
+    // to make a bad path look harmless, and the guard would go untested on every machine
+    // that had the variable exported.
+    it("refuses a bad path even when the keep opt-out would have spared it", () => {
+      process.env[KEEP_CASE_DIRS_ENV] = "1";
+
+      expect(() => disposeCaseDir("/", { failed: true })).toThrow(/refused to remove/);
+    });
+  });
+});

--- a/apps/price-feed/src/wrapper-harness/case-dir.testkit.ts
+++ b/apps/price-feed/src/wrapper-harness/case-dir.testkit.ts
@@ -85,9 +85,15 @@ function keepAlways(): boolean {
  * throws rather than returning quietly: a disposer handed a path it will not remove has a
  * caller that is wrong, and a silent return is how that stays unnoticed.
  *
- * THE RETRIES ARE NOT DECORATION. The timeout cases deliberately leave the wrapper's stray
- * processes alive inside the case dir at the moment the case ends, and a bare `rm` can lose
- * that race.
+ * THE RETRIES ARE NOT DECORATION, AND NEITHER IS THE `catch` AROUND THEM. The timeout cases
+ * deliberately leave the wrapper's stray processes alive inside the case dir at the moment
+ * the case ends — a TERM-deaf `tee` still appending to a file under `logDir` is an
+ * `ENOTEMPTY` against a recursive walk — and `rmSync` THROWS once it exhausts its retries.
+ * Since this runs from `onTestFinished`, that throw would redden a case that passed, for a
+ * fact about the filesystem rather than about the code under test. So the two failure kinds
+ * are split: the guard above keeps throwing, because it means the CALLER is wrong, while a
+ * delete that loses the race warns and returns. A warning names the directory that survived,
+ * which is the difference between a bounded, visible leak and the silent one #390 was.
  */
 export function disposeCaseDir(caseDir: string, options: { readonly failed: boolean }): void {
   if (!isAbsolute(caseDir)) {
@@ -110,7 +116,15 @@ export function disposeCaseDir(caseDir: string, options: { readonly failed: bool
   if (options.failed || keepAlways()) {
     return;
   }
-  rmSync(path, { recursive: true, force: true, maxRetries: 3, retryDelay: 50 });
+  try {
+    rmSync(path, { recursive: true, force: true, maxRetries: 3, retryDelay: 50 });
+  } catch (error) {
+    console.warn(
+      `wrapper harness could not remove the case dir ${path}: ${
+        error instanceof Error ? error.message : String(error)
+      }. It is left on disk; cleanup does not get a vote on the verdict.`,
+    );
+  }
 }
 
 export interface CaseDirs {
@@ -153,14 +167,21 @@ export interface CaseOptions {
  *
  * `onTestFinished` rather than an `afterEach`, because a case may mint several dirs and
  * each must be judged by the result of the test that minted it. It also runs AFTER the
- * result state is settled, so `pass` is a fact by the time the callback reads it — and
- * anything that is not `pass` is treated as a failure, so the doubtful direction keeps the
- * evidence.
+ * result state is settled, so the verdict is a fact by the time the callback reads it.
+ *
+ * ONLY `fail` KEEPS THE DIRECTORY, PLUS A VERDICT THAT CANNOT BE READ AT ALL. `fail` is
+ * what a plain assertion failure, a timeout and an `afterEach` throw all produce, so it
+ * covers every case that has evidence worth reading. A `skip` has none: its body stopped
+ * before it asserted anything, so keeping its dir is #390 reinstated for that one case. An
+ * ABSENT state keeps the dir, and that asymmetry is deliberate — an unreadable verdict is
+ * exceptional rather than the common path (vitest settles the state before `onFinished`
+ * runs), and the doubtful direction is the one that preserves evidence.
  */
 export function makeCaseDir(options: CaseOptions): CaseDirs {
   const caseDir = mkdtempSync(join(tmpdir(), CASE_DIR_PREFIX));
   onTestFinished((context) => {
-    disposeCaseDir(caseDir, { failed: context.task.result?.state !== "pass" });
+    const state = context.task.result?.state;
+    disposeCaseDir(caseDir, { failed: state === undefined || state === "fail" });
   });
   const binDir = installFakeBin(caseDir);
   const repoDir = join(caseDir, "repo");

--- a/apps/price-feed/src/wrapper-harness/case-dir.testkit.ts
+++ b/apps/price-feed/src/wrapper-harness/case-dir.testkit.ts
@@ -25,14 +25,93 @@
  */
 
 import { execFileSync } from "node:child_process";
-import { mkdirSync, mkdtempSync, readFileSync, writeFileSync, chmodSync } from "node:fs";
+import { mkdirSync, mkdtempSync, readFileSync, realpathSync, rmSync, writeFileSync, chmodSync } from "node:fs";
 import { tmpdir } from "node:os";
-import { join } from "node:path";
+import { basename, dirname, isAbsolute, join, resolve } from "node:path";
+import { onTestFinished } from "vitest";
 import { installFakeBin } from "./fake-bin.testkit.js";
 import { markEnv, type MarkConfig } from "./mark-window.testkit.js";
 
 /** The bare, non-login PATH launchd actually hands the job. */
 export const LAUNCHD_BARE_PATH = "/usr/bin:/bin:/usr/sbin:/sbin";
+
+/**
+ * The one name a case dir may have. It is both how `mkdtempSync` mints them and the only
+ * shape {@link disposeCaseDir} will remove, so the two cannot drift apart.
+ */
+export const CASE_DIR_PREFIX = "numisma-wrapper-case-";
+
+/** The debugging opt-out: set it and every case dir survives its run. */
+export const KEEP_CASE_DIRS_ENV = "NUMISMA_HARNESS_KEEP_CASE_DIRS";
+
+/**
+ * The values that mean "off". Everything else — including a typo — means KEEP.
+ *
+ * The forgiving direction is the deliberate one. Nothing in the suite sets this variable,
+ * so a value can only have arrived from a human who typed it to keep directories while
+ * debugging; a strict grammar would answer that human's `KEEP=y` by silently deleting the
+ * evidence they asked for. The cost of the other direction is bounded and visible: dirs
+ * pile up in the temp dir of exactly the machine whose owner exported the variable.
+ */
+const KEEP_OFF_VALUES = new Set(["", "0", "false", "no", "off"]);
+
+function keepAlways(): boolean {
+  const raw = process.env[KEEP_CASE_DIRS_ENV];
+  if (raw === undefined) {
+    return false;
+  }
+  return !KEEP_OFF_VALUES.has(raw.trim().toLowerCase());
+}
+
+/**
+ * THE ONLY THING IN THIS HARNESS THAT DELETES. Everything else here refuses; this removes
+ * a directory tree, so it is written to be wrong in the harmless direction.
+ *
+ * WHY IT EXISTS AT ALL (#390). `makeCaseDir` minted a fresh temp directory per run and
+ * nothing ever removed one. Measured on 2026-08-19: 6,725 `numisma-wrapper-case-*`
+ * directories in the temp dir, roughly 900 MB, accumulating since the harness landed. Not
+ * a correctness risk to any case — `mkdtempSync` is atomic and its cost does not move with
+ * sibling count — but unbounded growth on a dev machine is a real cost.
+ *
+ * A FAILING CASE KEEPS ITS DIRECTORY. These cases assert on files the WRAPPER wrote: the
+ * per-run log, `job-heartbeat.json`, the fake's sentinels. Deleting those on the way out
+ * of a red run deletes the only evidence of the red, and the post-mortem is then reading
+ * an empty temp dir. So `failed` is not a nicety; it is what makes this safe to run at all.
+ *
+ * THE PATH GUARD IS FAIL-CLOSED AND FIRST. It refuses anything that is not a DIRECT child
+ * of the temp dir carrying {@link CASE_DIR_PREFIX}, before it consults the keep rules —
+ * ordering that matters, because an opt-out consulted first would let an exported variable
+ * hide a caller passing the wrong path, and the guard would go untested on that machine. It
+ * throws rather than returning quietly: a disposer handed a path it will not remove has a
+ * caller that is wrong, and a silent return is how that stays unnoticed.
+ *
+ * THE RETRIES ARE NOT DECORATION. The timeout cases deliberately leave the wrapper's stray
+ * processes alive inside the case dir at the moment the case ends, and a bare `rm` can lose
+ * that race.
+ */
+export function disposeCaseDir(caseDir: string, options: { readonly failed: boolean }): void {
+  if (!isAbsolute(caseDir)) {
+    throw new Error(
+      `wrapper harness refused to remove ${JSON.stringify(caseDir)}: it is not an absolute path`,
+    );
+  }
+  const path = resolve(caseDir);
+  // macOS matters here exactly as it does in the isolation contract: the temp dir is
+  // `/var/folders/…` and `/var` is a symlink to `/private/var`, so both spellings of the
+  // temp root are legitimate parents of a case dir minted through `tmpdir()`.
+  const roots = new Set([resolve(tmpdir()), realpathSync(tmpdir())]);
+  if (!roots.has(dirname(path)) || !basename(path).startsWith(CASE_DIR_PREFIX)) {
+    throw new Error(
+      `wrapper harness refused to remove ${path}: only a direct child of ${tmpdir()} named ` +
+        `\`${CASE_DIR_PREFIX}*\` is a case dir, and this is a RECURSIVE delete`,
+    );
+  }
+
+  if (options.failed || keepAlways()) {
+    return;
+  }
+  rmSync(path, { recursive: true, force: true, maxRetries: 3, retryDelay: 50 });
+}
 
 export interface CaseDirs {
   readonly caseDir: string;
@@ -65,9 +144,24 @@ export interface CaseOptions {
  * and a non-repo would take the "not inside a git repo — skipping commit" branch on every
  * run, leaving the healthy case's most consequential steps unexercised. It holds nothing
  * but its own `.git`, so the commit is the idempotent no-op the wrapper documents.
+ *
+ * IT REGISTERS ITS OWN DISPOSAL, and that is a decision rather than a convenience. Roughly
+ * forty call sites across two files ask for a case dir, several of them inside the
+ * twelve-repetition loops, and a disposer the CALLER has to register is one the
+ * forty-first call site forgets — which is how #390 happened in the first place. Binding
+ * the removal to the mint means a new case cannot leak by omission.
+ *
+ * `onTestFinished` rather than an `afterEach`, because a case may mint several dirs and
+ * each must be judged by the result of the test that minted it. It also runs AFTER the
+ * result state is settled, so `pass` is a fact by the time the callback reads it — and
+ * anything that is not `pass` is treated as a failure, so the doubtful direction keeps the
+ * evidence.
  */
 export function makeCaseDir(options: CaseOptions): CaseDirs {
-  const caseDir = mkdtempSync(join(tmpdir(), "numisma-wrapper-case-"));
+  const caseDir = mkdtempSync(join(tmpdir(), CASE_DIR_PREFIX));
+  onTestFinished((context) => {
+    disposeCaseDir(caseDir, { failed: context.task.result?.state !== "pass" });
+  });
   const binDir = installFakeBin(caseDir);
   const repoDir = join(caseDir, "repo");
   const dataDir = join(caseDir, "data");

--- a/apps/price-feed/src/wrapper-harness/run-daily-fetch.test.ts
+++ b/apps/price-feed/src/wrapper-harness/run-daily-fetch.test.ts
@@ -2286,10 +2286,26 @@ describe.runIf(decision.run)("wrapper harness — the real wrapper, armed", () =
       // tightest wall-clock margins, so a red here is exactly the failure where knowing
       // whether run 9 was slow — or whether every run had been drifting — is the whole
       // diagnosis. Printed after the loop, none of it survives the throw.
+      //
+      // EACH SERIES IS PRINTED AGAINST THE BOUND IT IS JUDGED BY, with the worst run's
+      // headroom named. A bare list of milliseconds needs the reader to remember which
+      // constant each one is racing, and #372 records the cost of getting that wrong: the
+      // file's 475s wall clock looked like the signal and was noise, while the number that
+      // actually moved was one step running at ~60% of its own 2000ms budget. Headroom is
+      // the quantity that goes to zero before a budget flips red, so it is the one printed.
       onTestFinished(() => {
+        const against = (series: readonly number[], bound: number): string => {
+          if (series.length === 0) {
+            return "none recorded";
+          }
+          const worst = Math.max(...series);
+          return `${series.join(", ")} — worst ${worst} of ${bound}, ${bound - worst} to spare`;
+        };
         console.log(
-          `[wrapper harness] case 4 reached the step in (ms): ${reaches.join(", ")} · ran for (ms, ` +
-            `ceiling ${ceilingMs}): ${durations.join(", ")} · settle ms: ${settles.join(", ")}`,
+          `[wrapper harness] case 4 · reached the step (ms, bound ${REACH_STEP_BOUND_MS}): ` +
+            `${against(reaches, REACH_STEP_BOUND_MS)} · ran for (ms, ceiling ${ceilingMs}): ` +
+            `${against(durations, ceilingMs)} · settled (ms, deadline ${SETTLE_DEADLINE_MS}): ` +
+            `${against(settles, SETTLE_DEADLINE_MS)}`,
         );
       });
 


### PR DESCRIPTION
## What this fixes

`makeCaseDir` minted an `mkdtempSync` directory per wrapper-harness case and
nothing ever removed it. 6,725 `numisma-wrapper-case-*` directories had piled up
in `$TMPDIR` since Aug 17, the dominant contributor to a 1.9 G temp dir. That is
what closes #390.

## The shape

The seam is a pure function, `disposeCaseDir(caseDir, { failed })`, and it is
what the new tests exercise directly:

- deletes the directory when the case passed;
- **keeps it when the case failed** — these cases assert on files the wrapper
  wrote, and a post-mortem with the evidence deleted is a mystery;
- keeps it always under `NUMISMA_HARNESS_KEEP_CASE_DIRS`, for debugging;
- refuses, by throwing, any path that is not a direct child of the temp dir
  carrying the `numisma-wrapper-case-` prefix. The refusal runs before the keep
  rules, so the opt-out cannot mask a caller passing the wrong path at a
  recursive delete.

`makeCaseDir` registers that disposal itself through `onTestFinished`. None of
the roughly forty call sites changed. The alternative — a disposer each caller
registers — is one a future case forgets, and the testkit is shared by
`run-daily-fetch.test.ts` and `schedule-window.test.ts` alike.

The delete carries `maxRetries: 3` because the timeout cases deliberately leave
a stray `sleep` alive inside the case dir.

## The measurement rider

Case 4's report line now states each series against the budget it is judged
against, rather than as bare milliseconds, with the worst run's headroom spelled
out:

```
case 4 · reached the step (ms, bound 2000): 398, 425, ... — worst 425 of 2000, 1575 to spare
```

That is what issue 372's comment asked anyone chasing that flake to measure:
per-step latency against its budget, not file duration. The flake itself is
untouched, so 372 stays open as the recorded observation it was filed as. No
assertion and no budget value moved.

## Verified

- `pnpm typecheck` clean.
- `pnpm test`: 2609 passed, 19 skipped. The arming trigger fires on a
  wrapper-harness edit, so this run included the armed cases.
- `pnpm test:wrapper`: 83 passed.
- Leak count 14 before and 14 after both runs.
- Keep-on-failure proven empirically as well as by unit test: a throwaway probe
  with one passing and one deliberately failing case left the failing case's
  directory intact with its full contents, and removed the passing one's.
