### PR TITLE
fix(tui): give an unanswered question a value no operator can type

### DIFF
--- a/apps/tui/src/import-orders-cli.test.ts
+++ b/apps/tui/src/import-orders-cli.test.ts
@@ -173,7 +173,7 @@ interface ShellRun {
 // `ask` returns before `createInterface` is ever called. No case in this file constructs a
 // readline interface, and therefore none can observe one being closed. What IS pinned is
 // the no-terminal branch in front of it — the notice, its placement at the first
-// unanswerable question, and the empty answer the domain then refuses on.
+// unanswerable question, and the `UNANSWERED` the domain then refuses on.
 describe("import-orders-cli — the shell's own contract (argv, exit codes, env, no-terminal stdin)", () => {
   const createdDirs: string[] = [];
 
@@ -311,7 +311,7 @@ describe("import-orders-cli — the shell's own contract (argv, exit codes, env,
     // that `Funding reserve for this batch` never reaches stdout was the obvious probe and
     // it went vacuous under #346: that string exists only as the argument handed to `ask`
     // (`import-orders-funding-declaration.ts:68`), and a spawned run takes the no-terminal
-    // branch, which returns "" WITHOUT writing the question anywhere. The absence proved
+    // branch, which answers WITHOUT writing the question anywhere. The absence proved
     // nothing — it holds on a run that asked and on a run that did not. The notice does
     // discriminate: `ask` writes it the first time it is called on a stdin that is no
     // terminal, so stderr staying clean of it is the observable fact that NO QUESTION WAS
@@ -423,13 +423,13 @@ describe("import-orders-cli — the shell's own contract (argv, exit codes, env,
     // eagerly consumed a piped stdin, so the stream had already ended by the time the first
     // question was put. The shell now builds the interface AT the first question, and when
     // stdin is no terminal it never builds one at all — it says so in its own voice and
-    // returns an empty answer, which is the one honest answer an unattended run can give.
+    // answers `UNANSWERED`, which is the one honest answer an unattended run can give.
     //
-    // WHAT THAT UNLOCKS is the first test in this repo of `no-reserve-declared`
-    // (`import-orders.ts:588`). That refusal fires only when `declareFunding` returns
-    // undefined, which happens only on an empty batch answer — so before this change it was
-    // reachable exclusively from a TTY, i.e. from nowhere a test can stand. The shell
-    // returning "" rather than throwing is what puts it under a spawn.
+    // WHAT THAT UNLOCKS is the first test in this repo of `no-reserve-declared`. That
+    // refusal fires when `declareFunding` reports `not-declared`, which happens on an empty
+    // batch answer and on an unanswered one alike (#388) — so before the channel existed it
+    // was reachable exclusively from a TTY, i.e. from nowhere a test can stand. The shell
+    // ANSWERING rather than throwing is what puts it under a spawn.
 
     it("names the missing terminal, lets the FLOW refuse, exits 1, writes nothing", async () => {
       const dir = await dataDir();

--- a/apps/tui/src/import-orders-cli.ts
+++ b/apps/tui/src/import-orders-cli.ts
@@ -34,48 +34,37 @@ if (!csvPath) {
    * THE PROMPT CHANNEL — lazy interface, no-terminal notice, one-per-run (#346). The
    * mechanism lives in `prompt-channel.ts` now rather than here, because
    * `record-fill-cli.ts` needed the identical three decisions and had none of them
-   * (#370). What stays here is the part only this shell can know: what `""` MEANS to
-   * the questions this flow puts.
+   * (#370). What stays here is the part only this shell can know: the sentence the
+   * operator reads when there is no terminal, which names WHICH interview cannot be
+   * conducted.
    *
-   * `""` IS HONEST AT EXACTLY ONE CALL SITE, AND THAT IS AN ORDERING DEPENDENCY, not a
-   * property of the empty string. Read as an answer, `""` means different things to the
-   * questions this flow can put:
+   * THIS SITE USED TO ENUMERATE WHAT `""` MEANT TO EACH OF THIS FLOW'S QUESTIONS, AND WHY
+   * THE ORDERING MADE THAT SAFE. Both are obsolete (#388). The channel no longer answers a
+   * question it could not put with a blank line — it answers `UNANSWERED`, a symbol no
+   * operator can type — and every question of this interview refuses it:
    *
-   *   - `import-orders-funding-declaration.ts`'s batch question reads it as NO RESERVE
-   *     DECLARED, so `declareFunding` returns undefined and the flow refuses as
-   *     `no-reserve-declared`. This is the refusal that makes the empty answer safe.
-   *   - `import-orders-rung-picks.ts` reads it as ACCEPT EVERY PROPOSED RUNG, and, at its
-   *     other site, as TAKE THE DEFAULT.
-   *   - the funding declaration's second question reads it as NO PER-RUNG OVERRIDES.
+   *   - the batch reserve refuses it as `no-reserve-declared`, word for word as it refuses
+   *     a blank, which is what keeps #370's fix exactly where #370 put it;
+   *   - the funding override question, and the rung-pick prompt at both of its sites,
+   *     refuse it as `interview-abandoned` naming the question that went unanswered.
    *
-   * The last three are ratifications. A no-terminal run never reaches them ONLY because
-   * funding is asked FIRST and refuses the whole batch before any rung question is put.
-   * Reorder the interview — ask rung picks before funding, or make the funding question
-   * skippable — and this same `""` silently ratifies every default and the run WRITES,
-   * unattended, with nobody having answered anything. If that ordering ever moves, this
-   * must become a refusal that the domain cannot mistake for consent (a sentinel the
-   * questions reject, not a blank), and it must move in the same commit.
+   * Those last three are the ones that read a blank as CONSENT — accept every proposed
+   * rung, take the batch answer for this rung, no per-order overrides — and they are why
+   * the old argument needed the ordering at all: it was safe only while the first question
+   * a run reached unanswerable was one that refused. That was true of a piped run and
+   * false of Ctrl-D, which lands wherever the operator presses it. Reordering this
+   * interview no longer changes any of it.
    *
-   * AND THERE IS A SECOND DOOR INTO THOSE THREE RATIFICATIONS THAT IS NOT A REORDER:
-   * CTRL-D. The prompt channel resolves `""` for an ABANDONED question too, and for the
-   * whole rest of the interview after it, because the abort closes the interface (#370,
-   * clause 4 of `prompt-channel.ts`). That is what makes the FIRST question's Ctrl-D come
-   * back as `no-reserve-declared` in the domain's own voice instead of readline's
-   * `Aborted with Ctrl+D`, and it is the fix #370 asked for. But it also means the three
-   * ratifications above are reachable with blanks after ANY question — the ordering
-   * argument above covers the no-terminal path only, and the paragraph above predicted
-   * exactly this outcome by the one route it did not anticipate.
-   *
-   * WHAT STOPS THE WRITE ANYWAY, since the sentinel is not built yet: the channel LATCHES
-   * the abandonment (`prompt.aborted`), this shell hands that latch to the flow as
+   * THE LATCH IS THE SECOND DOOR, AND IT IS STILL WIRED. The channel remembers that a
+   * question was abandoned (`prompt.aborted`), this shell hands that fact to the flow as
    * `promptAbandoned`, and `importBitgetOpenOrders` refuses as `interview-abandoned`
-   * before `appendOrders` rather than appending. The guarantee is positional-independent —
-   * if the terminal was abandoned, nothing is written — so it does not depend on WHICH
-   * question caught the Ctrl-D, and it survives a reorder of this interview even though
-   * the sentence above does not. `import-orders.test.ts` pins both halves: the first
-   * question still refuses as `no-reserve-declared`, and an interview abandoned after it
-   * never reaches `appendOrders`. The sentinel remains owed; it would move the refusal to
-   * the abandoned question instead of catching it at the door.
+   * before `appendOrders`. With the per-question refusals in place nothing reaches that
+   * check that would not already have been refused — it is redundant by construction, and
+   * kept one increment longer so a regression in the new refusals meets a guarantee that
+   * is still proven rather than a gap. `import-orders.test.ts` pins the two doors
+   * separately: an interview abandoned at the override question refuses AT that question
+   * having put exactly two, and a run whose every question was answered on an abandoned
+   * terminal still writes nothing.
    */
   const prompt = createPromptChannel({
     isTTY: Boolean(process.stdin.isTTY),

--- a/apps/tui/src/import-orders-funding-declaration.test.ts
+++ b/apps/tui/src/import-orders-funding-declaration.test.ts
@@ -29,6 +29,7 @@
 import type { BitgetOpenOrder } from "@numisma/engine";
 import { describe, expect, it } from "vitest";
 import { declareFunding } from "./import-orders-funding-declaration.js";
+import { UNANSWERED, type Answer } from "./prompt-channel.js";
 
 function order(overrides: Partial<BitgetOpenOrder> = {}): BitgetOpenOrder {
   return {
@@ -53,15 +54,15 @@ function order(overrides: Partial<BitgetOpenOrder> = {}): BitgetOpenOrder {
  * throws rather than returning a blank, so a mutation that asks one question too many
  * fails loudly instead of being read as an empty answer.
  */
-function scriptedAsk(answers: readonly string[]): {
-  ask: (question: string) => Promise<string>;
+function scriptedAsk(answers: readonly Answer[]): {
+  ask: (question: string) => Promise<Answer>;
   asked: string[];
 } {
   const asked: string[] = [];
   const remaining = [...answers];
   return {
     asked,
-    ask: async (question: string) => {
+    ask: async (question: string): Promise<Answer> => {
       asked.push(question);
       const next = remaining.shift();
       if (next === undefined) {
@@ -81,6 +82,7 @@ describe("the batch answer", () => {
   it("is the declared reserve, and a declined override pass leaves no overrides", async () => {
     const { ask, asked } = scriptedAsk(["reserve-a", "n"]);
     expect(await declareFunding(ask, [order()])).toEqual({
+      status: "declared",
       fundingReserveId: "reserve-a",
       overrides: {},
     });
@@ -91,6 +93,7 @@ describe("the batch answer", () => {
   it("is TRIMMED — surrounding whitespace is not part of the reserve id (`M5`)", async () => {
     const { ask } = scriptedAsk(["  reserve-a  ", "n"]);
     expect(await declareFunding(ask, [order()])).toEqual({
+      status: "declared",
       fundingReserveId: "reserve-a",
       overrides: {},
     });
@@ -98,13 +101,13 @@ describe("the batch answer", () => {
 
   it("declares nothing when blank, and does not go on to ask about overrides", async () => {
     const { ask, asked } = scriptedAsk([""]);
-    expect(await declareFunding(ask, [order()])).toBeUndefined();
+    expect(await declareFunding(ask, [order()])).toEqual({ status: "not-declared" });
     expect(asked).toEqual([BATCH_QUESTION]);
   });
 
   it("declares nothing when it is only whitespace", async () => {
     const { ask, asked } = scriptedAsk(["   "]);
-    expect(await declareFunding(ask, [order()])).toBeUndefined();
+    expect(await declareFunding(ask, [order()])).toEqual({ status: "not-declared" });
     expect(asked).toEqual([BATCH_QUESTION]);
   });
 });
@@ -132,6 +135,7 @@ describe("the override question's answer", () => {
     it(`declines the per-order pass on ${JSON.stringify(answer)} (\`M1\`)`, async () => {
       const { ask, asked } = scriptedAsk(["reserve-a", answer]);
       expect(await declareFunding(ask, [order()])).toEqual({
+        status: "declared",
         fundingReserveId: "reserve-a",
         overrides: {},
       });
@@ -162,6 +166,7 @@ describe("the per-order override pass", () => {
     const { ask } = scriptedAsk(["reserve-a", "y", "reserve-b", "", "reserve-a", "  reserve-c  "]);
 
     expect(await declareFunding(ask, orders)).toEqual({
+      status: "declared",
       fundingReserveId: "reserve-a",
       // `rung-2` answered blank and `rung-3` answered the batch back: a redundant override
       // is not an override, and neither appears as a key.
@@ -174,13 +179,17 @@ describe("the per-order override pass", () => {
     const { ask, asked } = scriptedAsk(["reserve-a", "y", "reserve-b", "reserve-c"]);
 
     const declaration = await declareFunding(ask, orders);
-    expect(Object.keys(declaration?.overrides ?? {})).toEqual(["rung-1", "rung-2"]);
+    expect(declaration.status === "declared" && Object.keys(declaration.overrides)).toEqual([
+      "rung-1",
+      "rung-2",
+    ]);
     expect(asked).toHaveLength(4);
   });
 
   it("asks nothing per order when the batch has no orders", async () => {
     const { ask, asked } = scriptedAsk(["reserve-a", "y"]);
     expect(await declareFunding(ask, [])).toEqual({
+      status: "declared",
       fundingReserveId: "reserve-a",
       overrides: {},
     });
@@ -231,5 +240,62 @@ describe("the per-order prompt", () => {
     const { ask, asked } = scriptedAsk(["reserve-zulu", "y", ""]);
     await declareFunding(ask, [order()]);
     expect(asked[2]).toContain("[reserve-zulu]");
+  });
+});
+
+/**
+ * THE ANSWER NO OPERATOR CAN TYPE (#388), AND THE TWO THINGS IT DOES HERE.
+ *
+ * The batch question ALREADY refused a blank as `no-reserve-declared`, and that refusal is
+ * #370's actual fix — a Ctrl-D on question one reaches the domain rather than printing
+ * `Aborted with Ctrl+D`. So the sentinel joins the blank there, word for word: the reason
+ * the caller raises does not move.
+ *
+ * The other two questions are the change. `Override … for any individual order? [y/N]`
+ * read a blank as "no overrides" and the per-order prompt read one as "use the batch
+ * answer" — both ratifications, both durable `fundingReserveId` values on an append-only
+ * line, and both reachable by a Ctrl-D pressed one question after the operator named a
+ * reserve they were in the act of taking back.
+ */
+describe("a question that was never answered", () => {
+  it("declares nothing at the batch question — the same arm a blank lands on", async () => {
+    const { ask, asked } = scriptedAsk([UNANSWERED]);
+
+    expect(await declareFunding(ask, [order()])).toEqual({ status: "not-declared" });
+    // And it stops there, exactly as the blank case does.
+    expect(asked).toEqual([BATCH_QUESTION]);
+  });
+
+  it("abandons at the override question instead of quietly declining the pass", async () => {
+    const { ask, asked } = scriptedAsk(["reserve-a", UNANSWERED]);
+
+    expect(await declareFunding(ask, [order()])).toEqual({
+      status: "abandoned",
+      question: "whether to override the reserve per order",
+    });
+    // Nothing was declared — not even the reserve the first answer named, which is the
+    // point: the operator walked away one question after naming it.
+    expect(asked).toEqual([BATCH_QUESTION, OVERRIDE_QUESTION]);
+  });
+
+  it("abandons at a per-order prompt instead of taking the batch answer for that rung", async () => {
+    const { ask } = scriptedAsk(["reserve-a", "y", UNANSWERED]);
+
+    const outcome = await declareFunding(ask, [order()]);
+
+    expect(outcome.status).toBe("abandoned");
+    // The message names the rung, because "somewhere in the override pass" is not
+    // something an operator can act on.
+    expect(outcome.status === "abandoned" && outcome.question).toContain("BTCUSDT");
+  });
+
+  it("still reads a real blank in the override pass as `take the batch answer`", async () => {
+    const { ask } = scriptedAsk(["reserve-a", "y", ""]);
+
+    expect(await declareFunding(ask, [order()])).toEqual({
+      status: "declared",
+      fundingReserveId: "reserve-a",
+      overrides: {},
+    });
   });
 });

--- a/apps/tui/src/import-orders-funding-declaration.ts
+++ b/apps/tui/src/import-orders-funding-declaration.ts
@@ -34,22 +34,61 @@
  * means choosing a shared home for a TUI-wide prompt primitive — a decision, not a move —
  * so neither module imports the other.
  *
+ * IT TAKES `Answer`, AND IT NARROWS AT EACH QUESTION RATHER THAN INSIDE `isAffirmative`
+ * (#388). The channel resolves `UNANSWERED` for a question nobody could answer, and the
+ * tempting move is to widen the helper — `isAffirmative(UNANSWERED) === false` — which
+ * compiles, reads fine, and re-creates the exact defect being fixed one layer down: the
+ * override question would silently decline, the run would carry on, and the operator who
+ * pressed Ctrl-D would still watch a batch be attributed. So the sentinel is checked AT
+ * the question, before any helper sees it, because the question is where the refusal
+ * belongs. `isAffirmative` keeps its `string` parameter, and the compiler keeps it honest.
+ *
  * THE THREE END-TO-END TESTS STAY WHERE THEY ARE. They hold what no unit test over a
  * stubbed `io` can: that the declaration actually lands on the written record as
  * `fundingReserveId`, that the prompt happens exactly once per batch, and that a blank
  * batch answer writes nothing at all.
  */
 import type { BitgetOpenOrder } from "@numisma/engine";
+import { UNANSWERED, type Answer } from "./prompt-channel.js";
 
 /** How one rung is shown when the operator asks to override it. */
 function describe(order: BitgetOpenOrder): string {
   return `${order.symbol} ${order.side} ${order.quantity} @ ${order.price} (${order.observedAt})`;
 }
 
+/**
+ * An answer as text, with {@link UNANSWERED} read as the empty string.
+ *
+ * ONLY FOR QUESTIONS THAT ALREADY REFUSE A BLANK. At those, "the operator typed nothing"
+ * and "nobody could answer" earn the same refusal in the same words, and collapsing them
+ * here is what keeps that refusal exactly where #370 left it. Reaching for this at a
+ * question with a DEFAULT would hand the default to a keystroke nobody made, which is the
+ * whole defect #388 removes — those questions check the sentinel themselves.
+ */
+function typedOrNothing(answer: Answer): string {
+  return answer === UNANSWERED ? "" : answer.trim();
+}
+
 function isAffirmative(answer: string): boolean {
   const normalized = answer.trim().toLowerCase();
   return normalized === "y" || normalized === "yes";
 }
+
+/**
+ * What the declaration pass produced — declared, declined, or never answered at all.
+ *
+ * THREE ARMS RATHER THAN `undefined` AND A SECOND CHANNEL (#388). A blank batch answer and
+ * an abandoned terminal both used to arrive as `undefined`, and the caller could only
+ * refuse them as one thing: `no-reserve-declared`, which tells an operator who pressed
+ * Ctrl-D that they typed an empty reserve id. The reason CODES are the flow's existing
+ * ones either way — this arm only lets the caller pick the right one.
+ */
+export type FundingDeclaration =
+  | { status: "declared"; fundingReserveId: string; overrides: Record<string, string> }
+  /** The operator answered, and what they answered was "no reserve". */
+  | { status: "not-declared" }
+  /** A question in this pass went unanswered. Nobody declined anything. */
+  | { status: "abandoned"; question: string };
 
 /**
  * Prompt for the ONE declared field.
@@ -62,24 +101,42 @@ function isAffirmative(answer: string): boolean {
  * expressible.
  */
 export async function declareFunding(
-  ask: (question: string) => Promise<string>,
+  ask: (question: string) => Promise<Answer>,
   orders: readonly BitgetOpenOrder[],
-): Promise<{ fundingReserveId: string; overrides: Record<string, string> } | undefined> {
-  const batch = (await ask("Funding reserve for this batch: ")).trim();
+): Promise<FundingDeclaration> {
+  // THE ONE QUESTION HERE THAT ALREADY REFUSED, AND IT KEEPS ITS REFUSAL. A blank means
+  // the operator declared no reserve and the flow refuses as `no-reserve-declared`; an
+  // unanswered question declares no reserve either, and lands on the identical arm with
+  // the identical words. That is #370's pinned fix — a Ctrl-D at question one reaches the
+  // DOMAIN's refusal rather than a readline internal — and #388 does not get to move it.
+  const batch = typedOrNothing(await ask("Funding reserve for this batch: "));
   if (batch === "") {
-    return undefined;
+    return { status: "not-declared" };
   }
 
   const overrides: Record<string, string> = {};
-  const wantsOverrides = isAffirmative(
-    await ask(`Override the funding reserve for any individual order? [y/N] `),
+  // A RATIFICATION, AND THE REASON THE SENTINEL EXISTS. A blank declines the override pass
+  // and the batch answer stands for every rung — fine, the operator typed it. UNANSWERED
+  // declines nothing: it means the operator walked away one question after naming a
+  // reserve, which is precisely the moment they were most likely taking it back.
+  const wantsOverridesAnswer = await ask(
+    `Override the funding reserve for any individual order? [y/N] `,
   );
-  if (!wantsOverrides) {
-    return { fundingReserveId: batch, overrides };
+  if (wantsOverridesAnswer === UNANSWERED) {
+    return { status: "abandoned", question: "whether to override the reserve per order" };
+  }
+  if (!isAffirmative(wantsOverridesAnswer)) {
+    return { status: "declared", fundingReserveId: batch, overrides };
   }
 
   for (const order of orders) {
-    const answer = (await ask(`  ${describe(order)} [${batch}]: `)).trim();
+    const reply = await ask(`  ${describe(order)} [${batch}]: `);
+    // A blank takes the batch answer, so UNANSWERED cannot be allowed to: that default is
+    // a durable `fundingReserveId` on the rung's own line.
+    if (reply === UNANSWERED) {
+      return { status: "abandoned", question: `the funding reserve for ${describe(order)}` };
+    }
+    const answer = reply.trim();
     // A REDUNDANT OVERRIDE IS NOT AN OVERRIDE — and this guard is a SHAPE rule, not an
     // output rule, which is worth saying because the difference is invisible downstream.
     // `buildOrderPlacedRecords` resolves attribution as
@@ -91,5 +148,5 @@ export async function declareFunding(
       overrides[order.id] = answer;
     }
   }
-  return { fundingReserveId: batch, overrides };
+  return { status: "declared", fundingReserveId: batch, overrides };
 }

--- a/apps/tui/src/import-orders-rung-picks.test.ts
+++ b/apps/tui/src/import-orders-rung-picks.test.ts
@@ -29,9 +29,10 @@
  * Every ladder, price and id here is SYNTHESIZED: invented round figures and a counted,
  * obviously-fake UUID that is stable across runs.
  */
-import type { BitgetOpenOrder, InForceLadder } from "@numisma/engine";
+import type { BitgetOpenOrder, InForceLadder, RungPick } from "@numisma/engine";
 import { describe, expect, it } from "vitest";
 import { declareRungPicks } from "./import-orders-rung-picks.js";
+import { UNANSWERED, type Answer } from "./prompt-channel.js";
 
 const PLAN_A = "00000000-0000-4000-8000-00000000000a";
 const PLAN_B = "00000000-0000-4000-8000-00000000000b";
@@ -67,15 +68,15 @@ function order(overrides: Partial<BitgetOpenOrder> = {}): BitgetOpenOrder {
 }
 
 /** An `ask` that replays a script and records what it was asked; an unscripted prompt throws. */
-function scriptedAsk(answers: readonly string[]): {
-  ask: (question: string) => Promise<string>;
+function scriptedAsk(answers: readonly Answer[]): {
+  ask: (question: string) => Promise<Answer>;
   asked: string[];
 } {
   const asked: string[] = [];
   const remaining = [...answers];
   return {
     asked,
-    ask: async (question: string) => {
+    ask: async (question: string): Promise<Answer> => {
       asked.push(question);
       const next = remaining.shift();
       if (next === undefined) {
@@ -86,10 +87,30 @@ function scriptedAsk(answers: readonly string[]): {
   };
 }
 
+/**
+ * The picks, unwrapped — every case below drives a pass that COMPLETES.
+ *
+ * `declareRungPicks` returns an outcome rather than a bare map since #388, because a pass
+ * that was abandoned mid-interview has no picks to report and used to be indistinguishable
+ * from a pass that picked nothing. The abandonment arm is asserted directly in its own
+ * describe at the bottom; everywhere else the wrapper keeps the assertion on the picks,
+ * which is what those cases are about, and turns an unexpected abandonment into a loud
+ * failure rather than a silently empty map.
+ */
+async function picksFrom(
+  ...args: Parameters<typeof declareRungPicks>
+): Promise<Record<string, RungPick>> {
+  const outcome = await declareRungPicks(...args);
+  if (outcome.status !== "picked") {
+    throw new Error(`the pass abandoned at: ${outcome.question}`);
+  }
+  return outcome.picks;
+}
+
 describe("the batch pass — the happy path is one Enter", () => {
   it("one Enter accepts the whole batch of proposals", async () => {
     const { ask, asked } = scriptedAsk([""]);
-    const picks = await declareRungPicks(ask, [order()], LADDERS);
+    const picks = await picksFrom(ask, [order()], LADDERS);
     expect(picks).toEqual({ "order-1": { planId: PLAN_A, rungId: "rung-1" } });
     // ONE question, and only one: a batch the operator accepts costs a single keystroke.
     expect(asked).toHaveLength(1);
@@ -97,7 +118,7 @@ describe("the batch pass — the happy path is one Enter", () => {
 
   it("shows every order beside the rung its price matched, before asking", async () => {
     const { ask, asked } = scriptedAsk([""]);
-    await declareRungPicks(
+    await picksFrom(
       ask,
       [order(), order({ id: "order-2", price: 900 }), order({ id: "order-3", price: 850 })],
       LADDERS,
@@ -113,19 +134,19 @@ describe("the batch pass — the happy path is one Enter", () => {
 
   it("an order with no proposal is written with no pick — the legacy path, not an error", async () => {
     const { ask } = scriptedAsk([""]);
-    const picks = await declareRungPicks(ask, [order({ id: "order-x", price: 850 })], LADDERS);
+    const picks = await picksFrom(ask, [order({ id: "order-x", price: 850 })], LADDERS);
     expect(picks).toEqual({});
   });
 
   it("asks nothing at all when no ladder is in force", async () => {
     const { ask, asked } = scriptedAsk([]);
-    expect(await declareRungPicks(ask, [order()], [])).toEqual({});
+    expect(await picksFrom(ask, [order()], [])).toEqual({});
     expect(asked).toEqual([]);
   });
 
   it("never shows the operator a plan id — not in the batch pass, not in an override", async () => {
     const { ask, asked } = scriptedAsk(["n", ""]);
-    await declareRungPicks(ask, [order()], LADDERS);
+    await picksFrom(ask, [order()], LADDERS);
     expect(asked).not.toHaveLength(0);
     for (const question of asked) {
       expect(question).not.toContain(PLAN_A);
@@ -143,7 +164,7 @@ describe("the batch pass — the happy path is one Enter", () => {
 describe("a rung is proposed to at most one order", () => {
   it("does not propose one rung to two orders at the same price", async () => {
     const { ask, asked } = scriptedAsk([""]);
-    const picks = await declareRungPicks(
+    const picks = await picksFrom(
       ask,
       [order(), order({ id: "order-2", price: 1000 })],
       LADDERS,
@@ -158,7 +179,7 @@ describe("a rung is proposed to at most one order", () => {
     // Across imports, not just within one: the pick-list used to read no order book at
     // all, so a rung declared by a line on disk was proposed again to a re-placed order.
     const { ask, asked } = scriptedAsk([""]);
-    const picks = await declareRungPicks(ask, [order()], LADDERS, [
+    const picks = await picksFrom(ask, [order()], LADDERS, [
       { planId: PLAN_A, rungId: "rung-1" },
     ]);
 
@@ -182,7 +203,7 @@ describe("the prompt says WHICH silence it is reporting", () => {
       },
     ];
     const { ask, asked } = scriptedAsk([""]);
-    await declareRungPicks(ask, [order(), order({ id: "order-2", price: 850 })], twoAt1000);
+    await picksFrom(ask, [order(), order({ id: "order-2", price: 850 })], twoAt1000);
 
     expect(asked[0]).toContain("2 ladders declare a rung at this price");
     expect(asked[0]).toContain("no rung declared at this price");
@@ -202,7 +223,7 @@ describe("the override pass — any rung of any in-force ladder, or none", () =>
 
   it("declining the batch offers every rung of every ladder, numbered", async () => {
     const { ask, asked } = scriptedAsk(["n", "3"]);
-    const picks = await declareRungPicks(ask, [order()], TWO_LADDERS);
+    const picks = await picksFrom(ask, [order()], TWO_LADDERS);
     const question = asked[1] ?? "";
     expect(question).toContain("1) pos-a 2026-08-01 · rung at 1000 (size 250)");
     expect(question).toContain("2) pos-a 2026-08-01 · rung at 900 (size 250)");
@@ -214,7 +235,7 @@ describe("the override pass — any rung of any in-force ladder, or none", () =>
 
   it("a blank line keeps the proposal, so a dissent costs one line and agreement costs none", async () => {
     const { ask, asked } = scriptedAsk(["n", ""]);
-    expect(await declareRungPicks(ask, [order()], LADDERS)).toEqual({
+    expect(await picksFrom(ask, [order()], LADDERS)).toEqual({
       "order-1": { planId: PLAN_A, rungId: "rung-1" },
     });
     // The default is shown, or a blank line means something the operator cannot see.
@@ -223,11 +244,11 @@ describe("the override pass — any rung of any in-force ladder, or none", () =>
 
   it("an override can decline the join entirely, and `none` is the default with no proposal", async () => {
     const declined = scriptedAsk(["n", "0"]);
-    expect(await declareRungPicks(declined.ask, [order()], LADDERS)).toEqual({});
+    expect(await picksFrom(declined.ask, [order()], LADDERS)).toEqual({});
 
     const unproposed = scriptedAsk(["n", ""]);
     expect(
-      await declareRungPicks(unproposed.ask, [order({ price: 850 })], LADDERS),
+      await picksFrom(unproposed.ask, [order({ price: 850 })], LADDERS),
     ).toEqual({});
     expect(unproposed.asked[1]).toContain("[none]");
   });
@@ -236,14 +257,14 @@ describe("the override pass — any rung of any in-force ladder, or none", () =>
     // ALLOWED, and flagged by the report rather than refused here: the operator is
     // permitted to know something the price match does not.
     const { ask } = scriptedAsk(["n", "2"]);
-    expect(await declareRungPicks(ask, [order({ price: 1000 })], LADDERS)).toEqual({
+    expect(await picksFrom(ask, [order({ price: 1000 })], LADDERS)).toEqual({
       "order-1": { planId: PLAN_A, rungId: "rung-2" },
     });
   });
 
   it("re-asks rather than guessing when the answer is not a choice", async () => {
     const { ask, asked } = scriptedAsk(["n", "banana", "9", "2"]);
-    expect(await declareRungPicks(ask, [order()], LADDERS)).toEqual({
+    expect(await picksFrom(ask, [order()], LADDERS)).toEqual({
       "order-1": { planId: PLAN_A, rungId: "rung-2" },
     });
     // Four prompts: the batch, then the pick asked three times. A guess here would write
@@ -253,7 +274,7 @@ describe("the override pass — any rung of any in-force ladder, or none", () =>
 
   it("asks once per order, in the batch's own order", async () => {
     const { ask, asked } = scriptedAsk(["n", "", "0"]);
-    const picks = await declareRungPicks(
+    const picks = await picksFrom(
       ask,
       [order(), order({ id: "order-2", price: 900 })],
       LADDERS,
@@ -269,7 +290,7 @@ describe("the override pass — any rung of any in-force ladder, or none", () =>
     // operator one. Re-placing a rung whose earlier order was cancelled is ordinary, and
     // a permanent block on an append-only claim would make it unreachable forever.
     const { ask } = scriptedAsk(["n", "1"]);
-    const picks = await declareRungPicks(ask, [order()], LADDERS, [
+    const picks = await picksFrom(ask, [order()], LADDERS, [
       { planId: PLAN_A, rungId: "rung-1" },
     ]);
     expect(picks).toEqual({ "order-1": { planId: PLAN_A, rungId: "rung-1" } });
@@ -278,10 +299,56 @@ describe("the override pass — any rung of any in-force ladder, or none", () =>
   it("takes y/yes as acceptance, in any case and with any surrounding space", async () => {
     for (const answer of ["y", "Y", "yes", " YES "]) {
       const { ask, asked } = scriptedAsk([answer]);
-      expect(await declareRungPicks(ask, [order()], LADDERS)).toEqual({
+      expect(await picksFrom(ask, [order()], LADDERS)).toEqual({
         "order-1": { planId: PLAN_A, rungId: "rung-1" },
       });
       expect(asked).toHaveLength(1);
     }
+  });
+});
+
+/**
+ * BOTH QUESTIONS HERE RATIFY, WHICH IS WHY #388 REACHED THEM (#370's second door).
+ *
+ * `Accept all? [Y/n]` reads a blank as ACCEPT EVERY PROPOSAL — the reason the happy path
+ * is one Enter, and the reason an abandoned terminal used to write a declared
+ * `planId`/`rungId` join onto every rung of the batch. The per-order prompt reads a blank
+ * as KEEP THE PROPOSAL, inside a `for(;;)` that re-asks until the answer is a choice: an
+ * unanswered question there would either spin forever or ratify, depending on which branch
+ * it fell into. Neither happens now.
+ */
+describe("a question that was never answered (#388)", () => {
+  it("abandons the batch pass rather than accepting every proposal on screen", async () => {
+    const { ask, asked } = scriptedAsk([UNANSWERED]);
+
+    const outcome = await declareRungPicks(ask, [order()], LADDERS);
+
+    expect(outcome).toEqual({
+      status: "abandoned",
+      question: "whether to accept the proposed rung picks",
+    });
+    // One question, and the override pass was never opened.
+    expect(asked).toHaveLength(1);
+  });
+
+  it("still accepts every proposal on a real blank — one Enter is unchanged", async () => {
+    const { ask } = scriptedAsk([""]);
+
+    expect(await picksFrom(ask, [order()], LADDERS)).toEqual({
+      "order-1": { planId: PLAN_A, rungId: "rung-1" },
+    });
+  });
+
+  it("abandons the override loop rather than keeping the proposal or spinning", async () => {
+    const { ask, asked } = scriptedAsk(["n", UNANSWERED]);
+
+    const outcome = await declareRungPicks(ask, [order()], LADDERS);
+
+    expect(outcome.status).toBe("abandoned");
+    // The message names the rung — the loop is per order, so "the override pass" would not
+    // tell the operator where it stopped.
+    expect(outcome.status === "abandoned" && outcome.question).toContain("BTCUSDT");
+    // TWO questions: the loop did not re-ask a terminal that cannot answer.
+    expect(asked).toHaveLength(2);
   });
 });

--- a/apps/tui/src/import-orders-rung-picks.ts
+++ b/apps/tui/src/import-orders-rung-picks.ts
@@ -27,6 +27,13 @@
  * declaration.ts` AND STAY THAT WAY, on that module's own argument: de-duplicating them
  * means choosing a shared home for a TUI-wide prompt primitive — a decision, not a move —
  * so neither leaf imports the other.
+ *
+ * BOTH OF ITS QUESTIONS RATIFY, WHICH IS WHY #388 REACHED HERE FIRST. `Accept all? [Y/n]`
+ * reads a blank as ACCEPT EVERY PROPOSAL and the per-order prompt reads one as KEEP THE
+ * PROPOSED RUNG — two durable `planId`/`rungId` joins on an append-only file, from a line
+ * nobody typed. The channel's `UNANSWERED` is refused at each question rather than widened
+ * into `isAffirmative`, which would decline the batch and then walk the per-order loop
+ * ratifying every proposal in turn. The helper keeps its `string` parameter.
  */
 import {
   matchRungsByPrice,
@@ -34,6 +41,7 @@ import {
   type InForceLadder,
   type RungPick,
 } from "@numisma/engine";
+import { UNANSWERED, type Answer } from "./prompt-channel.js";
 
 /** How one rung is shown when the operator is asked about it. */
 function describeOrder(order: BitgetOpenOrder): string {
@@ -74,6 +82,11 @@ function labelOf(choices: readonly RungChoice[], pick: RungPick): string | undef
   )?.label;
 }
 
+export type RungPickOutcome =
+  | { status: "picked"; picks: Record<string, RungPick> }
+  /** A question in this pass went unanswered. No proposal was accepted or declined. */
+  | { status: "abandoned"; question: string };
+
 /**
  * Prompt for the declared rung join, one batch at a time.
  *
@@ -92,14 +105,14 @@ function labelOf(choices: readonly RungChoice[], pick: RungPick): string | undef
  * inference; a pick is something the operator said, and only the inference is blocked.
  */
 export async function declareRungPicks(
-  ask: (question: string) => Promise<string>,
+  ask: (question: string) => Promise<Answer>,
   orders: readonly BitgetOpenOrder[],
   ladders: readonly InForceLadder[],
   declaredOnFile: readonly RungPick[] = [],
-): Promise<Record<string, RungPick>> {
+): Promise<RungPickOutcome> {
   const choices = offerRungs(ladders);
   if (choices.length === 0) {
-    return {};
+    return { status: "picked", picks: {} };
   }
 
   // ONE RUNG STANDS FOR ONE ORDER, ACROSS THE BATCH **AND** ACROSS IMPORTS. Without this
@@ -157,9 +170,17 @@ export async function declareRungPicks(
   // Enter. It is NOT the refusal a blank funding answer is: there, a blank means the
   // operator declared no reserve and nothing may be written; here, every proposal is
   // already on screen and the question is only whether to keep them.
+  //
+  // AND THAT IS EXACTLY WHY UNANSWERED CANNOT REACH THE LINE BELOW. The blank's acceptance
+  // is earned by the operator having READ the summary this prompt just printed; a question
+  // that was never put earns nothing, and one Enter nobody pressed would ratify every
+  // proposal on screen.
+  if (accepted === UNANSWERED) {
+    return { status: "abandoned", question: "whether to accept the proposed rung picks" };
+  }
   const answer = accepted.trim();
   if (answer === "" || isAffirmative(answer)) {
-    return Object.fromEntries(proposals);
+    return { status: "picked", picks: Object.fromEntries(proposals) };
   }
 
   const menu = choices.map((choice, index) => `    ${index + 1}) ${choice.label}`).join("\n");
@@ -180,7 +201,14 @@ export async function declareRungPicks(
     // default would write a durable join into an append-only file that nobody declared,
     // and the operator would have no way to know which reading was taken.
     for (;;) {
-      const reply = (await ask(question)).trim();
+      const answered = await ask(question);
+      // THE RE-ASK LOOP IS NOT A PLACE TO WAIT OUT AN ABANDONED TERMINAL. Every later
+      // question resolves UNANSWERED too, so re-asking would spin; and falling through to
+      // the blank's branch would keep the proposed rung, which is the ratification.
+      if (answered === UNANSWERED) {
+        return { status: "abandoned", question: `which rung ${describeOrder(order)} filled` };
+      }
+      const reply = answered.trim();
       if (reply === "") {
         if (proposed !== undefined) {
           picks[order.id] = proposed;
@@ -197,5 +225,5 @@ export async function declareRungPicks(
       }
     }
   }
-  return picks;
+  return { status: "picked", picks };
 }

--- a/apps/tui/src/import-orders.test.ts
+++ b/apps/tui/src/import-orders.test.ts
@@ -28,6 +28,7 @@ import {
 import { afterEach, describe, expect, it } from "vitest";
 import { describeMerge } from "./import-orders-merge-notice.js";
 import { importBitgetOpenOrders, type OrdersImportIo } from "./import-orders.js";
+import { UNANSWERED, type Answer } from "./prompt-channel.js";
 
 const createdDirs: string[] = [];
 
@@ -160,7 +161,7 @@ interface HarnessOptions {
    * single harness can drive two successive imports (the re-import and re-price cases)
    * with the operator answering the same way both times.
    */
-  answers?: string[];
+  answers?: Answer[];
   /**
    * The LIVE reserves the folded fund carries, as `{ id, amount }` — synthesized into a
    * real `FundReviewData` by {@link syntheticFund}, because the guard takes the fund now
@@ -257,7 +258,11 @@ async function harness(options: HarnessOptions = {}): Promise<Harness> {
         if (answers.length === 0) {
           answers = [...script];
         }
-        return answers.shift() ?? "";
+        // A HARNESS WITH NO SCRIPT AT ALL ANSWERS `UNANSWERED`, NOT `""` (#388) — what the
+        // real channel hands this flow when there is no terminal. The funding question
+        // reads both the same way, `no-reserve-declared`, which is the point of collapsing
+        // them there; every other question refuses the sentinel outright.
+        return answers.shift() ?? UNANSWERED;
       },
       out: (message) => {
         outputs.push(message);
@@ -2059,38 +2064,37 @@ describe("importBitgetOpenOrders — the declared rung join", () => {
 });
 
 /**
- * THE ORDERING DEPENDENCY THAT MAKES AN EMPTY ANSWER SAFE (#370, symptom 2) — the pin
+ * A RUN NOBODY CAN ANSWER REFUSES AT THE FIRST QUESTION (#370, symptom 2) — the pin
  * `record-fill.test.ts` carries for the fill act, on this side of the pair.
  *
- * `import-orders-cli.ts` hands this flow `""` for every question when stdin is no
+ * `import-orders-cli.ts` hands this flow `UNANSWERED` for every question when stdin is no
  * terminal, so the shell can name the missing terminal and let the flow refuse in its own
- * voice instead of printing a readline internal. That is honest ONLY while the FIRST
- * question this flow reaches is one that refuses on `""` — a property of the ORDER the
- * interview asks in, not of the empty string. The funding batch question refuses; the
- * three questions behind it are ratifications, and `import-orders-cli.ts`'s construction
- * site enumerates them: the rung-pick prompt reads `""` as ACCEPT EVERY PROPOSED RUNG and,
- * at its other site, as TAKE THE DEFAULT, and the funding declaration's second question
- * reads it as NO PER-RUNG OVERRIDES. If any of those is ever reached first, the same `""`
- * silently ratifies every default and the import WRITES, unattended.
+ * voice instead of printing a readline internal. The funding batch question is the first
+ * this flow reaches, it refuses a declaration it did not get, and the sentinel lands on
+ * that same `no-reserve-declared` arm word for word.
  *
- * Until now that dependency was stated in prose on both shells and pinned on only one.
- * The fixture carries a LADDER on purpose: with `plans` empty no rung question exists to
- * run ahead of funding, so the case could not see the reorder it exists to catch. With one
- * in force every ratifying question is reachable, and the assertion below says none of
- * them was reached.
+ * WHAT THIS CASE USED TO BE. It pinned an ORDERING DEPENDENCY: `""` refused at the funding
+ * question and RATIFIED at the three behind it — accept every proposed rung, take the
+ * default, no per-order overrides — so the empty answer was honest only while funding was
+ * asked first, and a reorder would have let an unattended run write. #388 removed the
+ * dependency: all four questions refuse the sentinel now, the three ratifying ones as
+ * `interview-abandoned`. This case guards what it always measured — one question, the
+ * domain's own refusal, nothing on disk.
+ *
+ * The fixture carries a LADDER on purpose: with `plans` empty no rung question exists at
+ * all, so the case could not tell a flow that stopped from one that had nowhere to go.
  */
 describe("an import nobody can answer refuses at the FIRST question and writes nothing", () => {
   it("refuses as no-reserve-declared, having asked exactly one question", async () => {
-    // The script repeats once exhausted, so `[""]` answers EVERY question with the empty
-    // string — precisely what the shell hands the flow on a stdin that is no terminal.
-    const setup = await harness({ answers: [""], plans: [planLadder()] });
+    // The script repeats once exhausted, so this answers EVERY question with the
+    // sentinel — precisely what the shell hands the flow on a stdin that is no terminal.
+    const setup = await harness({ answers: [UNANSWERED], plans: [planLadder()] });
 
     const outcome = await importBitgetOpenOrders({ csvPath: setup.csvPath, io: setup.io });
 
     expect(outcome).toMatchObject({ status: "rejected", reason: "no-reserve-declared" });
     // THE PIN. One question — the funding declaration — and the refusal came from it.
-    // Reaching a second means a ratifying question now runs ahead of the refusing one,
-    // and the shell's `""` has stopped being an honest answer.
+    // Reaching a second would mean some question downstream accepted the sentinel.
     expect(setup.asked).toHaveLength(1);
     expect(setup.asked[0]).toContain("Funding reserve for this batch");
     // Nothing was written: the sidecar was never created.
@@ -2102,25 +2106,29 @@ describe("an import nobody can answer refuses at the FIRST question and writes n
  * THE OTHER DOOR INTO THOSE RATIFYING QUESTIONS: CTRL-D, WHICH IS NOT A REORDER.
  *
  * The case above pins the ORDERING argument — funding is asked first and refuses, so a
- * run with no terminal never reaches a ratification. That argument covers the no-terminal
- * path only. `prompt-channel.ts` clause 4 resolves `""` for an ABANDONED question too,
- * and for every question after it, because the abort closes the interface. So an operator
- * who types a real reserve, sees the override question, realises the reserve is the wrong
- * one and presses Ctrl-D used to get: the override blank read as "no overrides", the
- * rung-pick blank read as ACCEPT EVERY PROPOSAL, and `appendOrders` called with
- * `planId`/`rungId` joins nobody declared — durably, in an append-only file, attributed
- * to the reserve they were in the act of taking back. Before #370's channel change the
- * same keystroke ended the run with nothing on disk.
+ * run with no terminal never reaches a ratification. `prompt-channel.ts` clause 4 hands an
+ * abandoned question the same answer clause 2 does, and for every question after it,
+ * because the abort closes the interface. So an operator who types a real reserve, sees
+ * the override question, realises the reserve is the wrong one and presses Ctrl-D used to
+ * get: the override blank read as "no overrides", the rung-pick blank read as ACCEPT EVERY
+ * PROPOSAL, and `appendOrders` called with `planId`/`rungId` joins nobody declared —
+ * durably, in an append-only file, attributed to the reserve they were in the act of
+ * taking back.
  *
- * THE ASSERTION IS AT THIS SEAM RATHER THAN THE CHANNEL'S, because this is the layer
- * where the behaviour changed — the channel returning `""` was never the defect. No pty,
- * no spawn: `ask` is injected, and `promptAbandoned` is the channel's latch as a
- * predicate. The guarantee it pins is positional-independent — if the terminal was
- * abandoned, nothing is written — so it holds for a Ctrl-D at the LAST question too,
- * which is the case a latch that only re-answered later questions would still leak.
+ * TWO DOORS NOW STOP THAT, AND THEY ARE ASSERTED SEPARATELY. #388 gave the channel a
+ * sentinel no operator can type, so the question the operator walked away from refuses on
+ * its own and the run stops THERE — the first case below. The write-door latch (#386) is
+ * the second door and is still proven on its own terms in the case after it: even with
+ * every question answered, an abandoned terminal writes nothing. The second is redundant
+ * with the first by construction; it is kept one increment longer so a regression in the
+ * new per-question refusals meets a proven guarantee rather than a gap.
+ *
+ * THE ASSERTIONS ARE AT THIS SEAM RATHER THAN THE CHANNEL'S, because this is the layer
+ * where the behaviour changed. No pty, no spawn: `ask` is injected, and `promptAbandoned`
+ * is the channel's latch as a predicate.
  */
 describe("an interview abandoned at the terminal writes NOTHING (#370, clause 4)", () => {
-  /** Answers the funding question once, then `""` forever — what the channel really does. */
+  /** Answers the funding question once, then UNANSWERED forever — what the channel does. */
   function abandonAfterFirstAnswer(setup: Harness): { appended: number } {
     const calls = { appended: 0 };
     let abandoned = false;
@@ -2132,7 +2140,7 @@ describe("an interview abandoned at the terminal writes NOTHING (#370, clause 4)
         return "reserve-a";
       }
       abandoned = true;
-      return "";
+      return UNANSWERED;
     };
     setup.io.promptAbandoned = () => abandoned;
     setup.io.appendOrders = async () => {
@@ -2141,14 +2149,14 @@ describe("an interview abandoned at the terminal writes NOTHING (#370, clause 4)
     return calls;
   }
 
-  it("refuses as interview-abandoned and never reaches appendOrders", async () => {
+  it("refuses as interview-abandoned AT the abandoned question, and never reaches appendOrders", async () => {
     const setup = await harness({ plans: [planLadder()] });
     const calls = abandonAfterFirstAnswer(setup);
 
     const outcome = await importBitgetOpenOrders({ csvPath: setup.csvPath, io: setup.io });
 
-    // THE PIN. Without the write-door check this is `imported / appended: 2`, carrying
-    // declared rung joins the operator never accepted.
+    // THE PIN. Without a refusal at the question this is `imported / appended: 2`,
+    // carrying declared rung joins the operator never accepted.
     expect(calls.appended).toBe(0);
     expect(outcome).toMatchObject({ status: "rejected", reason: "interview-abandoned" });
     // The operator gets the refusal contract's literal second sentence, not a stack.
@@ -2157,19 +2165,43 @@ describe("an interview abandoned at the terminal writes NOTHING (#370, clause 4)
         (message) => message.startsWith("REFUSED —") && message.includes("Nothing was written"),
       ),
     ).toBe(true);
-    // And the interview really did get past the refusing question — otherwise this case
-    // would be passing for the reason the case above already covers.
-    expect(setup.asked.length).toBeGreaterThan(1);
+    // WHERE IT STOPPED, WHICH IS THE #388 HALF. Exactly two questions: the funding
+    // declaration, answered, and the override question, abandoned. The rung-pick prompts
+    // were never put, so the refusal came from the question the operator walked away from
+    // rather than from the write door thirty lines later. Before #388 this was FOUR.
+    expect(setup.asked).toHaveLength(2);
     expect(setup.asked[0]).toContain("Funding reserve for this batch");
+    expect(setup.asked[1]).toContain("Override the funding reserve");
+    // And the refusal names the question, which is what a single reason token cannot.
+    expect(outcome.status === "rejected" && outcome.message).toContain("override the reserve");
+  });
+
+  it("STILL refuses at the write door when every question was answered but the terminal was abandoned", async () => {
+    // THE SECOND DOOR, ON ITS OWN TERMS (#386, kept by #388). No question here goes
+    // unanswered — every one of them gets a real string — so nothing in the interview
+    // refuses, and the ONLY thing between this run and `appendOrders` is the latch. That
+    // is what makes the guarantee positional-independent: it does not matter which
+    // question caught the Ctrl-D, including the last one.
+    const setup = await harness({ answers: ["reserve-a", "n", ""], plans: [planLadder()] });
+    let appended = 0;
+    setup.io.appendOrders = async () => {
+      appended += 1;
+    };
+    setup.io.promptAbandoned = () => true;
+
+    const outcome = await importBitgetOpenOrders({ csvPath: setup.csvPath, io: setup.io });
+
+    expect(appended).toBe(0);
+    expect(outcome).toMatchObject({ status: "rejected", reason: "interview-abandoned" });
   });
 
   it("still lets a Ctrl-D at the FIRST question refuse as no-reserve-declared", async () => {
-    // #370's actual fix, unregressed: the channel's first rejecting question resolves
-    // `""`, the domain reads that as NO RESERVE DECLARED, and the operator gets the
-    // domain's own words rather than `Aborted with Ctrl+D`. The latch is true here too,
-    // but the funding refusal fires long before the write door, so it is that refusal —
-    // the specific one #370 names — the operator sees, not the new one.
-    const setup = await harness({ answers: [""], plans: [planLadder()] });
+    // #370's actual fix, unregressed, and #388 deliberately did not move it: the funding
+    // question already refused a blank, so the sentinel lands on that same arm with the
+    // same words. The operator gets the domain's own refusal rather than `Aborted with
+    // Ctrl+D`. The latch is true here too, but the funding refusal fires long before the
+    // write door, so it is that refusal — the specific one #370 names — the operator sees.
+    const setup = await harness({ answers: [UNANSWERED], plans: [planLadder()] });
     setup.io.promptAbandoned = () => true;
 
     const outcome = await importBitgetOpenOrders({ csvPath: setup.csvPath, io: setup.io });

--- a/apps/tui/src/import-orders.ts
+++ b/apps/tui/src/import-orders.ts
@@ -57,6 +57,7 @@ import {
 } from "./import-orders-report.js";
 import { renderUnattributedRefusal } from "./import-orders-unattributed-refusal.js";
 import { plural } from "./plural.js";
+import type { Answer } from "./prompt-channel.js";
 import { renderSkipMessage } from "./skip-message.js";
 
 /** Everything this flow touches that is not a pure function, in one injectable bag. */
@@ -108,27 +109,32 @@ export interface OrdersImportIo {
    */
   plansPath: string;
   loadPlans: (path: string) => Promise<LoadedPlans>;
-  /** Ask the operator one question; the answer is returned trimmed by the caller. */
-  ask: (question: string) => Promise<string>;
+  /**
+   * Ask the operator one question. Resolves what they typed, or `UNANSWERED` when there
+   * was no terminal to ask or the question was abandoned — see `prompt-channel.ts`. Every
+   * question in this flow narrows before it reads the answer as text, and every one of
+   * them refuses the sentinel: the batch reserve and the per-order override in
+   * `declareFunding`, both prompts in `declareRungPicks`.
+   */
+  ask: (question: string) => Promise<Answer>;
   /**
    * WHETHER THE TERMINAL CONDUCTING THIS INTERVIEW WAS ABANDONED — optional, and absent
    * means "it was not". Every caller that has no terminal to abandon (every fixture, and
    * any future non-interactive driver) is unaffected by omitting it.
    *
-   * WHY THE FLOW NEEDS A SECOND CHANNEL AT ALL. `ask` can only answer with a string, and
-   * the shell's prompt channel resolves `""` when a question is abandoned by Ctrl-D — it
-   * must, because that is what lets the FIRST question's blank come back as this flow's
-   * own `no-reserve-declared` refusal instead of a readline internal on the operator's
-   * screen (#370). But `""` is a RATIFICATION at three of this flow's questions: the
-   * funding override, and the rung-pick prompt at both of its sites. A Ctrl-D pressed
-   * after the funding declaration therefore used to race through them and land
-   * `planId`/`rungId` joins nobody declared, in an append-only file. The string cannot
-   * carry the difference, so the fact travels beside it.
+   * IT IS THE SECOND DOOR NOW (#388). It was the only one: `ask` used to answer `""` for
+   * an abandoned question, `""` is a RATIFICATION at three of this flow's questions — the
+   * funding override and the rung-pick prompt at both of its sites — so a Ctrl-D pressed
+   * after the funding declaration raced through them and landed `planId`/`rungId` joins
+   * nobody declared. The string could not carry the difference, so the fact travelled
+   * beside it. `ask` now answers `UNANSWERED`, which those three questions refuse where
+   * they stand, and the refusal names the question the operator walked away from rather
+   * than arriving at the door.
    *
-   * CHECKED AT THE WRITE DOOR, WHICH IS WHY THE GUARANTEE IS POSITIONAL-INDEPENDENT: if
-   * the terminal was abandoned, nothing is written — regardless of which question caught
-   * the Ctrl-D, including the last one. A latch that only changed later ANSWERS would
-   * still leak the interview whose final question was the abandoned one.
+   * WHAT THE LATCH STILL BUYS is a guarantee that holds without depending on any one
+   * question being written correctly: if the terminal was abandoned, nothing is written —
+   * regardless of which question caught the Ctrl-D. It is kept for exactly that reason
+   * while the per-question refusals are new. Removing it is its own change (#388).
    */
   promptAbandoned?: () => boolean;
   out: (message: string) => void;
@@ -143,10 +149,18 @@ export type OrdersImportRejection =
   | "unreadable-sidecar-lines"
   | "no-reserve-declared"
   /**
-   * THE OPERATOR ABANDONED THE INTERVIEW AT THE TERMINAL — Ctrl-D — and the answers
-   * behind that point are blanks nobody typed. See {@link OrdersImportIo.promptAbandoned}
-   * for why the flow cannot see this in the answers themselves, and `prompt-channel.ts`
-   * for the latch that carries it.
+   * THE OPERATOR ABANDONED THE INTERVIEW AT THE TERMINAL — Ctrl-D — or there was no
+   * terminal to conduct it on, which is the same fact to every question here.
+   *
+   * RAISED AT THE QUESTION THAT WENT UNANSWERED, and the message names it: `declareFunding`
+   * and `declareRungPicks` each return an `abandoned` arm carrying the question, and this
+   * flow turns either into this one reason. ONE reason rather than one per question, on
+   * purpose — the operator's next move is identical whichever prompt they walked away from
+   * (run the import again), and a reason token exists to distinguish next moves.
+   *
+   * ALSO RAISED AT THE WRITE DOOR, from {@link OrdersImportIo.promptAbandoned}. That check
+   * is redundant with the per-question refusals and is kept one increment longer as a
+   * belt on a guarantee that does not depend on any single question (#388).
    */
   | "interview-abandoned"
   /**
@@ -309,6 +323,25 @@ function reject(
   // be able to mistake a refusal for a quiet no-op.
   io.err(`REFUSED — ${message}\nNothing was written to ${io.ordersPath}.`);
   return { status: "rejected", reason, message };
+}
+
+/**
+ * The refusal an unanswered question earns, wherever in the interview it was put.
+ *
+ * ONE REASON, MANY QUESTIONS. The token is the flow's existing `interview-abandoned`; the
+ * MESSAGE names the prompt, because that is the half the operator needs and the half a
+ * reason code is bad at carrying. Nine per-question tokens would inflate the union without
+ * changing anybody's next move, which is to run the import again.
+ */
+function rejectAbandonedInterview(io: OrdersImportIo, question: string): OrdersImportOutcome {
+  return reject(
+    io,
+    "interview-abandoned",
+    `the interview stopped at ${question} — either the terminal was abandoned (Ctrl-D) or ` +
+      `there was no terminal to conduct it on, so that question was never answered. This ` +
+      `import attributes every rung to a declaration the operator made, and there is no ` +
+      `such declaration to attribute to. Nothing is written. Run the import again`,
+  );
 }
 
 /**
@@ -612,8 +645,13 @@ export async function importBitgetOpenOrders(
     // `io.ask` ALONE, not the bag: that module reads the prompt channel and nothing else,
     // and its signature says so — see its header.
     const declaration = await declareFunding(io.ask, admitted);
-    if (declaration === undefined) {
+    if (declaration.status === "not-declared") {
       return reject(io, "no-reserve-declared", "no funding reserve was declared for this batch");
+    }
+    // THE REFUSAL LANDS ON THE QUESTION THAT WAS WALKED AWAY FROM (#388), not thirty lines
+    // later at the write door. Nothing has been built, let alone written.
+    if (declaration.status === "abandoned") {
+      return rejectAbandonedInterview(io, declaration.question);
     }
 
     // THE DECLARED RUNG JOIN (#286), prompted after the funding declaration and before
@@ -624,13 +662,22 @@ export async function importBitgetOpenOrders(
     ladders = await loadInForceLadders(io, observedAt.slice(0, 10) as IsoDate);
     // `io.ask` ALONE again: the pick-list reads the prompt channel and nothing else —
     // the book on file arrives as VALUES, read here where the file already is.
-    const rungPicks = await declareRungPicks(
+    const picked = await declareRungPicks(
       io.ask,
       admitted,
       ladders,
       declaredJoinsOnFile(existingRecords),
     );
-    records.push(...buildOrderPlacedRecords(admitted, { ...declaration, rungPicks }));
+    if (picked.status === "abandoned") {
+      return rejectAbandonedInterview(io, picked.question);
+    }
+    records.push(
+      ...buildOrderPlacedRecords(admitted, {
+        fundingReserveId: declaration.fundingReserveId,
+        overrides: declaration.overrides,
+        rungPicks: picked.picks,
+      }),
+    );
 
     // `O1`. Coverage is checked over the WHOLE resting book — what is already on file plus
     // this batch — because a reserve funds every claim against it, not one import's slice.

--- a/apps/tui/src/import-orders.ts
+++ b/apps/tui/src/import-orders.ts
@@ -330,7 +330,7 @@ function reject(
  *
  * ONE REASON, MANY QUESTIONS. The token is the flow's existing `interview-abandoned`; the
  * MESSAGE names the prompt, because that is the half the operator needs and the half a
- * reason code is bad at carrying. Nine per-question tokens would inflate the union without
+ * reason code is bad at carrying. Five per-question tokens would inflate the union without
  * changing anybody's next move, which is to run the import again.
  */
 function rejectAbandonedInterview(io: OrdersImportIo, question: string): OrdersImportOutcome {
@@ -742,11 +742,17 @@ export async function importBitgetOpenOrders(
   const fresh: OrderRecord[] = [...records, ...observations].filter(
     (record) => !currentOnFile.has(appendKey(record)),
   );
-  // THE WRITE DOOR, AND THE LAST THING CHECKED BEFORE IT. An abandoned terminal makes
-  // every answer after the abandonment a blank nobody typed, and three of this flow's
-  // questions read a blank as consent — so the refusal cannot live at any one question,
-  // it has to live here, where every path that writes passes. Positional-independent: it
-  // does not matter which question caught the Ctrl-D, including the last one.
+  // THE WRITE DOOR, AND THE SECOND DOOR ONLY (#388). It is no longer what stops an
+  // abandoned interview writing: `ask` resolves `UNANSWERED`, every question of this flow
+  // refuses it where it stands, and the refusal names the question the operator walked
+  // away from. No blank is involved and no question reads one as consent.
+  //
+  // WHAT IT STILL BUYS is a guarantee that does not depend on any one question being
+  // written correctly: if the terminal was abandoned, nothing is written, whichever
+  // question caught the Ctrl-D. A regression in the new per-question refusals meets this
+  // rather than a gap. In production it is unreachable — reaching it means an `ask`
+  // returned the sentinel, and every path that could have is already gone — which is
+  // exactly what a second door should look like. Removing it is its own change.
   //
   // A REFUSAL, NOT A THROW, and in the established vocabulary — the operator gets the
   // same `REFUSED — ... Nothing was written` contract as `write-failed`, and the second
@@ -755,10 +761,10 @@ export async function importBitgetOpenOrders(
     return reject(
       io,
       "interview-abandoned",
-      `the interview was abandoned at the terminal (Ctrl-D), so the answers after that ` +
-        `point were blanks nobody typed — and three of this import's questions read a ` +
-        `blank as consent. Nothing about this batch is attributable to a declaration the ` +
-        `operator made, so none of it is written. Run the import again`,
+      `the interview was abandoned at the terminal (Ctrl-D) and reached this batch's write ` +
+        `anyway, which means a question of this import failed to refuse an answer nobody ` +
+        `gave. Nothing about this batch is attributable to a declaration the operator ` +
+        `made, so none of it is written. Run the import again`,
     );
   }
   try {

--- a/apps/tui/src/prompt-channel.test.ts
+++ b/apps/tui/src/prompt-channel.test.ts
@@ -256,7 +256,7 @@ describe("on a terminal where the question is aborted the channel ends the ANSWE
   // `record-fill-cli.ts` both print `error.message` there — putting Node's own wording,
   // "Aborted with Ctrl+D", on the operator's screen and ending the run. The consequence
   // the issue names: the domain's refusal, `REFUSED — no funding reserve was declared for
-  // this batch`, was never reached. Resolving with `""` is the same answer the
+  // this batch`, was never reached. Resolving with `UNANSWERED` is the same answer the
   // no-terminal path gives, and it lets the domain refuse in its own voice.
   it("RESOLVES with UNANSWERED when the question rejects with Node's measured Ctrl-D abort", async () => {
     const harness = channelOn(true, [], ctrlDInterface());

--- a/apps/tui/src/prompt-channel.test.ts
+++ b/apps/tui/src/prompt-channel.test.ts
@@ -28,7 +28,7 @@
  * There is no pty, no spawn and no child process anywhere in this file: nothing below
  * presses Ctrl-D, and nothing below is end-to-end coverage of a terminal delivering one.
  * What is pinned is: given a `question()` that rejects with the shape Node really
- * produces, this channel resolves with `""`.
+ * produces, this channel resolves with `UNANSWERED`.
  *
  * THAT SHAPE WAS MEASURED, NOT ASSUMED — node v24.14.0, `node:readline/promises` over an
  * in-process `PassThrough` pair with `terminal: true`, a pending `question()`, and a raw
@@ -48,7 +48,7 @@
  * Every fake is authored. Nothing here touches `process`, stdin, or a real readline.
  */
 import { describe, expect, it } from "vitest";
-import { createPromptChannel, type PromptInterface } from "./prompt-channel.js";
+import { createPromptChannel, UNANSWERED, type PromptInterface } from "./prompt-channel.js";
 
 const NOTICE = "No terminal on stdin: authored notice.";
 
@@ -190,7 +190,7 @@ describe("the prompt channel builds its interface at the first question, never a
   });
 });
 
-describe("on a stdin that is no terminal the channel says so and returns an empty answer", () => {
+describe("on a stdin that is no terminal the channel says so and answers UNANSWERED", () => {
   it("never touches readline at all", async () => {
     const harness = channelOn(false);
 
@@ -202,13 +202,14 @@ describe("on a stdin that is no terminal the channel says so and returns an empt
     expect(harness.rl.asked).toEqual([]);
   });
 
-  it("RESOLVES with '' rather than throwing", async () => {
+  it("RESOLVES with UNANSWERED rather than throwing", async () => {
     const harness = channelOn(false);
 
     // Throwing would unwind through the shell's outer catch and end the run there, which
-    // makes the domain's own refusal for an unanswered interview unreachable. The empty
-    // answer is the one answer a run with no terminal can honestly give.
-    await expect(harness.channel.ask("a? ")).resolves.toBe("");
+    // makes the domain's own refusal for an unanswered interview unreachable. And the
+    // value is NOT `""`: a run with no terminal did not answer nothing, it could not be
+    // asked, and `UNANSWERED` is the only value no question can read as consent (#388).
+    await expect(harness.channel.ask("a? ")).resolves.toBe(UNANSWERED);
   });
 
   it("writes the shell's own sentence, not readline's", async () => {
@@ -232,7 +233,7 @@ describe("on a stdin that is no terminal the channel says so and returns an empt
     const harness = channelOn(false);
 
     for (let index = 0; index < 9; index += 1) {
-      expect(await harness.channel.ask(`q${index}? `)).toBe("");
+      expect(await harness.channel.ask(`q${index}? `)).toBe(UNANSWERED);
     }
 
     expect(harness.errors).toEqual([NOTICE]);
@@ -257,10 +258,13 @@ describe("on a terminal where the question is aborted the channel ends the ANSWE
   // the issue names: the domain's refusal, `REFUSED — no funding reserve was declared for
   // this batch`, was never reached. Resolving with `""` is the same answer the
   // no-terminal path gives, and it lets the domain refuse in its own voice.
-  it("RESOLVES with '' when the question rejects with Node's measured Ctrl-D abort", async () => {
+  it("RESOLVES with UNANSWERED when the question rejects with Node's measured Ctrl-D abort", async () => {
     const harness = channelOn(true, [], ctrlDInterface());
 
-    await expect(harness.channel.ask("funding reserve? ")).resolves.toBe("");
+    // The SAME value clause 2 gives, which is #388's whole point: "there was no terminal"
+    // and "the operator walked away" are one fact to every question downstream, and
+    // neither is a blank line somebody typed.
+    await expect(harness.channel.ask("funding reserve? ")).resolves.toBe(UNANSWERED);
 
     // It really did reach readline — this is the terminal path, not the guard.
     expect(harness.built).toBe(1);
@@ -271,14 +275,15 @@ describe("on a terminal where the question is aborted the channel ends the ANSWE
   // whatever the flow asks next reaches a closed readline and rejects with
   // `ERR_USE_AFTER_CLOSE` — the readline internal #370's symptom 2 took off the
   // operator's screen. It must not come back through this door. Every later question
-  // answers `""` too, which is what carries a nineteen-question interview all the way to
-  // the domain's refusal instead of ending it at the first one.
-  it("keeps answering '' for the rest of the interview once the interface is closed", async () => {
+  // answers `UNANSWERED` too, which is what carries a nineteen-question interview to a
+  // refusal rather than a stack trace — and, since #388, what makes every question after
+  // the abandoned one refuse in turn instead of ratifying its default.
+  it("keeps answering UNANSWERED for the rest of the interview once the interface is closed", async () => {
     const harness = channelOn(true, [], ctrlDInterface());
 
-    expect(await harness.channel.ask("first? ")).toBe("");
-    expect(await harness.channel.ask("second? ")).toBe("");
-    expect(await harness.channel.ask("third? ")).toBe("");
+    expect(await harness.channel.ask("first? ")).toBe(UNANSWERED);
+    expect(await harness.channel.ask("second? ")).toBe(UNANSWERED);
+    expect(await harness.channel.ask("third? ")).toBe(UNANSWERED);
 
     expect(harness.rl.asked).toEqual(["first? ", "second? ", "third? "]);
     // Still one interface. An abort is not a reason to build another one.
@@ -335,10 +340,10 @@ describe("the channel remembers that a question was abandoned", () => {
   it("latches on the rejecting question, WITHOUT changing what it resolves", async () => {
     const harness = channelOn(true, [], ctrlDInterface());
 
-    // Both halves in one case on purpose: a latch that suppressed clause 4's `""` would
-    // put `Aborted with Ctrl+D` back on the operator's screen, which is the whole defect
-    // #370 removed.
-    expect(await harness.channel.ask("funding reserve? ")).toBe("");
+    // Both halves in one case on purpose: a latch that suppressed clause 4's resolution
+    // would put `Aborted with Ctrl+D` back on the operator's screen, which is the whole
+    // defect #370 removed.
+    expect(await harness.channel.ask("funding reserve? ")).toBe(UNANSWERED);
     expect(harness.channel.aborted()).toBe(true);
   });
 

--- a/apps/tui/src/prompt-channel.ts
+++ b/apps/tui/src/prompt-channel.ts
@@ -14,12 +14,12 @@
  *      eagerly consumes stdin, so constructing it up front ends a piped stream before any
  *      question is put and the first `ask` rejects with `ERR_USE_AFTER_CLOSE`. Memoized,
  *      so one interview shares one interface, and a run that never asks never builds one.
- *   2. ON A STDIN THAT IS NO TERMINAL, THE CHANNEL SAYS SO AND RETURNS "". It does not
- *      throw: throwing unwinds through the shell's outer catch and ends the run there,
- *      which makes the domain's own refusal for an unanswered interview unreachable. The
- *      empty answer is the one answer a run with no terminal can honestly give, and the
- *      domain then refuses in its own voice. Two sentences, two layers: the shell names
- *      WHY there is no answer, the flow names WHAT IT DID about it.
+ *   2. ON A STDIN THAT IS NO TERMINAL, THE CHANNEL SAYS SO AND RESOLVES {@link UNANSWERED}.
+ *      It does not throw: throwing unwinds through the shell's outer catch and ends the run
+ *      there, which makes the domain's own refusal for an unanswered interview unreachable.
+ *      A question nobody could be asked has no answer, and `UNANSWERED` is how the channel
+ *      says exactly that; the domain then refuses in its own voice. Two sentences, two
+ *      layers: the shell names WHY there is no answer, the flow names WHAT IT DID about it.
  *   3. THE NOTICE IS WRITTEN ONCE PER RUN, not once per question. The operator learns
  *      there is no terminal from the first unanswerable question; repeating it buries the
  *      flow's refusal under copies of the shell's. NEITHER SHELL OBSERVES THE DIFFERENCE
@@ -31,69 +31,59 @@
  *      `recordFill` reaches nineteen `ask` sites once the ones it delegates to
  *      `authorLadderTarget` and `resolveFunding` are counted, and the import shell's rung
  *      walk can put one question per rung.
- *   4. A QUESTION THAT REJECTS RESOLVES WITH "" TOO (#370, symptom 1). At a REAL terminal
- *      `isTTY` is true, so clause 2's guard never fires; Ctrl-D then makes
+ *   4. A QUESTION THAT REJECTS RESOLVES {@link UNANSWERED} TOO (#370, symptom 1). At a REAL
+ *      terminal `isTTY` is true, so clause 2's guard never fires; Ctrl-D then makes
  *      `rl.question()` reject, and that rejection used to unwind through each shell's
  *      outer catch, which prints `error.message` — putting Node's own wording, "Aborted
  *      with Ctrl+D" (measured: `AbortError`, code `ABORT_ERR`), on the operator's screen
  *      and ending the run there. So the domain's refusal, the message the operator
  *      actually needs, was never reached. Clause 2's reasoning applies unchanged: a
- *      question with no answer has one honest answer, `""`, and the domain refuses in its
- *      own voice. This clause is only the second door into the same decision.
+ *      question with no answer resolves the value that MEANS no answer, and the domain
+ *      refuses in its own voice. This clause is only the second door into the same
+ *      decision, and #388 collapsed the two meanings into one: "never able to answer" and
+ *      "abandoned mid-interview" are the same fact to every question downstream.
  *
- *      WHY THE CATCH IS WIDE AND NOT NARROWED TO THE ABORT. `.catch(() => "")` swallows
- *      every rejection, which is deliberate. Two rejections were measured and BOTH mean
- *      the same thing: `ABORT_ERR` (Ctrl-D) and `ERR_USE_AFTER_CLOSE` / "readline was
- *      closed", which is what every question AFTER the Ctrl-D gets, because the abort
- *      closes the interface. Narrowing to `ABORT_ERR` would therefore fix the first
- *      question and hand the operator the readline internal on the second — the exact
- *      string clause 1 exists to keep off the screen. And the generalisation holds past
- *      what was measured: whatever makes a question reject, no answer arrived, and the
- *      domain must be allowed to say so. A rejected question is a missing ANSWER, never a
- *      run that cannot continue — the shells' outer catch is for the domain's failures,
- *      not for the prompt's.
+ *      WHY THE CATCH IS WIDE AND NOT NARROWED TO THE ABORT. `.catch(() => UNANSWERED)`
+ *      swallows every rejection, which is deliberate. Two rejections were measured and
+ *      BOTH mean the same thing: `ABORT_ERR` (Ctrl-D) and `ERR_USE_AFTER_CLOSE` /
+ *      "readline was closed", which is what every question AFTER the Ctrl-D gets, because
+ *      the abort closes the interface. Narrowing to `ABORT_ERR` would therefore fix the
+ *      first question and hand the operator the readline internal on the second — the
+ *      exact string clause 1 exists to keep off the screen. And the generalisation holds
+ *      past what was measured: whatever makes a question reject, no answer arrived, and
+ *      the domain must be allowed to say so. A rejected question is a missing ANSWER,
+ *      never a run that cannot continue — the shells' outer catch is for the domain's
+ *      failures, not for the prompt's.
  *
- * WHAT `""` MEANS IS THE CALLER'S PROBLEM, AND IT IS AN ORDERING DEPENDENCY. Read as an
- * answer, `""` means different things to different questions — a refusal at one, "take the
- * default" at another. It is safe only while the FIRST question a run reaches unanswerable
- * is one that refuses on it. That dependency now governs BOTH paths, and clause 4 WIDENS
- * IT. Clause 2 only ever reaches the FIRST question — a no-terminal run is refused there
- * and never gets further, which is why each shell's construction site can argue safety
- * from the ordering alone. Clause 4 lands wherever the operator presses Ctrl-D, which is
- * any question in the interview and every question after it. Both shells enumerate their
- * questions and both name the ones that read `""` as a silent ratification rather than a
- * refusal — six of `record-fill`'s nineteen, three of the import shell's. Those are now
- * reachable by Ctrl-D, and the sentence "only the first is ever reached" is true of the
- * no-terminal path only.
+ * WHAT AN UNANSWERED QUESTION MEANS IS NO LONGER AN ORDERING DEPENDENCY (#388). This
+ * channel used to resolve `""`, and `""` is an ANSWER: a refusal at one question, "take
+ * the default" at another, and outright consent at a third — so the safety of both
+ * abandonment paths rested on the FIRST question a run reached unanswerable being one that
+ * refuses. That sentence was true of the no-terminal path and false of Ctrl-D, which lands
+ * wherever the operator presses it. `UNANSWERED` removes the dependency rather than
+ * surviving it: no operator can type a symbol, so no question can mistake it for consent,
+ * and each question refuses the moment it is handed one. Reorder either interview and
+ * nothing about that changes.
  *
- * SO CLAUSE 4 DOES NOT SHIP ALONE. A mid-interview Ctrl-D in `orders:import` was measured
- * reaching `import-orders.ts`'s `appendOrders` with `planId`/`rungId` joins nobody
- * declared — the batch attributed to a reserve the operator was in the act of taking back
- * — where the same keystroke previously ended the run with nothing on disk. Two things
- * stand between the widened `""` and a durable write now:
+ * THE SENTINEL IS A SYMBOL AND NOT A MAGIC STRING, DELIBERATELY. A reserved string flows
+ * through `isAffirmative("\0abandoned")` and is silently ratified — the same defect one
+ * layer down, with an invariant humans must remember forever. `Answer` makes every call
+ * site a TYPE ERROR instead: `.trim()` does not exist on `string | symbol`, and a helper
+ * typed `(answer: string)` will not take one, so the compiler enumerated all 24 sites once
+ * and enforces them from here on. It is not a discriminated record either
+ * (`{answered:true,text} | {answered:false}`): that buys no extra safety and breaks every
+ * test harness, because a fake `ask` typed `Promise<string>` stays assignable to
+ * `Promise<Answer>` under a union and does not under a record.
  *
- *   - THIS CHANNEL LATCHES THE ABANDONMENT (`aborted` below). The rejecting question
- *     still resolves `""` — clause 4 is unchanged, and the first-question Ctrl-D still
- *     ends in the domain's own refusal — but the channel REMEMBERS that a question was
- *     abandoned, so the fact survives the string that cannot carry it.
- *   - AND THE FLOW REFUSES AT ITS WRITE DOOR. `import-orders.ts` takes the latch as an
- *     injected predicate and refuses as `interview-abandoned` before `appendOrders`.
- *     THAT GUARANTEE IS POSITIONAL-INDEPENDENT — if the terminal was abandoned, nothing
- *     is written — so it holds no matter which question caught the Ctrl-D, INCLUDING the
- *     last question of an interview, which a latch that only re-answered later questions
- *     would still leak. `record-fill` reaches its own writes only through
- *     `Write BOTH? [y/N]`, on which `isAffirmative("")` is false, so an abandoned run
- *     there abandons at that gate; its construction site now says so.
- *
- * THE SENTINEL IS STILL OWED. What the latch does NOT buy is an unanswered question
- * distinguishable from an empty one AT THE QUESTION: every ratifying question in between
- * still reads the blank as consent, and the operator still watches a batch be ratified
- * before the write door refuses it. A sentinel the questions reject rather than a blank
- * would move the refusal to the question that was actually abandoned, and would remove
- * the ordering dependency instead of merely surviving it. Both construction sites still
- * name it, and it belongs to whichever increment makes that distinction. Each shell states
- * the dependency at its own site and each pins it, because neither this module nor the
- * other shell can see it.
+ * THE ABANDONMENT LATCH IS THE SECOND DOOR NOW, NOT THE GUARANTEE. Before the sentinel,
+ * a mid-interview Ctrl-D in `orders:import` was measured reaching `import-orders.ts`'s
+ * `appendOrders` with `planId`/`rungId` joins nobody declared, and the only thing standing
+ * between the widened `""` and a durable write was this channel latching the abandonment
+ * (`aborted` below) so the flow could refuse at its write door. The questions refuse for
+ * themselves now, so the refusal lands ON the abandoned question and the latch can no
+ * longer be the thing that saves a run. It is kept anyway, one increment longer, so a
+ * regression in the new per-question refusals meets a guarantee that is still proven
+ * rather than a gap; removing it is its own change.
  *
  * EVERYTHING IS INJECTED — `isTTY` as a value, the interface as a factory, the error sink
  * as a function — so the channel is testable with no terminal, no process and no spawn.
@@ -103,7 +93,31 @@
  * rejecting `question()`, and does NOT cover a real terminal delivering a real Ctrl-D.
  */
 
-/** The readline surface this channel uses — structural, so a test can hand it a fake. */
+/**
+ * THE ANSWER THAT IS NOT ONE — resolved by both abandonment paths, and by nothing else.
+ *
+ * A symbol because no operator can type one and no `Answer` can be confused for one. See
+ * the module header for why this is not a reserved string and not a record.
+ */
+export const UNANSWERED = Symbol("unanswered");
+
+/**
+ * What a question resolves: what the operator typed, or {@link UNANSWERED}.
+ *
+ * The union is what forces the discipline. Every consumer must narrow before it can treat
+ * the value as text, and `string` is still assignable to it — so a test fake that only
+ * ever answers can stay a `Promise<string>` function.
+ */
+export type Answer = string | typeof UNANSWERED;
+
+/**
+ * The readline surface this channel uses — structural, so a test can hand it a fake.
+ *
+ * IT RESOLVES A `string`, NEVER AN {@link Answer}. This is readline's own contract, and the
+ * sentinel is the CHANNEL's word about a question, not the terminal's: what readline does
+ * when there is no answer is reject, and turning that into `UNANSWERED` is clause 4's job
+ * one layer up.
+ */
 export interface PromptInterface {
   question(query: string): Promise<string>;
   close(): void;
@@ -129,23 +143,29 @@ export interface PromptChannelIo {
 }
 
 export interface PromptChannel {
-  ask: (question: string) => Promise<string>;
+  /**
+   * Put one question. Resolves what the operator typed, or {@link UNANSWERED} when there
+   * was no terminal to ask (clause 2) or the question was abandoned (clause 4).
+   */
+  ask: (question: string) => Promise<Answer>;
   /**
    * WHETHER ANY QUESTION IN THIS RUN WAS ABANDONED — a latch, set the first time a
    * `question()` rejects and never cleared. Readable without touching module state,
    * because it is a closure over this channel's own interview and nothing else.
    *
-   * IT DOES NOT CHANGE WHAT `ask` RESOLVES. Clause 4 stands exactly as written: the
-   * rejecting question still resolves `""`, so a Ctrl-D at the FIRST question still lets
-   * the domain refuse in its own voice rather than printing a readline internal — that is
-   * #370's actual fix and this latch must not regress it. What the latch adds is a fact
-   * the flow can consult BEFORE it writes: an answer of `""` that came from an abandoned
-   * terminal is not an answer at all, and no shell can tell the two apart from the string.
+   * IT IS THE SECOND DOOR, NOT THE FIRST. `ask` resolves `UNANSWERED` on the abandoned
+   * question and on every question after it, and each question refuses that value where it
+   * stands — so the refusal the operator reads names the question they walked away from.
+   * The latch adds nothing to that; what it still buys is a flow-level guarantee that does
+   * not depend on any one question having been written correctly: if the terminal was
+   * abandoned, `import-orders.ts` writes nothing. #388 kept it for exactly one increment
+   * longer so a regression in the per-question refusals meets a proven guarantee instead
+   * of a gap.
    *
    * THE NO-TERMINAL PATH DOES NOT SET IT. Clause 2 never asks readline anything, so no
-   * question was abandoned there; that path is still governed by the ordering argument
-   * each construction site makes, and the first question refuses on `""` before any write
-   * door is reached.
+   * question was abandoned there — it was unaskable. Both paths resolve the same sentinel,
+   * which is the point of #388; only this latch still tells them apart, and only for the
+   * benefit of the write-door check.
    */
   aborted: () => boolean;
   /**
@@ -163,21 +183,22 @@ export function createPromptChannel(io: PromptChannelIo): PromptChannel {
 
   return {
     aborted: () => aQuestionWasAbandoned,
-    ask: (question: string): Promise<string> => {
+    ask: (question: string): Promise<Answer> => {
       if (!io.isTTY) {
         if (!toldThereIsNoTerminal) {
           toldThereIsNoTerminal = true;
           io.err(io.noTerminalNotice);
         }
-        return Promise.resolve("");
+        // CLAUSE 2. There was nowhere to put the question, so there is no answer to give.
+        return Promise.resolve(UNANSWERED);
       }
       rl ??= io.createInterface();
       // CLAUSE 4. A rejected question is an ANSWER that did not arrive, not a run that
       // cannot continue. See the module docstring for why the catch is this wide.
       // THE LATCH IS SET HERE AND NOWHERE ELSE — see `PromptChannel.aborted`.
-      return rl.question(question).catch(() => {
+      return rl.question(question).catch((): Answer => {
         aQuestionWasAbandoned = true;
-        return "";
+        return UNANSWERED;
       });
     },
     close: (): void => {

--- a/apps/tui/src/record-fill-cli.test.ts
+++ b/apps/tui/src/record-fill-cli.test.ts
@@ -244,7 +244,8 @@ describe("record-fill-cli — a run with no terminal refuses in its own voice (#
     // uses for the same situation on the sibling shell: the notice is written ONCE PER
     // RUN rather than once per question, and no spawn here can see it. This case briefly
     // carried a count over the notice, which could not fail — a no-terminal run reaches
-    // EXACTLY ONE question. `record-fill.ts` asks "Which rung filled?" first, gets `""`,
+    // EXACTLY ONE question. `record-fill.ts` asks "Which rung filled?" first, gets the
+    // channel's `UNANSWERED`,
     // and refuses as `unknown-rung`; every later question sits past that refusal, and no
     // data-dir state reaches one. Delete the `toldThereIsNoTerminal` flag entirely, write
     // the notice unconditionally on every `ask`, and this file stays green. That is the

--- a/apps/tui/src/record-fill-cli.ts
+++ b/apps/tui/src/record-fill-cli.ts
@@ -69,15 +69,23 @@ const paths = resolveEventStorePaths();
  * PHRASING. Every writer of the act sits behind `Write BOTH? [y/N]`
  * (`record-fill.ts`), on which `isAffirmative("")` is false, so an abandoned run reached
  * that gate and abandoned — after ratifying six defaults on the way, in front of an
- * operator who had already walked away. That argument also had no equivalent for
- * `Append this lot? [Y/n]`, whose `[Y/n]` phrasing pointed the other way and which the
- * import shell's write-door latch does not cover. The refusal lives at each question now,
- * so neither the ordering of this interview nor the phrasing of its gates is load-bearing,
- * and this act still needs no abandonment latch of its own.
+ * operator who had already walked away. So no abandoned fill act ever reached a durable
+ * write, `Append this lot? [Y/n]` included: that gate's `[Y/n]` phrasing pointed the other
+ * way, but it is four questions upstream of the door, so the lot was attached in memory and
+ * the act still refused. What was wrong was resting the whole act's safety on ONE gate's
+ * wording. The refusal lives at each question now, so neither the ordering of this interview
+ * nor the phrasing of its gates is load-bearing, and this act still needs no abandonment
+ * latch of its own.
  *
  * `record-fill.test.ts` pins it: the happy-path script with exactly one answer replaced by
  * the sentinel abandons at THAT question, with both files byte-identical, and the count of
  * questions put says it stopped there rather than racing to the door.
+ *
+ * THE EXIT CODE IS THE SECOND HALF OF THE ANSWER, NEVER THE WHOLE OF IT. This shell maps
+ * any non-`recorded` outcome to 1 and prints nothing itself; the words are `recordFill`'s
+ * to write, and it writes them to `io.err` for `rejected` AND `abandoned` alike. An
+ * abandoned act that reached only this line would leave the operator a dropped prompt and
+ * a status, with no way to tell whether the fill landed.
  */
 const prompt = createPromptChannel({
   isTTY: Boolean(process.stdin.isTTY),

--- a/apps/tui/src/record-fill-cli.ts
+++ b/apps/tui/src/record-fill-cli.ts
@@ -38,65 +38,46 @@ const paths = resolveEventStorePaths();
  * run ended the stream before the first question was put and `ask` rejected with
  * `ERR_USE_AFTER_CLOSE` — `readline was closed`, a readline internal printed verbatim to
  * the operator by the outer catch below. The channel builds lazily and, on a stdin that is
- * no terminal, names the missing terminal in this shell's own voice and returns "".
+ * no terminal, names the missing terminal in this shell's own voice and hands the flow
+ * `UNANSWERED` — a symbol no operator can type — for every question it could not put.
  *
- * `""` IS HONEST HERE ONLY BECAUSE OF THE ORDER `recordFill` ASKS IN, and that is a
- * dependency rather than a property of the empty string. The reachable interview is
- * NINETEEN `ask` sites, not the nine `record-fill.ts` holds literally: it hands `io.ask`
- * onward to `authorLadderTarget` (`record-fill-ladder-target.ts`, eight more) and to
- * `resolveFunding` (`record-fill-funding.ts`, two more), and a delegated question is no
- * less reachable for being put from another file. They read `""` three ways:
+ * THIS SITE USED TO ENUMERATE WHAT `""` MEANT TO EACH OF THIS ACT'S QUESTIONS, AND TO
+ * ARGUE THAT THE ORDER `recordFill` ASKS IN MADE IT SAFE. The enumeration is obsolete
+ * (#388) and the argument is retired with it. What survives, because it is still true and
+ * still worth knowing: THE REACHABLE INTERVIEW IS NINETEEN `ask` SITES, not the nine
+ * `record-fill.ts` holds literally. It hands `io.ask` onward to `authorLadderTarget`
+ * (`record-fill-ladder-target.ts`, eight more) and to `resolveFunding`
+ * (`record-fill-funding.ts`, two more), and a delegated question is no less reachable for
+ * being put from another file. Every one of the nineteen refuses the sentinel:
  *
- *   - `record-fill.ts`'s "Which rung filled?" — the FIRST question the flow reaches —
- *     matches no rung and refuses as `unknown-rung`. This is the refusal that makes the
- *     empty answer safe, and nothing has been written when it fires. TEN more stop the
- *     act on a blank: the fill timestamp, a touched rung's observed quantity and the
- *     instrument id each reject one, as do `authorLadderTarget`'s five decision fields
- *     (together, as `incomplete-decision`) and `resolveFunding`'s capital tier; a blank
- *     position id abandons.
- *   - SIX are silent ratifications, and they are the hazard. "Filled quantity [n]" takes
- *     the remaining quantity; the per-rung book question takes its `[r]` default and
- *     records that rung as resting untouched; "Also record N confirmed cancellation(s)?"
- *     records NONE and lets the act continue; "Tempo [n]" takes the reserve's; "Cash
- *     debited [n]" takes the proposed figure; and `authorLadderTarget`'s "Append this lot
- *     to '<id>'? [Y/n]" — a gate phrased so that SILENCE MEANS YES — attaches the lot to
- *     an existing Position. That last one is the only thing standing between an
- *     unattended run and a lot landing in a Position nobody named.
- *   - only TWO "[y/N]" confirmations read `""` as NO and abandon: "Confirm these derived
- *     verdicts?" and "Write BOTH?".
+ *   - ELEVEN keep the refusal a blank already earned, in the same words — the rung pick
+ *     (`unknown-rung`, and it is the first question this act reaches, so it is the one a
+ *     piped run refuses at), the fill timestamp, a touched rung's observed quantity, the
+ *     instrument id, `authorLadderTarget`'s five decision fields (together, as
+ *     `incomplete-decision`) and `resolveFunding`'s capital tier; a blank position id
+ *     abandons, and so does an unanswered one.
+ *   - THE OTHER EIGHT ARE THE CHANGE, and they are the ones that used to read a blank as
+ *     an answer. "Filled quantity [n]" took the rung's whole remainder; the per-rung book
+ *     question took its `[r]` default and claimed that rung was resting untouched; "Also
+ *     record N confirmed cancellation(s)?" recorded none and let the act continue;
+ *     "Tempo [n]" took the reserve's; "Cash debited [n]" took the proposed figure; the two
+ *     "[y/N]" confirmations declined; and `authorLadderTarget`'s "Append this lot to
+ *     '<id>'? [Y/n]" — phrased so that SILENCE MEANS YES — attached the lot to an existing
+ *     Position. All eight now abandon the act, naming the question nobody answered.
  *
- * Only the first is ever reached without a terminal. Reorder the interview — ask the book
- * observation before the rung pick, or make the rung question skippable — and this same
- * `""` ratifies a quantity nobody stated and the run WRITES, unattended, with nobody
- * having answered anything. If that ordering moves, this must become a refusal the domain
- * cannot mistake for consent (a sentinel the questions reject, not a blank), and it must
- * move in the same commit. `record-fill.test.ts` pins the ordering itself — one question
- * asked, and it is the rung pick — so the move is loud rather than silent.
+ * WHAT USED TO STOP THIS ACT WRITING WAS ITS FINAL GATE, AND THAT WAS A PROPERTY OF THE
+ * PHRASING. Every writer of the act sits behind `Write BOTH? [y/N]`
+ * (`record-fill.ts`), on which `isAffirmative("")` is false, so an abandoned run reached
+ * that gate and abandoned — after ratifying six defaults on the way, in front of an
+ * operator who had already walked away. That argument also had no equivalent for
+ * `Append this lot? [Y/n]`, whose `[Y/n]` phrasing pointed the other way and which the
+ * import shell's write-door latch does not cover. The refusal lives at each question now,
+ * so neither the ordering of this interview nor the phrasing of its gates is load-bearing,
+ * and this act still needs no abandonment latch of its own.
  *
- * CTRL-D IS A SECOND DOOR INTO THOSE SIX RATIFICATIONS, AND IT IS NOT A REORDER. The
- * prompt channel resolves `""` for an ABANDONED question and for every question after it,
- * because the abort closes the interface (#370, clause 4 of `prompt-channel.ts`). So the
- * sentence "only the first is ever reached" is true of the NO-TERMINAL path only. Press
- * Ctrl-D anywhere in this nineteen-question interview and the run races through whatever
- * is left of it, ratifying the six — the remaining quantity, the per-rung book default,
- * no cancellations, the reserve's tempo, the proposed cash figure, and the lot appended
- * to an existing Position.
- *
- * WHAT STOPS THIS ACT WRITING ANYWAY IS ITS FINAL GATE, and that was verified rather than
- * assumed: every writer of the act sits BEHIND `Write BOTH? [y/N]` (`record-fill.ts:900`),
- * on which `isAffirmative("")` is false, so an abandoned run reaches that gate and
- * ABANDONS — `writeLogImage` and `appendOrders` are inside the two-file act just past it,
- * and the advisory trail's `appendReconciliation` is reached only through
- * `reconcileRecordedFill`, called once after the act is already durable. Nothing writes
- * ahead of the gate. `Confirm these derived verdicts? [y/N]` sits earlier and abandons on
- * a blank as well, so most abandoned runs stop before even reaching the final one.
- *
- * THAT IS A PROPERTY OF THIS SHELL, NOT OF THE CHANNEL, and it is why this act needs no
- * equivalent of the import shell's `interview-abandoned` refusal — the import flow has no
- * terminal gate at all, so it takes the channel's abandonment latch and refuses at its
- * write door instead. If a writer here is ever moved AHEAD of `Write BOTH?`, or that gate
- * is ever rephrased so that silence means yes, this argument dies with it and this act
- * must take the latch too.
+ * `record-fill.test.ts` pins it: the happy-path script with exactly one answer replaced by
+ * the sentinel abandons at THAT question, with both files byte-identical, and the count of
+ * questions put says it stopped there rather than racing to the door.
  */
 const prompt = createPromptChannel({
   isTTY: Boolean(process.stdin.isTTY),

--- a/apps/tui/src/record-fill-funding.test.ts
+++ b/apps/tui/src/record-fill-funding.test.ts
@@ -26,6 +26,7 @@ import {
   type RestingOrder,
 } from "@numisma/engine";
 import { resolveFunding } from "./record-fill-funding.js";
+import { UNANSWERED, type Answer } from "./prompt-channel.js";
 
 function reserve(overrides: Partial<ReserveRecord> = {}): ReserveRecord {
   return {
@@ -99,11 +100,11 @@ function rung(overrides: Partial<CommittedRung> = {}): CommittedRung {
 }
 
 /** Answers keyed by a prompt SUBSTRING; an unanticipated prompt throws rather than blanks. */
-function scripted(answers: Record<string, string>) {
+function scripted(answers: Record<string, Answer>) {
   const asked: string[] = [];
   return {
     asked,
-    ask: async (question: string): Promise<string> => {
+    ask: async (question: string): Promise<Answer> => {
       asked.push(question);
       const hit = Object.entries(answers).find(([key]) => question.includes(key));
       if (!hit) {
@@ -403,5 +404,35 @@ describe("resolveFunding — the tier is READ, never re-decided (T4)", () => {
 
     expect(outcome.status).toBe("rejected");
     expect(io.asked).toEqual(["Cash debited [4000]: "]);
+  });
+});
+
+/**
+ * A QUESTION NOBODY ANSWERED IS NOT A KEYSTROKE ON THE DEFAULT (#388).
+ *
+ * The two prompts here split, and the split is the whole rule. `Cash debited [n]`
+ * advertises a default, so an unanswered one used to debit a reserve for a figure nobody
+ * stated; it abandons now. The capital tier advertises none and already refused anything
+ * that is not `c1`/`c2`/`c3`, so an unanswered one lands on that same refusal, token and
+ * message unchanged.
+ */
+describe("an unanswered question (#388)", () => {
+  it("abandons the cash leg rather than debiting the proposed figure", async () => {
+    const io = scripted({ "Cash debited": UNANSWERED });
+
+    const outcome = await resolveFunding(io.ask, fold(reserve()), NO_RESTING, reserve(), rung(), 10);
+
+    expect(outcome.status).toBe("abandoned");
+    expect(outcome.status === "abandoned" && outcome.message).toContain("4000");
+    // It stopped at the cash question: the tier was never reached.
+    expect(io.asked).toHaveLength(1);
+  });
+
+  it("still takes the proposed figure on a real blank", async () => {
+    const io = scripted({ "Cash debited": "" });
+
+    const outcome = await resolveFunding(io.ask, fold(reserve()), NO_RESTING, reserve(), rung(), 10);
+
+    expect(outcome).toMatchObject({ status: "resolved", fundingAmount: 4000 });
   });
 });

--- a/apps/tui/src/record-fill-funding.ts
+++ b/apps/tui/src/record-fill-funding.ts
@@ -20,6 +20,13 @@
  * REJECTIONS ARE RETURNED, NOT PRINTED, and every message is byte-identical to what the
  * inline code fed `reject(io, …)`. The reason union is declared narrowly here rather than
  * imported from `RecordFillRejection` — no back-edge — and is assignable at the call site.
+ *
+ * ITS TWO QUESTIONS SPLIT ON #388. The capital tier already refuses anything that is not
+ * `c1`/`c2`/`c3`, so an `UNANSWERED` joins the blank there and stays `ambiguous-tier`, message and all.
+ * `Cash debited [n]` did not: a blank takes the proposed figure, so an abandoned terminal
+ * used to debit a reserve for an amount nobody stated. It abandons now — a fourth arm on
+ * the outcome, matching the one `authorLadderTarget` already had, rather than a new reason
+ * token, because the operator declined nothing and there is nothing to correct.
  */
 import {
   composeAvailableCapital,
@@ -30,9 +37,12 @@ import {
   type ReserveRecord,
   type RestingOrder,
 } from "@numisma/engine";
+import { UNANSWERED, type Answer } from "./prompt-channel.js";
 
 export type FundingOutcome =
   | { status: "resolved"; fundingAmount: number; tier: CapitalTier }
+  /** A question here went unanswered. The caller has written nothing. */
+  | { status: "abandoned"; message: string }
   | {
       status: "rejected";
       reason: "bad-quantity" | "uncovered-override" | "ambiguous-tier";
@@ -48,7 +58,7 @@ export type FundingOutcome =
  * that could drift from it.
  */
 export async function resolveFunding(
-  ask: (question: string) => Promise<string>,
+  ask: (question: string) => Promise<Answer>,
   folded: FundReviewData,
   resting: readonly RestingOrder[],
   reserve: ReserveRecord,
@@ -56,7 +66,17 @@ export async function resolveFunding(
   filledQuantity: number,
 ): Promise<FundingOutcome> {
   const proposedFunding = filled.price * filledQuantity;
-  const fundingAnswer = (await ask(`Cash debited [${proposedFunding}]: `)).trim();
+  const cashReply = await ask(`Cash debited [${proposedFunding}]: `);
+  // THE `[n]` DEFAULT IS AN ANSWER THE OPERATOR GIVES BY PRESSING ENTER, and an
+  // unanswered question gives nothing. Taking the proposal here would debit a reserve on
+  // a keystroke nobody made.
+  if (cashReply === UNANSWERED) {
+    return {
+      status: "abandoned",
+      message: `nobody answered the cash debited for this fill, and ${proposedFunding} is a proposal, not an answer`,
+    };
+  }
+  const fundingAnswer = cashReply.trim();
   const fundingAmount = fundingAnswer === "" ? proposedFunding : Number(fundingAnswer);
   if (!Number.isFinite(fundingAmount) || fundingAmount <= 0) {
     return {
@@ -137,7 +157,13 @@ export async function resolveFunding(
         `at Transfer time and this act does not get to re-decide it`,
     };
   }
-  const answer = (await ask("  Capital tier for this lot (c1/c2/c3): ")).trim();
+  // A QUESTION THAT ALREADY REFUSED, AND IT KEEPS ITS REFUSAL WORD FOR WORD. A blank is
+  // not a capital tier and neither is a question nobody answered, so the sentinel reads as
+  // the empty string here rather than earning an arm of its own. That collapse is safe
+  // ONLY because this prompt advertises no default; `Cash debited [n]` above does, which
+  // is why it checks the sentinel itself.
+  const tierAnswer = await ask("  Capital tier for this lot (c1/c2/c3): ");
+  const answer = tierAnswer === UNANSWERED ? "" : tierAnswer.trim();
   if (answer !== "c1" && answer !== "c2" && answer !== "c3") {
     return {
       status: "rejected",

--- a/apps/tui/src/record-fill-ladder-target.test.ts
+++ b/apps/tui/src/record-fill-ladder-target.test.ts
@@ -20,6 +20,7 @@
 import { describe, expect, it } from "vitest";
 import type { PositionRecord, ReserveRecord } from "@numisma/engine";
 import { authorLadderTarget } from "./record-fill-ladder-target.js";
+import { UNANSWERED, type Answer } from "./prompt-channel.js";
 
 function reserve(overrides: Partial<ReserveRecord> = {}): ReserveRecord {
   return {
@@ -58,13 +59,13 @@ function position(id: string, overrides: Partial<PositionRecord> = {}): Position
  * An unmatched prompt throws rather than defaulting to `""`, so a prompt this test did not
  * anticipate is a loud failure instead of a silently-blank answer that happens to abandon.
  */
-function scripted(answers: Record<string, string>) {
+function scripted(answers: Record<string, Answer>) {
   const asked: string[] = [];
   const printed: string[] = [];
   return {
     asked,
     printed,
-    ask: async (question: string): Promise<string> => {
+    ask: async (question: string): Promise<Answer> => {
       asked.push(question);
       const hit = Object.entries(answers).find(([key]) => question.includes(key));
       if (!hit) {
@@ -342,5 +343,86 @@ describe("authorLadderTarget — first fill on the ladder opens the Position (T6
       "  Planned holding horizon: ",
       "  Strategy: ",
     ]);
+  });
+});
+
+/**
+ * THE WORST RATIFICATION IN THE ACT, AND THE ONE WITH NO SECOND DOOR (#388).
+ *
+ * `Append this lot to '<id>'? [Y/n]` is phrased so that SILENCE MEANS YES. Before the
+ * sentinel, a Ctrl-D anywhere earlier in this nineteen-question interview resolved `""`
+ * here, `isNegative("")` was false, and the lot was attached to an existing Position —
+ * durably, with no operator having said so. The import flow's write-door latch does not
+ * cover this file, and `record-fill` has no equivalent, so nothing else caught it.
+ *
+ * The first case is the whole fix; the second is there so the fix cannot be mistaken for
+ * "the gate got stricter". A real blank still appends, which is what `[Y/n]` promises.
+ */
+describe("a question nobody answered is not consent (#388)", () => {
+  it("abandons rather than appending the lot when the append gate went unanswered", async () => {
+    const io = scripted({ "Append this lot": UNANSWERED });
+
+    const outcome = await authorLadderTarget(
+      io.ask,
+      io.out,
+      [position("position-synthetic")],
+      reserve(),
+      "instrument-synthetic",
+    );
+
+    expect(outcome.status).toBe("abandoned");
+    // The operator is told WHICH Position they did not agree to, and why silence was not
+    // taken for a yes.
+    expect(outcome.status === "abandoned" && outcome.message).toContain("position-synthetic");
+    expect(outcome.status === "abandoned" && outcome.message).toContain("silence");
+  });
+
+  it("still appends on a real blank — the [Y/n] default is unchanged", async () => {
+    const io = scripted({ "Append this lot": "" });
+
+    const outcome = await authorLadderTarget(
+      io.ask,
+      io.out,
+      [position("position-synthetic")],
+      reserve(),
+      "instrument-synthetic",
+    );
+
+    expect(outcome).toEqual({
+      status: "authored",
+      target: { mode: "add", positionId: "position-synthetic" },
+    });
+  });
+
+  it("abandons on an unanswered tempo rather than writing the reserve's own", async () => {
+    // `Tempo [n]` advertises the reserve's tempo as its default, and a Position carries
+    // whatever lands here for the rest of its life.
+    const io = scripted({
+      "Position id": "position-new",
+      Tempo: UNANSWERED,
+      ...FIVE_FIELDS,
+    });
+
+    const outcome = await authorLadderTarget(io.ask, io.out, [], reserve(), "instrument-synthetic");
+
+    expect(outcome.status).toBe("abandoned");
+    expect(outcome.status === "abandoned" && outcome.message).toContain("tempo");
+    // It stopped AT the tempo: the five decision fields were never put.
+    expect(io.asked.some((question) => question.includes("Entry thesis"))).toBe(false);
+  });
+
+  it("refuses an unanswered decision field as incomplete-decision, exactly as a blank one does", async () => {
+    // One of the fifteen that already refused. The reason token does not move, because
+    // the operator's next move — open the Position again with all five in hand — does not.
+    const io = scripted({
+      "Position id": "position-new",
+      Tempo: "",
+      ...FIVE_FIELDS,
+      "Risk budget": UNANSWERED,
+    });
+
+    const outcome = await authorLadderTarget(io.ask, io.out, [], reserve(), "instrument-synthetic");
+
+    expect(outcome).toMatchObject({ status: "rejected", reason: "incomplete-decision" });
   });
 });

--- a/apps/tui/src/record-fill-ladder-target.ts
+++ b/apps/tui/src/record-fill-ladder-target.ts
@@ -32,6 +32,16 @@
  * to the same function — so the operator's bytes are unchanged. The reason union is
  * declared narrowly HERE rather than imported from `RecordFillRejection`, which keeps the
  * back-edge out; it is assignable to the wider token set at the call site.
+ *
+ * IT HOLDS THIS ACT'S WORST RATIFICATION, AND #388 IS WHY THAT MATTERS. `Append this lot
+ * to '<id>'? [Y/n]` is phrased so that SILENCE MEANS YES: `isNegative("")` is false, so an
+ * unanswered question used to attach the lot to an existing Position — and unlike the
+ * import flow, nothing downstream of here latched the abandonment, so no second door ever
+ * stood behind it. The channel now hands an `UNANSWERED` that `isNegative` cannot be given,
+ * and this gate abandons on it. The sentinel is checked AT the question rather than widened
+ * into `isNegative`, which would return false for it and attach the lot exactly as before.
+ * `Tempo [n]` gets the same treatment for the same reason — a default nobody chose is
+ * still a value written onto a durable Position.
  */
 import {
   resolveLadderPosition,
@@ -40,6 +50,7 @@ import {
   type PositionRecord,
   type ReserveRecord,
 } from "@numisma/engine";
+import { UNANSWERED, type Answer } from "./prompt-channel.js";
 
 export type LadderTargetOutcome =
   | { status: "authored"; target: LadderTarget }
@@ -56,15 +67,25 @@ function isNegative(answer: string): boolean {
   return normalized === "n" || normalized === "no";
 }
 
-/** The five authored decision fields. All required; a blank one abandons the act. */
+/**
+ * The five authored decision fields. All required; a blank one abandons the act.
+ *
+ * AN UNANSWERED ONE LANDS IN THE SAME PLACE — `incomplete-decision`, the arm this pass
+ * already has for "one of these is missing". A question that was never put is the emptiest
+ * a field can be, and the operator's next move (open the Position again, with all five in
+ * hand) does not change with the reason it was missing. `text` is what turns the sentinel
+ * into the empty string these five already refuse, and it is deliberately local to the
+ * five fields that treat the two identically.
+ */
 async function askDecision(
-  ask: (question: string) => Promise<string>,
+  ask: (question: string) => Promise<Answer>,
 ): Promise<PositionDecision | undefined> {
-  const entryThesis = (await ask("  Entry thesis: ")).trim();
-  const invalidationCondition = (await ask("  Invalidation condition: ")).trim();
-  const riskBudget = (await ask("  Risk budget: ")).trim();
-  const plannedHoldingHorizon = (await ask("  Planned holding horizon: ")).trim();
-  const strategy = (await ask("  Strategy: ")).trim();
+  const text = (answer: Answer): string => (answer === UNANSWERED ? "" : answer.trim());
+  const entryThesis = text(await ask("  Entry thesis: "));
+  const invalidationCondition = text(await ask("  Invalidation condition: "));
+  const riskBudget = text(await ask("  Risk budget: "));
+  const plannedHoldingHorizon = text(await ask("  Planned holding horizon: "));
+  const strategy = text(await ask("  Strategy: "));
   if (
     !entryThesis ||
     !invalidationCondition ||
@@ -86,7 +107,7 @@ async function askDecision(
  * ambiguity away.
  */
 export async function authorLadderTarget(
-  ask: (question: string) => Promise<string>,
+  ask: (question: string) => Promise<Answer>,
   out: (message: string) => void,
   positions: readonly PositionRecord[],
   reserve: ReserveRecord,
@@ -108,7 +129,17 @@ export async function authorLadderTarget(
   }
 
   if (ladder.status === "one") {
-    if (isNegative(await ask(`Append this lot to '${ladder.positionId}'? [Y/n]: `))) {
+    const append = await ask(`Append this lot to '${ladder.positionId}'? [Y/n]: `);
+    if (append === UNANSWERED) {
+      return {
+        status: "abandoned",
+        message:
+          `nobody answered whether to append this lot to '${ladder.positionId}' — the gate ` +
+          `is phrased so that silence means yes, and silence from an abandoned terminal is ` +
+          `not consent`,
+      };
+    }
+    if (isNegative(append)) {
       return { status: "abandoned", message: "the ladder's existing Position was declined" };
     }
     return { status: "authored", target: { mode: "add", positionId: ladder.positionId } };
@@ -118,11 +149,19 @@ export async function authorLadderTarget(
   // never heard of a Tempo, so the decision context is authored here, at the moment of
   // the fill, and nowhere else.
   out("First fill on this ladder — opening the Position.\n");
-  const positionId = (await ask("  Position id: ")).trim();
+  const idAnswer = await ask("  Position id: ");
+  const positionId = idAnswer === UNANSWERED ? "" : idAnswer.trim();
   if (!positionId) {
     return { status: "abandoned", message: "no position id was given" };
   }
-  const tempoAnswer = (await ask(`  Tempo [${reserve.tempo}]: `)).trim();
+  const tempoReply = await ask(`  Tempo [${reserve.tempo}]: `);
+  if (tempoReply === UNANSWERED) {
+    return {
+      status: "abandoned",
+      message: `nobody answered the tempo for '${positionId}', and the reserve's own tempo is a default, not an answer`,
+    };
+  }
+  const tempoAnswer = tempoReply.trim();
   const decision = await askDecision(ask);
   if (!decision) {
     return {

--- a/apps/tui/src/record-fill-ladder-target.ts
+++ b/apps/tui/src/record-fill-ladder-target.ts
@@ -35,13 +35,16 @@
  *
  * IT HOLDS THIS ACT'S WORST RATIFICATION, AND #388 IS WHY THAT MATTERS. `Append this lot
  * to '<id>'? [Y/n]` is phrased so that SILENCE MEANS YES: `isNegative("")` is false, so an
- * unanswered question used to attach the lot to an existing Position — and unlike the
- * import flow, nothing downstream of here latched the abandonment, so no second door ever
- * stood behind it. The channel now hands an `UNANSWERED` that `isNegative` cannot be given,
- * and this gate abandons on it. The sentinel is checked AT the question rather than widened
- * into `isNegative`, which would return false for it and attach the lot exactly as before.
- * `Tempo [n]` gets the same treatment for the same reason — a default nobody chose is
- * still a value written onto a durable Position.
+ * unanswered question used to attach the lot to an existing Position. IT NEVER REACHED A
+ * WRITE: the lot was attached in memory, and `Write BOTH? [y/N]` four questions later
+ * refused the same abandoned terminal, because `isAffirmative("")` is false. What was
+ * wrong was the shape, not the outcome — the act's safety rested on ONE gate's phrasing,
+ * so this gate meaning YES on silence was a defect waiting on a reordering rather than one
+ * already costing durable bytes. The channel now hands an `UNANSWERED` that `isNegative`
+ * cannot be given, and this gate abandons on it. The sentinel is checked AT the question
+ * rather than widened into `isNegative`, which would return false for it and attach the lot
+ * exactly as before. `Tempo [n]` gets the same treatment for the same reason — a default
+ * nobody chose is still a value written onto a durable Position.
  */
 import {
   resolveLadderPosition,
@@ -68,19 +71,29 @@ function isNegative(answer: string): boolean {
 }
 
 /**
+ * An answer as text, with {@link UNANSWERED} read as the empty string.
+ *
+ * MODULE-LOCAL AND STAYING THAT WAY. Every question in this file that reaches for it —
+ * the five decision fields and the position id — ALREADY refuses a blank, so "nobody typed
+ * anything" and "nobody could be asked" earn the identical outcome and collapsing them
+ * costs nothing. That argument is per-question, not per-repo: at `Append this lot? [Y/n]`
+ * or `Tempo [n]`, twenty lines below, the same collapse would hand a default to a keystroke
+ * nobody made, which is the defect #388 removes. A shared home would put it within reach of
+ * those questions; here it is within reach only of the ones it is sound for.
+ */
+const text = (answer: Answer): string => (answer === UNANSWERED ? "" : answer.trim());
+
+/**
  * The five authored decision fields. All required; a blank one abandons the act.
  *
  * AN UNANSWERED ONE LANDS IN THE SAME PLACE — `incomplete-decision`, the arm this pass
  * already has for "one of these is missing". A question that was never put is the emptiest
  * a field can be, and the operator's next move (open the Position again, with all five in
- * hand) does not change with the reason it was missing. `text` is what turns the sentinel
- * into the empty string these five already refuse, and it is deliberately local to the
- * five fields that treat the two identically.
+ * hand) does not change with the reason it was missing.
  */
 async function askDecision(
   ask: (question: string) => Promise<Answer>,
 ): Promise<PositionDecision | undefined> {
-  const text = (answer: Answer): string => (answer === UNANSWERED ? "" : answer.trim());
   const entryThesis = text(await ask("  Entry thesis: "));
   const invalidationCondition = text(await ask("  Invalidation condition: "));
   const riskBudget = text(await ask("  Risk budget: "));
@@ -149,8 +162,7 @@ export async function authorLadderTarget(
   // never heard of a Tempo, so the decision context is authored here, at the moment of
   // the fill, and nowhere else.
   out("First fill on this ladder — opening the Position.\n");
-  const idAnswer = await ask("  Position id: ");
-  const positionId = idAnswer === UNANSWERED ? "" : idAnswer.trim();
+  const positionId = text(await ask("  Position id: "));
   if (!positionId) {
     return { status: "abandoned", message: "no position id was given" };
   }

--- a/apps/tui/src/record-fill-reconcile.test.ts
+++ b/apps/tui/src/record-fill-reconcile.test.ts
@@ -39,6 +39,7 @@ import {
   type ReconciliationRecord,
 } from "@numisma/engine";
 import type { OrdersLoad } from "@numisma/preferences";
+import { UNANSWERED } from "./prompt-channel.js";
 
 // The spy `S1a` is asserted with. It wraps the REAL selector and delegates to it, so
 // every other test in this file exercises production behaviour unchanged; the only thing
@@ -250,7 +251,9 @@ class Harness {
         this.appended.push(record);
       },
       toldAt: () => TOLD_AT,
-      ask: async () => this.answers.shift() ?? "",
+      // An exhausted script answers `UNANSWERED` — what the real channel gives when there
+      // is nobody to ask — rather than `""`, which would take the next default (#388).
+      ask: async () => this.answers.shift() ?? UNANSWERED,
       out: (message) => this.out.push(message),
       err: (message) => this.err.push(message),
     };

--- a/apps/tui/src/record-fill-reliable.test.ts
+++ b/apps/tui/src/record-fill-reliable.test.ts
@@ -28,6 +28,7 @@ import { appendOrders, appendReconciliation, loadOrders, loadPlans } from "@numi
 import { afterEach, describe, expect, it } from "vitest";
 import { restoreLogImage, writeLogImage } from "./event-store.js";
 import { recordFill, type RecordFillIo } from "./record-fill.js";
+import { UNANSWERED } from "./prompt-channel.js";
 
 const createdDirs: string[] = [];
 
@@ -195,7 +196,9 @@ function realIo(
       reconciliationsPath: resolve(dataDir, "reconciliations.jsonl"),
       appendReconciliation,
       toldAt: () => "2026-01-05T18:07:00-06:00",
-      ask: async () => remaining.shift() ?? "",
+      // An exhausted script answers `UNANSWERED` — what the real channel gives when there
+      // is nobody to ask — rather than `""`, which would take the next default (#388).
+      ask: async () => remaining.shift() ?? UNANSWERED,
       out: () => undefined,
       err: (message) => err.push(message),
     },

--- a/apps/tui/src/record-fill.test.ts
+++ b/apps/tui/src/record-fill.test.ts
@@ -308,6 +308,12 @@ describe("the fill act is ALL-OR-NOTHING across both files", () => {
     expect(outcome.status).toBe("abandoned");
     expect(harness.logImage).toBe(logBefore);
     expect(harness.ordersImage).toBe(ordersBefore);
+    // AND SAYS SO. `record-fill-cli.ts` only sets an exit code, so a decline that does not
+    // reach `io.err` leaves the operator a bare prompt and no way to tell whether the fill
+    // landed. Same contract as every refusal this act prints.
+    expect(harness.err).toHaveLength(1);
+    expect(harness.err.join("\n")).toContain("REFUSED — the fill act was not confirmed");
+    expect(harness.err.join("\n")).toContain("Nothing was written to");
   });
 
   it("writes NOTHING when the derived verdicts are not confirmed (`O3`)", async () => {
@@ -322,6 +328,9 @@ describe("the fill act is ALL-OR-NOTHING across both files", () => {
     expect(outcome.status).toBe("abandoned");
     expect(harness.logImage).toBe(logBefore);
     expect(harness.ordersImage).toBe(ordersBefore);
+    expect(harness.err).toHaveLength(1);
+    expect(harness.err.join("\n")).toContain("REFUSED — the derived verdicts were not confirmed");
+    expect(harness.err.join("\n")).toContain("Nothing was written to");
   });
 });
 
@@ -1183,6 +1192,12 @@ describe("an unanswered question abandons the act (#388)", () => {
     { at: 2, question: "Filled quantity", names: "rung-400" },
     { at: 3, question: "the per-rung book observation", names: "rung-300" },
     { at: 5, question: "Confirm these derived verdicts?", names: "verdicts" },
+    // DELEGATED, and included here for the half this file owns: `authorLadderTarget` and
+    // `resolveFunding` return their abandonment as a message with no `io` to speak it, so
+    // this flow is the only place it can reach the operator. Their own suites pin the
+    // words; these two pin that the words are said.
+    { at: 7, question: "Tempo [n]", names: "tempo" },
+    { at: 13, question: "Cash debited [n]", names: "cash debited" },
     { at: 14, question: "Write BOTH?", names: "write both" },
   ];
 
@@ -1201,6 +1216,12 @@ describe("an unanswered question abandons the act (#388)", () => {
       // Nothing was written, which is the whole claim — not "the write door caught it".
       expect(harness.ordersImage).toBe(ordersBefore);
       expect(harness.logImage).toBe(logBefore);
+      // AND THE OPERATOR IS TOLD, in the act's own refusal contract. The message names the
+      // question nobody answered; without this the shell exits 1 having printed nothing,
+      // and the message this case asserts on would be one no operator ever reads.
+      expect(harness.err).toHaveLength(1);
+      expect(harness.err.join("\n").toLowerCase()).toContain(names);
+      expect(harness.err.join("\n")).toContain("Nothing was written to");
     });
   }
 

--- a/apps/tui/src/record-fill.test.ts
+++ b/apps/tui/src/record-fill.test.ts
@@ -32,6 +32,7 @@ import {
   type ReconciliationRecord,
 } from "@numisma/engine";
 import type { OrdersLoad } from "@numisma/preferences";
+import { UNANSWERED, type Answer } from "./prompt-channel.js";
 import { recordFill, type RecordFillIo, type RecordFillOutcome } from "./record-fill.js";
 
 const ORDERS_PATH = "/synthetic/orders.jsonl";
@@ -95,12 +96,12 @@ class Harness {
   readonly asked: string[] = [];
   /** Trail lines the advisory reconcile appended — held, never asserted on here. */
   readonly reconciliations: ReconciliationRecord[] = [];
-  private readonly answers: string[];
+  private readonly answers: Answer[];
 
   constructor(options: {
     records?: OrderRecord[];
     events?: PortfolioEvent[];
-    answers: string[];
+    answers: Answer[];
     failWrite?: "log" | "orders" | "orders-and-rollback";
   }) {
     this.ordersImage = (options.records ?? ladderRecords())
@@ -167,7 +168,11 @@ class Harness {
       toldAt: () => "2026-01-05T18:07:00-06:00",
       ask: async (question) => {
         this.asked.push(question);
-        return this.answers.shift() ?? "";
+        // AN EXHAUSTED SCRIPT ANSWERS `UNANSWERED`, NOT `""` (#388). That is what the real
+        // channel hands a flow when there is nobody to ask, and it is the honest model of
+        // a harness that ran out: `""` would silently take whatever default the next
+        // question advertises and let the act carry on past the end of its own script.
+        return this.answers.shift() ?? UNANSWERED;
       },
       out: (message) => this.out.push(message),
       err: (message) => this.err.push(message),
@@ -220,7 +225,7 @@ class Harness {
  * The full happy-path answer sequence for opening the ladder's Position on the TOP rung.
  * Order mirrors the prompts in `recordFill`.
  */
-function openTopRungAnswers(): string[] {
+function openTopRungAnswers(): Answer[] {
   return [
     "rung-400", // which rung filled
     "2026-01-05T12:00:00", // fill timestamp
@@ -904,7 +909,7 @@ describe("the named crash window is DETECTABLE", () => {
  */
 describe("the cash-debited override is weighed against the reserve's available", () => {
   /** The answer sequence with the `Cash debited` prompt answered explicitly. */
-  function answersWithCash(cash: string, answers = openTopRungAnswers()): string[] {
+  function answersWithCash(cash: string, answers = openTopRungAnswers()): Answer[] {
     answers[answers.length - 2] = cash;
     return answers;
   }
@@ -1115,30 +1120,29 @@ describe("recording a fill over damaged history says so, and still records", () 
 });
 
 /**
- * THE ORDERING DEPENDENCY THAT MAKES AN EMPTY ANSWER SAFE (#370, symptom 2).
+ * A RUN NOBODY CAN ANSWER REFUSES AT THE FIRST QUESTION (#370, symptom 2).
  *
- * `record-fill-cli.ts` hands the flow `""` for every question when stdin is no terminal,
- * so the shell can name the missing terminal and let this flow refuse in its own voice
- * instead of printing a readline internal. That is honest ONLY while the FIRST question
- * this flow reaches is one that refuses on `""` — and it is a property of the ORDER the
- * interview asks in, not of the empty string. The reachable interview is NINETEEN `ask`
- * sites — this file holds nine literally and hands `io.ask` onward to `authorLadderTarget`
- * and `resolveFunding` for the other ten — and SIX of them read `""` as a ratification:
- * the filled-quantity question takes the remaining quantity, the per-rung book question
- * accepts the proposed verdict, the cancellation confirmation records none and CONTINUES,
- * "Tempo" and "Cash debited" take their bracketed defaults, and `authorLadderTarget`'s
- * "Append this lot to '<id>'? [Y/n]" attaches the lot on silence, because `isNegative("")`
- * is false. If any of those is ever reached first, the same `""` ratifies a quantity
- * nobody stated and the act WRITES, unattended.
+ * `record-fill-cli.ts` hands this flow `UNANSWERED` for every question when stdin is no
+ * terminal, so the shell can name the missing terminal and let this flow refuse in its own
+ * voice instead of printing a readline internal. The rung pick is the first question this
+ * act reaches, it refuses anything that matches no rung, and the sentinel lands on that
+ * arm word for word — so the operator reads `no resting rung matches ''` from the domain
+ * rather than `readline was closed` from Node.
  *
- * So the dependency is pinned rather than commented. Both shells' construction sites say
- * the same thing in prose; this is the assertion that goes red when the prose stops
- * being true.
+ * WHAT THIS CASE USED TO BE, AND WHY IT IS STILL HERE. It used to pin an ORDERING
+ * DEPENDENCY: `""` was a refusal at the first question and a ratification at six of the
+ * other eighteen, so the empty answer was honest only while the refusing question came
+ * first, and a reorder would have let an unattended run ratify a quantity nobody stated.
+ * #388 removed the dependency — the sentinel is refused at all nineteen questions, six of
+ * them for the first time — so a reorder is no longer a hazard and this case no longer
+ * guards one. It guards what it always MEASURED: that a run with nobody at the terminal
+ * ends at one question, in the domain's words, with both files untouched.
  */
 describe("an interview nobody can answer refuses at the FIRST question and writes nothing", () => {
   it("refuses as unknown-rung, having asked exactly one question", async () => {
-    // No scripted answers at all: the harness's `ask` falls through to `""` every time,
-    // which is precisely what the shell hands the flow on a stdin that is no terminal.
+    // No scripted answers at all: the harness's `ask` falls through to `UNANSWERED` every
+    // time, which is precisely what the shell hands the flow on a stdin that is no
+    // terminal.
     const harness = new Harness({ answers: [] });
     const ordersBefore = harness.ordersImage;
     const logBefore = harness.logImage;
@@ -1149,12 +1153,82 @@ describe("an interview nobody can answer refuses at the FIRST question and write
     if (outcome.status !== "rejected") throw new Error("expected a rejection");
     expect(outcome.reason).toBe("unknown-rung");
     // THE PIN. One question — the rung pick — and the refusal came from it. Reaching a
-    // second means a ratifying question now runs ahead of the refusing one, and the
-    // shell's `""` has stopped being an honest answer.
+    // second would mean some question downstream accepted the sentinel as an answer.
     expect(harness.asked).toHaveLength(1);
     expect(harness.asked[0]).toContain("Which rung filled?");
     // Nothing was written on either side before the refusal fired.
     expect(harness.logImage).toBe(logBefore);
     expect(harness.ordersImage).toBe(ordersBefore);
+  });
+});
+
+/**
+ * A QUESTION NOBODY ANSWERED STOPS THE ACT WHERE IT STANDS (#388).
+ *
+ * Before the sentinel the channel resolved `""` for an abandoned question AND for every
+ * question after it, because the Ctrl-D closes the interface. This act reads `""` as a
+ * DEFAULT at four of its own prompts, so one keystroke midway through a nineteen-question
+ * interview carried the run onward with: the rung's whole remainder recorded as the fill,
+ * every other rung claimed as resting untouched, no cancellations recorded, and the
+ * proposed cash figure debited. Only the final `Write BOTH? [y/N]` stopped it, and only
+ * because that gate happens to be phrased so silence means no — a property of the
+ * PHRASING, which is not a guarantee.
+ *
+ * Each case takes the fully-scripted happy path and blanks exactly ONE answer with the
+ * sentinel, so what the case measures is that question and nothing else. The act must
+ * abandon and both files must be byte-identical afterwards.
+ */
+describe("an unanswered question abandons the act (#388)", () => {
+  const cases: { at: number; question: string; names: string }[] = [
+    { at: 2, question: "Filled quantity", names: "rung-400" },
+    { at: 3, question: "the per-rung book observation", names: "rung-300" },
+    { at: 5, question: "Confirm these derived verdicts?", names: "verdicts" },
+    { at: 14, question: "Write BOTH?", names: "write both" },
+  ];
+
+  for (const { at, question, names } of cases) {
+    it(`abandons rather than taking the answer to '${question}'`, async () => {
+      const answers = openTopRungAnswers();
+      answers[at] = UNANSWERED;
+      const harness = new Harness({ answers });
+      const ordersBefore = harness.ordersImage;
+      const logBefore = harness.logImage;
+
+      const outcome = await recordFill(harness.io);
+
+      expect(outcome.status).toBe("abandoned");
+      expect(outcome.status === "abandoned" && outcome.message.toLowerCase()).toContain(names);
+      // Nothing was written, which is the whole claim — not "the write door caught it".
+      expect(harness.ordersImage).toBe(ordersBefore);
+      expect(harness.logImage).toBe(logBefore);
+    });
+  }
+
+  it("stops AT the abandoned question rather than racing to the write door", async () => {
+    // The #388 half. `Filled quantity` is the third question of nineteen; before this
+    // change the run answered it with the rung's whole remainder and went on to put every
+    // question after it. Counting them is what tells the two behaviours apart.
+    const answers = openTopRungAnswers();
+    answers[2] = UNANSWERED;
+    const harness = new Harness({ answers });
+
+    await recordFill(harness.io);
+
+    expect(harness.asked).toHaveLength(3);
+    expect(harness.asked[2]).toContain("Filled quantity");
+  });
+
+  it("refuses an unanswered rung pick as unknown-rung, exactly as a blank one does", async () => {
+    // One of the fifteen that already refused, and the one a run with no terminal reaches
+    // first. The reason token and the words do not move — that is what keeps
+    // `record-fill-cli.test.ts` pinning the same two sentences.
+    const answers = openTopRungAnswers();
+    answers[0] = UNANSWERED;
+    const harness = new Harness({ answers });
+
+    const outcome = await recordFill(harness.io);
+
+    expect(outcome).toMatchObject({ status: "rejected", reason: "unknown-rung" });
+    expect(outcome.status === "rejected" && outcome.message).toContain("no resting rung matches");
   });
 });

--- a/apps/tui/src/record-fill.ts
+++ b/apps/tui/src/record-fill.ts
@@ -222,12 +222,34 @@ function reject(
 }
 
 /**
+ * An act that ended with nothing written, SAID OUT LOUD — every `abandoned` exit goes here.
+ *
+ * SAME BYTES AS {@link reject}, deliberately. An abandoned act and a refused one differ in
+ * what the operator has to do next, never in what the shell owes them: a line naming why
+ * there is no fill, and the standing promise that both files are untouched. `record-fill-cli.ts`
+ * only sets an exit code, so a message this function does not print is a message nobody
+ * ever reads — which is what a mid-interview Ctrl-D used to be worth: exit 1 and a bare
+ * prompt. `prompt-channel.ts` clause 2 promises two sentences on that path, the shell's WHY
+ * and the flow's WHAT IT DID; this is where the flow's half reaches the screen.
+ *
+ * EVERY caller, including the two `[y/N]` gates where the operator typed a deliberate `n`.
+ * A decline is still an act that wrote nothing, and letting it exit in silence is a small
+ * defect of its own.
+ */
+function abandonWith(io: RecordFillIo, message: string): RecordFillOutcome {
+  io.err(
+    `REFUSED — ${message}\nNothing was written to ${io.eventsPath} or ${io.ordersPath}.`,
+  );
+  return { status: "abandoned", message };
+}
+
+/**
  * The outcome an unanswered question earns where the answer had a DEFAULT or was a gate.
  *
  * `abandoned`, not `rejected`, and that is this act's own vocabulary rather than a new
  * one: nothing was written, nobody declined anything, and the operator's next move is to
  * record the fill again. The MESSAGE names the question — the half a reason token carries
- * badly — which is why nine per-question tokens would have bought nothing.
+ * badly — which is why ten per-question tokens would have bought nothing.
  *
  * `isAffirmative` KEEPS ITS `string` PARAMETER and every caller narrows before it. Widening
  * the helper so `isAffirmative(UNANSWERED)` returned false would compile and would answer
@@ -235,13 +257,12 @@ function reject(
  * `[Y/n]` phrasing makes silence mean yes. A helper that decides what silence means is the
  * defect #388 removes, one layer down.
  */
-function abandon(question: string): RecordFillOutcome {
-  return {
-    status: "abandoned",
-    message:
-      `nobody answered ${question} — the terminal was abandoned (Ctrl-D), or there was ` +
+function abandon(io: RecordFillIo, question: string): RecordFillOutcome {
+  return abandonWith(
+    io,
+    `nobody answered ${question} — the terminal was abandoned (Ctrl-D), or there was ` +
       `none to conduct this interview on`,
-  };
+  );
 }
 
 /**
@@ -672,6 +693,7 @@ export async function recordFill(io: RecordFillIo): Promise<RecordFillOutcome> {
   // unanswered question here used to record the largest fill this rung could carry.
   if (quantityReply === UNANSWERED) {
     return abandon(
+      io,
       `how much of '${filled.orderId}' filled, and ${filled.remainingQuantity} is the ` +
         `rung's whole remainder rather than an answer`,
     );
@@ -759,7 +781,7 @@ export async function recordFill(io: RecordFillIo): Promise<RecordFillOutcome> {
     observedAt,
   );
   if (observed.status === "abandoned") {
-    return abandon(observed.question);
+    return abandon(io, observed.question);
   }
   if (observed.status === "bad-quantity") {
     return reject(
@@ -806,10 +828,10 @@ export async function recordFill(io: RecordFillIo): Promise<RecordFillOutcome> {
   // this answer: the inference is never recorded as an observation.
   const confirmed = await io.ask("Confirm these derived verdicts? [y/N]: ");
   if (confirmed === UNANSWERED) {
-    return abandon("whether the derived verdicts are right");
+    return abandon(io, "whether the derived verdicts are right");
   }
   if (!isAffirmative(confirmed)) {
-    return { status: "abandoned", message: "the derived verdicts were not confirmed" };
+    return abandonWith(io, "the derived verdicts were not confirmed");
   }
 
   const cancelled = proposal.verdicts.filter((verdict) => verdict.verdict === "cancelled");
@@ -822,7 +844,10 @@ export async function recordFill(io: RecordFillIo): Promise<RecordFillOutcome> {
     // about lines that go into an append-only file. An unanswered question is not that
     // decision, and the act does not get to continue on it.
     if (alsoAnswer === UNANSWERED) {
-      return abandon(`whether to record ${cancelled.length} confirmed cancellation(s) in this act`);
+      return abandon(
+        io,
+        `whether to record ${cancelled.length} confirmed cancellation(s) in this act`,
+      );
     }
     if (isAffirmative(alsoAnswer)) {
       alsoCancelled = cancelled.map((verdict) => verdict.orderId);
@@ -888,7 +913,8 @@ export async function recordFill(io: RecordFillIo): Promise<RecordFillOutcome> {
 
   // The authoring interview, behind its own seam (#audit-14). Its rejection arms carry the
   // reason token and the message this flow used to build inline, so `reject` still prints
-  // the identical bytes; `abandoned` passes straight through, nothing having been written.
+  // the identical bytes; its `abandoned` message is spoken here, by `abandonWith`, because
+  // a sub-flow that returns a message has no `io` to say it with.
   const authored = await authorLadderTarget(
     io.ask,
     io.out,
@@ -900,7 +926,7 @@ export async function recordFill(io: RecordFillIo): Promise<RecordFillOutcome> {
     return reject(io, authored.reason, authored.message);
   }
   if (authored.status === "abandoned") {
-    return authored;
+    return abandonWith(io, authored.message);
   }
   const target: LadderTarget = authored.target;
 
@@ -911,7 +937,7 @@ export async function recordFill(io: RecordFillIo): Promise<RecordFillOutcome> {
   // so `reject` still prints the identical bytes.
   const funding = await resolveFunding(io.ask, folded, resting, reserve, filled, filledQuantity);
   if (funding.status === "abandoned") {
-    return funding;
+    return abandonWith(io, funding.message);
   }
   if (funding.status === "rejected") {
     return reject(io, funding.reason, funding.message);
@@ -985,10 +1011,10 @@ export async function recordFill(io: RecordFillIo): Promise<RecordFillOutcome> {
   );
   const write = await io.ask("Write BOTH? [y/N]: ");
   if (write === UNANSWERED) {
-    return abandon("whether to write both files");
+    return abandon(io, "whether to write both files");
   }
   if (!isAffirmative(write)) {
-    return { status: "abandoned", message: "the fill act was not confirmed" };
+    return abandonWith(io, "the fill act was not confirmed");
   }
 
   // ---- 8. THE WRITE. Log first, sidecar second, roll the log back if the sidecar fails.

--- a/apps/tui/src/record-fill.ts
+++ b/apps/tui/src/record-fill.ts
@@ -101,6 +101,7 @@ import {
 import { formatFoldDiscards } from "@numisma/event-store";
 import type { OrdersLoad } from "@numisma/preferences";
 import { nextLogImage, serializeEvent } from "./event-store.js";
+import { UNANSWERED, type Answer } from "./prompt-channel.js";
 import { resolveFunding } from "./record-fill-funding.js";
 import { authorLadderTarget } from "./record-fill-ladder-target.js";
 import { renderSkipMessage } from "./skip-message.js";
@@ -138,7 +139,18 @@ export interface RecordFillIo {
    * telling is not the fill's date.
    */
   toldAt: () => string;
-  ask: (question: string) => Promise<string>;
+  /**
+   * Ask the operator one question. Resolves what they typed, or `UNANSWERED` when there
+   * was no terminal to ask or the question was abandoned — see `prompt-channel.ts`.
+   *
+   * EVERY QUESTION OF THIS ACT REFUSES THE SENTINEL, including the ones it delegates to
+   * `authorLadderTarget` and `resolveFunding`, which take this same function. The ones
+   * that already refused a blank keep their reason token (`unknown-rung`, `bad-timestamp`,
+   * `bad-quantity`, `unknown-instrument`, `ambiguous-tier`, `incomplete-decision`); the
+   * ones that took a DEFAULT abandon, which is this act's existing word for "nothing was
+   * written and nobody said to write it".
+   */
+  ask: (question: string) => Promise<Answer>;
   out: (message: string) => void;
   err: (message: string) => void;
 }
@@ -209,6 +221,44 @@ function reject(
   return { status: "rejected", reason, message };
 }
 
+/**
+ * The outcome an unanswered question earns where the answer had a DEFAULT or was a gate.
+ *
+ * `abandoned`, not `rejected`, and that is this act's own vocabulary rather than a new
+ * one: nothing was written, nobody declined anything, and the operator's next move is to
+ * record the fill again. The MESSAGE names the question — the half a reason token carries
+ * badly — which is why nine per-question tokens would have bought nothing.
+ *
+ * `isAffirmative` KEEPS ITS `string` PARAMETER and every caller narrows before it. Widening
+ * the helper so `isAffirmative(UNANSWERED)` returned false would compile and would answer
+ * NO to `Write BOTH?` — right by luck at that gate, and wrong at `Append this lot?`, whose
+ * `[Y/n]` phrasing makes silence mean yes. A helper that decides what silence means is the
+ * defect #388 removes, one layer down.
+ */
+function abandon(question: string): RecordFillOutcome {
+  return {
+    status: "abandoned",
+    message:
+      `nobody answered ${question} — the terminal was abandoned (Ctrl-D), or there was ` +
+      `none to conduct this interview on`,
+  };
+}
+
+/**
+ * An answer as text, with {@link UNANSWERED} read as the empty string.
+ *
+ * ONLY FOR QUESTIONS THAT ALREADY REFUSE A BLANK. At those — the rung pick, the fill
+ * timestamp, a touched rung's observed quantity, the instrument id — "nobody typed
+ * anything" and "nobody could be asked" earn the same refusal in the same words, and
+ * collapsing them here is what keeps those refusals exactly where they were. Reaching for
+ * this at a question with a DEFAULT would hand the default to a keystroke nobody made,
+ * which is the whole defect #388 removes; those questions check the sentinel themselves
+ * and {@link abandon}.
+ */
+function typedOrNothing(answer: Answer): string {
+  return answer === UNANSWERED ? "" : answer.trim();
+}
+
 function isAffirmative(answer: string): boolean {
   const normalized = answer.trim().toLowerCase();
   return normalized === "y" || normalized === "yes";
@@ -246,7 +296,9 @@ function describeVerdict(verdict: ProposedVerdict): string {
  */
 type BookObservationResult =
   | { status: "observed"; observation: BookObservation }
-  | { status: "bad-quantity"; orderId: string; answer: string };
+  | { status: "bad-quantity"; orderId: string; answer: string }
+  /** The `[r]` default is not an observation somebody made. */
+  | { status: "abandoned"; question: string };
 
 /**
  * Ask the operator what the venue shows for every OTHER rung of the ladder.
@@ -294,11 +346,16 @@ async function observeBook(
     if (rung.orderId === filled.orderId) {
       continue;
     }
-    const answer = (
-      await io.ask(`  ${rung.orderId} — [r]esting untouched / [t]ouched / [g]one? [r]: `)
-    )
-      .trim()
-      .toLowerCase();
+    const reply = await io.ask(
+      `  ${rung.orderId} — [r]esting untouched / [t]ouched / [g]one? [r]: `,
+    );
+    // THE `[r]` DEFAULT IS THE CONSERVATIVE ANSWER, WHICH IS NOT THE SAME AS A SAFE ONE.
+    // "resting untouched" is a positive claim about the venue that monotonicity reasons
+    // over, and an unanswered question makes no claim at all.
+    if (reply === UNANSWERED) {
+      return { status: "abandoned", question: `what the venue shows for rung '${rung.orderId}'` };
+    }
+    const answer = reply.trim().toLowerCase();
     if (answer === "g" || answer === "gone") {
       continue; // absent from the observation = disappeared
     }
@@ -306,12 +363,12 @@ async function observeBook(
       // The BASIS is named in the prompt, because the operator is reading a column and
       // only they can tell which number they are reading. Asking for "filled_quantity"
       // bare is what let a delta and a running total mean the same field (#176).
-      const rawQuantity = (
+      const rawQuantity = typedOrNothing(
         await io.ask(
           `      filled_quantity observed — the venue's CUMULATIVE total for this rung ` +
             `since it was placed, not just this session's: `,
-        )
-      ).trim();
+        ),
+      );
       const quantity = Number(rawQuantity);
       if (rawQuantity === "" || !Number.isFinite(quantity) || quantity <= 0) {
         // THE BOUNDARY IS `<= 0`, NOT MERELY UNPARSEABLE — and a literal `0` is refused
@@ -580,7 +637,11 @@ export async function recordFill(io: RecordFillIo): Promise<RecordFillOutcome> {
   }
   io.out(`Resting rungs:\n${rungs.map((rung, index) => describeRung(index, rung)).join("\n")}\n`);
 
-  const picked = (await io.ask("Which rung filled? [index or order id]: ")).trim();
+  // THE FIRST QUESTION OF THE ACT, and the one a run with no terminal reaches. It already
+  // refused a blank as `unknown-rung`; the sentinel joins that arm word for word, which is
+  // what keeps `record-fill-cli.test.ts` — "the missing terminal in the shell's voice, and
+  // the refusal in the flow's" — pinning the same two sentences through #388.
+  const picked = typedOrNothing(await io.ask("Which rung filled? [index or order id]: "));
   const byIndex = /^\d+$/.test(picked) ? rungs[Number(picked)] : undefined;
   const filled = byIndex ?? rungs.find((rung) => rung.orderId === picked);
   if (!filled) {
@@ -590,7 +651,7 @@ export async function recordFill(io: RecordFillIo): Promise<RecordFillOutcome> {
   // The prompt states the rule in advance and the refusal restates it — both from the one
   // shared phrase (#181), so neither can promise the operator a looser rule than the
   // predicate on the next line enforces.
-  const observedAt = (await io.ask(`Fill timestamp (${OBSERVED_AT_RULE}): `)).trim();
+  const observedAt = typedOrNothing(await io.ask(`Fill timestamp (${OBSERVED_AT_RULE}): `));
   if (!isObservedAtStamp(observedAt)) {
     return reject(
       io,
@@ -606,9 +667,16 @@ export async function recordFill(io: RecordFillIo): Promise<RecordFillOutcome> {
     );
   }
 
-  const quantityAnswer = (
-    await io.ask(`Filled quantity [${filled.remainingQuantity}]: `)
-  ).trim();
+  const quantityReply = await io.ask(`Filled quantity [${filled.remainingQuantity}]: `);
+  // A DEFAULT NOBODY TOOK. The bracketed figure is the whole remainder of the rung, so an
+  // unanswered question here used to record the largest fill this rung could carry.
+  if (quantityReply === UNANSWERED) {
+    return abandon(
+      `how much of '${filled.orderId}' filled, and ${filled.remainingQuantity} is the ` +
+        `rung's whole remainder rather than an answer`,
+    );
+  }
+  const quantityAnswer = quantityReply.trim();
   const filledQuantity =
     quantityAnswer === "" ? filled.remainingQuantity : Number(quantityAnswer);
   if (!Number.isFinite(filledQuantity) || filledQuantity <= 0) {
@@ -690,6 +758,9 @@ export async function recordFill(io: RecordFillIo): Promise<RecordFillOutcome> {
     filledQuantity,
     observedAt,
   );
+  if (observed.status === "abandoned") {
+    return abandon(observed.question);
+  }
   if (observed.status === "bad-quantity") {
     return reject(
       io,
@@ -733,20 +804,27 @@ export async function recordFill(io: RecordFillIo): Promise<RecordFillOutcome> {
 
   // `O3`. Nothing above this line has written anything and nothing below writes without
   // this answer: the inference is never recorded as an observation.
-  if (!isAffirmative(await io.ask("Confirm these derived verdicts? [y/N]: "))) {
+  const confirmed = await io.ask("Confirm these derived verdicts? [y/N]: ");
+  if (confirmed === UNANSWERED) {
+    return abandon("whether the derived verdicts are right");
+  }
+  if (!isAffirmative(confirmed)) {
     return { status: "abandoned", message: "the derived verdicts were not confirmed" };
   }
 
   const cancelled = proposal.verdicts.filter((verdict) => verdict.verdict === "cancelled");
   let alsoCancelled: string[] = [];
   if (cancelled.length > 0) {
-    if (
-      isAffirmative(
-        await io.ask(
-          `Also record ${cancelled.length} confirmed cancellation(s) in this act? [y/N]: `,
-        ),
-      )
-    ) {
+    const alsoAnswer = await io.ask(
+      `Also record ${cancelled.length} confirmed cancellation(s) in this act? [y/N]: `,
+    );
+    // A BLANK DECLINES AND LETS THE ACT CONTINUE, which is a decision the operator made
+    // about lines that go into an append-only file. An unanswered question is not that
+    // decision, and the act does not get to continue on it.
+    if (alsoAnswer === UNANSWERED) {
+      return abandon(`whether to record ${cancelled.length} confirmed cancellation(s) in this act`);
+    }
+    if (isAffirmative(alsoAnswer)) {
       alsoCancelled = cancelled.map((verdict) => verdict.orderId);
     }
   }
@@ -793,8 +871,13 @@ export async function recordFill(io: RecordFillIo): Promise<RecordFillOutcome> {
   const instrument = folded.instruments.find(
     (entry) => entry.symbol === filled.symbol || filled.symbol.startsWith(`${entry.symbol}/`),
   );
-  const instrumentId =
-    instrument?.id ?? (await io.ask(`Instrument id for ${filled.symbol}: `)).trim();
+  let instrumentId = instrument?.id;
+  if (instrumentId === undefined) {
+    // The fold knows no instrument for this symbol, and neither does an unanswered
+    // question — same `unknown-instrument` refusal, same words, that a blank has always
+    // earned.
+    instrumentId = typedOrNothing(await io.ask(`Instrument id for ${filled.symbol}: `));
+  }
   if (!instrumentId || !folded.instruments.some((entry) => entry.id === instrumentId)) {
     return reject(
       io,
@@ -827,6 +910,9 @@ export async function recordFill(io: RecordFillIo): Promise<RecordFillOutcome> {
   // rejection arms carry the reason token and the message this flow used to build inline,
   // so `reject` still prints the identical bytes.
   const funding = await resolveFunding(io.ask, folded, resting, reserve, filled, filledQuantity);
+  if (funding.status === "abandoned") {
+    return funding;
+  }
   if (funding.status === "rejected") {
     return reject(io, funding.reason, funding.message);
   }
@@ -897,7 +983,11 @@ export async function recordFill(io: RecordFillIo): Promise<RecordFillOutcome> {
         .map((record) => `  ${io.ordersPath}  ${JSON.stringify(record)}`)
         .join("\n")}\n`,
   );
-  if (!isAffirmative(await io.ask("Write BOTH? [y/N]: "))) {
+  const write = await io.ask("Write BOTH? [y/N]: ");
+  if (write === UNANSWERED) {
+    return abandon("whether to write both files");
+  }
+  if (!isAffirmative(write)) {
     return { status: "abandoned", message: "the fill act was not confirmed" };
   }
 

--- a/apps/tui/src/skip-message-shells.test.ts
+++ b/apps/tui/src/skip-message-shells.test.ts
@@ -245,8 +245,8 @@ const SHELLS: Shell[] = [
             skipped: [],
           }),
           // THIS FLOW MUST REFUSE BEFORE IT ASKS ANYTHING, so the honest answer is the one
-        // no question can use: `UNANSWERED` (#388).
-        ask: async () => UNANSWERED,
+          // no question can use: `UNANSWERED` (#388).
+          ask: async () => UNANSWERED,
           out: () => {},
           err: () => {},
         },

--- a/apps/tui/src/skip-message-shells.test.ts
+++ b/apps/tui/src/skip-message-shells.test.ts
@@ -33,6 +33,7 @@ import { loadAvailableCapital } from "./available-capital.js";
 import { cancelOrder } from "./cancel-order.js";
 import { importBitgetOpenOrders } from "./import-orders.js";
 import { recordFill } from "./record-fill.js";
+import { UNANSWERED } from "./prompt-channel.js";
 
 const ORDERS_PATH = "/synthetic/orders.jsonl";
 const EVENTS_PATH = "/synthetic/events.jsonl";
@@ -204,7 +205,9 @@ const SHELLS: Shell[] = [
           throw new Error("must not write");
         },
         toldAt: () => "2026-02-01T10:00:00Z",
-        ask: async () => "",
+        // THIS FLOW MUST REFUSE BEFORE IT ASKS ANYTHING, so the honest answer is the one
+        // no question can use: `UNANSWERED` (#388).
+        ask: async () => UNANSWERED,
         out: () => {},
         err: () => {},
       });
@@ -241,7 +244,9 @@ const SHELLS: Shell[] = [
             plans: [],
             skipped: [],
           }),
-          ask: async () => "",
+          // THIS FLOW MUST REFUSE BEFORE IT ASKS ANYTHING, so the honest answer is the one
+        // no question can use: `UNANSWERED` (#388).
+        ask: async () => UNANSWERED,
           out: () => {},
           err: () => {},
         },


### PR DESCRIPTION
Closes #388.

`""` was overloaded in the TUI prompt channel: it meant both "the operator
answered nothing" and "the operator was never able to answer" (Ctrl-D, or no
terminal on stdin). No question could tell those apart from the string it
received, so a Ctrl-D mid-interview raced through whatever was left of the
interview, ratifying every default on the way.

`ask` now resolves `string | typeof UNANSWERED`, and the questions refuse it.

## The three rulings this carries

**The sentinel is a symbol in a union, not a magic string.** A reserved string
flows through `isAffirmative("\0abandoned")` and is silently ratified, which is
the same defect one layer down plus an invariant humans have to remember
forever. `Answer = string | typeof UNANSWERED` makes every call site a type
error instead: `.trim()` does not exist on `string | symbol`, and a helper typed
`(answer: string)` will not take one. The compiler enumerated all 24 sites once
and enforces them from here. It is not a discriminated record either, because a
record breaks all nine test harnesses for no extra safety, while a fake `ask`
typed `Promise<string>` stays assignable under a union.

**The 15 questions that already refused a blank keep their reason codes.**
`no-reserve-declared`, `unknown-rung`, `bad-timestamp`, `incomplete-decision`,
`ambiguous-tier`, `bad-quantity`, `unknown-instrument`, `abandoned`. They fire
on `UNANSWERED` as well, through the same arm and the same words. The ten
default and ratifying sites are the behaviour change, and they refuse through
their flow's existing vocabulary rather than ten new reason codes.

**The write-door latch stays, demoted.** `PromptChannel.aborted`,
`OrdersImportIo.promptAbandoned` and the `interview-abandoned` check before
`appendOrders` are redundant now that the questions refuse for themselves. They
are kept one increment longer so a regression in the new per-question refusals
meets a guarantee that is still proven rather than a gap. Removing them is its
own change.

## What an operator sees differently

| question | was | now |
| --- | --- | --- |
| import: `Override the funding reserve per order? [y/N]` | declined the pass, the batch answer stood for every rung | `interview-abandoned`, naming the question |
| import: per-order `[batch]` | took the batch reserve for that rung | `interview-abandoned`, naming the rung |
| import: `Accept all? [Y/n]` | accepted every proposed rung join | `interview-abandoned` |
| import: `pick [hint]` loop | kept the proposal, and re-asked a terminal that cannot answer | `interview-abandoned`, no re-ask |
| fill: `Filled quantity [n]` | recorded the rung's whole remainder | `abandoned` |
| fill: per-rung `[r]/[t]/[g]` | claimed the rung resting untouched, a positive claim monotonicity reasons over | `abandoned` |
| fill: `Also record N cancellation(s)?` | recorded none and continued the act | `abandoned` |
| fill: `Cash debited [n]` | debited the proposed figure | `abandoned` |
| fill: `Append this lot to '<id>'? [Y/n]` | attached the lot, since silence meant yes | `abandoned` |
| fill: `Tempo [n]` | took the reserve's tempo | `abandoned` |

**Read the fill rows as intermediate state, not as durable writes.** Every
writer in `record-fill.ts` sits behind `Write BOTH? [y/N]`, on which
`isAffirmative("")` was already false, so an abandoned fill act reached that
gate and abandoned there with nothing on disk. What changes is where the refusal
lands: on the question the operator actually abandoned, rather than six answers
later at a gate that has by then been handed a quantity, a tempo, a cash figure
and a Position nobody named. The import flow is the one that could reach a
durable write, and it was the write-door latch that stopped it.

The two `[y/N]` confirmations, `Confirm these derived verdicts?` and
`Write BOTH?`, reach the same outcome as before. Only the message changed.

## Verification

`pnpm verify` green at the tip: 163 test files passed, 3 skipped; 2634 tests
passed, 20 skipped; `smoke:startup` exit 0. The TUI package went from 610 to 630
tests.

The must-not-regress case is green verbatim:
`import-orders.test.ts` `"still lets a Ctrl-D at the FIRST question refuse as
no-reserve-declared"`, which pins #370's actual fix. Both subprocess shell tests
that assert the no-terminal path end to end are unchanged in behaviour.

## Two things a reviewer should look at first

`record-fill.ts` now has both `typedOrNothing` and `abandon`. The whole second
ruling lives in which of the two each question calls, and getting one wrong is
silent. `typedOrNothing` reads the sentinel as `""` at exactly the questions
that already refuse a blank, which is what keeps the pinned refusal messages
identical.

`declareFunding` and `declareRungPicks` grew discriminated returns
(`{declared|not-declared|abandoned}` and `{picked|abandoned}`). There was no
other channel for "abandoned" versus "declared nothing", and the record-fill
leaves already use that shape.

## Known gap, not a regression

`abandoned` prints nothing today, which is the existing contract (`Write BOTH?
n` is silent too). The eight newly-abandoning sites therefore end the run with
exit 1 and no message. Giving `abandoned` an operator-facing channel is its own
increment.
