### PR TITLE
chore(release): adopt CalVer, 0.8.0 becomes 26.8.20

### DIFF
--- a/apps/price-feed/package.json
+++ b/apps/price-feed/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@numisma/price-feed",
-  "version": "0.8.0",
+  "version": "26.8.20",
   "private": true,
   "type": "module",
   "exports": {

--- a/apps/tui/package.json
+++ b/apps/tui/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@numisma/tui",
-  "version": "0.8.0",
+  "version": "26.8.20",
   "private": true,
   "type": "module",
   "dependencies": {

--- a/apps/web/README.md
+++ b/apps/web/README.md
@@ -4,7 +4,7 @@ The hosted read-projection dashboard — a phone-checkable view of fund
 composition, backed by a disposable Postgres projection of the local event
 log. Built on **TanStack Start** (Vite-based full-stack React), chosen over
 Next.js in ADR-009. Package name `@numisma/web`, version tracks the monorepo
-root (`0.8.0`). Deployed to Vercel as project `numisma-web`; see
+root (`26.8.20`). Deployed to Vercel as project `numisma-web`; see
 `docs/web-deploy-runbook.md` for the deploy mechanism.
 
 ## What this app owns

--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@numisma/web",
-  "version": "0.8.0",
+  "version": "26.8.20",
   "private": true,
   "type": "module",
   "scripts": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "numisma",
-  "version": "0.8.0",
+  "version": "26.8.20",
   "private": true,
   "type": "module",
   "packageManager": "pnpm@11.1.2",

--- a/packages/engine/package.json
+++ b/packages/engine/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@numisma/engine",
-  "version": "0.8.0",
+  "version": "26.8.20",
   "private": true,
   "type": "module",
   "exports": {

--- a/packages/event-store/package.json
+++ b/packages/event-store/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@numisma/event-store",
-  "version": "0.8.0",
+  "version": "26.8.20",
   "private": true,
   "type": "module",
   "exports": {

--- a/packages/preferences/package.json
+++ b/packages/preferences/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@numisma/preferences",
-  "version": "0.8.0",
+  "version": "26.8.20",
   "private": true,
   "type": "module",
   "exports": {


### PR DESCRIPTION
Bumps all seven workspace members from `0.8.0` to `26.8.20`, and the one README
line that states it tracks the root.

### Why a date

Semver's job is to warn a consumer about compatibility, and this version has no
consumer. The repo is `private: true` and never published. No runtime code reads
`package.json`'s version: the ingest commit trailer `numisma-version:` looks like
it does, but `readAppVersion` (`apps/tui/src/ingest-commit.ts:154`) returns a git
short SHA, so durable-data provenance is a commit id and always was.

That leaves one reader, a person, asking one question: is the thing in front of
me older or newer than the change I am looking for. A date answers it by
subtraction.

The versions that guard real contracts stay semantic and are untouched:

- `EVENT_SCHEMA_VERSION` = 2, the durable log's shape
- `MIN_SUPPORTED_SNAPSHOT_SCHEMA_VERSION` = 4, the projection reader's floor,
  against a pinned push of 6

Those are where compatibility actually lives, and they version independently and
correctly. The package version was never one of them.

### Safety

`26.8.20` is valid semver (no leading zeros, so no tooling breakage). Every
internal dependency uses `workspace:*`, so nothing resolves by range and
`pnpm-lock.yaml` is unchanged. `pnpm -r exec` reports all six members at
26.8.20.

No tag is created here; tagging is a release step and a separate decision.

Independent of #397, which is the docs sweep. Either can merge first.