### PR TITLE
fix(ops): render the plist's data dir instead of committing a home path

### DIFF
--- a/apps/price-feed/src/schedule-window.test.ts
+++ b/apps/price-feed/src/schedule-window.test.ts
@@ -519,3 +519,61 @@ describe("the launchd fetch window", () => {
     expect(ceiling).toBeGreaterThan(20 * 60);
   });
 });
+// The template is a TEMPLATE, and this is the assertion that keeps it one (#399).
+//
+// It sits in this file for the reason stated in the header: it has an ORACLE SOMEWHERE
+// ELSE. `packages/engine/src/data-dir.ts` states the rule — "Never a `/Users/...`
+// literal, in this file or in any test that pins it, ADR-006 forbids the literal, and a
+// committed one would leak the operator's real directory layout into a public repo" —
+// and scopes it to the engine. The plist was outside that scope and carried
+// `/Users/amet/Dev/accumulus/data` for exactly as long as nothing looked. The leak is
+// the same leak; this file is just as public.
+//
+// The plist's own defence of the literal was right about launchd and wrong about which
+// file it was defending: launchd does not expand `~`, so the RENDERED copy must be
+// absolute — which says nothing about the committed template, and is what the other two
+// placeholders already exist to handle.
+//
+// SCOPED TO THE PLIST, deliberately. `ops/price-feed/launchagent-reinstall.md` is full of
+// `/Users/amet` and stays that way: it is an operator runbook whose `sed` and `launchctl`
+// lines are meant to be pasted, and scrubbing them would leave commands nobody can run.
+// The template is the artifact that gets installed; the runbook is the one that gets read.
+describe("the launchd template carries placeholders, not the operator's paths", () => {
+  const template = readFileSync(PLIST_PATH, "utf8");
+
+  it("commits no home-directory literal in any value launchd will read", () => {
+    // XML comments are stripped first, and that scoping is the claim: the hazard is a
+    // VALUE, which is what gets installed and what a reader of a public repo learns the
+    // operator's layout from. The header's illustrative
+    // `<string>/Users/you/.asdf/shims:…</string>` inside a comment is a worked example of
+    // an OPTIONAL key, names nobody, and is the kind of thing this guard must not forbid.
+    const values = template.replace(/<!--[\s\S]*?-->/g, "");
+    const literals = values.split("\n").filter((line) => /\/Users\//.test(line));
+
+    expect(literals).toEqual([]);
+  });
+
+  it("renders the data dir through __DATA_DIR__, like the repo dir and the log paths", () => {
+    // Control on the assertion above: a template that had simply DROPPED the key would
+    // also carry no literal, and the job would then fall back to the wrapper's default
+    // silently rather than by decision.
+    expect(template).toMatch(/<key>NUMISMA_DATA_DIR<\/key>\s*<string>__DATA_DIR__<\/string>/);
+  });
+
+  it("names every placeholder it uses in the render step of the reinstall runbook", () => {
+    // The four-edits-in-order failure (#398) in its other form: adding a placeholder to
+    // the template without adding its substitution to the runbook produces an install
+    // that looks rendered and is not. The wrapper refuses such a value at startup, but
+    // this catches it a step earlier, at the edit.
+    const runbook = readFileSync(
+      fileURLToPath(new URL("ops/price-feed/launchagent-reinstall.md", REPO_ROOT)),
+      "utf8",
+    );
+    const placeholders = [...new Set(template.match(/__[A-Z_]+__/g) ?? [])].filter(
+      (name) => name !== "__PLACEHOLDERS__",
+    );
+
+    expect(placeholders.length).toBeGreaterThan(0);
+    expect(placeholders.filter((name) => !runbook.includes(`s|${name}|`))).toEqual([]);
+  });
+});

--- a/apps/price-feed/src/schedule-window.test.ts
+++ b/apps/price-feed/src/schedule-window.test.ts
@@ -569,11 +569,30 @@ describe("the launchd template carries placeholders, not the operator's paths", 
       fileURLToPath(new URL("ops/price-feed/launchagent-reinstall.md", REPO_ROOT)),
       "utf8",
     );
-    const placeholders = [...new Set(template.match(/__[A-Z_]+__/g) ?? [])].filter(
-      (name) => name !== "__PLACEHOLDERS__",
-    );
+    // Comments are stripped first, the same scoping the literal guard above uses and for
+    // the same reason: a placeholder only needs rendering if launchd will READ it. The
+    // header's prose about `__PLACEHOLDERS__` is placeholder-SHAPED and gets installed
+    // verbatim as a comment, so scanning the raw template forced a hardcoded exemption
+    // for it, and the next header note that names an optional placeholder would have
+    // needed another one. Strip the comments and the exemption is not needed at all.
+    const values = template.replace(/<!--[\s\S]*?-->/g, "");
+    const placeholders = [...new Set(values.match(/__[A-Z_]+__/g) ?? [])];
+
+    // And the search is scoped to the `sed` invocation itself, not to the whole runbook.
+    // `runbook.includes("s|__X__|")` matched the token in prose or in a commented-out
+    // sample line, so a placeholder that the runbook merely MENTIONS passed a test whose
+    // subject is whether the render step substitutes it.
+    const lines = runbook.split("\n");
+    const sedStart = lines.findIndex((line) => /^sed\s/.test(line));
+    expect(sedStart, "the reinstall runbook has no `sed` render step to check").toBeGreaterThan(-1);
+    const renderStep: string[] = [];
+    for (const line of lines.slice(sedStart)) {
+      renderStep.push(line);
+      if (!line.endsWith("\\")) break;
+    }
+    const sedBlock = renderStep.join("\n");
 
     expect(placeholders.length).toBeGreaterThan(0);
-    expect(placeholders.filter((name) => !runbook.includes(`s|${name}|`))).toEqual([]);
+    expect(placeholders.filter((name) => !sedBlock.includes(`s|${name}|`))).toEqual([]);
   });
 });

--- a/apps/price-feed/src/wrapper-harness/run-daily-fetch.test.ts
+++ b/apps/price-feed/src/wrapper-harness/run-daily-fetch.test.ts
@@ -2929,7 +2929,7 @@ describe.runIf(decision.run)("wrapper harness — the real wrapper, armed", () =
 // so even the paths the wrapper merely NAMES cannot be the real ones, and the environment
 // is built from an explicit allowlist rather than spread from `process.env` — a developer
 // running this with a live `NUMISMA_DATA_DIR` exported must not change the result.
-describe("wrapper config — a blank NUMISMA_DATA_DIR is REFUSED (always runs)", () => {
+describe("wrapper config — a blank or relative NUMISMA_DATA_DIR is REFUSED (always runs)", () => {
   /** sysexits.h EX_CONFIG. Distinct from the wrapper's 1 / 124 / 127 / 143. */
   const EX_CONFIG = 78;
 
@@ -2990,6 +2990,41 @@ describe("wrapper config — a blank NUMISMA_DATA_DIR is REFUSED (always runs)",
     // no `Dev/accumulus`, no `Library/Logs`.
     expect(existsSync(join(run.home, "Dev"))).toBe(false);
     expect(existsSync(join(run.home, "Library"))).toBe(false);
+  });
+
+  // THE RELATIVE ARM (#399). The blank cases above already describe arm 1 — a value that
+  // resolves against the process CWD — but they only ever reached it through whitespace.
+  // A plainly relative value took the OTHER path: `${VAR-default}` substitutes for unset
+  // only, so `data` survived verbatim, `HEARTBEAT_FILE` was built from it, and the run
+  // died a minute later inside `pnpm prices:fetch` when `normalizeDataDirOverride` threw.
+  // Loud, eventually, but after the wrapper had already named a directory it should have
+  // refused — and out of step with the TS resolver the wrapper claims parity with.
+  it("refuses a RELATIVE NUMISMA_DATA_DIR with EX_CONFIG, before any side effect", () => {
+    const run = runWrapperConfig({ NUMISMA_DATA_DIR: "data" });
+
+    expect(run.status, "a relative data dir must be a configuration refusal, not a run").toBe(
+      EX_CONFIG,
+    );
+    expect(run.stderr).toMatch(/FATAL: NUMISMA_DATA_DIR is not an absolute path \(got 'data'\)/);
+    // The consequence, in the same voice the blank arm uses.
+    expect(run.stderr).toMatch(/resolves against whatever directory the scheduler/);
+    // Nothing on disk: the refusal precedes HEARTBEAT_FILE= and the `exec … tee` redirect.
+    expect(existsSync(join(run.home, "Dev"))).toBe(false);
+    expect(existsSync(join(run.home, "Library"))).toBe(false);
+  });
+
+  // The case that made the relative arm worth closing rather than documenting. The plist
+  // template carries `__DATA_DIR__` instead of a committed home path (#399), so an install
+  // that skips the render step hands the job a set, non-blank, non-absolute value — and
+  // this is the only place that can tell the operator what actually went wrong, because
+  // by the time anything else notices, the message is about a data dir rather than about
+  // a plist.
+  it("refuses an UNRENDERED __DATA_DIR__ placeholder and names the render step", () => {
+    const run = runWrapperConfig({ NUMISMA_DATA_DIR: "__DATA_DIR__" });
+
+    expect(run.status).toBe(EX_CONFIG);
+    expect(run.stderr).toMatch(/is not an absolute path \(got '__DATA_DIR__'\)/);
+    expect(run.stderr).toMatch(/launchagent-reinstall\.md/);
   });
 
   it("an UNSET NUMISMA_DATA_DIR still takes the default — the refusal must not swallow unset", () => {

--- a/apps/price-feed/src/wrapper-harness/run-daily-fetch.test.ts
+++ b/apps/price-feed/src/wrapper-harness/run-daily-fetch.test.ts
@@ -2929,7 +2929,7 @@ describe.runIf(decision.run)("wrapper harness — the real wrapper, armed", () =
 // so even the paths the wrapper merely NAMES cannot be the real ones, and the environment
 // is built from an explicit allowlist rather than spread from `process.env` — a developer
 // running this with a live `NUMISMA_DATA_DIR` exported must not change the result.
-describe("wrapper config — a blank or relative NUMISMA_DATA_DIR is REFUSED (always runs)", () => {
+describe("wrapper config — NUMISMA_DATA_DIR walks the engine's table (always runs)", () => {
   /** sysexits.h EX_CONFIG. Distinct from the wrapper's 1 / 124 / 127 / 143. */
   const EX_CONFIG = 78;
 
@@ -3005,7 +3005,9 @@ describe("wrapper config — a blank or relative NUMISMA_DATA_DIR is REFUSED (al
     expect(run.status, "a relative data dir must be a configuration refusal, not a run").toBe(
       EX_CONFIG,
     );
-    expect(run.stderr).toMatch(/FATAL: NUMISMA_DATA_DIR is not an absolute path \(got 'data'\)/);
+    expect(run.stderr).toMatch(
+      /FATAL: NUMISMA_DATA_DIR must be an absolute path or start with '~\/' \(got 'data'\)/,
+    );
     // The consequence, in the same voice the blank arm uses.
     expect(run.stderr).toMatch(/resolves against whatever directory the scheduler/);
     // Nothing on disk: the refusal precedes HEARTBEAT_FILE= and the `exec … tee` redirect.
@@ -3023,8 +3025,77 @@ describe("wrapper config — a blank or relative NUMISMA_DATA_DIR is REFUSED (al
     const run = runWrapperConfig({ NUMISMA_DATA_DIR: "__DATA_DIR__" });
 
     expect(run.status).toBe(EX_CONFIG);
-    expect(run.stderr).toMatch(/is not an absolute path \(got '__DATA_DIR__'\)/);
+    expect(run.stderr).toMatch(/must be an absolute path or start with '~\/' \(got '__DATA_DIR__'\)/);
     expect(run.stderr).toMatch(/launchagent-reinstall\.md/);
+  });
+
+  // THE TILDE ARM. `normalizeDataDirOverride` expands a leading `~`, and the comment on
+  // that arm names the reason: a value that originated as `NUMISMA_DATA_DIR` in a launchd
+  // plist, which cannot expand `~` itself. An absolute-only wrapper refusal would kill
+  // that value at startup, so the run would never reach the engine row written for it.
+  // Nothing covered this input on either plane, which is how the two rules diverged
+  // unnoticed; these three cases pin the wrapper's half.
+  it("EXPANDS a `~/`-prefixed NUMISMA_DATA_DIR instead of refusing it", () => {
+    // Driven to the mark-timezone guard, the same named early exit the unset case uses:
+    // reaching it proves the value survived the data-dir block. Exit 1 is NOT 78.
+    const run = runWrapperConfig({
+      NUMISMA_DATA_DIR: "~/Dev/accumulus/data",
+      NUMISMA_MARK_TZ: "Not/AZone",
+      NUMISMA_PRICEFEED_LOG_DIR: join(mkdtempSync(join(tmpdir(), "numisma-wrapper-logs-")), "logs"),
+    });
+
+    expect(run.status, "a tilde path is what the engine expands, not a misconfiguration").not.toBe(
+      EX_CONFIG,
+    );
+    expect(run.status).toBe(1);
+    expect(run.stdout).toMatch(/mark timezone 'Not\/AZone' is not a resolvable IANA zone/);
+  });
+
+  it("EXPANDS a bare `~`, the other half of the engine's tilde row", () => {
+    const run = runWrapperConfig({
+      NUMISMA_DATA_DIR: "~",
+      NUMISMA_MARK_TZ: "Not/AZone",
+      NUMISMA_PRICEFEED_LOG_DIR: join(mkdtempSync(join(tmpdir(), "numisma-wrapper-logs-")), "logs"),
+    });
+
+    expect(run.status).not.toBe(EX_CONFIG);
+    expect(run.status).toBe(1);
+  });
+
+  it("still refuses `~foo`, which the engine does not expand either", () => {
+    // The boundary of the row: only `~` and `~/…` expand. `~username` is a shell
+    // affordance neither plane implements, so it stays relative and stays refused.
+    const run = runWrapperConfig({ NUMISMA_DATA_DIR: "~foo" });
+
+    expect(run.status).toBe(EX_CONFIG);
+    expect(run.stderr).toMatch(/must be an absolute path or start with '~\/' \(got '~foo'\)/);
+  });
+
+  // SURROUNDING WHITESPACE IS TRIMMED, NOT REFUSED. The engine trims before it tests, so
+  // a leading space in front of an absolute path names the same directory there. Before
+  // this, the wrapper tested the untrimmed value and refused it: one space, two verdicts.
+  it("TRIMS surrounding whitespace around an absolute path rather than refusing it", () => {
+    const run = runWrapperConfig({
+      NUMISMA_DATA_DIR: `  ${mkdtempSync(join(tmpdir(), "numisma-wrapper-trim-"))}  `,
+      NUMISMA_MARK_TZ: "Not/AZone",
+      NUMISMA_PRICEFEED_LOG_DIR: join(mkdtempSync(join(tmpdir(), "numisma-wrapper-logs-")), "logs"),
+    });
+
+    expect(run.status, "the engine accepts this value, so the wrapper must too").not.toBe(
+      EX_CONFIG,
+    );
+    expect(run.status).toBe(1);
+    expect(run.stdout).toMatch(/mark timezone 'Not\/AZone' is not a resolvable IANA zone/);
+  });
+
+  it("reports the TRIMMED value when a padded relative path is refused", () => {
+    // Trim runs before the absolute test on both planes, so the value the operator is
+    // shown is the value that was judged. A refusal quoting ' data ' would send them
+    // hunting for a whitespace bug that is not the finding.
+    const run = runWrapperConfig({ NUMISMA_DATA_DIR: "  data  " });
+
+    expect(run.status).toBe(EX_CONFIG);
+    expect(run.stderr).toMatch(/must be an absolute path or start with '~\/' \(got 'data'\)/);
   });
 
   it("an UNSET NUMISMA_DATA_DIR still takes the default — the refusal must not swallow unset", () => {

--- a/docs/price-feed-ops.md
+++ b/docs/price-feed-ops.md
@@ -22,10 +22,12 @@ any command below.
 | `ops/price-feed/com.numisma.pricefeed.daily.plist` | launchd definition firing the wrapper **hourly from 18:00 to 23:00 local** (six intervals; 18:00 is the default mark time), **every day** — plus `RunAtLoad` true. The first fire on an awake machine marks the day; later fires add 0 new marks (though they still spend credits and time). See "Why the window is hourly, not a single 18:00 fire" and "Why the schedule fires 7 days/week" below. |
 | `ops/price-feed/launchagent-reinstall.md` | Runbook for pushing a plist change into the job launchd actually runs. Not executed by anything — it exists because the wrapper installs via `git pull` (launchd runs it in place) while the plist is a resolved copy, so merging a plist change does nothing on its own. |
 
-Both `.plist` / `.sh` files are templates: replace `__REPO_DIR__` / `__HOME__`
-before installing. The plist's `NUMISMA_DATA_DIR` is **not** a placeholder. It
-ships as a literal absolute path (launchd cannot expand `~`), so repoint it at
-your own `<fund>` checkout when you install.
+Both `.plist` / `.sh` files are templates: replace `__REPO_DIR__`, `__HOME__` and
+`__DATA_DIR__` before installing. `__DATA_DIR__` used to be a committed absolute
+path rather than a placeholder (#399), on the argument that launchd cannot expand
+`~`. That is true of the *installed* file and says nothing about the template, so
+it renders like the other two now. The rendered value must still be absolute: the
+wrapper refuses a relative one at startup with exit 78.
 
 The wrapper reads nine `NUMISMA_*` variables in all. Three are lower-traffic
 overrides, each with a sensible default so most installs never need them:
@@ -192,18 +194,21 @@ threat model does not need.
 1. Set the Mac's timezone to America/Mexico_City (or shift **all six** of the plist's
    `Hour` entries to the local clock equal to 18:00–23:00 CDMX — they must stay
    at/after the mark time and inside the same CDMX day).
-2. Edit both placeholders in `run-daily-fetch.sh` (`REPO_DIR`) and the plist
-   (`__REPO_DIR__`, `__HOME__`).
-3. Set the durable-data home in the plist. The wrapper forwards `NUMISMA_DATA_DIR`
-   to every `pnpm` invocation; it is the **single machine-specific override** that
-   points the ledger at the sibling private `<fund>` repo. launchd **cannot expand
-   `~`**, so the plist's `NUMISMA_DATA_DIR` must be an **absolute** path (e.g.
-   `/Users/you/Dev/<fund>/data`) — unlike the code default, which derives
-   `~/Dev/<fund>/data` from `os.homedir()`. If left unset the wrapper's step-3
-   auto-commit and step-4 post-check both fall back to that **same** `~/Dev/<fund>/data`
-   default — the exact tree the in-process capture writes to — so an unset var is still
-   committed and still post-checked (no silent "log left uncommitted" gap). Setting it
-   explicitly is only required when your `<fund>` checkout lives somewhere else.
+2. Edit the placeholders in `run-daily-fetch.sh` (`REPO_DIR`) and the plist
+   (`__REPO_DIR__`, `__HOME__`, `__DATA_DIR__`).
+3. Set the durable-data home in the plist by rendering `__DATA_DIR__`. The wrapper
+   forwards `NUMISMA_DATA_DIR` to every `pnpm` invocation; it is the **single
+   machine-specific override** that points the ledger at the sibling private
+   `<fund>` repo. launchd **cannot expand `~`**, so the rendered value must be an
+   **absolute** path (e.g. `/Users/you/Dev/<fund>/data`) — unlike the code default,
+   which derives `~/Dev/<fund>/data` from `os.homedir()`. A value that is not
+   absolute, an unrendered `__DATA_DIR__` included, is refused at startup with exit
+   78 rather than resolved against the scheduler's working directory. If left unset
+   the wrapper's step-3 auto-commit and step-4 post-check both fall back to that
+   **same** `~/Dev/<fund>/data` default — the exact tree the in-process capture writes
+   to — so an unset var is still committed and still post-checked (no silent "log left
+   uncommitted" gap). Setting it explicitly is only required when your `<fund>`
+   checkout lives somewhere else.
    (On a fresh box with no `<fund>` checkout at all, the default path is not a git
    repo, so step 3 degrades gracefully — a logged warning and skip, never a FATAL.)
 4. Install and load:
@@ -215,8 +220,8 @@ threat model does not need.
    ```
 
    **The installed copy is a RESOLVED COPY, so a change to the template in this repo
-   does nothing until you reinstall by hand.** `cp` expands nothing — you edit
-   `__REPO_DIR__` / `__HOME__` in the installed file, so the two files diverge by
+   does nothing until you reinstall by hand.** `cp` expands nothing — you render
+   the placeholders in the installed file, so the two files diverge by
    design and no automation reconciles them. After pulling a change to the plist
    (e.g. the hourly window), redo the copy, re-edit the placeholders, then:
 

--- a/docs/price-feed-ops.md
+++ b/docs/price-feed-ops.md
@@ -58,11 +58,14 @@ heartbeat reading `exit 1` at step `startup` with `markWindow: false`, so a
 typo that kills every fire of an evening shows up as a failed run rather than
 as `job-heartbeat.json` still describing the last good one.
 
-**A set-but-blank `NUMISMA_DATA_DIR` kills the run before anything else, and it
-is the one failure with no heartbeat.** The wrapper reads
-`${NUMISMA_DATA_DIR-…}` without the colon, so *unset* takes the default while
-`""` or `"   "` is a knob the operator got wrong: the run prints a named `FATAL`
-and exits **78** (`EX_CONFIG`, chosen not to collide with 1, 124, 127 or 143).
+**A bad `NUMISMA_DATA_DIR` kills the run before anything else, and these are the
+two failures with no heartbeat.** The wrapper reads `${NUMISMA_DATA_DIR-…}`
+without the colon, so *unset* takes the default while `""` or `"   "` is a knob
+the operator got wrong. The second refusal is a value that is still not absolute
+after the wrapper trims the surrounding whitespace and expands a leading `~`;
+an unrendered `__DATA_DIR__` from a plist installed without its render step is
+how that one usually arrives. Either way the run prints a named `FATAL` and
+exits **78** (`EX_CONFIG`, chosen not to collide with 1, 124, 127 or 143).
 No heartbeat is written, deliberately: the heartbeat lives *inside*
 `NUMISMA_DATA_DIR`, which is the broken thing, and guessing a fallback location
 is the defect the refusal exists to prevent. The message lands on inherited
@@ -890,12 +893,12 @@ The same default is now written down in four places, in four languages:
 | Reader | Where | Form |
 | --- | --- | --- |
 | The engine (authority) | `packages/engine/src/data-dir.ts` — ADR-006's rule, reached from `resolveDataDirDefault` | `NUMISMA_DATA_DIR` else `homedir()/Dev/accumulus/data`, absolute and homedir-derived |
-| The wrapper | `DATA_DIR=` in `ops/price-feed/run-daily-fetch.sh` | `${NUMISMA_DATA_DIR:-$HOME/Dev/accumulus/data}` |
+| The wrapper | `DATA_DIR=` in `ops/price-feed/run-daily-fetch.sh` | `${NUMISMA_DATA_DIR-$HOME/Dev/accumulus/data}`, no colon, then trimmed, `~` expanded, and refused with exit 78 if it is still not absolute |
 | **This snippet** | your shell profile | the same expansion again |
 | The LaunchAgent | `EnvironmentVariables` in `ops/price-feed/com.numisma.pricefeed.daily.plist` | a literal absolute path, or absent — launchd cannot expand `~` and inherits nothing from your profile |
 
 (Four places, then — the plist is the environment the wrapper's expansion actually
-runs in, so it decides which branch of `${NUMISMA_DATA_DIR:-…}` the writer takes.)
+runs in, so it decides which branch of `${NUMISMA_DATA_DIR-…}` the writer takes.)
 
 The writer (the wrapper, through the engine) and the reader (your profile) resolve
 that path **independently**. If they ever disagree, the notice is written to
@@ -929,16 +932,22 @@ other two are divergences of *value format*.
   provider tokens; the data dir belongs in the plist.
 - **A `~/`-prefixed value.** The engine expands a leading `~/` itself
   (the tilde arm of `normalizeDataDirOverride` in
-  `packages/engine/src/data-dir.ts`). Bash does **not** expand a tilde that arrives inside a
-  variable's value, so the snippet reads a directory literally named `~`. The
+  `packages/engine/src/data-dir.ts`), and the wrapper now expands it the same way
+  before it tests for absoluteness, so writer and engine agree on the directory.
+  The snippet does not: bash does **not** expand a tilde that arrives inside a
+  variable's value, so your profile reads a directory literally named `~`. The
   wrapper writes the real notice; your shell reads an empty path and prints
   nothing, forever.
-- **A relative value.** The engine *refuses* it outright with a named error — "a
-  relative value resolves differently depending on the working directory, so it is
-  rejected to prevent a split-brain ledger" (the relative arm of the same
-  function). The snippet has
-  no such guard: it resolves the value against whatever directory the shell
-  happened to start in, which differs between terminals.
+- **A relative value.** Both the wrapper and the engine *refuse* it. The wrapper
+  gets there first, at startup: it prints a named `FATAL`, says the value must be
+  an absolute path or start with `~/`, and exits **78** without writing a
+  heartbeat, so the whole evening dies before step 1 rather than midway through
+  it. The engine's throw one layer down says the same thing in the same words
+  ("a relative value resolves differently depending on the working directory, so
+  it is rejected to prevent a split-brain ledger"), and a run only reaches it when
+  something other than the wrapper supplied the value. The snippet has no such
+  guard: it resolves the value against whatever directory the shell happened to
+  start in, which differs between terminals.
 
 **The mitigation is one rule, and it has both halves:** either leave
 `NUMISMA_DATA_DIR` unset **everywhere** and take the default all four readers agree

--- a/ops/price-feed/com.numisma.pricefeed.daily.plist
+++ b/ops/price-feed/com.numisma.pricefeed.daily.plist
@@ -77,7 +77,8 @@
   it there. You may ALSO set a PATH here in EnvironmentVariables as an extra
   safeguard, but the wrapper is self-sufficient.
 
-  Install (edit the two __PLACEHOLDERS__ first):
+  Install (render the three __PLACEHOLDERS__ first — __REPO_DIR__, __HOME__,
+  __DATA_DIR__; see ops/price-feed/launchagent-reinstall.md for the `sed` that does it):
     cp ops/price-feed/com.numisma.pricefeed.daily.plist \
        ~/Library/LaunchAgents/com.numisma.pricefeed.daily.plist
     launchctl load  ~/Library/LaunchAgents/com.numisma.pricefeed.daily.plist
@@ -111,12 +112,29 @@
   <dict>
     <key>NUMISMA_REPO_DIR</key>
     <string>__REPO_DIR__</string>
-    <!-- Durable-data home: the sibling private `accumulus` repo. launchd cannot
-         expand `~`, so this ops file uses an absolute machine-specific path (unlike
-         the code default, which derives it from os.homedir()). The wrapper forwards
-         this to `pnpm prices:fetch`/`pnpm spine`. -->
+    <!-- Durable-data home: the sibling private `accumulus` repo. The wrapper forwards
+         this to `pnpm prices:fetch`/`pnpm spine`.
+
+         RENDERED, NOT LITERAL (#399). launchd cannot expand `~`, so the INSTALLED plist
+         must carry an absolute machine-specific path — and that argument, which an
+         earlier version of this comment used to defend a committed home-directory
+         literal, covers the rendered copy only. This TEMPLATE is public. The rule
+         packages/engine/src/data-dir.ts states for the engine ("a committed one would
+         leak the operator's real directory layout into a public repo") is scoped to the
+         engine, so this file was never in breach as written, but the leak is the same
+         leak and this file is just as public.
+
+         Substituted by the render step in launchagent-reinstall.md, like the other two
+         placeholders. AN UNRENDERED PLACEHOLDER IS NOT BENIGN, and the honest cost of
+         moving off the literal is that this failure mode now exists at all: the wrapper
+         reads `${NUMISMA_DATA_DIR-...}` UNSET-ONLY, so a literal `__DATA_DIR__` is a
+         SET, non-blank value and survives verbatim as a CWD-RELATIVE path — the
+         split-brain arm ADR-006 forbids. Two things catch it, and the run never reaches
+         the durable log either way: the wrapper now refuses a non-absolute data dir up
+         front (exit 78, EX_CONFIG), and trap 2 of the reinstall runbook diffs the parsed
+         plists, where an unsubstituted value is visible on sight. -->
     <key>NUMISMA_DATA_DIR</key>
-    <string>/Users/amet/Dev/accumulus/data</string>
+    <string>__DATA_DIR__</string>
   </dict>
 
   <!-- Hourly 18:00-23:00 local, EVERY day (7-day schedule; see the header note on

--- a/ops/price-feed/launchagent-reinstall.md
+++ b/ops/price-feed/launchagent-reinstall.md
@@ -16,7 +16,7 @@ asymmetry is the single most confusing thing about it:
 | Half | How it installs | Live after `git pull`? |
 | --- | --- | --- |
 | `run-daily-fetch.sh` | The plist's `ProgramArguments` points at the **repo path**, so launchd executes the wrapper **in place**. `git pull` *is* its install. | **Yes** |
-| `com.numisma.pricefeed.daily.plist` | The installed file at `~/Library/LaunchAgents/` is a hand-resolved **copy** (`__REPO_DIR__` / `__HOME__` expanded). No automation reconciles it. | **No** |
+| `com.numisma.pricefeed.daily.plist` | The installed file at `~/Library/LaunchAgents/` is a hand-resolved **copy** (`__REPO_DIR__`, `__HOME__` and `__DATA_DIR__` expanded). No automation reconciles it. | **No** |
 
 So the normal post-merge state is a **new wrapper on an old schedule**. That is
 benign — the wrapper is correct standalone — but it means the schedule silently
@@ -57,9 +57,13 @@ launchctl unload ~/Library/LaunchAgents/com.numisma.pricefeed.daily.plist
 #    modern equivalent if it refuses:
 #    launchctl bootout gui/$(id -u)/com.numisma.pricefeed.daily
 
-# 4. Render the template over the installed copy.
+# 4. Render the template over the installed copy. Every __PLACEHOLDER__ in the
+#    template needs a line here — `apps/price-feed/src/schedule-window.test.ts`
+#    fails when one is missing, because an install that looks rendered and is not
+#    is the failure this step exists to avoid.
 sed -e "s|__REPO_DIR__|/Users/amet/Dev/numisma|g" \
     -e "s|__HOME__|/Users/amet|g" \
+    -e "s|__DATA_DIR__|/Users/amet/Dev/accumulus/data|g" \
     /Users/amet/Dev/numisma/ops/price-feed/com.numisma.pricefeed.daily.plist \
     > ~/Library/LaunchAgents/com.numisma.pricefeed.daily.plist
 
@@ -114,6 +118,12 @@ Two specific things to hunt for:
 
 Anything appearing beyond those two hunks — `ProgramArguments`, `NUMISMA_DATA_DIR`,
 the log paths — means step 4 or 5 went wrong. Stop and restore the `.bak`.
+
+A left-over `__DATA_DIR__` is the one to look hardest for since #399 moved that
+value off a committed literal and onto a placeholder. It is not silent: the
+wrapper refuses a non-absolute data dir at startup with exit 78 and says which
+runbook to open. But it refuses on the LOAD RUN that step 7 fires, so the cost of
+missing it here is an evening, and `plutil -p` shows it on sight.
 
 ## Verification
 

--- a/ops/price-feed/run-daily-fetch.sh
+++ b/ops/price-feed/run-daily-fetch.sh
@@ -116,6 +116,32 @@ if [[ -z "${DATA_DIR//[[:space:]]/}" ]]; then
   echo "No heartbeat was written: it lives under NUMISMA_DATA_DIR, which is what is broken." >&2
   exit 78
 fi
+# RELATIVE IS REFUSED TOO, and for the same reason the blank check above gives: a
+# CWD-dependent data dir resolves against whatever directory the scheduler started in,
+# which is the split-brain arm ADR-006 forbids. `normalizeDataDirOverride`
+# (packages/engine/src/data-dir.ts) has THROWN on a relative override since #369, so
+# until now the claim above that this block is "byte-identical to what `resolveDataDir`
+# does in TS" was true for blank and false for relative — the wrapper let a relative
+# value through and the first `pnpm` step threw on it a minute later, after the
+# heartbeat path had already been built from it.
+#
+# It stopped being theoretical with #399: the plist template now carries `__DATA_DIR__`
+# rather than a committed home path, and an unrendered placeholder is exactly this case —
+# set, non-blank, not absolute. Refusing here means a missed render dies before any side
+# effect rather than midway through step 1.
+#
+# Same exit 78 (EX_CONFIG) and the same no-heartbeat reasoning as above: the breadcrumb
+# lives under the directory we have just refused to trust.
+if [[ "$DATA_DIR" != /* ]]; then
+  echo "FATAL: NUMISMA_DATA_DIR is not an absolute path (got '$DATA_DIR')." >&2
+  echo "A relative value resolves against whatever directory the scheduler happened to" >&2
+  echo "start in, so this run's marks, heartbeat and git commit would land beside it" >&2
+  echo "instead of in the durable log. If this reads like an unsubstituted placeholder," >&2
+  echo "the plist was installed without its render step (ops/price-feed/launchagent-reinstall.md)." >&2
+  echo "Unset NUMISMA_DATA_DIR to choose the default deliberately, or give it an absolute path." >&2
+  echo "No heartbeat was written: it lives under NUMISMA_DATA_DIR, which is what is broken." >&2
+  exit 78
+fi
 # Wall-clock ceiling on the WHOLE run, enforced by the watchdog below. Must stay
 # comfortably under the 3600s gap between scheduled fires; the reasoning and the
 # guard are at the watchdog itself. 0 disables it (manual debugging only).

--- a/ops/price-feed/run-daily-fetch.sh
+++ b/ops/price-feed/run-daily-fetch.sh
@@ -73,9 +73,14 @@ PATH_PREPEND="${NUMISMA_PATH_PREPEND:-$HOME/.asdf/shims:$HOME/Library/pnpm:/opt/
 #
 # So: `${VAR-default}` (no colon) substitutes for UNSET ONLY, and blank in either
 # spelling is refused outright below. Unset → the default, deliberately. Set-but-blank
-# → a loud non-zero exit. Anything else → verbatim. Byte-identical to what
-# `resolveDataDir` does in TS, which is the only way this wrapper and the code it
-# drives can be said to agree.
+# → a loud non-zero exit.
+#
+# Every other value walks the SAME four rows `normalizeDataDirOverride` walks in TS
+# (packages/engine/src/data-dir.ts), in the same order: strip the surrounding
+# whitespace, expand a leading `~`, accept an absolute path, refuse the rest. That
+# ordering is the whole parity claim, and it is checked one row at a time below rather
+# than asserted here. A row that drifts on one plane and not the other is the defect
+# #369 filed, so each step names the arm of the TS table it mirrors.
 DATA_DIR="${NUMISMA_DATA_DIR-$HOME/Dev/accumulus/data}"
 # A blank `DATA_DIR` can ONLY mean a set-but-blank env var: the default above is never
 # blank. Stripping every space/tab/newline and testing what is left catches `""` and
@@ -116,24 +121,53 @@ if [[ -z "${DATA_DIR//[[:space:]]/}" ]]; then
   echo "No heartbeat was written: it lives under NUMISMA_DATA_DIR, which is what is broken." >&2
   exit 78
 fi
-# RELATIVE IS REFUSED TOO, and for the same reason the blank check above gives: a
-# CWD-dependent data dir resolves against whatever directory the scheduler started in,
-# which is the split-brain arm ADR-006 forbids. `normalizeDataDirOverride`
-# (packages/engine/src/data-dir.ts) has THROWN on a relative override since #369, so
-# until now the claim above that this block is "byte-identical to what `resolveDataDir`
-# does in TS" was true for blank and false for relative — the wrapper let a relative
-# value through and the first `pnpm` step threw on it a minute later, after the
-# heartbeat path had already been built from it.
+# ROW 1: SURROUNDING WHITESPACE IS STRIPPED, NOT REFUSED. `normalizeDataDirOverride`
+# trims before it resolves, so ` /Users/x/data ` names the same directory there that a
+# bare `/Users/x/data` does. Without these two expansions the wrapper refused that value
+# as non-absolute while the engine accepted it: one leading space, two verdicts. Interior
+# whitespace is left alone, because `/tmp/a b` is a real macOS path.
+#
+# The two `${var#...}` / `${var%...}` forms below are bash's trim: the inner expansion
+# builds the run of leading (then trailing) whitespace, and the outer one deletes exactly
+# that run.
+DATA_DIR="${DATA_DIR#"${DATA_DIR%%[![:space:]]*}"}"
+DATA_DIR="${DATA_DIR%"${DATA_DIR##*[![:space:]]}"}"
+# ROW 2: A LEADING `~` IS EXPANDED. Bash expands a tilde it PARSES, never one that
+# arrives inside a variable's value, so `NUMISMA_DATA_DIR=~/Dev/accumulus/data` in a
+# launchd plist reaches this line as the four literal characters `~/De…`. The engine
+# expands it (the `~` arm of `normalizeDataDirOverride`), and the comment on that arm
+# names this exact input as the reason it exists: a value that originated in a plist,
+# which cannot expand `~` itself. So the wrapper expands it here, before the absolute
+# test, or it would refuse the one input the engine added a row for.
+#
+# `$HOME` is the wrapper's `homedir()`. launchd sets it for every job, and `HEARTBEAT_FILE`
+# and the `git -C "$DATA_DIR"` at the commit step both need a path bash can use verbatim.
+if [[ "$DATA_DIR" == "~" ]]; then
+  DATA_DIR="$HOME"
+elif [[ "$DATA_DIR" == "~/"* ]]; then
+  DATA_DIR="$HOME/${DATA_DIR#\~/}"
+fi
+# ROWS 3 AND 4: ABSOLUTE IS ACCEPTED, EVERYTHING LEFT IS REFUSED, and for the same reason
+# the blank check above gives: a CWD-dependent data dir resolves against whatever
+# directory the scheduler started in, which is the split-brain arm ADR-006 forbids.
+# `normalizeDataDirOverride` (packages/engine/src/data-dir.ts) has THROWN on a relative
+# override since #369, so until now the wrapper's parity claim was true for blank and
+# false for relative — the wrapper let a relative value through and the first `pnpm` step
+# threw on it a minute later, after the heartbeat path had already been built from it.
 #
 # It stopped being theoretical with #399: the plist template now carries `__DATA_DIR__`
 # rather than a committed home path, and an unrendered placeholder is exactly this case —
 # set, non-blank, not absolute. Refusing here means a missed render dies before any side
 # effect rather than midway through step 1.
 #
+# The message says "absolute path or start with `~/`" because that is what the engine's
+# throw at the same row says. An operator who reads one plane's refusal and then the
+# other's must not be told two different rules for one value.
+#
 # Same exit 78 (EX_CONFIG) and the same no-heartbeat reasoning as above: the breadcrumb
 # lives under the directory we have just refused to trust.
 if [[ "$DATA_DIR" != /* ]]; then
-  echo "FATAL: NUMISMA_DATA_DIR is not an absolute path (got '$DATA_DIR')." >&2
+  echo "FATAL: NUMISMA_DATA_DIR must be an absolute path or start with '~/' (got '$DATA_DIR')." >&2
   echo "A relative value resolves against whatever directory the scheduler happened to" >&2
   echo "start in, so this run's marks, heartbeat and git commit would land beside it" >&2
   echo "instead of in the durable log. If this reads like an unsubstituted placeholder," >&2


### PR DESCRIPTION
`com.numisma.pricefeed.daily.plist` committed `<string>/Users/amet/Dev/accumulus/data</string>`
while carrying `__PLACEHOLDER__` values for every other machine-specific setting. The
plist's own comment defended the literal, and it was right about the runtime constraint —
launchd does not expand `~`, so the *rendered* file must be absolute. That covers the
rendered copy on the operator's machine and says nothing about the template, which is
what the other placeholders exist to keep clean.

Low severity, and fix-forward only: a directory layout, not a credential, already in
public history, nothing to rotate.

## What changed

**`__DATA_DIR__` renders like the other two.** The substitution joins `__REPO_DIR__` and
`__HOME__` in the reinstall runbook's `sed`.

**Three guards on the template**, in `schedule-window.test.ts` because that file already
reads the plist and already states the rule for what belongs there — a property with an
oracle somewhere else. Here the oracle is `packages/engine/src/data-dir.ts`: *"a committed
one would leak the operator's real directory layout into a public repo."* That rule is
scoped to the engine, so the plist was never in breach as written; the leak is the same
leak.

- no home literal in any value launchd reads
- the data dir goes through `__DATA_DIR__` — a control on the first, since simply deleting
  the key would also satisfy it, and the job would then take the wrapper default silently
  rather than by decision
- every placeholder the template uses has a substitution in the runbook — #398's
  four-edits-in-order failure in its other form, where adding a placeholder without its
  render line produces an install that *looks* rendered

The literal check strips XML comments first. The scoping is the claim: the hazard is a
value, which is what gets installed and what a reader of a public repo learns the layout
from. The header's illustrative `/Users/you/.asdf/shims` example names nobody.

## The part that goes past the issue

Moving off the literal creates a failure mode the literal did not have, and leaving it
open would have made this a worse trade than the leak. The wrapper reads
`${NUMISMA_DATA_DIR-...}` **unset-only**, so an unrendered `__DATA_DIR__` is set,
non-blank and not absolute — it survives verbatim as a CWD-relative path, which is the
split-brain arm ADR-006 forbids.

That gap predates this PR. `normalizeDataDirOverride` has THROWN on a relative override
since #369, while the wrapper refused only blank — so the wrapper's comment claiming it is
"byte-identical to what `resolveDataDir` does in TS" was true for blank and false for
relative. A relative value got through, `HEARTBEAT_FILE` was built from it, and the first
`pnpm` step threw a minute later.

The wrapper now refuses non-absolute with the same exit 78 (EX_CONFIG) beside the blank
check, before any side effect, and names the reinstall runbook when the value looks like
an unrendered placeholder — the only place that can say what actually went wrong, since
everything downstream reports a bad data dir rather than a bad plist.

## Docs

`docs/price-feed-ops.md` stated the opposite in three places ("The plist's
`NUMISMA_DATA_DIR` is **not** a placeholder"), and both it and the runbook enumerated the
placeholders as a pair. Reconciled, including the new refusal in the install steps and a
trap-2 note on spotting a left-over `__DATA_DIR__`.

## Not scrubbed, deliberately

`ops/price-feed/launchagent-reinstall.md` keeps its `/Users/amet` literals. It is an
operator runbook whose `sed` and `launchctl` lines are meant to be pasted; scrubbing them
leaves commands nobody can run. The guard is scoped to the template — the artifact that
gets installed — not the runbook, which gets read.

## Verification

- All three template guards seen RED before being trusted: restoring the literal fails two
  of them, deleting the key fails the control, and removing the runbook's `sed` line fails
  the third.
- Both wrapper cases seen RED with the new refusal removed.
- Full workspace typecheck clean; 292 `@numisma/price-feed` tests pass (287 + 5), including
  the wrapper harness running the real wrapper armed. `plutil -lint` OK.

## Operator action

The plist needs a **manual re-render** to reach the running job — the wrapper installs via
`git pull`, the plist does not. Until then the installed copy keeps its already-resolved
literal and the job is unaffected. Note trap 1 still applies: the render destroys
`NUMISMA_PATH_PREPEND`, which must be re-added by hand.

Found during the docs sweep in #397.

Closes #399
